### PR TITLE
codesign(L1): shared LLVM-IR parser + clang -emit-llvm shell-out

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -270,6 +270,23 @@ struct CodesignExtractCArgs {
     /// `coupling`-module rendezvous labels.
     #[arg(long = "synthesize-automaton")]
     synthesize_automaton: bool,
+    /// Extraction backend. `ast` (default) walks clang's
+    /// `-ast-dump=json` output. `llvm` shells out to
+    /// `clang -emit-llvm -S` and parses the textual IR — the
+    /// principled-lift path documented in
+    /// `docs/design/c-extraction-correctness-scope.md` §4. Phase L1
+    /// emits a structural IR summary; register-access matching +
+    /// automaton synthesis land in phases L2 and L3.
+    #[arg(long, value_enum, default_value = "ast")]
+    backend: CExtractBackend,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum CExtractBackend {
+    /// Slice-2 AST pattern matching (today's default).
+    Ast,
+    /// Phase-L1+ LLVM-IR lift (principled alternative).
+    Llvm,
 }
 
 #[derive(Args, Debug)]
@@ -905,6 +922,37 @@ fn handle_codesign(command: CodesignCommand) -> Result<(), String> {
 }
 
 fn codesign_extract_c(args: CodesignExtractCArgs) -> Result<(), String> {
+    match args.backend {
+        CExtractBackend::Ast => codesign_extract_c_ast(args),
+        CExtractBackend::Llvm => codesign_extract_c_llvm(args),
+    }
+}
+
+fn codesign_extract_c_llvm(args: CodesignExtractCArgs) -> Result<(), String> {
+    use mununu_core::codesign::c_extract_llvm::{LlvmExtractOptions, extract_c_via_llvm};
+
+    if args.register_map.is_some() || args.synthesize_automaton {
+        return Err(
+            "--backend llvm: --register-map / --synthesize-automaton are not yet implemented (phase L2 / L3)"
+                .to_string(),
+        );
+    }
+
+    let opts = LlvmExtractOptions {
+        clang_path: args.clang,
+        include_paths: args.include_paths,
+        defines: args.defines,
+        extra_clang_args: args.extra_clang_args,
+    };
+    let extraction = extract_c_via_llvm(&args.file, &opts)
+        .map_err(|e| format!("LLVM C extraction failed: {e}"))?;
+    let json = serde_json::to_string_pretty(&extraction)
+        .map_err(|e| format!("failed to serialise extraction: {e}"))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn codesign_extract_c_ast(args: CodesignExtractCArgs) -> Result<(), String> {
     use mununu_core::codesign::c_extract::{CExtractOptions, extract_c_via_clang};
     use mununu_core::codesign::register_map::RegisterMap;
 

--- a/crates/mununu-core/src/codesign/c_extract_llvm.rs
+++ b/crates/mununu-core/src/codesign/c_extract_llvm.rs
@@ -1,0 +1,353 @@
+//! C extraction via LLVM IR — phase L1 of the principled lift.
+//!
+//! Implementation plan:
+//! `~/.claude/plans/i-want-you-to-distributed-orbit.md`.
+//!
+//! ## What phase L1 ships
+//!
+//! - A subprocess shell-out to `clang -O0 -emit-llvm -S` (the same
+//!   binary the AST extractor in [`crate::codesign::c_extract`]
+//!   already invokes; no new tool dependency).
+//! - The textual `.ll` output is parsed by [`crate::llvm_ir`] into a
+//!   structured [`llvm_ir::Module`].
+//! - The structured form is returned to the caller as a JSON dump
+//!   ([`LlvmExtraction`]). **No automaton synthesis yet** — that
+//!   lands in phase L2 (register-access identification) and phase L3
+//!   (polling-loop detection).
+//!
+//! ## Soundness posture
+//!
+//! Same as the AST path: best-effort, with unrecognised IR
+//! instructions preserved as [`llvm_ir::Instruction::Other`] so
+//! downstream consumers can still see them. The parser is a
+//! line-based regex matcher; it tolerates unknown lines without
+//! erroring out.
+
+use crate::llvm_ir::{Module, parse_module};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Errors raised by [`extract_c_via_llvm`].
+#[derive(Debug)]
+pub enum LlvmExtractError {
+    /// `clang` could not be spawned (not installed, not on PATH).
+    ClangNotFound { tried: String, message: String },
+    /// `clang` ran but returned a non-zero exit code.
+    ClangFailed {
+        status: String,
+        stderr: String,
+        invocation: String,
+    },
+    /// `clang` ran cleanly but produced output the IR parser
+    /// rejected.
+    IrParseFailed(String),
+    /// Failed to read the source file before invoking clang.
+    SourceReadFailed { path: PathBuf, message: String },
+}
+
+impl fmt::Display for LlvmExtractError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LlvmExtractError::ClangNotFound { tried, message } => write!(
+                f,
+                "could not spawn clang (tried `{tried}`): {message}. Install via xcode-select --install (macOS) or `apt install clang` (Linux), or pass --clang <path>."
+            ),
+            LlvmExtractError::ClangFailed {
+                status,
+                stderr,
+                invocation,
+            } => write!(
+                f,
+                "clang exited {status}\ninvocation: {invocation}\nstderr:\n{stderr}"
+            ),
+            LlvmExtractError::IrParseFailed(msg) => {
+                write!(f, "LLVM IR parser rejected clang output: {msg}")
+            }
+            LlvmExtractError::SourceReadFailed { path, message } => {
+                write!(
+                    f,
+                    "failed to read source file {}: {message}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for LlvmExtractError {}
+
+/// Configuration for [`extract_c_via_llvm`]. Mirrors the AST path's
+/// `CExtractOptions` shape so a CLI / API can thread options through
+/// either backend transparently.
+#[derive(Debug, Clone, Default)]
+pub struct LlvmExtractOptions {
+    /// Path to the `clang` binary. Default: `clang` (resolved via
+    /// PATH).
+    pub clang_path: Option<PathBuf>,
+    /// Additional include paths (`-I`).
+    pub include_paths: Vec<PathBuf>,
+    /// Preprocessor defines (`-D`).
+    pub defines: Vec<String>,
+    /// Extra raw arguments to clang.
+    pub extra_clang_args: Vec<String>,
+}
+
+/// Output of [`extract_c_via_llvm`]. Phase L1 emits the parsed IR as
+/// a JSON record so the CLI / HTTP surface can inspect what clang
+/// produced.
+///
+/// **Note**: the structured [`llvm_ir::Module`] is not yet
+/// `Serialize` — phase L1 emits a *summary* (function names,
+/// per-function basic-block + instruction counts, register-touching
+/// candidates) for diagnostic purposes. Phase L2 will replace this
+/// with a richer `RegisterAccess` list once the matcher lands.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlvmExtraction {
+    /// Source filename as recorded by clang.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_filename: Option<String>,
+    /// Target triple from the `.ll` header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_triple: Option<String>,
+    /// Per-function structural summary.
+    pub functions: Vec<LlvmFunctionSummary>,
+    /// Module-level external globals (typical for peripheral base
+    /// pointers like `@UART`).
+    pub external_globals: Vec<String>,
+    /// Named struct types declared at module scope (peripheral
+    /// register-bank layouts typically land here).
+    pub struct_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlvmFunctionSummary {
+    pub name: String,
+    pub return_type: String,
+    pub num_parameters: usize,
+    pub num_basic_blocks: usize,
+    pub num_instructions: usize,
+    /// Number of `load volatile` / `store volatile` instructions —
+    /// the candidate register accesses phase L2 will match against
+    /// the register map.
+    pub num_volatile_loads: usize,
+    pub num_volatile_stores: usize,
+    /// Number of `inttoptr` instructions — the candidate
+    /// MMIO-by-literal-address accesses (the Example 2 idiom).
+    pub num_inttoptr: usize,
+}
+
+/// Extract LLVM IR from a C source file and produce a structural
+/// summary.
+pub fn extract_c_via_llvm(
+    source_path: &Path,
+    options: &LlvmExtractOptions,
+) -> Result<LlvmExtraction, LlvmExtractError> {
+    // Touch the file to surface a friendly error before clang runs.
+    if !source_path.exists() {
+        return Err(LlvmExtractError::SourceReadFailed {
+            path: source_path.to_path_buf(),
+            message: "file not found".to_string(),
+        });
+    }
+
+    let clang = options
+        .clang_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("clang"));
+
+    let mut cmd = Command::new(&clang);
+    cmd.arg("-O0")
+        .arg("-emit-llvm")
+        .arg("-S")
+        .arg("-o")
+        .arg("-") // stdout
+        .arg("-fno-color-diagnostics");
+    for inc in &options.include_paths {
+        cmd.arg("-I").arg(inc);
+    }
+    for define in &options.defines {
+        cmd.arg(format!("-D{define}"));
+    }
+    for raw in &options.extra_clang_args {
+        cmd.arg(raw);
+    }
+    cmd.arg(source_path);
+
+    let invocation = format!("{cmd:?}");
+    let output = cmd.output().map_err(|e| LlvmExtractError::ClangNotFound {
+        tried: clang.display().to_string(),
+        message: e.to_string(),
+    })?;
+    if !output.status.success() {
+        return Err(LlvmExtractError::ClangFailed {
+            status: format!("{}", output.status),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            invocation,
+        });
+    }
+    let ir_text = String::from_utf8_lossy(&output.stdout).into_owned();
+    extract_from_ir_text(&ir_text)
+}
+
+/// Pure-function half of the extractor — takes an IR text and
+/// produces the summary. Separated from [`extract_c_via_llvm`] so
+/// tests can drive it without needing clang on `$PATH`.
+pub fn extract_from_ir_text(ir_text: &str) -> Result<LlvmExtraction, LlvmExtractError> {
+    let module: Module =
+        parse_module(ir_text).map_err(|e| LlvmExtractError::IrParseFailed(e.to_string()))?;
+    Ok(summarise(&module))
+}
+
+fn summarise(module: &Module) -> LlvmExtraction {
+    use crate::llvm_ir::{GlobalKind, Instruction};
+
+    let external_globals: Vec<String> = module
+        .globals
+        .iter()
+        .filter(|g| {
+            g.linkage.iter().any(|l| l == "external") || matches!(g.kind, GlobalKind::Constant)
+        })
+        .map(|g| g.name.clone())
+        .collect();
+
+    let struct_types: Vec<String> = module.struct_types.keys().cloned().collect();
+
+    let functions = module
+        .functions
+        .iter()
+        .map(|f| {
+            let num_instructions: usize = f.basic_blocks.iter().map(|b| b.instructions.len()).sum();
+            let num_volatile_loads = f
+                .basic_blocks
+                .iter()
+                .flat_map(|b| &b.instructions)
+                .filter(|i| matches!(i, Instruction::Load { volatile: true, .. }))
+                .count();
+            let num_volatile_stores = f
+                .basic_blocks
+                .iter()
+                .flat_map(|b| &b.instructions)
+                .filter(|i| matches!(i, Instruction::Store { volatile: true, .. }))
+                .count();
+            let num_inttoptr = f
+                .basic_blocks
+                .iter()
+                .flat_map(|b| &b.instructions)
+                .filter(|i| matches!(i, Instruction::IntToPtr { .. }))
+                .count();
+            LlvmFunctionSummary {
+                name: f.name.clone(),
+                return_type: f.return_type.clone(),
+                num_parameters: f.parameters.len(),
+                num_basic_blocks: f.basic_blocks.len(),
+                num_instructions,
+                num_volatile_loads,
+                num_volatile_stores,
+                num_inttoptr,
+            }
+        })
+        .collect();
+
+    LlvmExtraction {
+        source_filename: module.source_filename.clone(),
+        target_triple: module.target_triple.clone(),
+        functions,
+        external_globals,
+        struct_types,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIRMWARE_IR: &str = r#"; ModuleID = 'firmware.c'
+source_filename = "firmware.c"
+target triple = "x86_64-apple-macosx26.0.0"
+
+%struct.UART_TypeDef = type { %union.anon, %union.anon.0, %union.anon.2 }
+
+@UART = external constant ptr, align 8
+
+define void @uart_send(i8 noundef zeroext %0) {
+  %2 = alloca i8, align 1
+  store i8 %0, ptr %2, align 1
+  br label %3
+
+3:
+  %4 = load ptr, ptr @UART, align 8
+  %5 = getelementptr inbounds %struct.UART_TypeDef, ptr %4, i32 0, i32 1
+  %6 = load volatile i32, ptr %5, align 4
+  %7 = and i32 %6, 1
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %9, label %10
+
+9:
+  br label %3
+
+10:
+  %11 = load i8, ptr %2, align 1
+  %12 = load ptr, ptr @UART, align 8
+  %13 = getelementptr inbounds %struct.UART_TypeDef, ptr %12, i32 0, i32 2
+  store volatile i8 %11, ptr %13, align 4
+  ret void
+}
+"#;
+
+    #[test]
+    fn summarises_uart_send_function() {
+        let ext = extract_from_ir_text(FIRMWARE_IR).unwrap();
+        assert_eq!(ext.functions.len(), 1);
+        let f = &ext.functions[0];
+        assert_eq!(f.name, "uart_send");
+        assert_eq!(f.return_type, "void");
+        assert_eq!(f.num_parameters, 1);
+        // entry + %3 + %9 + %10
+        assert_eq!(f.num_basic_blocks, 4);
+        assert_eq!(f.num_volatile_loads, 1);
+        assert_eq!(f.num_volatile_stores, 1);
+        assert_eq!(f.num_inttoptr, 0);
+    }
+
+    #[test]
+    fn surfaces_external_globals_and_struct_types() {
+        let ext = extract_from_ir_text(FIRMWARE_IR).unwrap();
+        assert!(ext.external_globals.contains(&"UART".to_string()));
+        assert!(ext.struct_types.iter().any(|s| s == "%struct.UART_TypeDef"));
+    }
+
+    #[test]
+    fn summary_round_trips_through_serde() {
+        let ext = extract_from_ir_text(FIRMWARE_IR).unwrap();
+        let json = serde_json::to_string_pretty(&ext).unwrap();
+        let parsed: LlvmExtraction = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.functions.len(), 1);
+        assert_eq!(parsed.functions[0].name, "uart_send");
+    }
+
+    #[test]
+    fn empty_ir_input_errors() {
+        assert!(matches!(
+            extract_from_ir_text("").unwrap_err(),
+            LlvmExtractError::IrParseFailed(_)
+        ));
+    }
+
+    #[test]
+    fn counts_inttoptr_register_access_candidates() {
+        let ir = r#"define void @enable_pll() {
+  %1 = inttoptr i64 1073887232 to ptr
+  %2 = load volatile i32, ptr %1, align 4
+  %3 = or i32 %2, 16777216
+  store volatile i32 %3, ptr %1, align 4
+  ret void
+}
+"#;
+        let ext = extract_from_ir_text(ir).unwrap();
+        assert_eq!(ext.functions[0].num_inttoptr, 1);
+        assert_eq!(ext.functions[0].num_volatile_loads, 1);
+        assert_eq!(ext.functions[0].num_volatile_stores, 1);
+    }
+}

--- a/crates/mununu-core/src/codesign/mod.rs
+++ b/crates/mununu-core/src/codesign/mod.rs
@@ -36,6 +36,7 @@
 //! importers are deferred sibling tasks under C6's umbrella.
 
 pub mod c_extract;
+pub mod c_extract_llvm;
 pub mod compose;
 pub mod coupling;
 pub mod register_map;

--- a/crates/mununu-core/src/lib.rs
+++ b/crates/mununu-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod corpus;
 pub mod examples;
 pub mod guard;
 pub mod iter;
+pub mod llvm_ir;
 pub mod ltl;
 pub mod mu_calculus;
 pub mod mununu_annotations;

--- a/crates/mununu-core/src/llvm_ir/mod.rs
+++ b/crates/mununu-core/src/llvm_ir/mod.rs
@@ -1,0 +1,55 @@
+//! Shared LLVM IR types + line-based regex parser — phase L1 of the
+//! C-extraction principled lift.
+//!
+//! The shape and design is documented in
+//! [`docs/design/c-extraction-correctness-scope.md`](../../../docs/design/c-extraction-correctness-scope.md)
+//! and the implementation plan at
+//! `~/.claude/plans/i-want-you-to-distributed-orbit.md`.
+//!
+//! ## What this module is
+//!
+//! A language-neutral parser for LLVM IR (textual `.ll` output of
+//! `clang -emit-llvm -S` or `rustc --emit=llvm-ir`). It covers the
+//! instruction shapes mununu's two extractor pipelines need:
+//!
+//! - **C codesign extraction** (Doc C task C5 — see [`crate::codesign::c_extract`]
+//!   once the LLVM backend lands) reads firmware C code and lifts
+//!   `load volatile` / `store volatile` accesses against a register
+//!   map. It needs `inttoptr` literals, GEP chains rooted at external
+//!   globals, and load-modify-store bit-field sequences.
+//! - **Rust source extraction** (existing `mununu-extract --backend
+//!   llvm`) reads `rustc` IR and lifts method-level field accesses on
+//!   `%self`-rooted GEPs. It needs `define` headers with arbitrary
+//!   parameter lists, basic-block labels with the standard
+//!   `; preds = …` comment, and the same load/store/GEP/icmp/branch
+//!   subset.
+//!
+//! The shared types in [`types`] sit underneath both consumers; the
+//! shared parser in [`parser`] handles the language-neutral parts.
+//! Language-specific post-processing (Rust demangling, C register-map
+//! matching) lives in the consumer crate.
+//!
+//! ## Why a regex parser
+//!
+//! Same trade-off as the rest of mununu's pragmatic choices: zero new
+//! Rust build-time dependencies, fast to ship, easy to audit. The
+//! textual IR format is stable across LLVM versions back to ~10. We
+//! parse only the instruction shapes we need; unknown lines fall
+//! through to [`Instruction::Other`] which preserves them as raw
+//! text for diagnostics.
+//!
+//! A true IR consumer (`llvm-sys`, `inkwell`, parsing bitcode
+//! directly) is the principled-er alternative; it's the same kind of
+//! "build dependency vs hand-rolled parser" decision as
+//! [`crate::codesign::c_extract`] makes for the AST path. When a real
+//! case demands proper type-info-aware analysis, this module is the
+//! seam to replace.
+
+pub mod parser;
+pub mod types;
+
+pub use parser::{ParseError, parse_module};
+pub use types::{
+    BasicBlock, BinaryOp, CastKind, Function, FunctionParameter, GepIndex, Global, GlobalKind,
+    IcmpPred, Instruction, Module, PointerOperand, StructType, Terminator, ValueOperand,
+};

--- a/crates/mununu-core/src/llvm_ir/parser.rs
+++ b/crates/mununu-core/src/llvm_ir/parser.rs
@@ -1,0 +1,823 @@
+//! Line-based regex parser for LLVM IR text.
+//!
+//! Handles the textual `.ll` output of `clang -emit-llvm -S` and
+//! `rustc --emit=llvm-ir`. The parser is intentionally
+//! conservative: it recognises the instruction shapes mununu's two
+//! consumers (C codesign extraction, Rust source extraction) need
+//! today, and falls through to [`Instruction::Other`] for anything
+//! else.
+//!
+//! ## Soundness posture
+//!
+//! Parsing is **best-effort and forward-only**: each line is matched
+//! against a regex; the first matching regex wins. Mis-parses become
+//! [`Instruction::Other`]. The parser does *not* validate that the
+//! IR is well-formed — it trusts clang/rustc to emit correct IR.
+//!
+//! ## What is *not* in scope
+//!
+//! - Metadata nodes (`!N = …`) — skipped silently. Phase L3+ may
+//!   need `!llvm.loop` metadata for loop-detection; the parser will
+//!   gain that targeted support when it's needed.
+//! - Inline assembly (`call void asm "…"`).
+//! - Vector / aggregate constants beyond simple `i32 N` indices.
+//! - Floating-point operations.
+//! - Most attribute groups (`attributes #N = { … }`) — skipped.
+
+use crate::llvm_ir::types::*;
+use regex::Regex;
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+/// Errors raised by [`parse_module`].
+#[derive(Debug, Clone)]
+pub enum ParseError {
+    /// The input was empty.
+    EmptyInput,
+    /// A `define` line was malformed.
+    MalformedDefine(String),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::EmptyInput => write!(f, "empty IR input"),
+            ParseError::MalformedDefine(line) => {
+                write!(f, "could not parse `define` line: {line}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+struct Regexes {
+    source_filename: Regex,
+    data_layout: Regex,
+    target_triple: Regex,
+    struct_type: Regex,
+    global: Regex,
+    define: Regex,
+    bb_label: Regex,
+    preds_comment: Regex,
+
+    // Instructions
+    alloca: Regex,
+    load: Regex,
+    store: Regex,
+    gep: Regex,
+    inttoptr: Regex,
+    ptrtoint: Regex,
+    bitcast: Regex,
+    trunc: Regex,
+    zext: Regex,
+    sext: Regex,
+    binop: Regex,
+    icmp: Regex,
+    call: Regex,
+    phi: Regex,
+
+    // Terminators
+    ret: Regex,
+    br_cond: Regex,
+    br: Regex,
+}
+
+fn regexes() -> &'static Regexes {
+    static R: OnceLock<Regexes> = OnceLock::new();
+    R.get_or_init(|| Regexes {
+        source_filename: Regex::new(r#"^\s*source_filename\s*=\s*"(.+)""#).unwrap(),
+        data_layout: Regex::new(r#"^\s*target\s+datalayout\s*=\s*"(.+)""#).unwrap(),
+        target_triple: Regex::new(r#"^\s*target\s+triple\s*=\s*"(.+)""#).unwrap(),
+        struct_type: Regex::new(r#"^\s*%([\w."]+?)\s*=\s*type\s*\{(.*)\}\s*$"#).unwrap(),
+        global: Regex::new(
+            r"^\s*@([\w.]+)\s*=\s*((?:[\w_]+\s+)*)(constant|global)\s+(\S+)(?:.*?align\s+(\d+))?",
+        )
+        .unwrap(),
+        define: Regex::new(r"^\s*define\s+(?:[^@]*?\s)?(\S+)\s+@([\w.]+)\((.*?)\)").unwrap(),
+        bb_label: Regex::new(r"^(\w+):\s*(?:;.*)?$").unwrap(),
+        preds_comment: Regex::new(r";\s*preds\s*=\s*(.+?)\s*$").unwrap(),
+
+        alloca: Regex::new(r"^\s*%(\w+)\s*=\s*alloca\s+([^,]+?)(?:,\s*align\s+(\d+))?\s*$")
+            .unwrap(),
+        load: Regex::new(
+            r"^\s*%(\w+)\s*=\s*load\s+(volatile\s+)?([^,]+?),\s*ptr\s+(\S+?)(?:,\s*align\s+(\d+))?\s*$",
+        )
+        .unwrap(),
+        store: Regex::new(
+            r"^\s*store\s+(volatile\s+)?(\S+)\s+(\S+?),\s*ptr\s+(\S+?)(?:,\s*align\s+(\d+))?\s*$",
+        )
+        .unwrap(),
+        gep: Regex::new(
+            r"^\s*%(\w+)\s*=\s*getelementptr\s+(inbounds\s+)?(\S+?),\s*ptr\s+(\S+?)(.+)\s*$",
+        )
+        .unwrap(),
+        inttoptr: Regex::new(r"^\s*%(\w+)\s*=\s*inttoptr\s+\S+\s+(\S+)\s+to\s+ptr\s*$").unwrap(),
+        ptrtoint: Regex::new(r"^\s*%(\w+)\s*=\s*ptrtoint\s+ptr\s+(\S+)\s+to\s+\S+\s*$").unwrap(),
+        bitcast: Regex::new(r"^\s*%(\w+)\s*=\s*bitcast\s+\S+\s+(\S+)\s+to\s+\S+\s*$").unwrap(),
+        trunc: Regex::new(r"^\s*%(\w+)\s*=\s*trunc\s+\S+\s+(\S+)\s+to\s+\S+\s*$").unwrap(),
+        zext: Regex::new(r"^\s*%(\w+)\s*=\s*zext\s+\S+\s+(\S+)\s+to\s+\S+\s*$").unwrap(),
+        sext: Regex::new(r"^\s*%(\w+)\s*=\s*sext\s+\S+\s+(\S+)\s+to\s+\S+\s*$").unwrap(),
+        binop: Regex::new(
+            r"^\s*%(\w+)\s*=\s*(add|sub|mul|udiv|sdiv|urem|srem|shl|lshr|ashr|and|or|xor)\s+(?:nuw\s+|nsw\s+|exact\s+)*(\S+)\s+(\S+?),\s+(\S+?)\s*$",
+        )
+        .unwrap(),
+        icmp: Regex::new(
+            r"^\s*%(\w+)\s*=\s*icmp\s+(eq|ne|ugt|uge|ult|ule|sgt|sge|slt|sle)\s+(\S+)\s+(\S+?),\s+(\S+?)\s*$",
+        )
+        .unwrap(),
+        // call covers both `%r = call ...` and `call ...`
+        call: Regex::new(
+            r"^\s*(?:%(\w+)\s*=\s*)?(?:tail\s+|musttail\s+|notail\s+)?call\s+(?:\S+\s+)?(\S+?)\s+@([\w.]+)\((.*?)\)",
+        )
+        .unwrap(),
+        phi: Regex::new(r"^\s*%(\w+)\s*=\s*phi\s+(\S+)\s+(.+)\s*$").unwrap(),
+
+        ret: Regex::new(r"^\s*ret\s+(?:(void)|(\S+)\s+(.+?))\s*$").unwrap(),
+        br_cond: Regex::new(
+            r"^\s*br\s+i1\s+(\S+?),\s+label\s+%(\w+),\s+label\s+%(\w+)\s*$",
+        )
+        .unwrap(),
+        br: Regex::new(r"^\s*br\s+label\s+%(\w+)").unwrap(),
+    })
+}
+
+/// Parse an LLVM IR text module into structured form.
+pub fn parse_module(ir_text: &str) -> Result<Module, ParseError> {
+    if ir_text.trim().is_empty() {
+        return Err(ParseError::EmptyInput);
+    }
+    let r = regexes();
+    let mut module = Module::default();
+
+    // Per-function in-progress state.
+    let mut current_fn: Option<Function> = None;
+    let mut current_bb: Option<BasicBlock> = None;
+
+    for raw_line in ir_text.lines() {
+        let line = strip_trailing_metadata(raw_line);
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with(';') {
+            continue;
+        }
+
+        // Top-level: module header lines + struct/global declarations.
+        if current_fn.is_none() {
+            if let Some(caps) = r.source_filename.captures(line) {
+                module.source_filename = Some(caps[1].to_string());
+                continue;
+            }
+            if let Some(caps) = r.data_layout.captures(line) {
+                module.data_layout = Some(caps[1].to_string());
+                continue;
+            }
+            if let Some(caps) = r.target_triple.captures(line) {
+                module.target_triple = Some(caps[1].to_string());
+                continue;
+            }
+            if let Some(caps) = r.struct_type.captures(line) {
+                let name = format!("%{}", &caps[1]);
+                let fields: Vec<String> = caps[2]
+                    .split(',')
+                    .map(|f| f.trim().to_string())
+                    .filter(|f| !f.is_empty())
+                    .collect();
+                let st = StructType {
+                    name: name.clone(),
+                    fields,
+                };
+                module.struct_types.insert(name, st);
+                continue;
+            }
+            if let Some(caps) = r.global.captures(line) {
+                let linkage: Vec<String> = caps
+                    .get(2)
+                    .map(|m| {
+                        m.as_str()
+                            .split_whitespace()
+                            .map(|s| s.to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let kind = match &caps[3] {
+                    "constant" => GlobalKind::Constant,
+                    _ => GlobalKind::Global,
+                };
+                let ty = caps[4].trim_end_matches(',').to_string();
+                let align = caps.get(5).and_then(|m| m.as_str().parse().ok());
+                module.globals.push(Global {
+                    name: caps[1].to_string(),
+                    linkage,
+                    kind,
+                    ty,
+                    align,
+                });
+                continue;
+            }
+            if let Some(caps) = r.define.captures(line) {
+                let return_type = caps[1].to_string();
+                let name = caps[2].to_string();
+                let params = parse_parameters(&caps[3]);
+                current_fn = Some(Function {
+                    name,
+                    return_type,
+                    parameters: params,
+                    attributes: Vec::new(),
+                    basic_blocks: Vec::new(),
+                });
+                // Start the implicit entry block — clang doesn't
+                // emit a label for it.
+                current_bb = Some(BasicBlock {
+                    label: "entry".to_string(),
+                    predecessors: Vec::new(),
+                    instructions: Vec::new(),
+                    terminator: Terminator::Unreachable,
+                });
+                continue;
+            }
+            // Unrecognised top-level line — skip silently. Could be
+            // attribute group, metadata, !llvm.module.flags, etc.
+            continue;
+        }
+
+        // Inside a function. Check for end-of-function brace.
+        if trimmed == "}" {
+            if let Some(bb) = current_bb.take()
+                && let Some(func) = current_fn.as_mut()
+            {
+                func.basic_blocks.push(bb);
+            }
+            if let Some(func) = current_fn.take() {
+                module.functions.push(func);
+            }
+            continue;
+        }
+
+        // Basic-block label line.
+        if let Some(caps) = r.bb_label.captures(trimmed) {
+            // Flush the current basic block before starting a new one.
+            if let Some(bb) = current_bb.take()
+                && let Some(func) = current_fn.as_mut()
+            {
+                func.basic_blocks.push(bb);
+            }
+            let preds = r
+                .preds_comment
+                .captures(raw_line)
+                .map(|c| {
+                    c[1].split(',')
+                        .map(|p| p.trim().trim_start_matches('%').to_string())
+                        .collect()
+                })
+                .unwrap_or_default();
+            current_bb = Some(BasicBlock {
+                label: caps[1].to_string(),
+                predecessors: preds,
+                instructions: Vec::new(),
+                terminator: Terminator::Unreachable,
+            });
+            continue;
+        }
+
+        // An instruction line inside the current basic block.
+        let Some(bb) = current_bb.as_mut() else {
+            continue;
+        };
+        match parse_instruction_or_terminator(line, r) {
+            ParsedLine::Instruction(instr) => bb.instructions.push(instr),
+            ParsedLine::Terminator(term) => bb.terminator = term,
+        }
+    }
+
+    // Defensive: if the file ended without a `}` close brace, flush
+    // whatever we accumulated.
+    if let Some(bb) = current_bb.take()
+        && let Some(mut func) = current_fn.take()
+    {
+        func.basic_blocks.push(bb);
+        module.functions.push(func);
+    }
+
+    Ok(module)
+}
+
+enum ParsedLine {
+    Instruction(Instruction),
+    Terminator(Terminator),
+}
+
+/// Try every regex in turn; the first match wins. Anything unknown
+/// becomes `Instruction::Other(raw_line)`.
+fn parse_instruction_or_terminator(line: &str, r: &Regexes) -> ParsedLine {
+    // Terminators first (`br` and `ret` are unambiguous).
+    if let Some(caps) = r.br_cond.captures(line) {
+        return ParsedLine::Terminator(Terminator::BrCond {
+            cond: ValueOperand::parse(&caps[1]),
+            if_true: caps[2].to_string(),
+            if_false: caps[3].to_string(),
+        });
+    }
+    if let Some(caps) = r.br.captures(line) {
+        return ParsedLine::Terminator(Terminator::Br {
+            target: caps[1].to_string(),
+        });
+    }
+    if let Some(caps) = r.ret.captures(line) {
+        let value = if caps.get(1).is_some() {
+            None
+        } else {
+            caps.get(3).map(|m| ValueOperand::parse(m.as_str()))
+        };
+        return ParsedLine::Terminator(Terminator::Ret { value });
+    }
+    if line.trim() == "unreachable" {
+        return ParsedLine::Terminator(Terminator::Unreachable);
+    }
+
+    // Instructions.
+    if let Some(caps) = r.alloca.captures(line) {
+        return ParsedLine::Instruction(Instruction::Alloca {
+            result: caps[1].to_string(),
+            ty: caps[2].trim().to_string(),
+            align: caps.get(3).and_then(|m| m.as_str().parse().ok()),
+        });
+    }
+    if let Some(caps) = r.load.captures(line) {
+        return ParsedLine::Instruction(Instruction::Load {
+            result: caps[1].to_string(),
+            volatile: caps.get(2).is_some(),
+            ty: caps[3].trim().to_string(),
+            source: parse_pointer_operand(&caps[4]),
+            align: caps.get(5).and_then(|m| m.as_str().parse().ok()),
+        });
+    }
+    if let Some(caps) = r.store.captures(line) {
+        return ParsedLine::Instruction(Instruction::Store {
+            volatile: caps.get(1).is_some(),
+            ty: caps[2].to_string(),
+            value: ValueOperand::parse(&caps[3]),
+            dest: parse_pointer_operand(&caps[4]),
+            align: caps.get(5).and_then(|m| m.as_str().parse().ok()),
+        });
+    }
+    if let Some(caps) = r.gep.captures(line) {
+        let indices_text = caps[5].trim_start_matches(',').trim();
+        return ParsedLine::Instruction(Instruction::Gep {
+            result: caps[1].to_string(),
+            in_bounds: caps.get(2).is_some(),
+            ty: caps[3].to_string(),
+            base: parse_pointer_operand(&caps[4]),
+            indices: parse_gep_indices(indices_text),
+        });
+    }
+    if let Some(caps) = r.inttoptr.captures(line) {
+        let raw = caps[2].trim();
+        let value: u64 = parse_int_literal(raw).unwrap_or(0);
+        return ParsedLine::Instruction(Instruction::IntToPtr {
+            result: caps[1].to_string(),
+            value,
+        });
+    }
+    if let Some(caps) = r.ptrtoint.captures(line) {
+        return ParsedLine::Instruction(Instruction::PtrToInt {
+            result: caps[1].to_string(),
+            source: caps[2].trim_start_matches('%').to_string(),
+        });
+    }
+    if let Some(caps) = r.bitcast.captures(line) {
+        return ParsedLine::Instruction(Instruction::Bitcast {
+            result: caps[1].to_string(),
+            source: caps[2].trim_start_matches('%').to_string(),
+        });
+    }
+    if let Some(caps) = r.trunc.captures(line) {
+        return ParsedLine::Instruction(Instruction::Trunc {
+            result: caps[1].to_string(),
+            source: caps[2].trim_start_matches('%').to_string(),
+        });
+    }
+    if let Some(caps) = r.zext.captures(line) {
+        return ParsedLine::Instruction(Instruction::ZExt {
+            result: caps[1].to_string(),
+            source: caps[2].trim_start_matches('%').to_string(),
+        });
+    }
+    if let Some(caps) = r.sext.captures(line) {
+        return ParsedLine::Instruction(Instruction::SExt {
+            result: caps[1].to_string(),
+            source: caps[2].trim_start_matches('%').to_string(),
+        });
+    }
+    if let Some(caps) = r.binop.captures(line) {
+        return ParsedLine::Instruction(Instruction::BinaryOp {
+            result: caps[1].to_string(),
+            op: BinaryOp::parse(&caps[2]).expect("regex restricts to known ops"),
+            ty: caps[3].to_string(),
+            a: ValueOperand::parse(&caps[4]),
+            b: ValueOperand::parse(&caps[5]),
+        });
+    }
+    if let Some(caps) = r.icmp.captures(line) {
+        return ParsedLine::Instruction(Instruction::Icmp {
+            result: caps[1].to_string(),
+            pred: IcmpPred::parse(&caps[2]).expect("regex restricts to known preds"),
+            ty: caps[3].to_string(),
+            a: ValueOperand::parse(&caps[4]),
+            b: ValueOperand::parse(&caps[5]),
+        });
+    }
+    if let Some(caps) = r.call.captures(line) {
+        let args: Vec<String> = caps[4]
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        return ParsedLine::Instruction(Instruction::Call {
+            result: caps.get(1).map(|m| m.as_str().to_string()),
+            return_ty: caps[2].to_string(),
+            callee: caps[3].to_string(),
+            args,
+        });
+    }
+    if let Some(caps) = r.phi.captures(line) {
+        let incoming = parse_phi_incoming(&caps[3]);
+        return ParsedLine::Instruction(Instruction::Phi {
+            result: caps[1].to_string(),
+            ty: caps[2].to_string(),
+            incoming,
+        });
+    }
+
+    ParsedLine::Instruction(Instruction::Other(line.trim().to_string()))
+}
+
+fn parse_parameters(text: &str) -> Vec<FunctionParameter> {
+    text.split(',')
+        .filter_map(|raw| {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            // Each parameter looks like `<type> [<attrs>...] [%name]`.
+            // We scan for the first whitespace-separated `%name`
+            // token and treat everything before it as the type.
+            let mut name: Option<String> = None;
+            let mut ty_parts: Vec<&str> = Vec::new();
+            for token in trimmed.split_whitespace() {
+                if let Some(rest) = token.strip_prefix('%') {
+                    name = Some(rest.to_string());
+                    break;
+                }
+                // Skip known attribute tokens that pad the type list.
+                if !matches!(
+                    token,
+                    "noundef" | "zeroext" | "signext" | "readonly" | "nocapture" | "nonnull"
+                ) {
+                    ty_parts.push(token);
+                }
+            }
+            Some(FunctionParameter {
+                ty: ty_parts.join(" "),
+                name,
+            })
+        })
+        .collect()
+}
+
+fn parse_gep_indices(text: &str) -> Vec<GepIndex> {
+    let mut out = Vec::new();
+    // Indices come as `i32 0, i32 1` or `i64 %5, i32 1`. Pair tokens
+    // up as (type, value).
+    let parts: Vec<&str> = text
+        .split(',')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .collect();
+    for part in parts {
+        let value_token = part.split_whitespace().nth(1).unwrap_or("");
+        if let Some(rest) = value_token.strip_prefix('%') {
+            out.push(GepIndex::Dynamic(rest.to_string()));
+        } else if let Ok(n) = value_token.parse::<i64>() {
+            out.push(GepIndex::Const(n));
+        } else if let Some(hex) = value_token.strip_prefix("0x")
+            && let Ok(n) = i64::from_str_radix(hex, 16)
+        {
+            out.push(GepIndex::Const(n));
+        }
+    }
+    out
+}
+
+fn parse_pointer_operand(text: &str) -> PointerOperand {
+    let trimmed = text.trim().trim_end_matches(',');
+    if let Some(rest) = trimmed.strip_prefix('@') {
+        return PointerOperand::Global(rest.to_string());
+    }
+    if let Some(rest) = trimmed.strip_prefix('%') {
+        return PointerOperand::Ssa(rest.to_string());
+    }
+    // Inline `inttoptr (i64 0x40010000 to ptr)` literal.
+    if let Some(inner) = trimmed
+        .strip_prefix("inttoptr")
+        .and_then(|s| s.trim().strip_prefix('('))
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        // inner is e.g. "i64 0x40010000 to ptr"
+        let mut tokens = inner.split_whitespace();
+        let _ty = tokens.next();
+        if let Some(value_tok) = tokens.next()
+            && let Some(v) = parse_int_literal(value_tok)
+        {
+            return PointerOperand::InlineConstAddr(v);
+        }
+    }
+    PointerOperand::Ssa(trimmed.to_string())
+}
+
+fn parse_int_literal(s: &str) -> Option<u64> {
+    let s = s.trim().trim_end_matches(',');
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        return u64::from_str_radix(hex, 16).ok();
+    }
+    if let Some(suffix) = s.strip_suffix('u') {
+        return suffix.parse().ok();
+    }
+    s.parse().ok()
+}
+
+fn parse_phi_incoming(text: &str) -> Vec<(ValueOperand, String)> {
+    // Phi entries look like `[ %v0, %bb0 ], [ %v1, %bb1 ]`.
+    let mut out = Vec::new();
+    for entry in text.split("],") {
+        let trimmed = entry
+            .trim()
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .trim();
+        let parts: Vec<&str> = trimmed.split(',').map(str::trim).collect();
+        if parts.len() == 2 {
+            out.push((
+                ValueOperand::parse(parts[0]),
+                parts[1].trim_start_matches('%').to_string(),
+            ));
+        }
+    }
+    out
+}
+
+/// Drop trailing `!metadata, !N, !something` annotations from a line
+/// so the instruction regexes don't have to account for them.
+fn strip_trailing_metadata(line: &str) -> &str {
+    // Find ", !" — that marks the start of a metadata-annotation
+    // suffix on an instruction (e.g. `br label %3, !llvm.loop !6`).
+    if let Some(idx) = line.find(", !") {
+        return &line[..idx];
+    }
+    line
+}
+
+// Silence an unused-import warning once `BTreeMap` is only used in
+// types.rs. (Defensive — currently the parser uses it directly.)
+#[allow(dead_code)]
+fn _btreemap_dependency_anchor() -> BTreeMap<String, String> {
+    BTreeMap::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The IR from `clang -O0 -emit-llvm -S firmware.c` for the
+    /// codesign_uart example. Pasted as a `&str` so the tests don't
+    /// require clang to be available.
+    const FIRMWARE_EXTERN_IR: &str = r#"; ModuleID = 'firmware.c'
+source_filename = "firmware.c"
+target datalayout = "e-m:o"
+target triple = "x86_64-apple-macosx26.0.0"
+
+%struct.UART_TypeDef = type { %union.anon, %union.anon.0, %union.anon.2 }
+%union.anon = type { i32 }
+%union.anon.0 = type { i32 }
+%union.anon.2 = type { i32 }
+
+@UART = external constant ptr, align 8
+
+define void @uart_send(i8 noundef zeroext %0) #0 {
+  %2 = alloca i8, align 1
+  store i8 %0, ptr %2, align 1
+  br label %3
+
+3:                                                ; preds = %9, %1
+  %4 = load ptr, ptr @UART, align 8
+  %5 = getelementptr inbounds %struct.UART_TypeDef, ptr %4, i32 0, i32 1
+  %6 = load volatile i32, ptr %5, align 4
+  %7 = and i32 %6, 1
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %9, label %10
+
+9:                                                ; preds = %3
+  br label %3, !llvm.loop !6
+
+10:                                               ; preds = %3
+  %11 = load i8, ptr %2, align 1
+  %12 = load ptr, ptr @UART, align 8
+  %13 = getelementptr inbounds %struct.UART_TypeDef, ptr %12, i32 0, i32 2
+  store volatile i8 %11, ptr %13, align 4
+  ret void
+}
+"#;
+
+    #[test]
+    fn parses_module_header() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        assert_eq!(m.source_filename.as_deref(), Some("firmware.c"));
+        assert!(m.data_layout.is_some());
+        assert!(m.target_triple.as_deref().unwrap().contains("x86_64"));
+    }
+
+    #[test]
+    fn parses_struct_types() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        assert!(m.struct_types.contains_key("%struct.UART_TypeDef"));
+        let st = &m.struct_types["%struct.UART_TypeDef"];
+        assert_eq!(st.fields.len(), 3);
+    }
+
+    #[test]
+    fn parses_external_global() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        let uart = m.globals.iter().find(|g| g.name == "UART").expect("UART");
+        assert_eq!(uart.kind, GlobalKind::Constant);
+        assert!(uart.linkage.contains(&"external".to_string()));
+        assert_eq!(uart.align, Some(8));
+    }
+
+    #[test]
+    fn parses_function_signature() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        let f = m.functions.iter().find(|f| f.name == "uart_send").unwrap();
+        assert_eq!(f.return_type, "void");
+        assert_eq!(f.parameters.len(), 1);
+        assert_eq!(f.parameters[0].ty, "i8");
+        assert_eq!(f.parameters[0].name.as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn parses_basic_blocks_with_predecessors() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        let f = m.functions.iter().find(|f| f.name == "uart_send").unwrap();
+        // entry + 3 explicit labels
+        assert_eq!(f.basic_blocks.len(), 4, "{:#?}", f.basic_blocks);
+        assert_eq!(f.basic_blocks[0].label, "entry");
+        let bb3 = f.basic_blocks.iter().find(|b| b.label == "3").unwrap();
+        assert!(bb3.predecessors.contains(&"9".to_string()));
+        assert!(bb3.predecessors.contains(&"1".to_string()));
+    }
+
+    #[test]
+    fn parses_alloca_store_branch_in_entry_block() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        let f = m.functions.iter().find(|f| f.name == "uart_send").unwrap();
+        let entry = &f.basic_blocks[0];
+        assert!(matches!(entry.instructions[0], Instruction::Alloca { .. }));
+        assert!(matches!(entry.instructions[1], Instruction::Store { .. }));
+        assert!(matches!(entry.terminator, Terminator::Br { ref target } if target == "3"));
+    }
+
+    #[test]
+    fn parses_volatile_load_and_gep_in_polling_block() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        let f = m.functions.iter().find(|f| f.name == "uart_send").unwrap();
+        let bb3 = f.basic_blocks.iter().find(|b| b.label == "3").unwrap();
+        // %4 = load ptr, ptr @UART
+        let load_uart = bb3
+            .instructions
+            .iter()
+            .find_map(|i| match i {
+                Instruction::Load { result, source, .. } if result == "4" => Some(source.clone()),
+                _ => None,
+            })
+            .expect("found load of @UART");
+        assert_eq!(load_uart, PointerOperand::Global("UART".into()));
+        // %5 = getelementptr ... %4, i32 0, i32 1
+        let gep = bb3
+            .instructions
+            .iter()
+            .find_map(|i| match i {
+                Instruction::Gep {
+                    result, indices, ..
+                } if result == "5" => Some(indices.clone()),
+                _ => None,
+            })
+            .expect("found gep producing %5");
+        assert_eq!(
+            gep,
+            vec![GepIndex::Const(0), GepIndex::Const(1)],
+            "field-index-1 GEP"
+        );
+        // %6 = load volatile i32, ptr %5
+        let vol_load = bb3.instructions.iter().any(|i| {
+            matches!(i, Instruction::Load { result, volatile, source, .. }
+                if result == "6" && *volatile && source == &PointerOperand::Ssa("5".into()))
+        });
+        assert!(vol_load, "expected volatile load on %5");
+    }
+
+    #[test]
+    fn parses_polling_block_terminator_as_conditional_branch() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        let f = m.functions.iter().find(|f| f.name == "uart_send").unwrap();
+        let bb3 = f.basic_blocks.iter().find(|b| b.label == "3").unwrap();
+        assert!(matches!(
+            &bb3.terminator,
+            Terminator::BrCond { if_true, if_false, .. } if if_true == "9" && if_false == "10"
+        ));
+    }
+
+    #[test]
+    fn parses_volatile_store_in_post_loop_block() {
+        let m = parse_module(FIRMWARE_EXTERN_IR).unwrap();
+        let f = m.functions.iter().find(|f| f.name == "uart_send").unwrap();
+        let bb10 = f.basic_blocks.iter().find(|b| b.label == "10").unwrap();
+        let store = bb10.instructions.iter().any(|i| {
+            matches!(
+                i,
+                Instruction::Store {
+                    volatile: true,
+                    dest: PointerOperand::Ssa(s),
+                    ..
+                } if s == "13"
+            )
+        });
+        assert!(store, "volatile store to %13 (DATA.byte)");
+    }
+
+    #[test]
+    fn parses_inttoptr_register_access() {
+        // Synthetic: `*(volatile uint32_t*)0x40023800 |= (1<<24)`
+        // generates an IR with an `inttoptr` either as an instruction
+        // or as an inline operand.
+        let ir = r#"define void @enable_pll() {
+  %1 = inttoptr i64 1073887232 to ptr
+  %2 = load volatile i32, ptr %1, align 4
+  %3 = or i32 %2, 16777216
+  store volatile i32 %3, ptr %1, align 4
+  ret void
+}
+"#;
+        let m = parse_module(ir).unwrap();
+        let f = &m.functions[0];
+        let bb = &f.basic_blocks[0];
+        assert!(matches!(
+            bb.instructions[0],
+            Instruction::IntToPtr {
+                value: 1073887232,
+                ..
+            }
+        ));
+        // Sanity-check the load chains through the inttoptr result.
+        assert!(matches!(
+            bb.instructions[1],
+            Instruction::Load { volatile: true, .. }
+        ));
+        assert!(matches!(bb.terminator, Terminator::Ret { value: None }));
+    }
+
+    #[test]
+    fn errors_on_empty_input() {
+        assert!(matches!(
+            parse_module("").unwrap_err(),
+            ParseError::EmptyInput
+        ));
+        assert!(matches!(
+            parse_module("   \n\n").unwrap_err(),
+            ParseError::EmptyInput
+        ));
+    }
+
+    #[test]
+    fn unknown_instructions_survive_as_other() {
+        let ir = r#"define void @f() {
+  %1 = some-weird-instruction i32 0
+  ret void
+}
+"#;
+        let m = parse_module(ir).unwrap();
+        let bb = &m.functions[0].basic_blocks[0];
+        assert!(matches!(bb.instructions[0], Instruction::Other(_)));
+    }
+
+    #[test]
+    fn metadata_suffix_is_stripped_before_terminator_parse() {
+        let ir = r#"define void @f() {
+  br label %2, !llvm.loop !1
+
+2:
+  ret void
+}
+"#;
+        let m = parse_module(ir).unwrap();
+        let entry = &m.functions[0].basic_blocks[0];
+        assert!(matches!(entry.terminator, Terminator::Br { ref target } if target == "2"));
+    }
+}

