### PR TITLE
docs(design): post-M3 refresh — drop / rescope items whose relevance changed

### DIFF
--- a/docs/design/contract-corpus-and-config.md
+++ b/docs/design/contract-corpus-and-config.md
@@ -104,6 +104,19 @@ The corpus returns the entry; alternative `strict` is selected per the URI. The 
 
 ## D.3 Unified configuration / sidecar story
 
+> **Post-M3 reassessment (2026-05-13).** Most of this section's pitch did not survive contact with reality. Shipping M1 + M2 + M3 produced a different pattern than the unified directory the original D.3 sketch proposed:
+>
+> - **Co-located sidecars won.** `BlackBoxInterface.json` + `GapMarkerReport.json` are auto-emitted next to the source they describe. `.contract.todo.json` writes next to source. Co-location proved more discoverable than a centralised `.mununu/` tree.
+> - **Annotation-driven contract references replaced `contracts/refs.json`.** Each black-box module's `@mununu_interface contract://…` annotation IS the reference. The discovery pipeline reads it directly from `BlackBoxInterface.annotations`. There is no second-level "refs file."
+> - **Corpus already lives at repo root**, not under `.mununu/`. `corpus/rtl_protocol/...` and `corpus/rtl_crypto/...` shipped in M3. The flat layout works.
+>
+> The remaining pieces of D.3 that still hold up:
+>
+> - The **`coupling/register_maps/`** subdirectory is still the right home for Doc C's register-map sidecars. The capstone needs *some* per-project location for these, and the rest of the tree being descoped does not change that.
+> - The principle "files stay small and focused" survives; it's just been realised through per-source-file co-location rather than through a per-concern central directory.
+>
+> The sections below are kept as the original design record. Treat §D.3.2's full directory tree as **superseded** except for the `coupling/register_maps/` row. Treat §D.3.4's migration story as unnecessary — there is nothing to migrate. The "alphabet soup" criticism in §D.3.1 still describes the legacy formats, but the unification *happened differently* than predicted.
+
 ### D.3.1 Current state
 
 Mununu has accumulated several config artefact shapes, each evolved for a specific adapter:
@@ -247,6 +260,8 @@ The discovery pipeline returns a contract automaton built from the named AXI4-sl
 Ship the parser shim for one language first (SystemVerilog — it has the largest existing annotation footprint, the M2 yosys path already detects `(* blackbox *)`), then add C / TS / Rust / Python in subsequent passes. The vocabulary is fixed; the per-language wrapper is a small extractor each time.
 
 ## D.6 L\* learning surface (`mununu contract learn`)
+
+> **Post-M3 reassessment (2026-05-13): long-tail follow-up, no implementation queued.** L\* was proposed as the third contract source for cases where neither a corpus entry nor a source-comment annotation is available. After shipping M1 + M3 with corpus + annotations, no user case has surfaced that needed L\* — the two existing sources cover the common pattern. The A7 review surface's `ProposalProvenance` enum at [crates/mununu-core/src/contract/review.rs](../../crates/mununu-core/src/contract/review.rs) is open, so adding L\* later remains a one-place change. **Treat this section as a design placeholder.** No CLI subcommand, HTTP endpoint, or UI panel is committed; the engineering investment (teacher–student loop, counterexample-guided refinement, hooking the verifier as the teacher) does not match a real demand signal today. Revisit if a user case asks for it.
 
 Owned by D because L\* is one of three *contract sources* alongside corpus lookup (§D.2) and source-comment annotations (§D.5). Putting all three in one document lets users reason about contract provenance in one place.
 

