### PR TITLE
chore: weekly cargo-sweep across mununu's git_repo siblings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PROPTEST_CASES ?= 64
 
 .PHONY: build test lint verify ci clean help \
         test-fast test-properties stress fuzz proptest-deep \
-        coverage mem-profile \
+        coverage mem-profile sweep \
         bench-baseline bench-compare bench-record \
         experiment replay publish-prep
 
@@ -41,6 +41,9 @@ help:
 	@echo "Coverage / memory:"
 	@echo "  coverage        - cargo-llvm-cov HTML + JSON summary"
 	@echo "  mem-profile     - run dhat-instrumented stress tests"
+	@echo
+	@echo "Disk hygiene:"
+	@echo "  sweep           - cargo sweep on mununu's siblings under ~/git_repo/ (dry-run; SWEEP_APPLY=1 to delete)"
 	@echo
 	@echo "Benchmarks:"
 	@echo "  bench-baseline  - cargo bench --save-baseline $(BASELINE)"
@@ -88,6 +91,12 @@ coverage:
 
 mem-profile:
 	$(CARGO) test --workspace --features dhat,stress --tests 'stress_*' -- --ignored --nocapture
+
+# Reclaim Cargo build artifacts on mununu's siblings under ~/git_repo/.
+# Default: dry-run (shows what would be removed). Set SWEEP_APPLY=1 to delete.
+# Override age threshold with SWEEP_DAYS=N (default 14).
+sweep:
+	@./scripts/sweep_targets.sh
 
 lint:
 	$(CARGO) fmt --all -- --check

--- a/scripts/com.vscorza.mununu-sweep.plist
+++ b/scripts/com.vscorza.mununu-sweep.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Weekly cargo-sweep across mununu's siblings under ~/git_repo/.
+  Runs Sundays at 03:00 in apply mode (SWEEP_APPLY=1).
+
+  Install:
+      cp scripts/com.vscorza.mununu-sweep.plist ~/Library/LaunchAgents/
+      launchctl load ~/Library/LaunchAgents/com.vscorza.mununu-sweep.plist
+
+  Inspect last run:    log show --predicate 'subsystem=="com.vscorza.mununu-sweep"' --last 1d
+  Or check the log:    cat ~/Library/Logs/mununu-sweep.log
+  Trigger manually:    launchctl start com.vscorza.mununu-sweep
+  Uninstall:           launchctl unload ~/Library/LaunchAgents/com.vscorza.mununu-sweep.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.vscorza.mununu-sweep</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/marianocerrutti/git_repo/mununu/scripts/sweep_targets.sh</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>SWEEP_APPLY</key>
+        <string>1</string>
+        <key>PATH</key>
+        <string>/Users/marianocerrutti/.cargo/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/marianocerrutti/Library/Logs/mununu-sweep.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/marianocerrutti/Library/Logs/mununu-sweep.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/sweep_targets.sh
+++ b/scripts/sweep_targets.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Reclaim Cargo build artifacts in mununu's siblings under ~/git_repo/.
+#
+# Walks every immediate sibling directory of the repo this script lives in
+# (i.e. peers of mununu under ~/git_repo/), and for any sibling whose root
+# carries a Cargo.toml runs `cargo sweep --time N` on it. cargo-sweep deletes
+# build outputs whose access time is older than N days, keeping the most
+# recent build cache warm so day-to-day iteration is unaffected.
+#
+# Default age threshold: 14 days. Override with SWEEP_DAYS=N.
+# Defaults to dry-run; set SWEEP_APPLY=1 to actually delete.
+#
+# Skips Docker volumes/images entirely — cleaning those is a separate concern.
+#
+# Install cargo-sweep once: cargo install cargo-sweep
+# Manual run:                make sweep              (this script via Makefile)
+# Schedule weekly:           cp scripts/com.vscorza.mununu-sweep.plist ~/Library/LaunchAgents/
+#                            launchctl load ~/Library/LaunchAgents/com.vscorza.mununu-sweep.plist
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SIBLINGS_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
+DAYS="${SWEEP_DAYS:-14}"
+APPLY="${SWEEP_APPLY:-0}"
+
+if ! command -v cargo-sweep >/dev/null 2>&1; then
+    echo "cargo-sweep not installed. Install with: cargo install cargo-sweep" >&2
+    exit 1
+fi
+
+if [ "$APPLY" = "1" ]; then
+    DRY_FLAG=""
+    mode="apply"
+else
+    DRY_FLAG="--dry-run"
+    mode="dry-run (set SWEEP_APPLY=1 to delete)"
+fi
+
+echo "Sweeping Cargo targets older than ${DAYS}d under ${SIBLINGS_ROOT} — ${mode}"
+echo
+
+reclaimed_kb=0
+
+for d in "$SIBLINGS_ROOT"/*/; do
+    [ -f "${d}Cargo.toml" ] || continue
+    name="$(basename "$d")"
+    target="${d}target"
+
+    before_kb=0
+    if [ -d "$target" ]; then
+        before_kb=$(du -sk "$target" 2>/dev/null | awk '{print $1}')
+    fi
+
+    printf "==> %s\n" "$name"
+    cargo sweep --time "$DAYS" $DRY_FLAG "$d" 2>&1 | sed 's/^/    /'
+
+    if [ "$APPLY" = "1" ] && [ -d "$target" ]; then
+        after_kb=$(du -sk "$target" 2>/dev/null | awk '{print $1}')
+        diff=$(( before_kb - after_kb ))
+        if [ "$diff" -gt 0 ]; then
+            reclaimed_kb=$(( reclaimed_kb + diff ))
+            printf "    reclaimed %s MiB\n" "$(awk "BEGIN { printf \"%.1f\", $diff/1024 }")"
+        fi
+    fi
+done
+
+if [ "$APPLY" = "1" ]; then
+    printf "\nTotal reclaimed: %s MiB\n" "$(awk "BEGIN { printf \"%.1f\", $reclaimed_kb/1024 }")"
+fi


### PR DESCRIPTION
## Summary

Adds a 'make sweep' verb plus a launchd plist template so Cargo build artifacts in mununu's siblings under '~/git_repo/' are reclaimed weekly.

- [scripts/sweep_targets.sh](scripts/sweep_targets.sh) walks immediate siblings of mununu under '~/git_repo/', runs 'cargo sweep --time \$SWEEP_DAYS' (default 14d) on each with a 'Cargo.toml', and skips Docker entirely. Defaults to dry-run; 'SWEEP_APPLY=1' actually deletes.
- [scripts/com.vscorza.mununu-sweep.plist](scripts/com.vscorza.mununu-sweep.plist) is a launchd template — install with 'cp ... ~/Library/LaunchAgents/ && launchctl load ...'. Runs Sunday 03:00 in apply mode, logs to '~/Library/Logs/mununu-sweep.log'.
- New 'make sweep' verb in [Makefile](Makefile) calls the script.

This is the same scope as the original closed PR #2, re-opened from clean main per the recovery plan.

## Test plan

- [x] Dry-run script bails cleanly when 'cargo-sweep' is missing
- [x] Sibling-iteration logic verified — 8 Rust repos detected
- [ ] After merge: 'cargo install cargo-sweep && make sweep' (defaults to dry-run; safe)
- [ ] 'SWEEP_APPLY=1 make sweep' to actually reclaim
- [ ] Install launchd plist for weekly automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)