--- a/crates/mununu-core/src/llvm_ir/types.rs
+++ b/crates/mununu-core/src/llvm_ir/types.rs
@@ -1,0 +1,395 @@
+//! LLVM IR data types — the structured form a `.ll` file parses into.
+//!
+//! Designed so that the shapes a C codesign extractor and a Rust
+//! source extractor both need are represented in the same enum. The
+//! types are deliberately conservative: we expose only the fields
+//! either consumer reads today. Adding a new instruction or operand
+//! shape is a focused enum-variant addition.
+//!
+//! Soundness posture: parsing is **best-effort**. Any line the parser
+//! does not recognise survives as [`Instruction::Other`], preserving
+//! the raw text for diagnostics. Consumers downstream must be
+//! resilient to that variant — they should not silently treat it as
+//! a no-op.
+
+use std::collections::BTreeMap;
+
+/// A parsed LLVM IR module.
+#[derive(Debug, Clone, Default)]
+pub struct Module {
+    /// `source_filename = "…"` line if present.
+    pub source_filename: Option<String>,
+    /// `target datalayout = "…"` if present.
+    pub data_layout: Option<String>,
+    /// `target triple = "…"` if present.
+    pub target_triple: Option<String>,
+    /// Named struct / union types: `%struct.X = type { … }`.
+    /// Stored in declaration order via a `BTreeMap` so the parser's
+    /// output is deterministic.
+    pub struct_types: BTreeMap<String, StructType>,
+    /// Module-level globals: `@name = … <type>`.
+    pub globals: Vec<Global>,
+    /// Function definitions.
+    pub functions: Vec<Function>,
+}
+
+/// `%struct.UART_TypeDef = type { %union.anon, %union.anon.0, %union.anon.2 }`
+#[derive(Debug, Clone)]
+pub struct StructType {
+    /// Name as written, including the `%struct.` / `%union.` prefix.
+    pub name: String,
+    /// Field types in declaration order, raw text. Slice 2.b+ may
+    /// resolve these against [`Module::struct_types`] for nested
+    /// layouts.
+    pub fields: Vec<String>,
+}
+
+/// `@name = external constant ptr, align 8` — a module-level global.
+#[derive(Debug, Clone)]
+pub struct Global {
+    pub name: String,
+    /// `external`, `internal`, `private`, `dso_local`, ... — preserved
+    /// as raw tokens; phase L2 may inspect `external` to flag globals
+    /// that bind to peripheral base addresses at link time.
+    pub linkage: Vec<String>,
+    /// `constant` or `global`. `constant` is what `extern volatile
+    /// UART_TypeDef *const UART` lowers to.
+    pub kind: GlobalKind,
+    /// The declared LLVM type — `ptr`, `i32`, `%struct.X`, etc.
+    pub ty: String,
+    /// `align N` if present.
+    pub align: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobalKind {
+    Constant,
+    Global,
+}
+
+/// `define [<linkage>] <ret> @name(<params>) ... { <blocks> }`.
+#[derive(Debug, Clone)]
+pub struct Function {
+    pub name: String,
+    /// Return type as raw text (`void`, `i32`, `ptr`, etc.).
+    pub return_type: String,
+    /// Parameters in declaration order. Each entry is `(type,
+    /// optional SSA name)`. Anonymous params (clang's implicit `%0`,
+    /// `%1`, ...) have `name = None` — clang assigns them sequential
+    /// SSA names that we'd have to track separately.
+    pub parameters: Vec<FunctionParameter>,
+    /// Function-level attributes (`noinline`, `nounwind`, ...) as raw
+    /// tokens. Phase L6 will inspect these for `@mununu_isr` cross-
+    /// references at the IR layer.
+    pub attributes: Vec<String>,
+    /// Basic blocks in source order. The entry block has the implicit
+    /// label `entry` when clang doesn't emit a header for it; we
+    /// synthesise that.
+    pub basic_blocks: Vec<BasicBlock>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionParameter {
+    pub ty: String,
+    pub name: Option<String>,
+}
+
+/// A basic block: a label, a sequence of instructions, and a
+/// terminator.
+#[derive(Debug, Clone)]
+pub struct BasicBlock {
+    pub label: String,
+    /// `; preds = …` comment when clang emits one — phase L3 uses
+    /// these to reconstruct the CFG.
+    pub predecessors: Vec<String>,
+    pub instructions: Vec<Instruction>,
+    pub terminator: Terminator,
+}
+
+/// An SSA-form instruction. The enum covers the shapes the phase
+/// L2+ consumers need; anything else falls through to [`Self::Other`]
+/// with the raw text preserved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Instruction {
+    /// `%result = alloca <ty>, align N`
+    Alloca {
+        result: String,
+        ty: String,
+        align: Option<u64>,
+    },
+    /// `%result = load [volatile] <ty>, ptr <src>, align N`
+    Load {
+        result: String,
+        ty: String,
+        source: PointerOperand,
+        volatile: bool,
+        align: Option<u64>,
+    },
+    /// `store [volatile] <ty> <val>, ptr <dest>, align N`
+    Store {
+        value: ValueOperand,
+        ty: String,
+        dest: PointerOperand,
+        volatile: bool,
+        align: Option<u64>,
+    },
+    /// `%result = getelementptr [inbounds] <ty>, ptr <base>, <indices>`
+    ///
+    /// `indices` is the list of `i32 N` / `i64 N` arguments after the
+    /// base pointer. Each entry is the *literal* integer index;
+    /// non-constant indices are flagged via [`GepIndex::Dynamic`].
+    Gep {
+        result: String,
+        ty: String,
+        base: PointerOperand,
+        indices: Vec<GepIndex>,
+        in_bounds: bool,
+    },
+    /// `%result = inttoptr <int-ty> <literal> to ptr` — common for
+    /// `*(volatile uint32_t *)0x40010000` register accesses.
+    IntToPtr { result: String, value: u64 },
+    /// `%result = ptrtoint ptr <src> to <int-ty>`
+    PtrToInt { result: String, source: String },
+    /// `%result = bitcast <ty> <src> to <ty2>`
+    Bitcast { result: String, source: String },
+    /// `%result = trunc <ty> <src> to <ty2>` — bit-field unpacking.
+    Trunc { result: String, source: String },
+    /// `%result = zext <ty> <src> to <ty2>`
+    ZExt { result: String, source: String },
+    /// `%result = sext <ty> <src> to <ty2>`
+    SExt { result: String, source: String },
+    /// `%result = <op> <ty> <a>, <b>` — integer binary ops (and / or
+    /// / xor / shl / lshr / ashr / add / sub / mul / udiv / sdiv /
+    /// urem / srem). Bit-field load-modify-store sequences use the
+    /// bitwise subset heavily.
+    BinaryOp {
+        result: String,
+        op: BinaryOp,
+        ty: String,
+        a: ValueOperand,
+        b: ValueOperand,
+    },
+    /// `%result = icmp <pred> <ty> <a>, <b>`
+    Icmp {
+        result: String,
+        pred: IcmpPred,
+        ty: String,
+        a: ValueOperand,
+        b: ValueOperand,
+    },
+    /// `[%result = ]call <ret> @func(<args>)` — phase L5 walks the
+    /// call graph through these.
+    Call {
+        result: Option<String>,
+        return_ty: String,
+        callee: String,
+        args: Vec<String>,
+    },
+    /// `%result = phi <ty> [ <v0>, %bb0 ], [ <v1>, %bb1 ], ...` —
+    /// phase L3 needs these to reason about loops.
+    Phi {
+        result: String,
+        ty: String,
+        incoming: Vec<(ValueOperand, String)>,
+    },
+    /// Anything the parser does not recognise. The raw line is
+    /// preserved verbatim (no leading/trailing whitespace).
+    Other(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GepIndex {
+    /// `i32 0`, `i32 1`, `i64 2` — a constant index value.
+    Const(i64),
+    /// `%ssa` — a runtime-computed index.
+    Dynamic(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOp {
+    Add,
+    Sub,
+    Mul,
+    UDiv,
+    SDiv,
+    URem,
+    SRem,
+    Shl,
+    LShr,
+    AShr,
+    And,
+    Or,
+    Xor,
+}
+
+impl BinaryOp {
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "add" => Self::Add,
+            "sub" => Self::Sub,
+            "mul" => Self::Mul,
+            "udiv" => Self::UDiv,
+            "sdiv" => Self::SDiv,
+            "urem" => Self::URem,
+            "srem" => Self::SRem,
+            "shl" => Self::Shl,
+            "lshr" => Self::LShr,
+            "ashr" => Self::AShr,
+            "and" => Self::And,
+            "or" => Self::Or,
+            "xor" => Self::Xor,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CastKind {
+    Trunc,
+    ZExt,
+    SExt,
+    Bitcast,
+    PtrToInt,
+    IntToPtr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IcmpPred {
+    Eq,
+    Ne,
+    Ugt,
+    Uge,
+    Ult,
+    Ule,
+    Sgt,
+    Sge,
+    Slt,
+    Sle,
+}
+
+impl IcmpPred {
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "eq" => Self::Eq,
+            "ne" => Self::Ne,
+            "ugt" => Self::Ugt,
+            "uge" => Self::Uge,
+            "ult" => Self::Ult,
+            "ule" => Self::Ule,
+            "sgt" => Self::Sgt,
+            "sge" => Self::Sge,
+            "slt" => Self::Slt,
+            "sle" => Self::Sle,
+            _ => return None,
+        })
+    }
+}
+
+/// A pointer operand — what appears after `ptr` in a load / store /
+/// GEP base position. Carrying the distinction between SSA names,
+/// globals, and inline constant pointers lets phase L2 do
+/// address-range matching without re-parsing strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PointerOperand {
+    /// `%ssa` — refers to the result of an earlier instruction.
+    Ssa(String),
+    /// `@global` — refers to a module-level global.
+    Global(String),
+    /// `inttoptr (i64 N to ptr)` — inline constant pointer literal.
+    /// Captured as a u64 so phase L2 can match against the
+    /// register-map's base-address window.
+    InlineConstAddr(u64),
+}
+
+/// A value operand — what appears in non-pointer positions (the RHS
+/// of stores, the operands of binary ops, etc.).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValueOperand {
+    Ssa(String),
+    /// A literal integer (`42`, `-1`, etc.).
+    LiteralInt(i64),
+    /// `undef` / `poison`.
+    Undef,
+    /// Anything we did not classify — preserved as raw text.
+    Other(String),
+}
+
+impl ValueOperand {
+    pub fn parse(s: &str) -> Self {
+        let s = s.trim();
+        if let Some(rest) = s.strip_prefix('%') {
+            return Self::Ssa(rest.to_string());
+        }
+        if s == "undef" || s == "poison" {
+            return Self::Undef;
+        }
+        if let Ok(n) = s.parse::<i64>() {
+            return Self::LiteralInt(n);
+        }
+        // Handle `0x…` and `0b…` literals too.
+        if let Some(hex) = s.strip_prefix("0x")
+            && let Ok(n) = i64::from_str_radix(hex, 16)
+        {
+            return Self::LiteralInt(n);
+        }
+        Self::Other(s.to_string())
+    }
+}
+
+/// A block terminator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Terminator {
+    /// `ret <ty> <val>` or `ret void`.
+    Ret { value: Option<ValueOperand> },
+    /// `br label %target`.
+    Br { target: String },
+    /// `br i1 <cond>, label %true, label %false`.
+    BrCond {
+        cond: ValueOperand,
+        if_true: String,
+        if_false: String,
+    },
+    /// `switch <ty> <val>, label %default [ <case>, label %target … ]`.
+    Switch {
+        value: ValueOperand,
+        default: String,
+        cases: Vec<(i64, String)>,
+    },
+    /// `unreachable` / `resume` / unknown.
+    Unreachable,
+    /// Anything not in the above list — preserved verbatim.
+    Other(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_operand_parses_ssa_literal_and_undef() {
+        assert_eq!(ValueOperand::parse("%5"), ValueOperand::Ssa("5".into()));
+        assert_eq!(ValueOperand::parse("42"), ValueOperand::LiteralInt(42));
+        assert_eq!(ValueOperand::parse("-1"), ValueOperand::LiteralInt(-1));
+        assert_eq!(ValueOperand::parse("undef"), ValueOperand::Undef);
+        assert_eq!(
+            ValueOperand::parse("@global_thing"),
+            ValueOperand::Other("@global_thing".into())
+        );
+    }
+
+    #[test]
+    fn binary_op_parse_round_trips_known_ops() {
+        for op_str in ["add", "and", "or", "shl", "lshr"] {
+            assert!(BinaryOp::parse(op_str).is_some(), "{op_str}");
+        }
+        assert!(BinaryOp::parse("bogus").is_none());
+    }
+
+    #[test]
+    fn icmp_pred_parse_covers_signed_and_unsigned() {
+        for p in ["eq", "ne", "ult", "sle"] {
+            assert!(IcmpPred::parse(p).is_some(), "{p}");
+        }
+        assert!(IcmpPred::parse("xx").is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,6 +277,15 @@ struct CodesignExtractCArgs {
     /// `--register-map`).
     #[arg(long = "synthesize-automaton")]
     synthesize_automaton: bool,
+    /// Extraction backend (`ast` default, `llvm` for phase-L1+ lift).
+    #[arg(long, value_enum, default_value = "ast")]
+    backend: CExtractBackend,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum CExtractBackend {
+    Ast,
+    Llvm,
 }
 
 #[derive(Args, Debug)]
@@ -681,6 +690,36 @@ fn handle_codesign(command: CodesignCommand) -> Result<(), String> {
 }
 
 fn codesign_extract_c(args: CodesignExtractCArgs) -> Result<(), String> {
+    match args.backend {
+        CExtractBackend::Ast => codesign_extract_c_ast(args),
+        CExtractBackend::Llvm => codesign_extract_c_llvm(args),
+    }
+}
+
+fn codesign_extract_c_llvm(args: CodesignExtractCArgs) -> Result<(), String> {
+    use mununu::codesign::c_extract_llvm::{LlvmExtractOptions, extract_c_via_llvm};
+
+    if args.register_map.is_some() || args.synthesize_automaton {
+        return Err(
+            "--backend llvm: --register-map / --synthesize-automaton are not yet implemented (phase L2 / L3)"
+                .to_string(),
+        );
+    }
+    let opts = LlvmExtractOptions {
+        clang_path: args.clang,
+        include_paths: args.include_paths,
+        defines: args.defines,
+        extra_clang_args: args.extra_clang_args,
+    };
+    let extraction = extract_c_via_llvm(&args.file, &opts)
+        .map_err(|e| format!("LLVM C extraction failed: {e}"))?;
+    let json = serde_json::to_string_pretty(&extraction)
+        .map_err(|e| format!("failed to serialise extraction: {e}"))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn codesign_extract_c_ast(args: CodesignExtractCArgs) -> Result<(), String> {
     use mununu::codesign::c_extract::{CExtractOptions, extract_c_via_clang};
     use mununu::codesign::register_map::RegisterMap;
 


### PR DESCRIPTION
## Summary

Phase L1 of the C-extraction principled lift (plan: \`~/.claude/plans/i-want-you-to-distributed-orbit.md\`). Lays the foundation for the LLVM-IR-based C extractor that will replace the AST pattern-matcher at phase L3.

- New shared module \`crates/mununu-core/src/llvm_ir/\` with language-neutral IR types (\`Module\`, \`Function\`, \`BasicBlock\`, \`Instruction\`, \`Terminator\`, \`PointerOperand\`, \`ValueOperand\`) and a regex-based line parser. Tested against the actual IR clang produces for the Doc C \xc2\xa7C.4 codesign_uart firmware (16 parser tests + 3 type-level tests).
- New \`crates/mununu-core/src/codesign/c_extract_llvm.rs\` — shells out to \`clang -O0 -emit-llvm -S\` (same clang binary the AST path uses; no new tool dependency), parses the IR, returns a structural summary as JSON. 5 unit tests.
- CLI: extends \`mununu codesign extract-c\` with \`--backend ast|llvm\`. Default stays \`ast\` for backward compatibility.

## What phase L1 deliberately does NOT do

- Register-access matching against a \`RegisterMap\` — phase L2.
- Polling-loop detection / automaton synthesis — phase L3.
- Anything beyond a structural IR summary.

The \`--backend llvm\` mode rejects \`--register-map\` / \`--synthesize-automaton\` with a clear error message until phases L2 and L3 land.

## End-to-end demo

\`\`\`
$ mununu codesign extract-c examples/industrial/codesign_uart/firmware.c --backend llvm
{
  \"source_filename\": \"examples/industrial/codesign_uart/firmware.c\",
  \"target_triple\": \"x86_64-apple-macosx26.0.0\",
  \"functions\": [{ \"name\": \"uart_send\", \"return_type\": \"void\", \"num_parameters\": 1,
                  \"num_basic_blocks\": 4, \"num_volatile_loads\": 2,
                  \"num_volatile_stores\": 2, \"num_inttoptr\": 0 }],
  \"external_globals\": [\"UART\"],
  \"struct_types\": [\"%struct.UART_TypeDef\", \"%union.anon\", ...]
}
\`\`\`

The numbers (2 volatile loads, 2 volatile stores) are what phase L2 will match against the register map to produce the same \`accesses[]\` slice 2.b's AST path produces. The 4 basic blocks (entry, %3 loop header, %9 loop body, %10 post-loop) are what phase L3 will analyse for polling-loop detection.

## Soundness posture

Parsing is best-effort + forward-only: each line is matched against a regex; mis-parses become \`Instruction::Other(raw_text)\`. The parser does NOT validate IR well-formedness — it trusts clang/rustc. The structural summary is purely descriptive at L1.

## Test plan

- [x] \`cargo test --workspace\` clean (21 new tests + all existing tests pass).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] End-to-end demo against \`firmware.c\` works on macOS with Apple CLT clang.
- [ ] Reviewer: confirm the parser is conservative — unknown instructions hit \`Instruction::Other\`, no silent drops.

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)