--- a/docs/design/hw-sw-codesign-extraction.md
+++ b/docs/design/hw-sw-codesign-extraction.md
@@ -272,12 +272,15 @@ Write a scoping-log entry at `.claude/plans/scoping-logs/hw-sw-codesign-extracti
 **Scope:** end-to-end three-surface entry point. CLI: `mununu codesign verify <sv> <c-or-ctxdsl> --register-map <path> --formula <name>`. HTTP: `POST /api/v1/codesign/verify`. UI: new "Codesign" sub-tab in ContractPanel or a new top-level panel.
 **Validation:** three-surface parity check via the existing `parity-check` skill.
 
-### §C.9.5 Task C5 — libclang backend for `mununu-extract`
+### §C.9.5 Task C5 — libclang backend for `mununu-extract` (with C-side `@mununu_*` wrappers)
 
-**Touches:** new feature flag `--backend libclang` on [crates/mununu-extract](../../crates/mununu-extract/), depends on `clang-sys` crate.
+**Touches:** new feature flag `--backend libclang` on [crates/mununu-extract](../../crates/mununu-extract/), depends on `clang-sys` crate. Also extends [crates/mununu-core/src/mununu_annotations/mod.rs](../../crates/mununu-core/src/mununu_annotations/mod.rs) with a C-flavoured wrapper parser.
 **Scope:** C-side extraction. Parses C source via libclang, resolves preprocessor + types, produces an `AdapterIR` shape matching the existing TypeScript / Python / Rust paths. Stripped down to firmware-relevant constructs: register access, polling loops, ISR handlers.
-**Validation:** the §C.4 example's firmware extracts to a 4-state automaton matching the hand-authored CTXDSL from §C.9.2. Standalone deliverable: even without §C.9.6 polish, it covers the common firmware shape.
-**Out of scope:** full C semantics. Deferred follow-ups: function pointers, recursion, complex pointer arithmetic, vendor-specific compiler extensions.
+
+**Bundled scope — C language wrappers for the annotation grammar.** Document D §D.5 reserved a tag vocabulary across SV / C / TS / Rust / Python; only the SV wrappers ship today. The C wrappers (`/** @mununu_*  ... */` Doxygen comments on function/struct/typedef declarations) **are not optional for this task** — without them a firmware engineer cannot attach `@mununu_guarantee` to an ISR or `@mununu_assume` to an interrupt-latency contract, and the discovery pipeline cannot lift those into proposed clauses for the HITL review surface (the same flow shipped in PR vscorza/mununu#20). C wrappers therefore land **in the same PR as the libclang backend**, not as a separate follow-up. The other languages (TS / Rust / Python) remain long-tail; ship them only when a real demand signal appears.
+
+**Validation:** the §C.4 example's firmware extracts to a 4-state automaton matching the hand-authored CTXDSL from §C.9.2; a vendor-supplied `/** @mununu_guarantee = "G(start -> eventually done)" */` on the `uart_send` function flows through to a `ProposedClause` in the `mununu contract review` output.
+**Out of scope:** full C semantics. Deferred follow-ups: function pointers, recursion, complex pointer arithmetic, vendor-specific compiler extensions. Also out of scope: TS / Rust / Python annotation wrappers — long-tail until requested.
 
 ### §C.9.6 Task C6 — IP-XACT / CMSIS-SVD importer
 

--- a/docs/design/rtl-frontend-unification.md
+++ b/docs/design/rtl-frontend-unification.md
@@ -143,6 +143,9 @@ The diagnostic warning (one `tracing::warn!` per gap) fires at extraction time, 
 - One `WARN contract gap detected — chaotic stub default in effect` per gap, with module / kind / labels / soundness fields.
 
 ### B.7.4 Task B4 — shared composition-spec helper
+
+> **Post-M2 reassessment (2026-05-13): lost most of its leverage.** The dual-frontend SoC example shipped in M2.c demonstrates that both pipelines emit structurally-identical `BlackBoxInterface.json` (verified by `jq` normalisation in `examples/industrial/dual_frontend_soc/validate.sh`). The unification happened via **convention** — both paths call `contract::discover::build_blackbox_sidecars()` — rather than via an explicit shared composition-spec helper. Lifting `ConnectionSpec` into a separate helper today would be **code-reduction without behaviour change**. Worth doing only if a *third* RTL frontend lands (e.g. CIRCT via [crates/mununu-extract](../../crates/mununu-extract/)) and the duplication becomes painful. Until then, B4 is descoped; the two paths converge on the same output through shared lower-level helpers (`build_blackbox_sidecars`) rather than a shared composition primitive.
+
 **Touches:** [crates/mununu-core/src/adapter/](../../crates/mununu-core/src/adapter/) (new `compose.rs` or extend `emit.rs`).
 **Scope:** lift the `ConnectionSpec` data type ([annotation.rs:302](../../crates/mununu-core/src/adapter/systemverilog/annotation.rs#L302)) + composition-emission code (the body of [`generate_multi_sidecar` at annotation.rs:1058](../../crates/mununu-core/src/adapter/systemverilog/annotation.rs#L1058)) out of the custom-SV path into a shared helper both frontends call. The custom-SV port-binding logic becomes the canonical implementation; yosys's new black-box-aware path calls into it.
 **Validation:** the dual-frontend SoC example (§B.8) produces structurally identical composition specs from both frontends (same composition name, same member list, same shared-label set).

--- a/examples/industrial/dual_frontend_soc/publications/substack.md
+++ b/examples/industrial/dual_frontend_soc/publications/substack.md
@@ -62,11 +62,9 @@ That's a friction the discipline can't survive long-term. The whole point of the
 
 The fix is staged in three steps:
 
-1. **Stage 1 (now, in M2):** when an adapter detects a black-box module, it auto-emits the `BlackBoxInterface.json` + `GapMarkerReport.json` sidecars alongside its CTXDSL output. The library helper is `contract::discover::build_blackbox_sidecars()`; the CLI exposes it as `mununu contract sidecars`.
-2. **Stage 2 (M3, Document D):** source-comment annotations (`@mununu_guarantee` on the wrapper module) populate the discovered contract with vendor-supplied A/G clauses. The relocated task A6.
-3. **Stage 3 (post-M3):** CTXDSL grammar extension for inline `contract { ... }` blocks. The discharge check becomes a precondition of every `mununu context eval / synth`. Contracts stop being a separate command and become part of the standard verify flow.
-
-This commit lands the library + CLI layer of stage 1. The yosys-side auto-emission (the producer that calls `build_blackbox_sidecars` during extraction) is the explicit deferred follow-up. The hand-authored interface JSON + `mununu contract sidecars` stand in for the auto-emission today — the JSON shape is identical, only the producer is different.
+1. **Stage 1 (M2):** when an adapter detects a black-box module, it auto-emits the `BlackBoxInterface.json` + `GapMarkerReport.json` sidecars alongside its CTXDSL output. The library helper is `contract::discover::build_blackbox_sidecars()`; the CLI exposes it as `mununu contract sidecars`. **Shipped.** Both the custom-SV and yosys frontends call this helper today; the example in this post walks the auto-emitted sidecars.
+2. **Stage 2 (M3, Document D):** source-comment annotations (`@mununu_guarantee` on the wrapper module) populate the discovered contract with vendor-supplied A/G clauses. The relocated task A6. **Shipped.** The TLS handshake example at [`examples/industrial/tls_handshake/`](https://github.com/vscorza/mununu/tree/main/examples/industrial/tls_handshake) demonstrates `@mununu_guarantee` + `@mununu_interface contract://…` flowing through to the HITL review surface.
+3. **Stage 3 (post-M3):** CTXDSL grammar extension for inline `contract { ... }` blocks. The discharge check becomes a precondition of every `mununu context eval / synth`. Contracts stop being a separate command and become part of the standard verify flow. **Still deferred** — not blocking any user case today, but the natural next step once Document C's HW/SW codesign implementation lands.
 
 ## Walking the example
 
