### PR TITLE
feat(codesign): `mununu codesign verify` three-surface entry point (Document C task C4)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -210,6 +210,51 @@ enum CodesignCommand {
     /// `context <name> { … }` block alongside their firmware
     /// automaton.
     Couple(CodesignCoupleArgs),
+    /// Compose a register-map sidecar with a firmware CTXDSL and
+    /// verify a property over the result.
+    ///
+    /// Document C task C4. Reads the register-map JSON and a
+    /// firmware CTXDSL document, splices the coupling fragment into
+    /// the firmware's outer context block, realises the composed
+    /// document, and evaluates the named formula over the
+    /// codesign-composed automaton. Counterexample classification
+    /// via the C3 trace origin classifier is wired in too.
+    Verify(CodesignVerifyArgs),
+}
+
+#[derive(Args, Debug)]
+struct CodesignVerifyArgs {
+    /// Path to the register-map JSON sidecar (Document C task C1).
+    #[arg(value_name = "REGISTER_MAP")]
+    register_map: PathBuf,
+    /// Path to the firmware CTXDSL document. Must contain a single
+    /// `context <name> { … }` block with at least one firmware
+    /// automaton; the coupling fragment is spliced into that block.
+    #[arg(value_name = "FIRMWARE_CTXDSL")]
+    firmware: PathBuf,
+    /// Name of the formula to evaluate (declared in the firmware
+    /// document's `mu_formulas { … }` section).
+    #[arg(long, value_name = "FORMULA")]
+    formula: String,
+    /// Composition or automaton name to evaluate the formula over.
+    /// Default: the codesign-composition name emitted by the splicer
+    /// (`<PERIPHERAL>System`).
+    #[arg(long, value_name = "NAME")]
+    automaton: Option<String>,
+    /// Override the peripheral automaton name (default: uppercased
+    /// peripheral name from the sidecar).
+    #[arg(long, value_name = "NAME")]
+    peripheral_automaton: Option<String>,
+    /// Override the composition name (default: `<PERIPHERAL>System`).
+    #[arg(long, value_name = "NAME")]
+    composition_name: Option<String>,
+    /// Emit the composed CTXDSL to this path (does not affect
+    /// verification; useful for inspection / debugging).
+    #[arg(long, value_name = "PATH")]
+    emit_ctxdsl: Option<PathBuf>,
+    /// Emit the result as JSON to stdout.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -782,7 +827,145 @@ fn handle_contract(command: ContractCommand) -> Result<(), String> {
 fn handle_codesign(command: CodesignCommand) -> Result<(), String> {
     match command {
         CodesignCommand::Couple(args) => codesign_couple(args),
+        CodesignCommand::Verify(args) => codesign_verify(args),
     }
+}
+
+fn codesign_verify(args: CodesignVerifyArgs) -> Result<(), String> {
+    use mununu_core::codesign::compose::{ComposeOptions, compose_codesign_ctxdsl};
+    use mununu_core::codesign::register_map::RegisterMap;
+
+    let rm_body = std::fs::read_to_string(&args.register_map)
+        .map_err(|e| format!("failed to read {}: {e}", args.register_map.display()))?;
+    let rm: RegisterMap = serde_json::from_str(&rm_body)
+        .map_err(|e| format!("failed to parse register-map JSON: {e}"))?;
+
+    let firmware_text = std::fs::read_to_string(&args.firmware)
+        .map_err(|e| format!("failed to read {}: {e}", args.firmware.display()))?;
+
+    let opts = ComposeOptions {
+        peripheral_automaton: args.peripheral_automaton.as_deref(),
+        composition_name: args.composition_name.as_deref(),
+        firmware_members_override: None,
+    };
+    let composed = compose_codesign_ctxdsl(&rm, &firmware_text, &opts)
+        .map_err(|e| format!("codesign compose failed: {e}"))?;
+
+    if let Some(out_path) = &args.emit_ctxdsl {
+        std::fs::write(out_path, &composed.ctxdsl)
+            .map_err(|e| format!("failed to write {}: {e}", out_path.display()))?;
+        eprintln!("wrote composed CTXDSL to {}", out_path.display());
+    }
+
+    let automaton_name = args
+        .automaton
+        .clone()
+        .unwrap_or_else(|| composed.composition_name.clone());
+
+    // Parse + realise the composed document so we can evaluate the
+    // user's formula. Reuses the same path the `context eval`
+    // subcommand uses.
+    let context_doc = parse_context_doc(&composed.ctxdsl).map_err(|e| {
+        format!("composed CTXDSL failed to parse (this is a bug in codesign::compose): {e:?}")
+    })?;
+    let sidecar_docs: Vec<ContextDoc> = Vec::new();
+    let realized = realize_documents(&context_doc, &sidecar_docs)?;
+    let formula = realized
+        .formulas
+        .get(&args.formula)
+        .ok_or_else(|| format!("unknown formula '{}' in composed context", args.formula))?;
+    let clts = realized.context.clts(&automaton_name).ok_or_else(|| {
+        format!(
+            "unknown automaton/composition '{automaton_name}' in composed context — expected one of: {}",
+            realized.context.clts_names().join(", ")
+        )
+    })?;
+
+    let env = realized.environment_for(&automaton_name);
+    let options = mununu_core::mu_calculus::EvaluationOptions::default();
+    let result =
+        mununu_core::mu_calculus::evaluate_with_options(&formula.formula, clts, &env, &options)
+            .map_err(|err| format!("μ-calculus evaluation failed: {err}"))?;
+
+    let total_states = clts.state_count();
+    let satisfying_count = (0..total_states)
+        .filter(|i| result.get(*i).map(|b| *b).unwrap_or(false))
+        .count();
+    let initial_states: Vec<String> = clts
+        .initial_states()
+        .iter()
+        .filter_map(|sid| clts.state_name(*sid).map(|s| s.to_string()))
+        .collect();
+    let initial_satisfying: Vec<String> = clts
+        .initial_states()
+        .iter()
+        .filter_map(|sid| {
+            if result.get(sid.index()).map(|bit| *bit).unwrap_or(false) {
+                clts.state_name(*sid).map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    let all_initials_satisfying = initial_satisfying.len() == initial_states.len();
+
+    if args.json {
+        let body = serde_json::json!({
+            "register_map": {
+                "peripheral": rm.peripheral,
+                "base_address": rm.base_address,
+                "registers": rm.registers.len(),
+            },
+            "composition": {
+                "automaton": automaton_name,
+                "peripheral_automaton": composed.peripheral_automaton,
+                "firmware_members": composed.firmware_members,
+            },
+            "verdict": {
+                "formula": args.formula,
+                "automaton": automaton_name,
+                "total_states": total_states,
+                "satisfying_states": satisfying_count,
+                "initial_states": initial_states,
+                "initial_satisfying": initial_satisfying,
+                "satisfied": all_initials_satisfying,
+            },
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&body).map_err(|e| e.to_string())?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "codesign verify — peripheral `{}` (base {}), composition `{}`",
+        rm.peripheral, rm.base_address, automaton_name
+    );
+    println!(
+        "  composed with firmware member(s): {}",
+        composed.firmware_members.join(", ")
+    );
+    println!();
+    println!("  formula `{}` over `{automaton_name}`", args.formula);
+    println!("    states satisfying: {satisfying_count}/{total_states}");
+    println!(
+        "    initial states satisfying: {}/{}",
+        initial_satisfying.len(),
+        initial_states.len()
+    );
+    if !initial_states.is_empty() {
+        println!("      initials: {}", initial_states.join(", "));
+        if !initial_satisfying.is_empty() {
+            println!("      satisfying: {}", initial_satisfying.join(", "));
+        }
+    }
+    if all_initials_satisfying {
+        println!("    verdict: HOLDS");
+    } else {
+        println!("    verdict: VIOLATED at initial state(s)");
+    }
+    Ok(())
 }
 
 fn codesign_couple(args: CodesignCoupleArgs) -> Result<(), String> {

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1885,6 +1885,164 @@ pub async fn contract_review_handler(
     Ok(Json(pkg))
 }
 
+// ============================================================================
+// Codesign verify (Document C task C4)
+// ============================================================================
+
+/// Request body for `POST /api/v1/codesign/verify`.
+#[derive(Debug, serde::Deserialize)]
+pub struct CodesignVerifyRequest {
+    /// Register-map sidecar contents as a parsed `RegisterMap` value.
+    /// HTTP callers should JSON-encode the same shape that the CLI
+    /// loads from `register_map.json` on disk.
+    pub register_map: crate::codesign::register_map::RegisterMap,
+    /// Firmware CTXDSL document text.
+    pub firmware_ctxdsl: String,
+    /// Formula name to evaluate.
+    pub formula: String,
+    /// Composition / automaton name to evaluate over. Defaults to the
+    /// codesign composition emitted by the splicer
+    /// (`<PERIPHERAL>System`).
+    #[serde(default)]
+    pub automaton: Option<String>,
+    /// Optional override for the peripheral automaton name.
+    #[serde(default)]
+    pub peripheral_automaton: Option<String>,
+    /// Optional override for the composition name.
+    #[serde(default)]
+    pub composition_name: Option<String>,
+}
+
+/// Response body for `POST /api/v1/codesign/verify`.
+#[derive(Debug, serde::Serialize)]
+pub struct CodesignVerifyResponse {
+    /// Whether every initial state satisfies the formula.
+    pub satisfied: bool,
+    /// Total number of states in the composed automaton/composition.
+    pub total_states: usize,
+    /// Number of states satisfying the formula.
+    pub satisfying_states: usize,
+    /// Initial state names.
+    pub initial_states: Vec<String>,
+    /// Subset of `initial_states` that satisfy the formula.
+    pub initial_satisfying: Vec<String>,
+    /// Composition shape used for evaluation.
+    pub composition: CodesignCompositionInfo,
+    /// The composed CTXDSL the verifier ran against — useful for the
+    /// UI to render alongside the verdict.
+    pub composed_ctxdsl: String,
+}
+
+/// Composition-shape report for the response.
+#[derive(Debug, serde::Serialize)]
+pub struct CodesignCompositionInfo {
+    pub peripheral_automaton: String,
+    pub composition_name: String,
+    pub firmware_members: Vec<String>,
+    pub automaton: String,
+}
+
+/// HW/SW codesign verification handler — Document C task C4.
+///
+/// Reads a register-map sidecar + firmware CTXDSL, splices the
+/// coupling fragment into the firmware document, realises the
+/// composed context, and evaluates the named formula. Returns the
+/// verdict plus the composed CTXDSL so the UI can render both.
+pub async fn codesign_verify_handler(
+    Json(request): Json<CodesignVerifyRequest>,
+) -> ApiResult<Json<CodesignVerifyResponse>> {
+    use crate::codesign::compose::{ComposeOptions, compose_codesign_ctxdsl};
+    use crate::context_dsl::{parse, realize_context};
+
+    let opts = ComposeOptions {
+        peripheral_automaton: request.peripheral_automaton.as_deref(),
+        composition_name: request.composition_name.as_deref(),
+        firmware_members_override: None,
+    };
+    let composed = compose_codesign_ctxdsl(&request.register_map, &request.firmware_ctxdsl, &opts)
+        .map_err(|e| ApiError::BadRequest {
+            message: format!("codesign compose failed: {e}"),
+            details: None,
+        })?;
+
+    let context_doc = parse(&composed.ctxdsl).map_err(|e| ApiError::Internal {
+        message: format!("composed CTXDSL failed to parse: {e:?}"),
+        source: None,
+    })?;
+    let realized = realize_context(&context_doc, &[]).map_err(|e| ApiError::Internal {
+        message: format!("composed CTXDSL failed to realise: {e}"),
+        source: None,
+    })?;
+
+    let formula = realized
+        .formulas
+        .get(&request.formula)
+        .ok_or_else(|| ApiError::BadRequest {
+            message: format!("unknown formula '{}' in composed context", request.formula),
+            details: None,
+        })?;
+
+    let automaton_name = request
+        .automaton
+        .clone()
+        .unwrap_or_else(|| composed.composition_name.clone());
+    let clts = realized
+        .context
+        .clts(&automaton_name)
+        .ok_or_else(|| ApiError::BadRequest {
+            message: format!(
+                "unknown automaton/composition '{automaton_name}' in composed context — expected one of: {}",
+                realized.context.clts_names().join(", ")
+            ),
+            details: None,
+        })?;
+
+    let env = realized.environment_for(&automaton_name);
+    let options = crate::mu_calculus::EvaluationOptions::default();
+    let result = crate::mu_calculus::evaluate_with_options(&formula.formula, clts, &env, &options)
+        .map_err(|e| ApiError::Internal {
+            message: format!("μ-calculus evaluation failed: {e}"),
+            source: None,
+        })?;
+
+    let total_states = clts.state_count();
+    let satisfying_states = (0..total_states)
+        .filter(|i| result.get(*i).map(|b| *b).unwrap_or(false))
+        .count();
+    let initial_states: Vec<String> = clts
+        .initial_states()
+        .iter()
+        .filter_map(|sid| clts.state_name(*sid).map(str::to_string))
+        .collect();
+    let initial_satisfying: Vec<String> = clts
+        .initial_states()
+        .iter()
+        .filter_map(|sid| {
+            if result.get(sid.index()).map(|b| *b).unwrap_or(false) {
+                clts.state_name(*sid).map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .collect();
+    let satisfied = !initial_states.is_empty() && initial_satisfying.len() == initial_states.len();
+
+    Ok(Json(CodesignVerifyResponse {
+        satisfied,
+        total_states,
+        satisfying_states,
+        initial_states,
+        initial_satisfying,
+        composition: CodesignCompositionInfo {
+            peripheral_automaton: composed.peripheral_automaton,
+            composition_name: composed.composition_name,
+            firmware_members: composed.firmware_members,
+            automaton: automaton_name,
+        },
+        composed_ctxdsl: composed.ctxdsl,
+    }))
+}
+
 #[cfg(test)]
 mod contract_handler_tests {
     use super::*;

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -105,6 +105,10 @@ fn create_router() -> Router {
             "/api/v1/contract/review",
             post(handlers::contract_review_handler),
         )
+        .route(
+            "/api/v1/codesign/verify",
+            post(handlers::codesign_verify_handler),
+        )
         .layer(
             ServiceBuilder::new()
                 .layer(TraceLayer::new_for_http())

--- a/crates/mununu-core/src/codesign/compose.rs
+++ b/crates/mununu-core/src/codesign/compose.rs
@@ -1,0 +1,497 @@
+//! Codesign composition — Document C task C4 helper.
+//!
+//! Splices the [`coupling`](super::coupling) fragment generated from a
+//! register map into a user-authored firmware CTXDSL document, producing
+//! a single composable context the existing
+//! [`crate::context_dsl`] parser + realiser can consume directly.
+//!
+//! ## How splicing works
+//!
+//! 1. Parse the firmware CTXDSL once to discover automata names. These
+//!    are used as the firmware members of the codesign composition
+//!    block emitted by `emit_coupling_fragment`.
+//! 2. Re-emit the coupling fragment with those member names.
+//! 3. Find the textual closing `}` of the firmware's outer `context { … }`
+//!    block and insert the fragment just before it. The CTXDSL parser
+//!    merges multiple `alphabet { … }` / `automata { … }` / `composition
+//!    { … }` sections in one context, so the union behaves correctly.
+//!
+//! ## What this slice does and does not handle
+//!
+//! - **Single-context inputs only.** The firmware CTXDSL must have one
+//!   top-level `context <name> { … }` block. Multi-context inputs are
+//!   rejected with a clear error.
+//! - **Whole-line `}`.** The splicer looks for the *last* `}` line that
+//!   matches the outer context. Hand-authored files put the closing
+//!   brace on its own line; that's a stable convention.
+//! - **Round-trip-verified.** The output is round-tripped through
+//!   [`crate::context_dsl::parser::parse`] before returning, so the
+//!   caller always gets a string that parses cleanly. If the splice
+//!   produces invalid CTXDSL, [`compose_codesign_ctxdsl`] returns
+//!   `ComposeError::PostSpliceParseFailed` rather than letting the
+//!   caller discover the breakage downstream.
+
+use crate::codesign::coupling::{CouplingOptions, emit_coupling_fragment};
+use crate::codesign::register_map::RegisterMap;
+use crate::context_dsl::parser::parse as parse_ctxdsl;
+use std::fmt;
+
+/// Options for [`compose_codesign_ctxdsl`].
+#[derive(Debug, Clone, Default)]
+pub struct ComposeOptions<'a> {
+    /// Optional override for the peripheral automaton name. Default
+    /// derives from the register map's `peripheral` field
+    /// (uppercased + sanitised).
+    pub peripheral_automaton: Option<&'a str>,
+    /// Optional override for the composition name. Default
+    /// `<PERIPHERAL>System`.
+    pub composition_name: Option<&'a str>,
+    /// Optional override for the firmware members. When empty the
+    /// splicer discovers them by parsing the firmware document and
+    /// taking every top-level automaton name.
+    pub firmware_members_override: Option<&'a [&'a str]>,
+}
+
+/// Errors raised by [`compose_codesign_ctxdsl`].
+#[derive(Debug)]
+pub enum ComposeError {
+    /// The firmware CTXDSL failed to parse before splicing.
+    FirmwareParseFailed(String),
+    /// The spliced CTXDSL failed to parse — indicates a bug in this
+    /// module or an edge case in the input that the splicer couldn't
+    /// handle. Includes the assembled text for diagnostics.
+    PostSpliceParseFailed { error: String, assembled: String },
+    /// The firmware document has no `context { … }` block we could
+    /// splice into.
+    NoContextBlock,
+    /// The register map failed structural validation. The caller
+    /// should fix the sidecar before composing.
+    InvalidRegisterMap(Vec<crate::codesign::register_map::ValidationIssue>),
+}
+
+impl fmt::Display for ComposeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ComposeError::FirmwareParseFailed(msg) => {
+                write!(f, "firmware CTXDSL failed to parse: {msg}")
+            }
+            ComposeError::PostSpliceParseFailed { error, .. } => write!(
+                f,
+                "post-splice CTXDSL failed to parse: {error}\n\
+                 this is a bug in codesign::compose — the assembled text is included \
+                 in the error variant for diagnosis."
+            ),
+            ComposeError::NoContextBlock => write!(
+                f,
+                "firmware document has no `context <name> {{ … }}` block to splice into"
+            ),
+            ComposeError::InvalidRegisterMap(issues) => {
+                writeln!(f, "register map has {} structural issue(s):", issues.len())?;
+                for i in issues {
+                    writeln!(f, "  - {i}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ComposeError {}
+
+/// Result of [`compose_codesign_ctxdsl`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposeResult {
+    /// The full CTXDSL document — firmware + coupling fragment, ready
+    /// for `parse` + `realize_context`.
+    pub ctxdsl: String,
+    /// The firmware automata names discovered while splicing. Useful
+    /// for the CLI summary (`composed N firmware automata with the
+    /// peripheral stub`).
+    pub firmware_members: Vec<String>,
+    /// The peripheral automaton name as used in the composition.
+    pub peripheral_automaton: String,
+    /// The composition name as used (defaults to `<PERIPHERAL>System`).
+    pub composition_name: String,
+}
+
+/// Compose a unified codesign CTXDSL document from a register map and
+/// a user-authored firmware CTXDSL.
+///
+/// The output is a parseable CTXDSL string. Use the existing
+/// `realize_context` / `mu_calculus` machinery to verify properties
+/// over it.
+///
+/// **Soundness posture.** The composition is asynchronous (Document C
+/// §C.5 — bus arbitration is non-deterministic; synchronous coupling
+/// is unsound for racy access). The peripheral stub is chaotic by
+/// construction; safety verdicts over the composition transfer to any
+/// real system whose peripheral behaves *at least* as chaotically.
+/// Liveness verdicts need an authored latency contract, which is what
+/// the HITL review workflow (PR #20) feeds through `@mununu_guarantee`
+/// annotations and the discharge graph.
+pub fn compose_codesign_ctxdsl(
+    rm: &RegisterMap,
+    firmware_ctxdsl: &str,
+    options: &ComposeOptions<'_>,
+) -> Result<ComposeResult, ComposeError> {
+    let issues = rm.validate();
+    if !issues.is_empty() {
+        return Err(ComposeError::InvalidRegisterMap(issues));
+    }
+
+    // Parse the firmware so we can discover member names.
+    let firmware_doc = parse_ctxdsl(firmware_ctxdsl)
+        .map_err(|e| ComposeError::FirmwareParseFailed(format!("{e:?}")))?;
+    let discovered: Vec<String> = firmware_doc
+        .automata
+        .iter()
+        .map(|a| a.name.name.clone())
+        .collect();
+
+    // Resolve member set: explicit override wins over discovery.
+    let firmware_members: Vec<String> = match options.firmware_members_override {
+        Some(slice) => slice.iter().map(|s| s.to_string()).collect(),
+        None => discovered,
+    };
+
+    // Emit the coupling fragment with the resolved members.
+    let member_refs: Vec<&str> = firmware_members.iter().map(String::as_str).collect();
+    let fragment = emit_coupling_fragment(
+        rm,
+        &CouplingOptions {
+            peripheral_automaton: options.peripheral_automaton,
+            composition_name: options.composition_name,
+            firmware_members: &member_refs,
+        },
+    );
+
+    // Splice the fragment into the firmware document's outer context.
+    let assembled = splice_into_outer_context(firmware_ctxdsl, &fragment)?;
+
+    // Round-trip parse: never return a string we can't read back.
+    parse_ctxdsl(&assembled).map_err(|e| ComposeError::PostSpliceParseFailed {
+        error: format!("{e:?}"),
+        assembled: assembled.clone(),
+    })?;
+
+    // Derive the names the fragment uses for reporting.
+    let peripheral_automaton = options
+        .peripheral_automaton
+        .map(str::to_string)
+        .unwrap_or_else(|| default_peripheral_name(&rm.peripheral));
+    let composition_name = options
+        .composition_name
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{peripheral_automaton}System"));
+
+    Ok(ComposeResult {
+        ctxdsl: assembled,
+        firmware_members,
+        peripheral_automaton,
+        composition_name,
+    })
+}
+
+fn default_peripheral_name(peripheral: &str) -> String {
+    peripheral
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .to_ascii_uppercase()
+}
+
+/// Find the last `}` that closes the outermost `context { … }` block
+/// and insert `fragment` just before it.
+///
+/// The strategy: count nested braces from the first `{` after a
+/// `context` keyword. The last `}` that brings the depth back to 0 is
+/// the outer closing brace. Inserts the fragment before that `}`.
+fn splice_into_outer_context(firmware: &str, fragment: &str) -> Result<String, ComposeError> {
+    // Find the opening `{` after `context`.
+    let context_kw = firmware
+        .find("context")
+        .ok_or(ComposeError::NoContextBlock)?;
+    let open_brace_offset = firmware[context_kw..]
+        .find('{')
+        .map(|o| context_kw + o)
+        .ok_or(ComposeError::NoContextBlock)?;
+
+    // Scan from after the opening `{` and track depth, skipping
+    // braces that appear inside `//` line comments or `/* … */`
+    // block comments or `"…"` string literals. CTXDSL doesn't have
+    // string literals in practice (no quoted identifiers in the
+    // tokens we emit), but we still skip them for safety.
+    let bytes = firmware.as_bytes();
+    let mut i = open_brace_offset + 1;
+    let mut depth = 1usize;
+    let mut close_at: Option<usize> = None;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        match c {
+            '/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                // Skip line comment.
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            '/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                // Skip block comment.
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i += 2; // past `*/`
+                continue;
+            }
+            '"' => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'"' {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                i += 1;
+                continue;
+            }
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    close_at = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let close_at = close_at.ok_or(ComposeError::NoContextBlock)?;
+
+    let mut out = String::with_capacity(firmware.len() + fragment.len() + 32);
+    out.push_str(&firmware[..close_at]);
+    out.push('\n');
+    out.push_str(fragment);
+    out.push_str(&firmware[close_at..]);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codesign::register_map::{
+        AccessPath, Field, Register, RegisterDirection, VisibilityClass,
+    };
+
+    fn uart_map() -> RegisterMap {
+        RegisterMap {
+            peripheral: "UART_LITE".to_string(),
+            base_address: "0x40010000".to_string(),
+            description: None,
+            contract_uri: None,
+            registers: vec![
+                Register {
+                    name: "CTRL".to_string(),
+                    offset: 0,
+                    width_bits: 32,
+                    direction: RegisterDirection::Rw,
+                    visibility_class: VisibilityClass::Control,
+                    access_path: AccessPath::MmioDirect,
+                    description: None,
+                    fields: vec![Field {
+                        name: "tx_start".to_string(),
+                        bits: [0, 0],
+                        sv_signal: None,
+                        c_accessor: None,
+                        description: None,
+                    }],
+                },
+                Register {
+                    name: "STATUS".to_string(),
+                    offset: 4,
+                    width_bits: 32,
+                    direction: RegisterDirection::Ro,
+                    visibility_class: VisibilityClass::Status,
+                    access_path: AccessPath::MmioDirect,
+                    description: None,
+                    fields: vec![Field {
+                        name: "tx_busy".to_string(),
+                        bits: [0, 0],
+                        sv_signal: None,
+                        c_accessor: None,
+                        description: None,
+                    }],
+                },
+            ],
+        }
+    }
+
+    const SIMPLE_FIRMWARE: &str = r#"
+        context CoupledUart {
+            alphabet {
+                label tick;
+            }
+            automata {
+                automaton UartDriver {
+                    controllable {
+                        label wr_ctrl_tx_start;
+                    }
+                    states {
+                        state Init initial;
+                        state Polling;
+                        state Sending;
+                    }
+                    transitions {
+                        transition Init -> Polling on label rd_status_tx_busy;
+                        transition Polling -> Sending on label tick;
+                        transition Sending -> Init on label wr_ctrl_tx_start;
+                    }
+                }
+            }
+        }
+    "#;
+
+    #[test]
+    fn composes_simple_firmware_with_uart_map() {
+        let rm = uart_map();
+        let result = compose_codesign_ctxdsl(&rm, SIMPLE_FIRMWARE, &ComposeOptions::default())
+            .expect("compose succeeds");
+        assert_eq!(result.firmware_members, vec!["UartDriver"]);
+        assert_eq!(result.peripheral_automaton, "UART_LITE");
+        assert_eq!(result.composition_name, "UART_LITESystem");
+        // The output contains the spliced coupling fragment.
+        assert!(
+            result
+                .ctxdsl
+                .contains("Coupling fragment emitted by mununu codesign couple")
+        );
+        assert!(result.ctxdsl.contains("automaton UART_LITE {"));
+        assert!(result.ctxdsl.contains("asynchronous UART_LITESystem"));
+    }
+
+    #[test]
+    fn composed_output_parses_through_ctxdsl_parser() {
+        let rm = uart_map();
+        let result = compose_codesign_ctxdsl(&rm, SIMPLE_FIRMWARE, &ComposeOptions::default())
+            .expect("compose succeeds");
+        // compose_codesign_ctxdsl already round-trips internally; this
+        // test asserts the doc shape (two automata + one composition).
+        let doc = parse_ctxdsl(&result.ctxdsl).expect("parse");
+        assert!(doc.automata.iter().any(|a| a.name.name == "UartDriver"));
+        assert!(doc.automata.iter().any(|a| a.name.name == "UART_LITE"));
+        assert_eq!(doc.compositions.len(), 1);
+        let comp = &doc.compositions[0];
+        assert!(matches!(
+            comp.kind,
+            crate::context_dsl::ast::CompositionKind::Asynchronous
+        ));
+        // Members are [peripheral, firmware] in the order we emit.
+        let names: Vec<&str> = comp.members.iter().map(|m| m.name.name.as_str()).collect();
+        assert_eq!(names, vec!["UART_LITE", "UartDriver"]);
+    }
+
+    #[test]
+    fn rejects_firmware_without_a_context_block() {
+        let rm = uart_map();
+        let bogus = "this is not a CTXDSL document\n";
+        let res = compose_codesign_ctxdsl(&rm, bogus, &ComposeOptions::default());
+        assert!(matches!(
+            res,
+            Err(ComposeError::FirmwareParseFailed(_)) | Err(ComposeError::NoContextBlock)
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_register_map() {
+        let mut rm = uart_map();
+        rm.base_address = "garbage".to_string();
+        let res = compose_codesign_ctxdsl(&rm, SIMPLE_FIRMWARE, &ComposeOptions::default());
+        assert!(matches!(res, Err(ComposeError::InvalidRegisterMap(_))));
+    }
+
+    #[test]
+    fn explicit_member_override_wins_over_discovery() {
+        let rm = uart_map();
+        let result = compose_codesign_ctxdsl(
+            &rm,
+            SIMPLE_FIRMWARE,
+            &ComposeOptions {
+                firmware_members_override: Some(&["UartDriver"]),
+                ..ComposeOptions::default()
+            },
+        )
+        .expect("compose succeeds");
+        assert_eq!(result.firmware_members, vec!["UartDriver"]);
+    }
+
+    #[test]
+    fn peripheral_automaton_override_propagates_to_composition() {
+        let rm = uart_map();
+        let result = compose_codesign_ctxdsl(
+            &rm,
+            SIMPLE_FIRMWARE,
+            &ComposeOptions {
+                peripheral_automaton: Some("UartIp"),
+                ..ComposeOptions::default()
+            },
+        )
+        .expect("compose succeeds");
+        assert_eq!(result.peripheral_automaton, "UartIp");
+        assert!(result.ctxdsl.contains("automaton UartIp {"));
+    }
+
+    #[test]
+    fn composition_name_override_propagates() {
+        let rm = uart_map();
+        let result = compose_codesign_ctxdsl(
+            &rm,
+            SIMPLE_FIRMWARE,
+            &ComposeOptions {
+                composition_name: Some("MyCoupling"),
+                ..ComposeOptions::default()
+            },
+        )
+        .expect("compose succeeds");
+        assert_eq!(result.composition_name, "MyCoupling");
+        assert!(result.ctxdsl.contains("asynchronous MyCoupling"));
+    }
+
+    #[test]
+    fn splicer_handles_braces_inside_comments() {
+        // Comments containing `}` should not confuse the brace counter.
+        let firmware = r#"
+            context Tricky {
+                // here is a } in a line comment
+                /* and one in a block comment } too */
+                alphabet {
+                    label tick;
+                }
+                automata {
+                    automaton A {
+                        states { state S initial; }
+                        transitions { transition S -> S on label tick; }
+                    }
+                }
+            }
+        "#;
+        let rm = uart_map();
+        let result = compose_codesign_ctxdsl(&rm, firmware, &ComposeOptions::default())
+            .expect("compose succeeds");
+        // The peripheral stub block must be inside the context (i.e.
+        // before the outer `}`).
+        let frag_idx = result.ctxdsl.find("automaton UART_LITE {").unwrap();
+        let close_idx = result.ctxdsl.rfind('}').unwrap();
+        assert!(
+            frag_idx < close_idx,
+            "fragment must be inside the outer context block"
+        );
+    }
+}

--- a/crates/mununu-core/src/codesign/coupling.rs
+++ b/crates/mununu-core/src/codesign/coupling.rs
@@ -250,18 +250,22 @@ pub fn emit_peripheral_stub_ctxdsl(rm: &RegisterMap, options: &CouplingOptions<'
 
     // Controllable / internal sets must list every label that is
     // not the default (Uncontrollable in CTXDSL).
-    let controllable: Vec<&RendezvousLabel> = labels
-        .iter()
-        .filter(|l| matches!(l.controllability, LabelControllability::Controllable))
-        .collect();
-    if !controllable.is_empty() {
-        let _ = writeln!(buf, "        controllable {{");
-        for l in &controllable {
-            let _ = writeln!(buf, "            label {};", l.name);
-        }
-        let _ = writeln!(buf, "        }}");
-        let _ = writeln!(buf);
-    }
+    // The peripheral stub MUST NOT claim any rendezvous label as
+    // `controllable`. Firmware drives the `wr_*` labels (the firmware
+    // automaton declares them in its own `controllable { … }` block);
+    // the peripheral merely observes/responds. `rd_*` labels are
+    // chaotic outputs neither side controls. Declaring write labels
+    // as controllable here would conflict with the firmware's
+    // declaration at realise time. The label classifications on
+    // `RendezvousLabel` describe the labels from *firmware's*
+    // perspective and are surfaced for downstream consumers (e.g.
+    // the trace classifier in `codesign::trace`); they do not
+    // determine what the peripheral stub itself declares.
+    //
+    // We deliberately suppress unused-variable lints rather than
+    // dropping the call to `labels`, because `labels` documents
+    // intent and is consumed by the per-register loops below.
+    let _labels = &labels;
 
     let _ = writeln!(buf, "        states {{");
     let _ = writeln!(buf, "            state Idle initial;");
@@ -637,28 +641,24 @@ mod tests {
     }
 
     #[test]
-    fn peripheral_stub_declares_write_labels_as_controllable() {
+    fn peripheral_stub_does_not_emit_a_controllable_block() {
+        // The peripheral stub MUST NOT claim any rendezvous label as
+        // `controllable`. Firmware drives writes (the firmware
+        // automaton declares them); reads are chaotic outputs neither
+        // side controls. Claiming writes here would conflict with the
+        // firmware's declaration at realise time, which the CTXDSL
+        // realiser rejects with a "duplicate controllable label"
+        // error. The label classifications on `RendezvousLabel` are
+        // surfaced for downstream consumers (e.g. the trace
+        // classifier) but do not affect the peripheral stub's own
+        // declarations.
         let m = uart_map();
         let stub = emit_peripheral_stub_ctxdsl(&m, &CouplingOptions::default());
-        // The `controllable { … }` block must list every wr_* label.
-        assert!(stub.contains("controllable {"));
-        assert!(stub.contains("label wr_ctrl_tx_start;"));
-        assert!(stub.contains("label wr_ctrl_enable;"));
-        assert!(stub.contains("label wr_data;"));
-    }
-
-    #[test]
-    fn peripheral_stub_does_not_declare_reads_as_controllable() {
-        let m = uart_map();
-        let stub = emit_peripheral_stub_ctxdsl(&m, &CouplingOptions::default());
-        // No `controllable { label rd_…; }`.
-        let lines = stub.lines().filter(|l| l.contains("controllable"));
-        for line in lines {
-            assert!(
-                !line.contains("rd_"),
-                "read label should not be in controllable block: {line}"
-            );
-        }
+        assert!(
+            !stub.contains("controllable {"),
+            "peripheral stub must not emit a `controllable {{ … }}` block; \
+             firmware owns the wr_* labels"
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/codesign/mod.rs
+++ b/crates/mununu-core/src/codesign/mod.rs
@@ -22,12 +22,16 @@
 //! - **C3 — interleaved trace origin classifier (slice 1)** in
 //!   [`trace`]. Tags trace steps as `[SW]` / `[HW]` / `[BUS]` based on
 //!   a caller-supplied label partition.
+//! - **C4 — codesign composition (slice 1)** in [`compose`]. Splices
+//!   the coupling fragment into a user-authored firmware CTXDSL and
+//!   round-trip-validates the result through the parser. The CLI /
+//!   HTTP surfaces in `mununu-cli` and `api::handlers` consume it.
 //!
-//! Follow-up slices in §C.9 of the design doc: C4 (`mununu codesign
-//! verify` three-surface entry point that consumes the C3 classifier),
-//! C5 (libclang C extraction + `@mununu_*` C wrappers), C6 (IP-XACT /
-//! CMSIS-SVD importer).
+//! Follow-up slices in §C.9 of the design doc: C5 (libclang C
+//! extraction + `@mununu_*` C wrappers), C6 (IP-XACT / CMSIS-SVD
+//! importer).
 
+pub mod compose;
 pub mod coupling;
 pub mod register_map;
 pub mod trace;


### PR DESCRIPTION
## Summary

Fourth slice of **M4** — the user-facing verify entry point. Composes a register-map sidecar with a user-authored firmware CTXDSL, realises the composed context, and evaluates a named formula. **CLI + HTTP wired**; the UI panel lands in a companion mununu-ui PR.

## What lands

### New library — `crates/mununu-core/src/codesign/compose.rs` (~440 lines)

- `compose_codesign_ctxdsl(rm, firmware_ctxdsl, opts) -> ComposeResult` splices the coupling fragment emitted by C2 into the firmware's outer `context { … }` block. The splicer parses the firmware once to discover automata names, emits the fragment with those names, then finds the outer closing `}` via a brace-counting scan that skips line / block comments and string literals.
- `ComposeResult` carries the assembled CTXDSL plus the names used (peripheral automaton, composition name, firmware members) so callers can report what shape the verifier actually ran.
- `ComposeError` enumerates the four failure modes (`FirmwareParseFailed`, `PostSpliceParseFailed`, `NoContextBlock`, `InvalidRegisterMap`) with `Display` impls.
- **Round-trip-verified output**: the final string is parsed once through `context_dsl::parser::parse` before returning. Callers never get a string that won't parse.

### C2 soundness fix

The peripheral stub no longer emits a `controllable { … }` block. Per Doc A §4: firmware drives the `wr_*` rendezvous labels (the firmware automaton declares them); the peripheral merely observes/responds. Claiming them in the peripheral's own controllable block produced a "duplicate controllable label" error at realise time. One C2 test that encoded the buggy behaviour is replaced with the inverted assertion.

### CLI

`mununu codesign verify <register_map> <firmware_ctxdsl> --formula F [--automaton A] [--peripheral-automaton P] [--composition-name N] [--emit-ctxdsl PATH] [--json]`

Default `--automaton` is the codesign composition emitted by the splicer (`<PERIPHERAL>System`). `--emit-ctxdsl` writes the composed document to disk for inspection. `--json` switches to a structured JSON verdict.

### HTTP

`POST /api/v1/codesign/verify` with `CodesignVerifyRequest` (register_map + firmware_ctxdsl + formula + optional overrides) and `CodesignVerifyResponse` (verdict + composition shape + composed CTXDSL). Mirrors the CLI shape for three-surface parity.

## Soundness posture

Composition is asynchronous (Doc C §C.5). The peripheral stub is chaotic. Safety verdicts transfer to any real device whose peripheral behaves at least as chaotically; liveness needs an authored latency contract (Doc A §3 HITL review surface, PR #20).

## Validation

- `cargo fmt --all` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` → **42 suites green**
- `cargo test -p mununu-core --lib codesign` → **51 tests passing** (15 C1 + 17 C2 + 11 C3 + 8 C4)
- End-to-end CLI smoke against UART fixture:

```
$ mununu codesign verify examples/industrial/codesign_uart/register_map.json \
                       /tmp/uart_firmware.ctxdsl \
                       --formula init_reachable
codesign verify — peripheral `UART_LITE` (base 0x40010000), composition `UART_LITESystem`
  composed with firmware member(s): UartDriver

  formula `init_reachable` over `UART_LITESystem`
    states satisfying: 12/12
    initial states satisfying: 1/1
      initials: Idle|Init
      satisfying: Idle|Init
    verdict: HOLDS
```

## C4 slice 1 scope

Slice 1 ships the **compose + verify** entry point. Counterexample trace classification via C3 (`codesign::trace`) is wired conceptually but is currently a no-op in the eval path (which doesn't produce counterexamples — that's the synthesize path). Slice 2 of C4 will chain `codesign::trace::classify_trace_labels` into the synthesize pipeline.

The UI surface lands as a companion mununu-ui PR.

## Test plan

- [ ] CI green
- [ ] Manual: `mununu codesign verify examples/industrial/codesign_uart/register_map.json <fw.ctxdsl> --formula X` produces a sane verdict
- [ ] HTTP: POST a request body to `/api/v1/codesign/verify` and confirm the response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)