### PR TITLE
governance: forbid destructive git ops without explicit user instruction

### DIFF
--- a/.claude/agents/domain-adequacy.md
+++ b/.claude/agents/domain-adequacy.md
@@ -17,6 +17,8 @@ allowed_tools:
   - WebFetch
 ---
 
+> **Git safety**: this agent must never invoke destructive git commands (`reset --hard`, `push --force`, `checkout -- <paths>`, `clean -f`, `stash drop`, `branch -D`) without explicit user instruction in the current session. See `CLAUDE.md` → Governance Rules → Git Operations & Destructive Commands.
+
 You are a senior domain analyst for the mununu formal verification tool. Your job is to evaluate whether the project's examples and use cases are realistic, working, cohesive, and covering the right ground across all target domains.
 
 **Tone**: Be slightly critical and realistic. Do not inflate results or extrapolate beyond what examples actually demonstrate. When an example fails verification unexpectedly, report it as a finding. When a domain has weak coverage, say so. Avoid big claims.

--- a/.claude/agents/quality-session.md
+++ b/.claude/agents/quality-session.md
@@ -15,6 +15,8 @@ allowed_tools:
   - Skill
 ---
 
+> **Git safety**: this agent must never invoke destructive git commands (`reset --hard`, `push --force`, `checkout -- <paths>`, `clean -f`, `stash drop`, `branch -D`) without explicit user instruction in the current session. See `CLAUDE.md` → Governance Rules → Git Operations & Destructive Commands.
+
 You are a quality engineering agent for the mununu formal verification tool (Rust workspace: mununu-core, mununu-cli, mununu-extract).
 
 Run a metric-driven quality improvement session on $ARGUMENTS (or the most-changed modules if no args). Follow all six phases in order. Never skip the before-measurement or after-measurement.

--- a/.claude/agents/review-orchestrator.md
+++ b/.claude/agents/review-orchestrator.md
@@ -12,6 +12,8 @@ allowed_tools:
   - Skill
 ---
 
+> **Git safety**: this agent must never invoke destructive git commands (`reset --hard`, `push --force`, `checkout -- <paths>`, `clean -f`, `stash drop`, `branch -D`) without explicit user instruction in the current session. See `CLAUDE.md` → Governance Rules → Git Operations & Destructive Commands.
+
 You are a senior engineering reviewer for the mununu formal verification tool (Rust workspace with three crates: mununu-core, mununu-cli, mununu-extract).
 
 Run a full review by invoking each specialist skill on the changed files. First determine scope:

--- a/.claude/agents/target-executor.md
+++ b/.claude/agents/target-executor.md
@@ -17,6 +17,8 @@ allowed_tools:
   - WebFetch
 ---
 
+> **Git safety**: this agent must never invoke destructive git commands (`reset --hard`, `push --force`, `checkout -- <paths>`, `clean -f`, `stash drop`, `branch -D`) without explicit user instruction in the current session. See `CLAUDE.md` → Governance Rules → Git Operations & Destructive Commands.
+
 You are the target-executor for the mununu formal verification tool. Your job is to take ONE candidate target from the prospector backlog and run it end-to-end through mununu — write the model artifact, invoke the adapter, evaluate the properties, and produce a structured execution report. You do not search for new targets; you do not write user-facing content; you do not edit any agent definition files.
 
 **Tone:** literal, defensive, evidence-only. If a step fails, record the exact command and stderr — never hand-wave. If the target's source can't be fetched, abort cleanly with a structured rejection.

--- a/.claude/agents/verification-prospector.md
+++ b/.claude/agents/verification-prospector.md
@@ -19,6 +19,8 @@ allowed_tools:
   - WebFetch
 ---
 
+> **Git safety**: this agent must never invoke destructive git commands (`reset --hard`, `push --force`, `checkout -- <paths>`, `clean -f`, `stash drop`, `branch -D`) without explicit user instruction in the current session. See `CLAUDE.md` → Governance Rules → Git Operations & Destructive Commands.
+
 You are a senior verification researcher for the mununu formal verification tool. Your job is to find real systems whose state-machine or protocol logic can be modeled and verified by mununu, with enough public source-of-truth that any proposed target survives the Claims Integrity policy.
 
 **Tone:** methodical, skeptical, citation-first. Reject any candidate that requires hand-waving about what the system "probably does." Prefer one well-evidenced target over five speculative ones. If a session produces zero targets that meet the bar, that is a valid outcome — say so.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,29 @@ This applies to: README examples, wiki case studies, blog posts linked from the 
 - Validate and constrain all external input.
 - No sensitive data in logs.
 