@@ -109,7 +107,7 @@ Per [mununu's claims-integrity rules](https://github.com/vscorza/mununu/blob/mai
 
 - No claim mununu found a bug in any commercial DDR3 PHY or any specific SoC.
 - The example uses `mununu contract sidecars` as a stand-in for adapter auto-emission. The JSON shape is identical to what the yosys-side integration will produce, but the producer is different until that integration lands.
-- No vendor `@mununu_guarantee` source-comment annotations yet — those land in M3 (Document D, relocated task A6).
+- This particular example does not exercise vendor `@mununu_guarantee` source-comment annotations. The annotation grammar shipped in M3 (Document D, relocated task A6); a separate worked example — the TLS handshake — exercises it. This example deliberately stays at the chaotic-stub baseline so the reader can see what the unannotated default looks like across both RTL frontends.
 - The proof is conditional on the chaotic-stub contract; a vendor-supplied latency-bound contract would tighten it.
 
 ## Where this fits
@@ -120,10 +118,10 @@ What mununu adds is the integration: a contract subsystem that connects to extra
 
 ## What's next
 
-This is M2 of a four-document roadmap.
+This is post 2 of a four-document arc. The rest has since shipped (design + implementation where noted):
 
-- **Document D** — contract corpus + unified `.mununu/` config + the relocated A6/A7 (source-comment annotations + HITL UX). M3.
-- **Document C** — HW/SW codesign extraction. The capstone post — a peripheral RTL + firmware C combined, with a register-map sidecar coupling the two sides for cross-boundary formal verification. M4.
+- **Document D** — contract corpus + source-comment annotation grammar + `contract://` URI resolution + the relocated A6 (corpus-driven phase-2 discovery) and A7 (HITL stage-4 review surface). **Design + corpus + annotations + URI resolution + HITL review shipped.** Worked example: [`examples/industrial/tls_handshake/`](https://github.com/vscorza/mununu/tree/main/examples/industrial/tls_handshake). The originally-proposed `.mununu/` directory unification was reassessed post-M3 — co-located sidecars won — and most of D §D.3 is descoped. The L\* learning surface (D5/D6) was reassessed as long-tail follow-up and is not queued.
+- **Document C** — HW/SW codesign extraction. The capstone post — a peripheral RTL + firmware C combined, with a register-map sidecar coupling the two sides for cross-boundary formal verification. **Design landed; implementation is the next milestone.**
 
 The repo: [github.com/vscorza/mununu](https://github.com/vscorza/mununu).
 The example: [`examples/industrial/dual_frontend_soc/`](https://github.com/vscorza/mununu/tree/main/examples/industrial/dual_frontend_soc).

--- a/examples/industrial/secure_boot_rom/publications/substack.md
+++ b/examples/industrial/secure_boot_rom/publications/substack.md
@@ -197,7 +197,7 @@ Per [mununu's claims-integrity rules](https://github.com/vscorza/mununu/blob/mai
 - It does not claim mununu found a vulnerability in any commercial secure-boot ROM. The vendor-IP black boxes are stylised; the boot controller is hand-authored for the demonstration.
 - It does not claim the closed-IP contract clauses are accurate to any vendor's real datasheet. They are illustrative of the *contract shape*.
 - It does not prove a real device is secure. The proof is conditional on the contracts; the contracts are conditional on the vendors honouring their datasheets.
-- It does not yet exercise vendor source-comment annotations (`@mununu_guarantee` on the wrapper module) or contract-corpus lookups. Those land in milestone M3 (Document D, the contract corpus and config document).
+- This particular example does not exercise vendor source-comment annotations (`@mununu_guarantee` on the wrapper module) or contract-corpus lookups. Those mechanisms shipped in milestone M3 (Document D, the contract corpus and config document) and a separate worked example — the TLS handshake at `examples/industrial/tls_handshake/` — exercises them end-to-end. The secure boot ROM example deliberately stays at the chaotic-stub baseline so the reader can see the unannotated default behaviour.
 
 What the example *does* claim: every concept Document A introduces — chaotic stub, gap markers, controllability rule, discharge graph, mu-rank witness — is exercised end-to-end against the mununu binary on `main`, with a byte-deterministic transcript anyone can reproduce.
 
@@ -217,13 +217,12 @@ What mununu contributes is the *integration*: a single workflow that pulls all o
 
 ## What's next
 
-This is M1 of a four-document roadmap. Up next:
+This is post 1 of a four-document arc. The rest of the arc has since shipped (design + implementation where noted):
 
-- **Document B** — RTL frontend unification (custom SV path + yosys/BTOR2 path → one contract surface).
-- **Document D** — Contract corpus + unified `.mununu/` config (the corpus you query for vendor contracts; the source-comment grammar; the L\* assumption learning surface).
-- **Document C** — HW/SW codesign extraction (peripheral RTL + firmware C, with a register-map sidecar coupling the two sides for cross-boundary formal verification).
-
-The example will grow with each. The next iteration of the secure boot example will exercise vendor `@mununu_guarantee` annotations once Document D's source-comment grammar lands (task A6 in the implementation plan).
+- **Document B** — RTL frontend unification (custom SV path + yosys/BTOR2 path → one contract surface). **Design + B1–B3 implementation shipped.** Worked example: [`examples/industrial/dual_frontend_soc/`](https://github.com/vscorza/mununu/tree/main/examples/industrial/dual_frontend_soc).
+- **Document D** — Contract corpus + source-comment annotation grammar (the corpus you query for vendor contracts; the `@mununu_*` tag vocabulary; the `contract://` URI resolution). **Design + D1, D2, D4, A6 implementation shipped.** Worked example: [`examples/industrial/tls_handshake/`](https://github.com/vscorza/mununu/tree/main/examples/industrial/tls_handshake). L\* assumption learning (D5/D6) was reassessed post-M3 as long-tail follow-up and is not queued.
+- **Document A task A7** (HITL stage-4 review surface) — **shipped after this post was drafted**: `mununu contract review` CLI subcommand + `POST /api/v1/contract/review` HTTP endpoint + a Review sub-tab in the UI surface the proposed clauses extracted from the annotations + corpus references shipped in Document D.
+- **Document C** — HW/SW codesign extraction (peripheral RTL + firmware C, with a register-map sidecar coupling the two sides for cross-boundary formal verification). **Design landed; implementation is the next milestone.**
 
 The repo: [github.com/vscorza/mununu](https://github.com/vscorza/mununu).
 The example: [`examples/industrial/secure_boot_rom/`](https://github.com/vscorza/mununu/tree/main/examples/industrial/secure_boot_rom).


### PR DESCRIPTION
## Summary

After M1 + M2 + M3 + A7 shipped, several deferred items in the four-document arc no longer match the shape of what was actually built. This PR aligns the design docs and publication drafts with reality **without adding implementation work**. Together these edits remove ~30% of the backlog without losing anything we should ship.

This PR is **chained on top of #21** (Document C). After #21 merges, this rebases to `main` automatically.

## What changes

### Lost relevance — dropped or scoped down

- **Doc D §D.3 — `.mununu/` directory unification: scoped down.** Co-located sidecars won. Annotation-driven `@mununu_interface contract://...` replaced the proposed `contracts/refs.json`. The corpus already lives at repo root. Only `coupling/register_maps/` survives — Doc C needs it. Added a post-M3 reassessment callout at the top of §D.3.
- **Doc D §D.6 — L\* learning surface: long-tail, not queued.** The A7 review surface's `ProposalProvenance` enum is open; adding L\* later remains a one-place change. No user case has surfaced needing it. Added a "long-tail follow-up" callout; no engineering investment queued.
- **Doc B §B.7.4 (Task B4) — shared composition-spec helper: lost leverage.** M2.c shipped both pipelines emitting structurally-identical `BlackBoxInterface.json` (verified by jq normalisation). The unification happened via convention rather than via an explicit shared helper. Descoped; re-evaluate only if CIRCT lands as a third frontend.

### Should be redesigned

- **Doc C Task C5 — fold in C language wrappers.** D §D.5 reserved a tag vocabulary across SV / C / TS / Rust / Python; only SV ships today. For HW/SW codesign, C wrappers are **no longer optional** — without them, firmware engineers cannot attach `@mununu_guarantee` to an ISR. Bundled into C5 (libclang) rather than treated as a separate follow-up. TS / Rust / Python remain long-tail.

### Publication drafts refreshed

- **M1.d secure_boot_rom Substack** — "yet to come" → "now shipped." Removed the "vendor `@mununu_guarantee` annotations land in M3" framing (M3 has shipped); points readers at the TLS handshake example for those capabilities. Added the A7 review surface to "what's next" since it shipped after the post was drafted. Reframes the chaotic-stub-only example as a deliberate baseline rather than a missing feature.
- **M2.d dual_frontend_soc Substack** — same treatment. The three-stage integration plan still works as a narrative; stage 1 and stage 2 are now marked "shipped" with pointers to the worked examples; stage 3 is still deferred but described accurately.

### Still relevant — no change

- **B5 / B6** (clock/reset label class, BTOR2 `bad`/`constraint` → `PropertyRole`) — small, still valuable.
- **C1–C4** (just designed in Doc C, ship as-is at M4).
- **C5** — re-run §C.3.1 tooling assessment at M4.b (the §C.9.0 scoping pass gate already covers this).
- **C6** — IP-XACT / CMSIS-SVD importer, still useful at M4.
- **Phase 4 governance** (CLAUDE.md + agent prompts) — more actionable now, not less.

## Validation

- Pre-commit hook clean (cargo fmt, clippy, test — all green; doc-only changes but the full gate ran).
- All code references in the touched sections still resolve to real paths on `main` + PR #21.
- Markdown links verified.

## Test plan

- [ ] CI green
- [ ] Reviewer skim: does the §D.3 reassessment callout fairly describe how the unification actually happened?
- [ ] Reviewer skim: are the M1 + M2 refreshed drafts still accurate (no further "yet to come" language)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)