### PR TITLE
feat(codesign): interleaved trace origin classifier (Document C task C3, slice 1)

### DIFF
--- a/crates/mununu-core/src/codesign/mod.rs
+++ b/crates/mununu-core/src/codesign/mod.rs
@@ -12,13 +12,22 @@
 //! "register-map sidecar" that names each register, its bit-layout, and
 //! how each side accesses it.
 //!
-//! Today only **Task C1** ships: the [`register_map`] module spells out
-//! the canonical JSON schema, serde types, and the schema-validation
-//! plumbing. Coupling synthesis (C2), interleaved counterexample
-//! reporting (C3), the `mununu codesign verify` three-surface entry
-//! point (C4), libclang-backed C extraction with `@mununu_*` C
-//! wrappers (C5), and the IP-XACT / CMSIS-SVD importer (C6) are
-//! follow-up slices in §C.9 of the design doc.
+//! What ships today:
+//!
+//! - **C1 — register-map sidecar schema** in [`register_map`]. JSON
+//!   schema + serde types + structural validation.
+//! - **C2 — coupling synthesis (slice 1)** in [`coupling`]. Emits the
+//!   CTXDSL fragment (alphabet + chaotic peripheral stub + async
+//!   composition) the user splices into a hand-authored context.
+//! - **C3 — interleaved trace origin classifier (slice 1)** in
+//!   [`trace`]. Tags trace steps as `[SW]` / `[HW]` / `[BUS]` based on
+//!   a caller-supplied label partition.
+//!
+//! Follow-up slices in §C.9 of the design doc: C4 (`mununu codesign
+//! verify` three-surface entry point that consumes the C3 classifier),
+//! C5 (libclang C extraction + `@mununu_*` C wrappers), C6 (IP-XACT /
+//! CMSIS-SVD importer).
 
 pub mod coupling;
 pub mod register_map;
+pub mod trace;

