### PR TITLE
graph endpoint + UI/CLI render: surface state valuations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust
 /target/
+**/target/
 *.pdb
 
 # IDE

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2696,6 +2696,11 @@ enum CytoscapeData {
         vars: Option<serde_json::Value>,
         #[serde(skip_serializing_if = "Option::is_none")]
         actions: Option<serde_json::Value>,
+        /// Structured per-state valuations (`{key: value}`). Sourced from
+        /// `Clts::state_valuation()`. Rendered inline under the state label
+        /// by the Cytoscape style function in `generate_cytoscape_html`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        valuations: Option<serde_json::Value>,
         #[serde(skip_serializing_if = "Option::is_none")]
         note: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -2784,6 +2789,10 @@ struct StateElementParams {
     is_initial: bool,
     is_dead: bool,
     state_var_str: Option<String>,
+    /// Structured per-state valuations keyed by variable name. Sourced from
+    /// `Clts::state_valuation()`. The HTML template renders them inline
+    /// under the state label as `{key1=val1, key2=val2}`.
+    state_valuations: Option<std::collections::BTreeMap<String, String>>,
     x: f64,
     y: f64,
     entry_node_id: Option<String>,
@@ -2810,6 +2819,10 @@ fn build_state_elements(p: StateElementParams) -> Vec<CytoscapeElement> {
             label: Some(p.label),
             vars: p.state_var_str.map(|s| json!(s)),
             actions: None,
+            valuations: p
+                .state_valuations
+                .filter(|m| !m.is_empty())
+                .map(|m| json!(m)),
             note: if p.is_initial {
                 Some("Initial state".to_string())
             } else if p.is_dead {
@@ -2834,6 +2847,7 @@ fn build_state_elements(p: StateElementParams) -> Vec<CytoscapeElement> {
                 label: None,
                 vars: None,
                 actions: None,
+                valuations: None,
                 note: None,
                 isStart: None,
                 isDead: None,
@@ -2883,6 +2897,7 @@ fn counterstrategy_to_cytoscape(
             parent: None,
             vars: None,
             actions: None,
+            valuations: None,
             note: None,
             isStart: None,
             isDead: None,
@@ -2905,6 +2920,11 @@ fn counterstrategy_to_cytoscape(
             classes.push("start");
         }
 
+        let val = clts
+            .state_valuation(state_id)
+            .filter(|m| !m.is_empty())
+            .map(|m| json!(m));
+
         elements.push(CytoscapeElement {
             data: CytoscapeData::Node {
                 id: node_id,
@@ -2912,6 +2932,7 @@ fn counterstrategy_to_cytoscape(
                 parent: Some(automaton_name.to_string()),
                 vars: None,
                 actions: None,
+                valuations: val,
                 note: None,
                 isStart: Some(is_initial),
                 isDead: Some(false),
@@ -3039,6 +3060,7 @@ fn dsl_automata_to_cytoscape(
                 } else {
                     Some(json!(action_info))
                 },
+                valuations: None,
                 note: None,
                 isStart: None,
                 isDead: None,
@@ -3078,6 +3100,11 @@ fn dsl_automata_to_cytoscape(
 
             state_positions.insert(state_name.clone(), (x_pos, y_offset + 100.0));
 
+            let state_valuations = clts
+                .state_id(state_name)
+                .ok()
+                .and_then(|sid| clts.state_valuation(sid).cloned());
+
             elements.extend(build_state_elements(StateElementParams {
                 state_id,
                 automaton_id: automaton_id.clone(),
@@ -3085,6 +3112,7 @@ fn dsl_automata_to_cytoscape(
                 is_initial,
                 is_dead,
                 state_var_str,
+                state_valuations,
                 x: x_pos,
                 y: y_offset + 100.0,
                 entry_node_id: if is_initial {
@@ -3355,6 +3383,7 @@ fn unrolled_automata_to_cytoscape(
                 } else {
                     Some(json!(action_info))
                 },
+                valuations: None,
                 note: None,
                 isStart: None,
                 isDead: None,
@@ -3428,6 +3457,7 @@ fn unrolled_automata_to_cytoscape(
                 is_initial,
                 is_dead,
                 state_var_str,
+                state_valuations: None,
                 x: x_pos,
                 y: y_offset + 100.0,
                 entry_node_id: if is_initial {
@@ -3553,17 +3583,26 @@ fn generate_cytoscape_html(elements: &[CytoscapeElement]) -> Result<String, Stri
         {
           selector: "node.state",
           style: {
-            "shape": "ellipse",
+            "shape": "round-rectangle",
             "background-color": "#ffffff",
             "border-width": 1,
             "border-style": "solid",
             "border-color": "#000000",
-            "width": 60,
-            "height": 60,
-            "label": "data(label)",
+            "width": "label",
+            "height": "label",
+            "padding": "8px",
+            "label": ele => {
+              const base = ele.data("label") || "";
+              const v = ele.data("valuations");
+              if (v && typeof v === "object" && Object.keys(v).length > 0) {
+                const pairs = Object.keys(v).map(k => k + "=" + v[k]).join(", ");
+                return base + "\n{" + pairs + "}";
+              }
+              return base;
+            },
             "font-size": 12,
             "text-wrap": "wrap",
-            "text-max-width": 70,
+            "text-max-width": 200,
             "text-halign": "center",
             "text-valign": "center"
           }

--- a/crates/mununu-core/Cargo.toml
+++ b/crates/mununu-core/Cargo.toml
@@ -66,6 +66,10 @@ test_support = ["dep:rand", "dep:rand_chacha"]
 stress = ["test_support"]
 dhat = ["dep:dhat"]
 
+[[test]]
+name = "api_graph_valuations"
+required-features = ["api"]
+
 [[bench]]
 name = "clts_composition"
 harness = false

--- a/crates/mununu-core/src/api/graph.rs
+++ b/crates/mununu-core/src/api/graph.rs
@@ -3,7 +3,7 @@
 //! This module extracts graph generation logic from the CLI for use in the REST API.
 //! It converts automata into graph elements that can be serialized to JSON for visualization.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::abstraction::unrolling::{
     Effect, OriginalState, OriginalTransition, UnrollingOptions, VariableDecl, unroll_states,
@@ -18,6 +18,17 @@ use crate::api::models::{
     AutomatonSummary, ContextSummary, GraphData, GraphElement, GraphElementData, GraphMetadata,
     GraphPosition, GraphType, GraphTypeResponse,
 };
+
+/// Look up structured per-state valuations on a CLTS by state name. Returns
+/// `None` when the state is unknown or has no valuation attached.
+fn valuation_for_state(
+    clts: &Clts<DefaultStateIdx, DefaultLabelIdx>,
+    state_name: &str,
+) -> Option<BTreeMap<String, String>> {
+    let sid = clts.state_id(state_name).ok()?;
+    let v = clts.state_valuation(sid)?;
+    if v.is_empty() { None } else { Some(v.clone()) }
+}
 
 /// Generate graphs from context based on request parameters.
 ///
@@ -373,6 +384,7 @@ pub fn counterstrategy_to_graph_elements(
             parent: None,
             vars: Vec::new(),
             actions: Vec::new(),
+            valuations: None,
         },
         position: None,
         classes: None,
@@ -398,6 +410,7 @@ pub fn counterstrategy_to_graph_elements(
                 parent: Some(automaton_id.clone()),
                 vars: Vec::new(),
                 actions: Vec::new(),
+                valuations: valuation_for_state(clts, &state_name),
             },
             position: Some(GraphPosition {
                 x: x_pos,
@@ -415,6 +428,7 @@ pub fn counterstrategy_to_graph_elements(
                     parent: Some(automaton_id.clone()),
                     vars: Vec::new(),
                     actions: Vec::new(),
+                    valuations: None,
                 },
                 position: Some(GraphPosition {
                     x: 40.0,
@@ -487,6 +501,7 @@ fn clts_to_graph_elements_with_labels(
             parent: None,
             vars: Vec::new(),
             actions: Vec::new(),
+            valuations: None,
         },
         position: None,
         classes: None,
@@ -507,6 +522,17 @@ fn clts_to_graph_elements_with_labels(
             classes.push("dead");
         }
 
+        // Prefer valuations from `clts` itself; for synthesized controllers (which inherit
+        // state IDs but may not carry valuations), fall back to the source CLTS by name.
+        let state_valuations = clts.state_valuation(state_id).cloned().or_else(|| {
+            label_source.and_then(|src| {
+                src.state_id(&state_name)
+                    .ok()
+                    .and_then(|sid| src.state_valuation(sid).cloned())
+            })
+        });
+        let state_valuations = state_valuations.filter(|m| !m.is_empty());
+
         elements.push(GraphElement {
             data: GraphElementData::Node {
                 id: node_id.clone(),
@@ -514,6 +540,7 @@ fn clts_to_graph_elements_with_labels(
                 parent: Some(automaton_id.clone()),
                 vars: Vec::new(),
                 actions: Vec::new(),
+                valuations: state_valuations,
             },
             position: Some(GraphPosition {
                 x: x_pos,
@@ -532,6 +559,7 @@ fn clts_to_graph_elements_with_labels(
                     parent: Some(automaton_id.clone()),
                     vars: Vec::new(),
                     actions: Vec::new(),
+                    valuations: None,
                 },
                 position: Some(GraphPosition {
                     x: 40.0,
@@ -692,6 +720,7 @@ fn dsl_automata_to_graph_elements(
                 parent: None,
                 vars: var_names.clone(),
                 actions: action_info.clone(),
+                valuations: None,
             },
             position: None,
             classes: None,
@@ -721,6 +750,8 @@ fn dsl_automata_to_graph_elements(
                     .unwrap_or_default()
             };
 
+            let state_valuations = valuation_for_state(clts, state_name);
+
             let position = GraphPosition {
                 x: x_pos,
                 y: y_offset + 100.0,
@@ -741,6 +772,7 @@ fn dsl_automata_to_graph_elements(
                     parent: Some(automaton_id.clone()),
                     vars: state_vars,
                     actions: Vec::new(),
+                    valuations: state_valuations,
                 },
                 position: Some(position),
                 classes: Some(classes.join(" ")),
@@ -756,6 +788,7 @@ fn dsl_automata_to_graph_elements(
                         parent: Some(automaton_id.clone()),
                         vars: Vec::new(),
                         actions: Vec::new(),
+                        valuations: None,
                     },
                     position: Some(GraphPosition {
                         x: 40.0,
@@ -1067,6 +1100,7 @@ fn unrolled_automata_to_graph_elements(
                 parent: None,
                 vars: var_names.clone(),
                 actions: action_info.clone(),
+                valuations: None,
             },
             position: None,
             classes: None,
@@ -1140,6 +1174,7 @@ fn unrolled_automata_to_graph_elements(
                     parent: Some(automaton_id.clone()),
                     vars: state_vars,
                     actions: Vec::new(),
+                    valuations: None,
                 },
                 position: Some(position),
                 classes: Some(classes.join(" ")),
@@ -1155,6 +1190,7 @@ fn unrolled_automata_to_graph_elements(
                         parent: Some(automaton_id.clone()),
                         vars: Vec::new(),
                         actions: Vec::new(),
+                        valuations: None,
                     },
                     position: Some(GraphPosition {
                         x: 40.0,

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 // ============================================================================
 // Common Types
@@ -348,6 +349,11 @@ pub enum GraphElementData {
         vars: Vec<String>,
         #[serde(skip_serializing_if = "Vec::is_empty", default)]
         actions: Vec<String>,
+        /// Structured per-state variable valuations (e.g. `{is_red: "0", phase: "green"}`).
+        /// Sourced from `Clts::state_valuation()` — populated by adapter side-channels
+        /// (SV Kripke, BTOR2, extraction) injected through `ContextDoc.state_valuations`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        valuations: Option<BTreeMap<String, String>>,
     },
     Edge {
         id: String,
@@ -491,6 +497,7 @@ mod tests {
             parent: Some("parent".to_string()),
             vars: vec!["x".to_string(), "y".to_string()],
             actions: vec!["start".to_string()],
+            valuations: None,
         };
         let json = serde_json::to_string(&node).unwrap();
         let deserialized: GraphElementData = serde_json::from_str(&json).unwrap();
@@ -523,6 +530,7 @@ mod tests {
                 parent: None,
                 vars: vec![],
                 actions: vec![],
+                valuations: None,
             },
             position: Some(GraphPosition { x: 100.0, y: 200.0 }),
             classes: Some("state start".to_string()),

--- a/crates/mununu-core/tests/api_graph_valuations.rs
+++ b/crates/mununu-core/tests/api_graph_valuations.rs
@@ -1,0 +1,187 @@
+use mununu_core::api::graph::generate_graphs;
+use mununu_core::api::models::{GraphElementData, GraphType};
+use mununu_core::context_dsl;
+use mununu_core::context_dsl::realize::realize;
+use std::collections::{BTreeMap, HashMap};
+
+const TRAFFIC_CTXDSL: &str = r#"
+context traffic {
+    alphabet { label tick; label expire; label sense; }
+    automata {
+        automaton TrafficLight {
+            controllable { label expire; }
+            states {
+                state Green initial;
+                state Yellow;
+                state Red;
+                state RedWait;
+            }
+            transitions {
+                transition Green -> Green on label tick;
+                transition Green -> Yellow on label expire;
+                transition Yellow -> Yellow on label tick;
+                transition Yellow -> Red on label expire;
+                transition Red -> Red on label tick;
+                transition Red -> RedWait on label expire;
+                transition RedWait -> Green on label sense;
+                transition RedWait -> RedWait on label tick;
+            }
+        }
+    }
+}
+"#;
+
+fn pair(k: &str, v: &str) -> (String, String) {
+    (k.to_string(), v.to_string())
+}
+
+fn assert_state_has_valuation(
+    elements: &[mununu_core::api::models::GraphElement],
+    state_label: &str,
+    expected: &[(&str, &str)],
+) {
+    let node = elements
+        .iter()
+        .find(|el| match &el.data {
+            GraphElementData::Node { label, .. } => label == state_label,
+            _ => false,
+        })
+        .unwrap_or_else(|| panic!("state node `{}` not found", state_label));
+
+    let valuations = match &node.data {
+        GraphElementData::Node { valuations, .. } => valuations.as_ref().unwrap_or_else(|| {
+            panic!(
+                "state `{}` is missing the `valuations` payload",
+                state_label
+            )
+        }),
+        _ => unreachable!(),
+    };
+
+    for (k, v) in expected {
+        assert_eq!(
+            valuations.get(*k).map(String::as_str),
+            Some(*v),
+            "state `{}` valuation `{}` mismatch (full map: {:?})",
+            state_label,
+            k,
+            valuations
+        );
+    }
+}
+
+#[test]
+fn dsl_graph_includes_state_valuations_from_side_channel() {
+    let mut doc = context_dsl::parse(TRAFFIC_CTXDSL).expect("CTXDSL parses");
+
+    // Inject side-channel valuations as an adapter would (e.g., the BTOR2 reader
+    // populates `ContextDoc.state_valuations` from the cross-product enumeration
+    // of register values). The realize layer then registers them on the CLTS via
+    // `Clts::with_valuation_for_state`.
+    let mut per_state: HashMap<String, BTreeMap<String, String>> = HashMap::new();
+    per_state.insert(
+        "Green".to_string(),
+        [
+            pair("is_red", "0"),
+            pair("is_green", "1"),
+            pair("is_yellow", "0"),
+            pair("phase", "green"),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    per_state.insert(
+        "Yellow".to_string(),
+        [pair("is_yellow", "1"), pair("phase", "yellow")]
+            .into_iter()
+            .collect(),
+    );
+    per_state.insert(
+        "Red".to_string(),
+        [pair("is_red", "1"), pair("phase", "red")]
+            .into_iter()
+            .collect(),
+    );
+    per_state.insert(
+        "RedWait".to_string(),
+        [pair("is_red", "1"), pair("phase", "red_wait")]
+            .into_iter()
+            .collect(),
+    );
+    doc.state_valuations
+        .insert("TrafficLight".to_string(), per_state);
+
+    let realized = realize(&doc, &[]).expect("realization succeeds");
+
+    let (graphs, _summary) = generate_graphs(
+        &doc,
+        &[],
+        &realized,
+        Some("TrafficLight"),
+        &[GraphType::Dsl],
+    )
+    .expect("graph generation succeeds");
+
+    assert_eq!(graphs.len(), 1, "exactly one graph for the DSL view");
+    let elements = &graphs[0].elements;
+
+    assert_state_has_valuation(
+        elements,
+        "Green",
+        &[
+            ("is_red", "0"),
+            ("is_green", "1"),
+            ("is_yellow", "0"),
+            ("phase", "green"),
+        ],
+    );
+    assert_state_has_valuation(
+        elements,
+        "Yellow",
+        &[("is_yellow", "1"), ("phase", "yellow")],
+    );
+    assert_state_has_valuation(elements, "Red", &[("is_red", "1"), ("phase", "red")]);
+    assert_state_has_valuation(
+        elements,
+        "RedWait",
+        &[("is_red", "1"), ("phase", "red_wait")],
+    );
+}
+
+#[test]
+fn graph_omits_valuations_when_state_has_none() {
+    // No `state_valuations` injection. Each state node should serialize without
+    // the `valuations` field (Option::None → skipped by serde).
+    const SRC: &str = r#"
+context demo {
+    alphabet { label a; }
+    automata {
+        automaton A {
+            states { state s0 initial; state s1; }
+            transitions { transition s0 -> s1 on label a; }
+        }
+    }
+}
+"#;
+    let doc = context_dsl::parse(SRC).expect("context parses");
+    let realized = realize(&doc, &[]).expect("realization succeeds");
+
+    let (graphs, _summary) =
+        generate_graphs(&doc, &[], &realized, Some("A"), &[GraphType::Dsl]).expect("graph ok");
+    let elements = &graphs[0].elements;
+
+    for el in elements {
+        if let GraphElementData::Node {
+            label, valuations, ..
+        } = &el.data
+            && (label == "s0" || label == "s1")
+        {
+            assert!(
+                valuations.is_none(),
+                "state `{}` should have no valuations, got {:?}",
+                label,
+                valuations
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Re-introduces the graph state-valuations work cleanly after the Phase A revert (PR #3). This PR is **scoped narrowly** — only the graph endpoint payload + the two visualizations consume the new field. It does **not** touch \`ContextImportResponse\`, \`ContextDoc.transition_observations\`, or anything else from the broader state-valuations feature surface (that lands in the follow-up PR per the recovery plan).

## Acceptance criteria

1. **Graph endpoint payload includes \`valuations\`** — \`/api/v1/context/graphs\` JSON response carries \`data.valuations: { key: value, … }\` on each state node when the underlying CLTS has a valuation. Verified by \`tests/api_graph_valuations.rs::dsl_graph_includes_state_valuations_from_side_channel\`.
2. **CLI HTML renders valuations under state name** — \`mununu context graph --output X.html\` produces nodes whose label reads \`\\\${state_name}\\\\n{key1=val1, …}\` via the Cytoscape style function in \`generate_cytoscape_html\`.
3. **UI parity** — the matching mununu-ui PR will add \`valuations?: Record<string, string> | null\` to \`GraphElementData\` and a \`stateNodeLabel\` function in \`graphStyles.ts\` so the same multi-line label renders below each node (this PR ships the API; the UI PR is filed separately).

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` exits 0 locally (incl. the new \`api_graph_valuations\` tests)
- [ ] GitHub Actions \`make ci\` in dev image — must finish exit 0
- [ ] After merge: \`gh run list --branch main --limit 1\` shows \`success\`
- [ ] Manual UI smoke (post-mununu-ui PR merge): import an SV/BTOR2 file with valuations; verify each state node shows its valuation line beneath the state name

🤖 Generated with [Claude Code](https://claude.com/claude-code)