+### Git Operations & Destructive Commands
+
+**Destructive git operations require explicit user instruction in the current session prompt.** This applies to:
+
+- `git reset --hard` (discards working tree changes — irrecoverable from reflog)
+- `git push --force` / `git push -f` / `git push --force-with-lease` (overwrites remote history)
+- `git checkout -- <paths>` / `git restore <paths>` (discards working tree changes for paths)
+- `git clean -f` / `git clean -fd` (deletes untracked files)
+- `git branch -D <branch>` (force-deletes a branch with unmerged commits)
+- `git stash drop` / `git stash clear`
+- `git rebase --interactive` followed by squash/drop of unpushed-but-staged work
+
+**Why**: working-tree state is not recoverable from `git reflog` — only commits are. A `--hard` reset on a working tree carrying hours of uncommitted work permanently loses that work unless an editor's local history snapshot exists. (See incident: `.claude/plans/update-the-graph-endpoint-crystalline-frost.md` — a botched revert + `--hard` reset cost ~1730 lines of in-flight work that VSCode local history, Time Machine, and APFS snapshots could not recover.)
+
+**How to apply**:
+- Never run any of the above commands "to clean up" or "to reset state" unless the user has typed an instruction containing the specific command (e.g. "do a hard reset to main", "force-push the rebase").
+- If a botched `git revert` or merge-conflict resolution is in progress, prefer `git revert --abort`, `git merge --abort`, `git cherry-pick --abort`, or `git reset --soft` (which preserves working tree).
+- If the working tree must be discarded for a routine operation (e.g. switching branches), first run `git stash push -u -m "<reason>"` to preserve untracked files too. Surface the stash to the user.
+- For pre-commit hook failures, *create a new commit* — never `--amend` and never `--no-verify` unless the user explicitly authorised it.
+- Before any operation that may modify the working tree of files the user has been actively editing, snapshot via a "savepoint" branch + push to remote (`git checkout -b recovery/savepoint-<date> && git add -A && git commit --no-verify -m "savepoint" && git push -u origin <branch>`).
+
+**Agents must propagate this rule.** Any subagent invocation that performs git operations on a real repo (not an `isolation: "worktree"` clone) inherits this restriction. Subagents may take destructive actions only inside `isolation: "worktree"` agents (the worktree is a throwaway clone).
+
 ## Private Files Policy
 
 Sensitive or unpublished materials must live in the **sibling private repo**, not in this repo:


### PR DESCRIPTION
## Summary

Adds a 'Git Operations & Destructive Commands' subsection under Governance Rules in [CLAUDE.md](CLAUDE.md) plus a cross-reference header in each of the 5 project agents under [.claude/agents/](.claude/agents/).

Triggered by an incident this session where a botched 'git revert' followed by 'git reset --hard HEAD~1' destroyed ~1730 lines of the user's uncommitted in-flight work. Recovery sources audited and exhausted:
- VSCode local history: zero entries (Claude Code never opens files via VSCode UI)
- Time Machine: not configured on this Mac ('tmutil destinationinfo' → 'No destinations configured')
- APFS local snapshots: only OS-update snapshot, no user snapshot
- VSCode Backups: empty 'file/' dir

## What changes

[CLAUDE.md](CLAUDE.md) — new subsection enumerates the destructive ops requiring explicit consent ('reset --hard', 'push --force', 'checkout -- <paths>', 'clean -f', 'stash drop', 'branch -D', interactive rebase that drops staged work) plus the recommended safer alternatives ('reset --soft', '*--abort', savepoint branches).

[.claude/agents/*.md](.claude/agents/) — one-line safety header on all 5 agents (domain-adequacy, quality-session, review-orchestrator, target-executor, verification-prospector) so subagent invocations inherit the restriction unless they run inside an 'isolation: \"worktree\"' agent (where the worktree is a throwaway clone).

## Test plan

- [x] CLAUDE.md sub-section renders correctly
- [x] All 5 agents have the safety header inserted between frontmatter and body
- [ ] GitHub Actions CI — must finish exit 0 (this PR is docs-only; should pass trivially)

🤖 Generated with [Claude Code](https://claude.com/claude-code)