--- a/crates/mununu-core/src/codesign/trace.rs
+++ b/crates/mununu-core/src/codesign/trace.rs
@@ -1,0 +1,407 @@
+//! Interleaved trace origin classifier — Document C task C3, slice 1.
+//!
+//! Counterexample / counterstrategy traces over a codesign-composed
+//! model become **interleaved**: each transition came from either the
+//! firmware side, the peripheral side, or the bus (a rendezvous on a
+//! register-access label). When mununu reports such a trace, the
+//! reader needs to know **which side fired which step** to make sense
+//! of a race or a missed-acknowledgement bug.
+//!
+//! This module is the classifier. Given a label name and a
+//! [`CouplingInfo`] describing the codesign-composed model's label
+//! partition, it returns a [`TraceOrigin`] tag. Slice 1 ships the
+//! classifier + a trace-list helper + a human-readable formatter.
+//! Task C4 (`mununu codesign verify`) is the consumer that pulls a
+//! trace out of the verifier and runs it through this module.
+//!
+//! ## Why a separate module
+//!
+//! The composition engine ([`crate::composition`]) produces flat
+//! state-name traces — composed states look like `"Idle|Polling"` and
+//! labels are bare strings. The composition engine deliberately does
+//! not know about HW/SW semantics; that's a Doc C concern. This
+//! module is the bridge: it brings the codesign vocabulary
+//! (`rendezvous`, `peripheral`, `firmware`) to bear on those flat
+//! traces *after* verification, without polluting the verifier.
+//!
+//! ## Soundness posture
+//!
+//! Classification is **lookup-based and total**:
+//!   - If the label is in `rendezvous_labels` → `Bus`.
+//!   - Else if the label is in `peripheral_internal_labels` → `Hw`.
+//!   - Else if the label is in `firmware_internal_labels` → `Sw`.
+//!   - Else → `Unknown`.
+//!
+//! Order matters because real codesign vocabularies have some overlap
+//! (a peripheral-driven status read shows up in both sides' alphabets,
+//! and it's deliberately a `Bus` event). The caller is responsible for
+//! constructing label sets that respect this order; the helpers in
+//! this module compute them correctly when given a register map.
+
+use crate::codesign::coupling::register_map_labels;
+use crate::codesign::register_map::RegisterMap;
+use std::collections::HashSet;
+use std::fmt;
+
+/// Origin of a single trace step in a codesign-composed model.
+///
+/// The verifier produces flat traces; this enum is the codesign-layer
+/// annotation a reader needs to see at the same time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceOrigin {
+    /// Firmware-side internal transition. Not visible to the peripheral.
+    Sw,
+    /// Peripheral RTL-side internal transition. Not visible to firmware.
+    Hw,
+    /// Rendezvous on a register-access label. Both sides synchronise.
+    Bus,
+    /// Could not be classified — the label is not in any of the
+    /// caller-supplied label sets. Surfaces honestly rather than
+    /// guessing.
+    Unknown,
+}
+
+impl TraceOrigin {
+    /// One-character display tag used in CLI / UI traces.
+    pub fn tag(self) -> &'static str {
+        match self {
+            TraceOrigin::Sw => "SW",
+            TraceOrigin::Hw => "HW",
+            TraceOrigin::Bus => "BUS",
+            TraceOrigin::Unknown => "?",
+        }
+    }
+}
+
+impl fmt::Display for TraceOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.tag())
+    }
+}
+
+/// What the trace classifier needs to know about the codesign-composed
+/// model. The caller assembles these label sets from whichever sources
+/// they have: the [`RegisterMap`] (for rendezvous labels), and the
+/// firmware / peripheral CTXDSL alphabets (for the per-side internals).
+#[derive(Debug, Clone, Default)]
+pub struct CouplingInfo {
+    /// Labels both sides synchronise on (output of
+    /// [`register_map_labels`]). A trace step on any of these is a
+    /// `Bus` event.
+    pub rendezvous_labels: HashSet<String>,
+    /// Labels visible only to the peripheral side — internal ticks,
+    /// chaotic-stub housekeeping, peripheral-internal events. A trace
+    /// step on any of these is a `Hw` event.
+    pub peripheral_internal_labels: HashSet<String>,
+    /// Labels visible only to the firmware side — internal control
+    /// flow, polling counter ticks, ISR housekeeping. A trace step on
+    /// any of these is a `Sw` event.
+    pub firmware_internal_labels: HashSet<String>,
+}
+
+impl CouplingInfo {
+    /// Build a [`CouplingInfo`] with just the rendezvous labels
+    /// derived from a register map. Useful when the caller has no
+    /// per-side internal vocabulary to declare yet — every non-bus
+    /// trace step will classify as `Unknown` in that case. Callers
+    /// typically extend the result by filling
+    /// `peripheral_internal_labels` and `firmware_internal_labels`
+    /// from the CTXDSL alphabets of the respective automata.
+    pub fn from_register_map(rm: &RegisterMap) -> Self {
+        let rendezvous_labels = register_map_labels(rm)
+            .into_iter()
+            .map(|l| l.name)
+            .collect();
+        Self {
+            rendezvous_labels,
+            peripheral_internal_labels: HashSet::new(),
+            firmware_internal_labels: HashSet::new(),
+        }
+    }
+
+    /// Add a peripheral-internal label.
+    pub fn with_peripheral_label(mut self, label: impl Into<String>) -> Self {
+        self.peripheral_internal_labels.insert(label.into());
+        self
+    }
+
+    /// Add a firmware-internal label.
+    pub fn with_firmware_label(mut self, label: impl Into<String>) -> Self {
+        self.firmware_internal_labels.insert(label.into());
+        self
+    }
+
+    /// Extend the peripheral-internal label set from any iterable of
+    /// label names.
+    pub fn extend_peripheral_labels<I, S>(mut self, labels: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for l in labels {
+            self.peripheral_internal_labels.insert(l.into());
+        }
+        self
+    }
+
+    /// Extend the firmware-internal label set from any iterable of
+    /// label names.
+    pub fn extend_firmware_labels<I, S>(mut self, labels: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for l in labels {
+            self.firmware_internal_labels.insert(l.into());
+        }
+        self
+    }
+}
+
+/// Classify a single label by which side of the coupling it belongs
+/// to.
+///
+/// Lookup order:
+///   1. Rendezvous → `Bus` (shared-by-design takes precedence).
+///   2. Peripheral-internal → `Hw`.
+///   3. Firmware-internal → `Sw`.
+///   4. None of the above → `Unknown`.
+///
+/// The order matters when label sets overlap: a label declared as
+/// both peripheral-internal and rendezvous always classifies as
+/// `Bus`. Callers who want to avoid overlap should ensure the three
+/// sets are disjoint before passing them in.
+pub fn classify_label(label: &str, info: &CouplingInfo) -> TraceOrigin {
+    if info.rendezvous_labels.contains(label) {
+        TraceOrigin::Bus
+    } else if info.peripheral_internal_labels.contains(label) {
+        TraceOrigin::Hw
+    } else if info.firmware_internal_labels.contains(label) {
+        TraceOrigin::Sw
+    } else {
+        TraceOrigin::Unknown
+    }
+}
+
+/// Classify every label in a trace.
+///
+/// `labels[i]` is the label that drove the transition into `states[i+1]`
+/// (matching the existing `LassoTraceApi.prefix_labels` /
+/// `cycle_labels` convention from the API surface).
+pub fn classify_trace_labels(labels: &[String], info: &CouplingInfo) -> Vec<TraceOrigin> {
+    labels.iter().map(|l| classify_label(l, info)).collect()
+}
+
+/// Format an interleaved trace as human-readable lines.
+///
+/// One line per transition, with the origin tag in brackets followed
+/// by the label and a `→` to the next state. Matches the rendering
+/// shape from Doc C §C.4's worked example:
+///
+/// ```text
+/// [SW]  poll_busy returns 0      → Polling|Idle
+/// [HW]  tx_busy rises             → Polling|Busy_status
+/// [BUS] wr_data_byte              → Sending|Busy_data
+/// ```
+///
+/// `states[0]` is the initial state. `labels[i]` drove the transition
+/// into `states[i + 1]`. The function tolerates a mismatched
+/// `labels.len() != states.len() - 1` by stopping at the shorter of
+/// the two — surfaces partial traces rather than panicking.
+pub fn format_interleaved_trace(
+    states: &[String],
+    labels: &[String],
+    info: &CouplingInfo,
+) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    if states.is_empty() {
+        return out;
+    }
+    let _ = writeln!(out, "      {}", states[0]);
+    let step_count = labels.len().min(states.len().saturating_sub(1));
+    for i in 0..step_count {
+        let label = &labels[i];
+        let origin = classify_label(label, info);
+        let next_state = &states[i + 1];
+        let _ = writeln!(out, "[{}] {label:<30} → {next_state}", origin.tag());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codesign::register_map::{
+        AccessPath, Field, Register, RegisterDirection, RegisterMap, VisibilityClass,
+    };
+
+    fn uart_map() -> RegisterMap {
+        RegisterMap {
+            peripheral: "UART_LITE".to_string(),
+            base_address: "0x40010000".to_string(),
+            description: None,
+            contract_uri: None,
+            registers: vec![
+                Register {
+                    name: "CTRL".to_string(),
+                    offset: 0,
+                    width_bits: 32,
+                    direction: RegisterDirection::Rw,
+                    visibility_class: VisibilityClass::Control,
+                    access_path: AccessPath::MmioDirect,
+                    description: None,
+                    fields: vec![Field {
+                        name: "tx_start".to_string(),
+                        bits: [0, 0],
+                        sv_signal: None,
+                        c_accessor: None,
+                        description: None,
+                    }],
+                },
+                Register {
+                    name: "STATUS".to_string(),
+                    offset: 4,
+                    width_bits: 32,
+                    direction: RegisterDirection::Ro,
+                    visibility_class: VisibilityClass::Status,
+                    access_path: AccessPath::MmioDirect,
+                    description: None,
+                    fields: vec![Field {
+                        name: "tx_busy".to_string(),
+                        bits: [0, 0],
+                        sv_signal: None,
+                        c_accessor: None,
+                        description: None,
+                    }],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn rendezvous_label_classifies_as_bus() {
+        let info = CouplingInfo::from_register_map(&uart_map());
+        assert_eq!(classify_label("rd_status_tx_busy", &info), TraceOrigin::Bus);
+        assert_eq!(classify_label("wr_ctrl_tx_start", &info), TraceOrigin::Bus);
+    }
+
+    #[test]
+    fn peripheral_internal_label_classifies_as_hw() {
+        let info =
+            CouplingInfo::from_register_map(&uart_map()).with_peripheral_label("sha_compute_tick");
+        assert_eq!(classify_label("sha_compute_tick", &info), TraceOrigin::Hw);
+    }
+
+    #[test]
+    fn firmware_internal_label_classifies_as_sw() {
+        let info = CouplingInfo::from_register_map(&uart_map()).with_firmware_label("isr_dispatch");
+        assert_eq!(classify_label("isr_dispatch", &info), TraceOrigin::Sw);
+    }
+
+    #[test]
+    fn unknown_label_classifies_as_unknown() {
+        let info = CouplingInfo::from_register_map(&uart_map());
+        assert_eq!(
+            classify_label("never_declared", &info),
+            TraceOrigin::Unknown
+        );
+    }
+
+    #[test]
+    fn rendezvous_takes_precedence_over_internal_classification() {
+        // A peripheral-side label that is *also* a rendezvous (e.g. the
+        // user accidentally listed it in both sets) must classify as
+        // `Bus`, not `Hw`. The classifier's order encodes that
+        // rendezvous-by-design wins.
+        let mut info = CouplingInfo::from_register_map(&uart_map());
+        info.peripheral_internal_labels
+            .insert("rd_status_tx_busy".to_string());
+        assert_eq!(classify_label("rd_status_tx_busy", &info), TraceOrigin::Bus);
+    }
+
+    #[test]
+    fn classify_trace_labels_per_step() {
+        let info = CouplingInfo::from_register_map(&uart_map())
+            .with_firmware_label("isr_dispatch")
+            .with_peripheral_label("baud_tick");
+        let labels: Vec<String> = vec![
+            "isr_dispatch".to_string(),
+            "rd_status_tx_busy".to_string(),
+            "baud_tick".to_string(),
+            "wr_ctrl_tx_start".to_string(),
+            "phantom".to_string(),
+        ];
+        let origins = classify_trace_labels(&labels, &info);
+        assert_eq!(
+            origins,
+            vec![
+                TraceOrigin::Sw,
+                TraceOrigin::Bus,
+                TraceOrigin::Hw,
+                TraceOrigin::Bus,
+                TraceOrigin::Unknown,
+            ]
+        );
+    }
+
+    #[test]
+    fn format_interleaved_trace_renders_one_line_per_step() {
+        let info = CouplingInfo::from_register_map(&uart_map()).with_firmware_label("isr_dispatch");
+        let states = vec!["S0".to_string(), "S1".to_string(), "S2".to_string()];
+        let labels = vec!["isr_dispatch".to_string(), "rd_status_tx_busy".to_string()];
+        let rendered = format_interleaved_trace(&states, &labels, &info);
+        // Initial state present.
+        assert!(rendered.contains("S0"));
+        // Per-step tags + label + next state.
+        assert!(rendered.contains("[SW]"));
+        assert!(rendered.contains("isr_dispatch"));
+        assert!(rendered.contains("→ S1"));
+        assert!(rendered.contains("[BUS]"));
+        assert!(rendered.contains("rd_status_tx_busy"));
+        assert!(rendered.contains("→ S2"));
+    }
+
+    #[test]
+    fn format_handles_empty_states() {
+        let info = CouplingInfo::default();
+        let out = format_interleaved_trace(&[], &[], &info);
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn format_tolerates_label_count_one_short_of_states() {
+        // states.len() = 3, labels.len() = 1 → should render initial
+        // + 1 transition + skip the missing label rather than panic.
+        let info = CouplingInfo::default();
+        let states = vec!["S0".to_string(), "S1".to_string(), "S2".to_string()];
+        let labels = vec!["a".to_string()];
+        let rendered = format_interleaved_trace(&states, &labels, &info);
+        assert!(rendered.contains("S0"));
+        assert!(rendered.contains("→ S1"));
+        assert!(!rendered.contains("→ S2"));
+    }
+
+    #[test]
+    fn extend_helpers_populate_sets() {
+        let info = CouplingInfo::from_register_map(&uart_map())
+            .extend_peripheral_labels(["tick", "drain"])
+            .extend_firmware_labels(["pop"]);
+        assert_eq!(info.peripheral_internal_labels.len(), 2);
+        assert_eq!(info.firmware_internal_labels.len(), 1);
+        assert!(info.peripheral_internal_labels.contains("tick"));
+        assert!(info.firmware_internal_labels.contains("pop"));
+    }
+
+    #[test]
+    fn trace_origin_tag_strings_match_doc_c_convention() {
+        // Doc C §C.4 worked example uses `[SW]`, `[HW]`, `[BUS]` tags.
+        // The `?` tag is mununu-specific (no Doc-C precedent) so the
+        // test is just that it doesn't collide with the three real
+        // tags.
+        assert_eq!(TraceOrigin::Sw.tag(), "SW");
+        assert_eq!(TraceOrigin::Hw.tag(), "HW");
+        assert_eq!(TraceOrigin::Bus.tag(), "BUS");
+        assert_eq!(TraceOrigin::Unknown.tag(), "?");
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of **M4**. Tags counterexample / counterstrategy trace steps with `[SW]` / `[HW]` / `[BUS]` based on whether the firing label belongs to the firmware side, the peripheral side, or the rendezvous set produced by C2's coupling synthesis. Implements Doc C §C.9.3's trace-origin scope.

## What lands

### Library — `crates/mununu-core/src/codesign/trace.rs`
- `TraceOrigin` enum (`Sw | Hw | Bus | Unknown`) with `tag()` → `"SW" | "HW" | "BUS" | "?"`.
- `CouplingInfo` struct holding the three disjoint label sets (rendezvous, peripheral-internal, firmware-internal) plus a `from_register_map()` constructor that derives `rendezvous_labels` directly from a `RegisterMap` (C2's output).
- Builder helpers (`with_peripheral_label`, `with_firmware_label`, `extend_peripheral_labels`, `extend_firmware_labels`) so callers can fold in the firmware automaton's alphabet incrementally.
- `classify_label(label, info)` and `classify_trace_labels(labels, info)` — total, lookup-based classification. Rendezvous takes precedence over per-side membership so a label declared in two sets always classifies as `Bus`.
- `format_interleaved_trace(states, labels, info)` — produces the Doc C §C.4 worked-example output shape with one line per transition. Tolerates mismatched lengths (partial traces render rather than panic).

## Why this is a separate module

The composition engine produces flat state-name traces; it deliberately doesn't know about HW/SW semantics. This module is the **codesign-layer bridge**: it brings the `rendezvous` / `peripheral` / `firmware` vocabulary to bear on flat traces *after* verification, without polluting the verifier.

## Soundness posture

Classification is **lookup-based and total** — no heuristic guesses. An unrecognised label classifies as `Unknown` rather than defaulting to one side. The order (`rendezvous` → `peripheral` → `firmware` → unknown) encodes that rendezvous-by-design wins over any per-side membership.

## Slice 1 scope

This slice ships the **classifier library** + tests. Task C4 (`mununu codesign verify` three-surface entry point) is the consumer: it pulls a counterexample out of the verifier, feeds it through `classify_trace_labels`, and surfaces the result through CLI / HTTP / UI parity. Keeping C3 fully library means the existing counterexample API (`SynthesisDiagnostics.counterexample_trace`, `LassoTraceApi`) does not change.

## Validation

- `cargo fmt --all` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p mununu-core --lib codesign::trace` → **11 tests passing**
- `cargo test -p mununu-core --lib codesign` → **44 codesign tests total** green (15 C1 + 18 C2 + 11 C3)

## Test plan

- [ ] CI green
- [ ] Reviewer skim: does the classifier's precedence order (rendezvous → HW → SW → unknown) match Doc C §C.4's example?

🤖 Generated with [Claude Code](https://claude.com/claude-code)