### PR TITLE
feat(sv-adapter): binary XOR + DMR commit-gate fault-tolerance example

### DIFF
--- a/crates/mununu-core/src/adapter/systemverilog/ast.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/ast.rs
@@ -205,6 +205,7 @@ pub enum BinOp {
     And,
     Or,
     BitOr,
+    BitXor,
     BitAnd,
     Add,
     Sub,

--- a/crates/mununu-core/src/adapter/systemverilog/kripke.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/kripke.rs
@@ -1656,6 +1656,13 @@ fn eval_binop(
             let (l, r) = to_i64_pair(lv, rv, registers)?;
             Some(AbstractValue::Counter(l | r))
         }
+        BinOp::BitXor => {
+            // SOUNDNESS: like BitOr/BitAnd, the result is not masked to the
+            // declared source width — caller must keep operands within the
+            // bounded_counter range. The OOB-sink mechanic catches escapees.
+            let (l, r) = to_i64_pair(lv, rv, registers)?;
+            Some(AbstractValue::Counter(l ^ r))
+        }
         BinOp::BitAnd => {
             let (l, r) = to_i64_pair(lv, rv, registers)?;
             Some(AbstractValue::Counter(l & r))

--- a/crates/mununu-core/src/adapter/systemverilog/kripke_smt.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/kripke_smt.rs
@@ -597,6 +597,7 @@ pub mod engine {
                     BinOp::Shr => l.bvlshr(&r),
                     BinOp::BitAnd => l.bvand(&r),
                     BinOp::BitOr => l.bvor(&r),
+                    BinOp::BitXor => l.bvxor(&r),
                     BinOp::And => {
                         let zero = z3::ast::BV::from_i64(0, l.get_size());
                         let one = z3::ast::BV::from_i64(1, l.get_size());
@@ -777,6 +778,7 @@ pub mod engine {
                     BinOp::Or => "||",
                     BinOp::BitAnd => "&",
                     BinOp::BitOr => "|",
+                    BinOp::BitXor => "^",
                     BinOp::Shl => "<<",
                     BinOp::Shr => ">>",
                 };

--- a/crates/mununu-core/src/adapter/systemverilog/parser.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/parser.rs
@@ -1438,7 +1438,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_bitor_expr(&mut self) -> Result<Expr, AdapterError> {
-        let mut left = self.parse_bitand_expr()?;
+        let mut left = self.parse_bitxor_expr()?;
         loop {
             self.skip_whitespace_and_comments();
             if self.remaining().starts_with('|')
@@ -1447,9 +1447,34 @@ impl<'a> Parser<'a> {
             {
                 self.pos += 1;
                 self.col += 1;
-                let right = self.parse_bitand_expr()?;
+                let right = self.parse_bitxor_expr()?;
                 left = Expr::BinOp {
                     op: BinOp::BitOr,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(left)
+    }
+
+    fn parse_bitxor_expr(&mut self) -> Result<Expr, AdapterError> {
+        let mut left = self.parse_bitand_expr()?;
+        loop {
+            self.skip_whitespace_and_comments();
+            // Binary XOR `^`. Reject `^=` (assignment) and `^~`/`~^` (XNOR,
+            // not yet supported — bail rather than mis-parse).
+            if self.remaining().starts_with('^')
+                && !self.remaining().starts_with("^=")
+                && !self.remaining().starts_with("^~")
+            {
+                self.pos += 1;
+                self.col += 1;
+                let right = self.parse_bitand_expr()?;
+                left = Expr::BinOp {
+                    op: BinOp::BitXor,
                     left: Box::new(left),
                     right: Box::new(right),
                 };
@@ -1887,6 +1912,7 @@ fn expr_to_string(expr: &Expr) -> String {
                 BinOp::And => "&&",
                 BinOp::Or => "||",
                 BinOp::BitOr => "|",
+                BinOp::BitXor => "^",
                 BinOp::BitAnd => "&",
                 BinOp::Add => "+",
                 BinOp::Sub => "-",
@@ -2432,5 +2458,82 @@ mod tests {
         if let Some(Declaration::Logic { width, .. }) = req_decl {
             assert_eq!(*width, 9, "struct: 8 + 1 = 9 bits");
         }
+    }
+
+    #[test]
+    fn parse_bitxor_expression() {
+        let module = parse(
+            r#"
+            module xor_test(input logic [3:0] a, input logic [3:0] b);
+                logic [3:0] y;
+                assign y = a ^ b;
+            endmodule
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(module.assigns.len(), 1);
+        match &module.assigns[0].value {
+            Expr::BinOp { op, .. } => assert_eq!(*op, BinOp::BitXor),
+            other => panic!("expected BinOp::BitXor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_bitxor_precedence_between_and_or() {
+        // SystemVerilog precedence: `&` > `^` > `|`.
+        // `a & b ^ c | d` must parse as `((a & b) ^ c) | d`.
+        let module = parse(
+            r#"
+            module prec_test(input logic [3:0] a, input logic [3:0] b, input logic [3:0] c, input logic [3:0] d);
+                logic [3:0] y;
+                assign y = a & b ^ c | d;
+            endmodule
+            "#,
+        )
+        .unwrap();
+
+        let Expr::BinOp { op, left, right } = &module.assigns[0].value else {
+            panic!("expected outer BinOp");
+        };
+        assert_eq!(*op, BinOp::BitOr, "outermost op must be |");
+        assert!(matches!(right.as_ref(), Expr::Ident(n) if n == "d"));
+        let Expr::BinOp {
+            op: inner_op,
+            left: xor_l,
+            right: xor_r,
+        } = left.as_ref()
+        else {
+            panic!("expected nested BinOp on the left of |");
+        };
+        assert_eq!(*inner_op, BinOp::BitXor, "middle op must be ^");
+        assert!(matches!(xor_r.as_ref(), Expr::Ident(n) if n == "c"));
+        let Expr::BinOp { op: and_op, .. } = xor_l.as_ref() else {
+            panic!("expected nested BinOp on the left of ^");
+        };
+        assert_eq!(*and_op, BinOp::BitAnd, "innermost op must be &");
+    }
+
+    #[test]
+    fn parse_bitxor_with_shift_and_ternary() {
+        // The DMR fault-injection pattern that motivated XOR support
+        // (examples/hw/dmr_commit_4bit/dmr_top.sv).
+        let module = parse(
+            r#"
+            module flip_test(input logic [3:0] x, input logic [1:0] idx, input logic en);
+                logic [3:0] y;
+                assign y = en ? (x ^ (4'b0001 << idx)) : x;
+            endmodule
+            "#,
+        )
+        .unwrap();
+
+        let Expr::Ternary { then_expr, .. } = &module.assigns[0].value else {
+            panic!("expected outer ternary");
+        };
+        let Expr::BinOp { op, .. } = then_expr.as_ref() else {
+            panic!("expected XOR inside then-branch");
+        };
+        assert_eq!(*op, BinOp::BitXor);
     }
 }

--- a/docs/design/fault-tolerance-contracts.md
+++ b/docs/design/fault-tolerance-contracts.md
@@ -1,0 +1,165 @@
+# Fault-tolerance contracts for hardware functional units
+
+> **Status:** planning
+> **Audience:** reviewers thinking about whether mununu's contract framework
+> should host explicit fault-model assumptions, and what realistic scope a
+> first example should cover.
+> **Companion documents:** [A — Black-box modules in compositional extraction](black-box-modules.md), and the worked example at [`examples/hw/dmr_commit_4bit/`](../../examples/hw/dmr_commit_4bit/).
+
+## 1. The question
+
+In hardware verification, a recurring failure pattern is:
+
+> Given the possibility of a bit-flip in a functional unit (FU), the accelerator
+> must not commit a result corrupted by that flip.
+
+The standard mitigation is *duplicate the compute, compare before commit*
+(DMR — dual modular redundancy; or TMR — triple modular redundancy with
+voter). Industry validation of these mitigations is almost exclusively
+simulator-based (UVM constrained-random + fault-injection campaigns).
+Public formal-method coverage of fault-tolerance proofs exists in academic
+work (Braibant–Chlipala ITP 2013 for TMR voter correctness; Krstic et al.
+TCAD 2008 for fault-tolerant FSM synthesis) but is not standard practice.
+
+Two recent results from production silicon make the gap concrete:
+
+- Dixit et al., *Silent Data Corruptions at Scale*, arXiv:2102.11245 (Meta, 2021).
+- Hochschild et al., *Cores that don't count*, HotOS 2021 (Google).
+
+Both report that real SDCs in datacenter CPUs are *input-pattern-dependent*
+and *computation-correlated* — they hit both DMR replicas identically,
+defeating the i.i.d. single-fault model behind classical DMR/TMR proofs. The
+proof is sound for the stated assumption; the assumption is wrong for the
+real world.
+
+This is the same shape as the assume/guarantee discharge problem
+[Document A](black-box-modules.md) was already solving for protocol
+contracts. The contribution of this document is to argue that fault-model
+contracts belong in the same framework, and to scope a first runnable
+example.
+
+## 2. Where the contract sits
+
+The framework in [`crates/mununu-core/src/contract/mod.rs`](../../crates/mununu-core/src/contract/mod.rs)
+already carries everything needed:
+
+- A *user* (system integrator, safety engineer, certification authority)
+  authors an `Assumption` clause declaring the fault model they expect.
+- A *designer* (RTL author, IP vendor) authors `Guarantee` and `Invariant`
+  clauses describing the mitigation structure.
+- A `DischargeEdge` graph captures which guarantee discharges which
+  assumption. The SCC check at [`contract/discharge.rs`](../../crates/mununu-core/src/contract/discharge.rs)
+  rejects circular reasoning and unmet assumptions.
+
+The gap [Document A §3.x](black-box-modules.md) names — *circular A/G is
+unsound without an inductive condition* — is exactly the gap the Meta and
+Google papers point at, viewed from the contract-discharge side: if the
+"DMR works" guarantee secretly depends on the "faults are independent"
+assumption, and that assumption depends on the same vendor's "replicas are
+independent" guarantee, the cycle ships an unsound proof.
+
+> Source of truth: [`crates/mununu-core/src/contract/discharge.rs`](../../crates/mununu-core/src/contract/discharge.rs) — surface: CLI (`mununu contract validate`)
+
+## 3. What is tractable in mununu's SV pipeline today
+
+The SystemVerilog adapter at [`crates/mununu-core/src/adapter/systemverilog/kripke.rs`](../../crates/mununu-core/src/adapter/systemverilog/kripke.rs)
+imposes hard limits that shape what can serve as a runnable example:
+
+| Limit | Location | Consequence |
+|---|---|---|
+| 2^18 state cap | [kripke.rs:207](../../crates/mununu-core/src/adapter/systemverilog/kripke.rs#L207) | A 32-bit datapath does not fit. |
+| Auto-abstract ≤ 4 bits | [kripke.rs:918](../../crates/mununu-core/src/adapter/systemverilog/kripke.rs#L918) | Wider widths need sidecar domains or are silently ignored. |
+| Concat truncates to LSB | [kripke.rs:1551](../../crates/mununu-core/src/adapter/systemverilog/kripke.rs#L1551) | Fault masks must use shift, not concat. |
+| Default-false signal init | [kripke.rs:1405](../../crates/mununu-core/src/adapter/systemverilog/kripke.rs#L1405) | Every register must be explicitly initialised. |
+
+Within these limits, **tractable** sub-properties for a fault-tolerance
+example include:
+
+- A 4-bit DMR comparator + commit gate with environment-controlled fault
+  injection.
+- A 3-of-N TMR voter FSM with a 1-of-N fault-location input.
+- Multi-module composition of comparator + commit handshake.
+
+**Not tractable** today:
+
+- 32-bit ALU / FMA datapath (state explosion).
+- Floating-point semantics.
+- Multi-bit upsets (MBU) — encoding burst location alone is exponential.
+- Liveness under chaotic vendor IP latency.
+
+## 4. The worked example
+
+The runnable example lives at [`examples/hw/dmr_commit_4bit/`](../../examples/hw/dmr_commit_4bit/).
+It is a 4-bit DMR commit gate with:
+
+- Two identity replicas of a 4-bit FU (`y_a = x`, `y_b = x`).
+- A one-hot adversarial XOR on `y_a` only, gated by an environment input.
+- A comparator producing `equal = (y_a_post == y_b)`.
+- A registered commit stage that asserts `commit_valid` / `broadcast_valid`
+  only when `equal` was true the previous cycle.
+- An observer register `corrupted_broadcast` that latches if a commit ever
+  broadcasts a value disagreeing with the pipelined golden reference
+  `y_b_q`. The observer is the safety property expressed in observable form.
+
+The contract set has one `A_env` assumption (single-bit flip on `y_a` per
+cycle), three guarantees (`G_compare`, `G_commit`, `G_top`), and a linear
+discharge chain `A_env ← G_compare ← G_commit ← G_top`. Tarjan SCC returns
+`Acyclic`.
+
+The mu-calculus property is `nu X. (!corrupted_broadcast_T && [] X)`.
+
+The example's README is explicit about what is **not** verified — the
+datapath, common-mode failures, MBU, persistent faults, faults in the
+comparator or commit register, and liveness.
+
+> Source of truth: [`examples/hw/dmr_commit_4bit/dmr_top.sv`](../../examples/hw/dmr_commit_4bit/dmr_top.sv) — surface: CLI
+
+## 5. Why not extend `GapKind` yet
+
+[`crates/mununu-core/src/contract/gap.rs`](../../crates/mununu-core/src/contract/gap.rs)
+has a `GapKind::Other` slot. A future refinement could introduce
+`GapKind::FaultModel` carrying named soundness implications for the three
+boundaries fault assumptions usually drop on the floor — *multiplicity*
+(single vs multi-bit), *location* (which signals are in-scope), *temporal
+shape* (transient vs persistent).
+
+The worked example does not require this variant; `GapKind::Other` with a
+free-form description suffices for now. Adding the variant should be paired
+with a CLAUDE.md note in §"Adapter / Emitter Capability Use" naming the
+fault-injection pattern (env-controlled one-hot XOR mask, explicit register
+init, no concat) so future contributors do not reinvent the SV-adapter
+traps. Both additions are deferred until a second use case (TMR voter or
+ECC scrubber) makes the variant pay for itself.
+
+## 6. Honest scope statement
+
+The proposed standard of formal contracts between fault-anticipating users
+and mitigation-providing architects fills a real gap in published practice
+(A/G contract frameworks — Benveniste et al. INRIA RR-8147; OCRA ASE 2013
+— handle protocols and timing well but have no off-the-shelf instantiation
+with explicit fault-model assumptions).
+
+Within mununu, the verifiable scope is **narrow** — the commit gate that
+the contract reduces to — and the datapath remains an act of trust. That is
+the same boundary every published formal proof of DMR/TMR sits behind, and
+stating it explicitly through an A/G contract is the proposal's actual
+contribution. The worked example at [`examples/hw/dmr_commit_4bit/`](../../examples/hw/dmr_commit_4bit/)
+is a faithful demonstration of the pattern; it is not a claim about any
+real GPU.
+
+## 7. What comes next
+
+This document is planning-grade until:
+
+1. The example transcript at [`examples/hw/dmr_commit_4bit/`](../../examples/hw/dmr_commit_4bit/)
+   is reproduced under the pinned `mununu-dev` container with verdicts
+   captured as evidence (the SAT case for the intact gate, the UNSAT case
+   for the negative control).
+2. A second use case (TMR voter, or an ECC scrubber for a small register
+   file) is added to confirm the contract pattern generalises beyond DMR.
+3. If both succeed, the `GapKind::FaultModel` variant and the CLAUDE.md
+   adapter-pattern note become worth adding.
+
+Until then this document sits under `docs/design/`, the example carries
+the LTS-witness-only disclaimer in its README, and no public claim is made
+about real silicon.

--- a/examples/hw/dmr_commit_4bit/README.md
+++ b/examples/hw/dmr_commit_4bit/README.md
@@ -1,0 +1,187 @@
+# 4-bit DMR Commit Gate — Fault-Tolerance Contract Example
+
+> Status: LTS verdict reproduced on this branch. The verdict has not yet
+> been reproduced under simulation in `hw-verif:latest`. Per
+> [CLAUDE.md §Claims Integrity rule 8](../../../CLAUDE.md), the SAT /
+> UNSAT pair below is "LTS witness only — not reproduced in simulation."
+
+This directory illustrates the assume/guarantee contract pattern from
+[`docs/design/black-box-modules.md`](../../../docs/design/black-box-modules.md)
+applied to a fault-tolerance question: an adversary may flip exactly one
+bit of a functional unit's output per cycle; the design must not
+broadcast a corrupted result.
+
+The example is intentionally tiny — a 4-bit dual-modular-redundancy
+(DMR) commit gate — because that is the scope at which the
+SystemVerilog → Kripke pipeline produces a tractable state space (see
+"What this example does NOT prove" below).
+
+## Files
+
+- [`dmr_top.sv`](dmr_top.sv) — intact SV source. Two identical 4-bit
+  replicas, a one-hot adversarial XOR mask on replica A, a comparator, a
+  registered commit stage, and an observer register that latches if a
+  commit ever broadcasts a value disagreeing with the pipelined golden
+  reference.
+- [`dmr_top_broken.sv`](dmr_top_broken.sv) — negative control. Same
+  structure but `commit_valid_r <= 1'b1` (commits unconditionally,
+  ignoring the comparator). Demonstrates the formal verdict catches the
+  missing mitigation.
+- [`dmr_top.mununu.json`](dmr_top.mununu.json) and
+  [`dmr_top_broken.mununu.json`](dmr_top_broken.mununu.json) — signal
+  abstractions + the safety property formulas.
+- [`contracts.json`](contracts.json) — the contract set: one environment
+  assumption (`A_env`), three guarantees / one invariant
+  (`G_compare`, `G_commit`, `G_top`), and the linear discharge chain.
+
+## Reproducing the verdicts
+
+Run from the repo root:
+
+```bash
+# 1. Discharge graph check — proves the *structure* of the assume/guarantee
+#    proof obligation is sound (no circular reasoning, every assumption has
+#    a guarantor).
+mununu contract validate examples/hw/dmr_commit_4bit/contracts.json
+# expected: discharge: acyclic
+#   topological order: G_top, G_commit, G_compare, A_env
+
+# 2. Safety check on the intact design.
+mununu context eval examples/hw/dmr_commit_4bit/dmr_top.sv \
+  --adapter systemverilog \
+  --formula no_corrupt_broadcast \
+  --automaton dmr_top
+# expected: States satisfying: 81/81
+#           Initial states satisfying: 1/1
+
+# 3. Deadlock-freedom baseline on the intact design.
+mununu context eval examples/hw/dmr_commit_4bit/dmr_top.sv \
+  --adapter systemverilog \
+  --formula no_deadlock \
+  --automaton dmr_top
+# expected: States satisfying: 81/81
+
+# 4. Negative control on the broken variant.
+mununu context eval examples/hw/dmr_commit_4bit/dmr_top_broken.sv \
+  --adapter systemverilog \
+  --formula no_corrupt_broadcast \
+  --automaton dmr_top_broken
+# expected: States satisfying: 0/161
+#           Initial states satisfying: 0/1
+#   ↑ the safety property fails: removing the commit gate produces a
+#     trace where the observer latches.
+```
+
+Step 1 and steps 2–4 are independent checks. Step 1 catches dishonest
+contract structure at the IR level — an assumption with no real
+guarantor, the Meta/Google 2021 SDC failure mode reframed as a contract
+graph. Steps 2–4 catch an SV body that does not actually implement the
+contract.
+
+## Fault model
+
+Precise single-bit-flip per cycle, encoded structurally:
+
+```systemverilog
+y_a_post = flip_en ? (y_a ^ (4'b0001 << flip_idx)) : y_a;
+```
+
+- The mask `4'b0001 << flip_idx` is **one-hot by construction** for any
+  `flip_idx` ∈ {0,1,2,3}. MBU is excluded by encoding, not by
+  assumption alone.
+- When `flip_en=0` the value passes through unchanged.
+- `flip_idx` and `flip_en` are environment-controlled inputs, so the
+  model explores all 4×2 = 8 fault scenarios per cycle for every operand
+  `x` ∈ {0..15}.
+
+XOR support landed on this branch via `BinOp::BitXor` in
+[crates/mununu-core/src/adapter/systemverilog/ast.rs](../../../crates/mununu-core/src/adapter/systemverilog/ast.rs),
+[parser.rs:parse_bitxor_expr](../../../crates/mununu-core/src/adapter/systemverilog/parser.rs),
+and [kripke.rs](../../../crates/mununu-core/src/adapter/systemverilog/kripke.rs).
+Three parser tests confirm precedence (`& > ^ > |`) and the DMR
+fault-injection pattern (`x ^ (4'b0001 << idx)`) parses correctly.
+
+## What this example does NOT prove
+
+Per [CLAUDE.md §Claims Integrity](../../../CLAUDE.md), the load-bearing
+honesty caveats:
+
+1. **Datapath correctness is unverified.** Both replicas are modelled as
+   `y = x`. In a real functional unit they would compute the same
+   nontrivial function on the same input, and the contract only proves
+   "if both agree, commit." A bug present in *both* replicas (correlated
+   failure) is not detected. This is exactly the failure mode documented
+   in Dixit et al., *Silent Data Corruptions at Scale* (Meta, 2021,
+   arXiv:2102.11245) and Hochschild et al., *Cores that don't count*
+   (Google, HotOS 2021): real SDCs are input-pattern-dependent and hit
+   both DMR replicas identically.
+
+2. **Single fault per cycle only.** Multi-bit upsets are excluded by
+   the one-hot mask. Real radiation environments at advanced
+   semiconductor nodes see MBU (Baumann, IEEE TDMR 2005). Persistent
+   faults (a stuck bit) are also excluded; `flip_en` is
+   non-deterministic per cycle.
+
+3. **Only `y_a` is faulted.** A symmetric model would add a
+   `fault_b_en` and the assumption would become "at most one of the two
+   replicas is faulted in any cycle." That requires a mutual-exclusion
+   environment assumption this example does not bake in.
+
+4. **The comparator, commit register, and observer are in the trusted
+   compute base.** A bit-flip *inside* the comparator's combinational
+   logic, or in `commit_valid_r` / `broadcast_data_r` /
+   `corrupted_broadcast_r` themselves, bypasses the proof. In real
+   RAD-hard designs the comparator output is itself triplicated (the
+   LEON3-FT errata showed a registered voter output as the actual
+   failure site); this example does not model that nesting.
+
+5. **No liveness.** The contract proves "no corrupted broadcast ever
+   occurs," not "every valid result eventually broadcasts." Liveness
+   would need a fairness assumption on `flip_en` that the chaotic fault
+   model does not admit.
+
+6. **Replicas modelled as identity, not as a real FU.** A faithful 4-bit
+   ALU could be substituted with no change to the contract or the
+   property; the identity choice keeps the state space minimal and the
+   focus on the gating layer.
+
+## Why this scope, not more
+
+The SystemVerilog adapter at [`crates/mununu-core/src/adapter/systemverilog/kripke.rs`](../../../crates/mununu-core/src/adapter/systemverilog/kripke.rs)
+has a hard state cap of 2^18 ([kripke.rs:207](../../../crates/mununu-core/src/adapter/systemverilog/kripke.rs#L207))
+and auto-abstracts signal widths > 4 bits ([kripke.rs:918](../../../crates/mununu-core/src/adapter/systemverilog/kripke.rs#L918)).
+A full 32-bit FMA datapath does not fit; a 4-bit commit gate fits
+comfortably (81 reachable states on the intact design, 161 on the
+broken).
+
+The contract framework is independent of this scope limit. The same A/G
+discharge check would apply to a 32-bit design verified by a different
+backend; only the mu-calculus verdict in steps 2–4 is bounded by
+mununu's SV adapter.
+
+## Adapter-safety patterns used
+
+These are documented in CLAUDE.md §"Adapter / Emitter Capability Use"
+and apply to any SV file fed to the Kripke pipeline:
+
+- **Output ports are pure shadows of internal registers.** The SV Kripke
+  builder treats `output logic` as combinational and only picks up
+  internal `logic` declarations as state. The example uses internal
+  `<name>_r` registers plus `assign output = <name>_r;` continuous
+  assigns.
+- **XOR (`^`)** is the natural primitive for the fault mask; supported
+  on this branch.
+- **No `concat()`** — sidesteps the LSB-truncation in [kripke.rs:1551](../../../crates/mununu-core/src/adapter/systemverilog/kripke.rs#L1551).
+- **Every register has an explicit reset value** — sidesteps the
+  fall-back-to-false unsoundness at [kripke.rs:1405](../../../crates/mununu-core/src/adapter/systemverilog/kripke.rs#L1405).
+- **All datapath widths ≤ 4 bits** — within auto-abstract scope.
+
+## Provenance and honesty
+
+The contract clauses in [`contracts.json`](contracts.json) are
+hand-authored for this example. They are not derived from any real
+vendor IP datasheet, and the example does not claim to find a
+vulnerability in any commercial GPU functional unit. The contribution
+is the *pattern* — explicit fault assumption + explicit gating
+guarantee + machine-checked discharge — not a finding about any
+specific real-world chip.

--- a/examples/hw/dmr_commit_4bit/contracts.json
+++ b/examples/hw/dmr_commit_4bit/contracts.json
@@ -1,0 +1,39 @@
+{
+  "_note": "Fault-tolerance contract set for the 4-bit DMR commit gate. Discharge is a linear chain: A_env <- G_compare <- G_commit <- G_top. Tarjan SCC returns Acyclic. See README.md for what the contract does and does not entail.",
+  "clauses": [
+    {
+      "id": "A_env",
+      "kind": "assumption",
+      "owner": "env",
+      "description": "Adversary may flip exactly ONE bit of replica_a's output (y_a) per cycle. Encoded structurally as `y_a ^ (4'b0001 << flip_idx)` gated by flip_en. The mask is one-hot by construction — MBU is excluded by encoding, not by assumption.",
+      "provenance": "user_authored"
+    },
+    {
+      "id": "G_compare",
+      "kind": "guarantee",
+      "owner": "comparator",
+      "description": "Combinational signal `equal` is high iff y_a_post == y_b. Structurally derived from the SV body; under A_env the comparator de-asserts on any one-hot flip.",
+      "provenance": "user_authored"
+    },
+    {
+      "id": "G_commit",
+      "kind": "guarantee",
+      "owner": "commit_stage",
+      "description": "broadcast_valid and commit_valid only assert when the previous cycle's `equal` was high. Same-cycle registers; no detached commit path.",
+      "provenance": "user_authored"
+    },
+    {
+      "id": "G_top",
+      "kind": "invariant",
+      "owner": "dmr_top",
+      "description": "Observer `corrupted_broadcast` never latches. Equivalently: every cycle where commit_valid is high has broadcast_data == y_b_q (the pipelined fault-free reference).",
+      "provenance": "user_authored"
+    }
+  ],
+  "discharges": [
+    { "discharger": "G_compare", "dischargee": "A_env" },
+    { "discharger": "G_commit", "dischargee": "G_compare" },
+    { "discharger": "G_top", "dischargee": "G_commit" }
+  ],
+  "environment_assumptions": ["A_env"]
+}

--- a/examples/hw/dmr_commit_4bit/dmr_top.mununu.json
+++ b/examples/hw/dmr_commit_4bit/dmr_top.mununu.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "mununu_sv_annotation_v1",
+  "module": "dmr_top",
+  "source": "dmr_top.sv",
+  "_note": "DMR commit-gate fault-tolerance contract example. One-hot single-bit-flip fault model (XOR with shifted mask). See README.md for the explicit list of what this DOES and DOES NOT verify.",
+  "signals": [
+    {
+      "name": "commit_valid_r",
+      "abstraction": "boolean",
+      "note": "Registered comparator output."
+    },
+    {
+      "name": "broadcast_valid_r",
+      "abstraction": "boolean",
+      "note": "External broadcast handshake — registered same cycle as commit_valid_r."
+    },
+    {
+      "name": "broadcast_data_r",
+      "abstraction": "bounded_counter",
+      "bound": 15,
+      "note": "4-bit registered broadcast payload."
+    },
+    {
+      "name": "y_b_q",
+      "abstraction": "bounded_counter",
+      "bound": 15,
+      "note": "Pipelined fault-free golden reference."
+    },
+    {
+      "name": "corrupted_broadcast_r",
+      "abstraction": "boolean",
+      "note": "Observer: latches if broadcast_data_r ever disagrees with y_b_q while commit_valid_r is high. Safety property in observable form."
+    }
+  ],
+  "inputs": [
+    {
+      "name": "x",
+      "abstraction": "bounded_counter",
+      "bound": 15
+    },
+    {
+      "name": "flip_idx",
+      "abstraction": "bounded_counter",
+      "bound": 3
+    },
+    {
+      "name": "flip_en",
+      "abstraction": "boolean"
+    }
+  ],
+  "properties": [
+    {
+      "id": "no_corrupt_broadcast",
+      "formula": "nu X. (!corrupted_broadcast_r_T && [] X)",
+      "description": "Safety: the observer never latches a mismatch. Under the one-hot single-bit-flip fault model on y_a, commit_valid only asserts when y_a_post == y_b, so broadcast_data always equals the pipelined reference y_b_q."
+    },
+    {
+      "id": "no_deadlock",
+      "formula": "nu X. ([] X)",
+      "description": "Baseline: every reachable state has at least one outgoing transition."
+    }
+  ]
+}

--- a/examples/hw/dmr_commit_4bit/dmr_top.sv
+++ b/examples/hw/dmr_commit_4bit/dmr_top.sv
@@ -1,0 +1,114 @@
+// 4-bit DMR (dual modular redundancy) commit gate — fault-tolerance contract example.
+//
+// Plan: /Users/marianocerrutti/.claude/plans/read-this-description-for-tranquil-aurora.md
+// Companion design note: docs/design/fault-tolerance-contracts.md
+//
+// Property under verification:
+//   "Given a single-bit fault in replica A's output, the commit gate must
+//    never broadcast a value that disagrees with the fault-free reference
+//    (replica B)."
+//
+// Fault model (one-hot single-bit flip):
+//   - When `flip_en` is asserted, exactly ONE bit of y_a is XORed with 1.
+//     The bit index is the env-chosen `flip_idx` ∈ {0,1,2,3}.
+//   - Encoded structurally as `y_a ^ (4'b0001 << flip_idx)`. The mask is
+//     one-hot by construction — MBU is excluded by encoding, not by
+//     assumption alone.
+//
+// What this DOES verify:
+//   - Under every reachable (x, flip_idx, flip_en) input combination, the
+//     comparator catches every one-hot fault and de-asserts commit_valid.
+//   - When commit_valid is asserted, broadcast_data matches the registered
+//     fault-free reference y_b_q.
+//
+// What this DOES NOT verify (see README caveats):
+//   - Datapath correctness (replicas modelled as y = x).
+//   - Faults that hit both replicas identically (correlated / common-mode
+//     failure — the Meta/Google 2021 SDC failure mode).
+//   - Multi-bit upsets, persistent faults, faults on the comparator or
+//     commit register themselves.
+//   - Liveness.
+//
+// Adapter-safety patterns used (see CLAUDE.md "Adapter / Emitter Capability Use"):
+//   - All registered signals declared as INTERNAL `logic`, then `assign`-ed
+//     to outputs. The SV Kripke builder only treats internal `logic` regs
+//     as state; output-port `logic` is treated as combinational.
+//   - `^` (XOR) is the natural primitive for the fault mask. Supported on
+//     this branch (see parser.rs:parse_bitxor_expr and kripke.rs BinOp::BitXor).
+//   - No `concat()` — sidesteps the kripke.rs:1551 LSB truncation.
+//   - Explicit reset for every registered signal — sidesteps the
+//     kripke.rs:1405 fall-back-to-false unsoundness.
+//   - All datapath widths ≤ 4 bits — fits the kripke.rs:918 auto-abstract.
+//
+// State budget: commit_valid_r(1) + broadcast_valid_r(1) + broadcast_data_r(4)
+//   + y_b_q(4) + corrupted_broadcast_r(1) = 11 bits ≈ 2048 states. Well under
+//   the 2^18 cap at kripke.rs:207.
+//
+// @mununu mode kripke
+// @mununu domain x: bounded_counter 0..15
+// @mununu domain flip_idx: bounded_counter 0..3
+// @mununu input x, flip_idx, flip_en
+module dmr_top(
+    input  logic       clk,
+    input  logic       rst,
+    input  logic [3:0] x,             // env-driven operand
+    input  logic [1:0] flip_idx,      // env: which bit of y_a to flip (0..3)
+    input  logic       flip_en,       // env: enable single-bit flip on y_a
+    output logic       commit_valid,
+    output logic       broadcast_valid,
+    output logic [3:0] broadcast_data,
+    output logic       corrupted_broadcast
+);
+
+    // Two replicas of the same 4-bit FU. Identity here; in a real FU each
+    // would compute the same nontrivial function. Verification only proves
+    // the gating layer.
+    logic [3:0] y_a;
+    logic [3:0] y_b;
+    assign y_a = x;
+    assign y_b = x;
+
+    // Adversarial single-bit flip on replica A. The mask is `4'b0001 << flip_idx`,
+    // structurally one-hot. When flip_en=0 the value passes through unchanged.
+    logic [3:0] y_a_post;
+    assign y_a_post = flip_en ? (y_a ^ (4'b0001 << flip_idx)) : y_a;
+
+    // Comparator (combinational).
+    logic equal;
+    assign equal = (y_a_post == y_b);
+
+    // Internal registers — the actual state. Output ports are pure shadows.
+    logic       commit_valid_r;
+    logic       broadcast_valid_r;
+    logic [3:0] broadcast_data_r;
+    logic [3:0] y_b_q;
+    logic       corrupted_broadcast_r;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            commit_valid_r        <= 1'b0;
+            broadcast_valid_r     <= 1'b0;
+            broadcast_data_r      <= 4'b0000;
+            y_b_q                 <= 4'b0000;
+            corrupted_broadcast_r <= 1'b0;
+        end else begin
+            commit_valid_r    <= equal;
+            broadcast_valid_r <= equal;
+            broadcast_data_r  <= y_a_post;
+            y_b_q             <= y_b;
+            // Observer: latches if a commit ever broadcasts a value that
+            // disagrees with the pipelined golden reference. This is the
+            // safety property expressed in observable form — translation
+            // of the contract spec, not a "bug detector."
+            if (commit_valid_r && (broadcast_data_r != y_b_q)) begin
+                corrupted_broadcast_r <= 1'b1;
+            end
+        end
+    end
+
+    assign commit_valid        = commit_valid_r;
+    assign broadcast_valid     = broadcast_valid_r;
+    assign broadcast_data      = broadcast_data_r;
+    assign corrupted_broadcast = corrupted_broadcast_r;
+
+endmodule

--- a/examples/hw/dmr_commit_4bit/dmr_top_broken.mununu.json
+++ b/examples/hw/dmr_commit_4bit/dmr_top_broken.mununu.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "mununu_sv_annotation_v1",
+  "module": "dmr_top_broken",
+  "source": "dmr_top_broken.sv",
+  "_note": "Sidecar for the broken (negative control) variant. Same one-hot fault model as dmr_top.mununu.json; expected verdict on no_corrupt_broadcast is UNSAT.",
+  "signals": [
+    { "name": "commit_valid_r",       "abstraction": "boolean" },
+    { "name": "broadcast_valid_r",    "abstraction": "boolean" },
+    { "name": "broadcast_data_r",     "abstraction": "bounded_counter", "bound": 15 },
+    { "name": "y_b_q",                "abstraction": "bounded_counter", "bound": 15 },
+    { "name": "corrupted_broadcast_r","abstraction": "boolean" }
+  ],
+  "inputs": [
+    { "name": "x",        "abstraction": "bounded_counter", "bound": 15 },
+    { "name": "flip_idx", "abstraction": "bounded_counter", "bound": 3 },
+    { "name": "flip_en",  "abstraction": "boolean" }
+  ],
+  "properties": [
+    {
+      "id": "no_corrupt_broadcast",
+      "formula": "nu X. (!corrupted_broadcast_r_T && [] X)",
+      "description": "Same safety property as the intact design. Expected verdict: UNSAT — the observer latches as soon as flip_en=1 fires a one-hot flip and the commit register propagates the corrupted value."
+    }
+  ]
+}

--- a/examples/hw/dmr_commit_4bit/dmr_top_broken.sv
+++ b/examples/hw/dmr_commit_4bit/dmr_top_broken.sv
@@ -1,0 +1,76 @@
+// 4-bit DMR commit gate — NEGATIVE CONTROL (intentionally broken).
+//
+// Companion: dmr_top.sv (correct).
+// Plan: /Users/marianocerrutti/.claude/plans/read-this-description-for-tranquil-aurora.md
+//
+// The break: commit_valid_r is asserted unconditionally instead of being
+// gated by `equal`. This simulates the design without the DMR comparator
+// in the commit path — exactly the failure mode the contract is meant to
+// detect.
+//
+// Expected verdict for property `no_corrupt_broadcast`:
+//   UNSAT — the observer latches as soon as flip_en=1 fires a one-hot
+//   fault and the commit register propagates the corrupted value. This
+//   demonstrates the formal verdict is meaningful: removing the mitigation
+//   produces a counterexample, so the SAT verdict on the intact design
+//   (dmr_top.sv) carries proof content.
+//
+// @mununu mode kripke
+// @mununu domain x: bounded_counter 0..15
+// @mununu domain flip_idx: bounded_counter 0..3
+// @mununu input x, flip_idx, flip_en
+module dmr_top_broken(
+    input  logic       clk,
+    input  logic       rst,
+    input  logic [3:0] x,
+    input  logic [1:0] flip_idx,
+    input  logic       flip_en,
+    output logic       commit_valid,
+    output logic       broadcast_valid,
+    output logic [3:0] broadcast_data,
+    output logic       corrupted_broadcast
+);
+
+    logic [3:0] y_a;
+    logic [3:0] y_b;
+    assign y_a = x;
+    assign y_b = x;
+
+    logic [3:0] y_a_post;
+    assign y_a_post = flip_en ? (y_a ^ (4'b0001 << flip_idx)) : y_a;
+
+    // BUG: comparator is structurally present but its output is ignored.
+    logic equal;
+    assign equal = (y_a_post == y_b);
+
+    logic       commit_valid_r;
+    logic       broadcast_valid_r;
+    logic [3:0] broadcast_data_r;
+    logic [3:0] y_b_q;
+    logic       corrupted_broadcast_r;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            commit_valid_r        <= 1'b0;
+            broadcast_valid_r     <= 1'b0;
+            broadcast_data_r      <= 4'b0000;
+            y_b_q                 <= 4'b0000;
+            corrupted_broadcast_r <= 1'b0;
+        end else begin
+            // BUG: commit fires unconditionally, ignoring `equal`.
+            commit_valid_r    <= 1'b1;
+            broadcast_valid_r <= 1'b1;
+            broadcast_data_r  <= y_a_post;
+            y_b_q             <= y_b;
+            if (commit_valid_r && (broadcast_data_r != y_b_q)) begin
+                corrupted_broadcast_r <= 1'b1;
+            end
+        end
+    end
+
+    assign commit_valid        = commit_valid_r;
+    assign broadcast_valid     = broadcast_valid_r;
+    assign broadcast_data      = broadcast_data_r;
+    assign corrupted_broadcast = corrupted_broadcast_r;
+
+endmodule


### PR DESCRIPTION
## Summary

- Adds binary XOR (`^`) to the SystemVerilog adapter's expression parser, AST, Kripke evaluator, and SMT bridge — unlocks ECC encoders, CRC generators, scramblers, LFSRs, parity trees, and the single-bit-flip fault-injection pattern.
- New `examples/hw/dmr_commit_4bit/` — a 4-bit DMR commit gate exercising the assume/guarantee contract framework from Document A around a one-hot single-bit-flip fault hypothesis. Two SV files (intact + negative control), two `.mununu.json` sidecars, one `contracts.json`, and a load-bearing README of "what this does and does NOT prove".
- New `docs/design/fault-tolerance-contracts.md` (Status: planning) — design note scoping fault-tolerance contracts within Document A's framework.

## Why

A user asked whether formal A/G contracts could codify the user-vs-architect agreement around bit-flip mitigations (DMR/TMR + compare-before-commit). Literature survey confirmed this is a real gap: A/G frameworks (Benveniste et al. INRIA RR-8147; OCRA at ASE 2013) handle protocols well but have no off-the-shelf fault-model instantiation. Mununu's contract framework is well-shaped to host this — what was missing was a runnable example and the SV primitive (XOR) needed to encode the fault model precisely.

## SV adapter changes

| File | Change |
|---|---|
| `ast.rs` | `BitXor` variant added to `BinOp` between `BitOr` and `BitAnd` |
| `parser.rs` | `parse_bitxor_expr` inserted between bitor and bitand precedence levels (SV: `& > ^ > |`); rejects `^=` and `^~`/`~^` |
| `kripke.rs` | `BinOp::BitXor` evaluation arm with `// SOUNDNESS:` note matching `BitOr`/`BitAnd` parity |
| `kripke_smt.rs` | `bvxor` lowering in `expr_to_z3` + pretty-printer entry |

Three new unit tests under `adapter::systemverilog::parser::tests`:
- `parse_bitxor_expression`
- `parse_bitxor_precedence_between_and_or`  (verifies `a & b ^ c | d` → `((a & b) ^ c) | d`)
- `parse_bitxor_with_shift_and_ternary`     (the DMR pattern `x ^ (4'b0001 << idx)` inside a ternary)

## Example verdicts (reproduced locally on this branch)

| Check | Verdict |
|---|---|
| `mununu contract validate contracts.json` | discharge: acyclic, order `G_top → G_commit → G_compare → A_env` |
| `dmr_top.sv` ⊨ `no_corrupt_broadcast` | **SAT** — 81/81 states, initial 1/1 |
| `dmr_top.sv` ⊨ `no_deadlock` | **SAT** — 81/81 states |
| `dmr_top_broken.sv` ⊨ `no_corrupt_broadcast` | **UNSAT** — 0/161 states, initial 0/1 (negative control fails as expected) |

## What this example does NOT claim

Per CLAUDE.md §Claims Integrity, the example README is explicit:
- Datapath correctness is unverified (replicas modelled as `y = x`); correlated/common-mode failures defeat the proof — the Meta/Google 2021 SDC failure mode.
- MBU and persistent faults excluded by the one-hot mask.
- Comparator, commit register, and observer in the trusted compute base.
- No liveness.
- LTS witness only — not yet reproduced under simulator (`hw-verif:latest`).

## Test plan

- [x] `cargo build -p mununu-core`
- [x] `cargo test -p mununu-core --lib adapter::systemverilog::parser::tests::parse_bitxor` — 3 passed
- [x] `make lint` — clean (fmt + clippy -D warnings)
- [x] All four CLI verdicts above reproduced via the binary
- [ ] Simulator reproduction under `hw-verif:latest` — deferred per CLAUDE.md §Claims Integrity rule 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)