### PR TITLE
codesign(L9/gap1): in-source state-name annotations via MUNUNU_STATE markers

### DIFF
--- a/crates/mununu-core/cmsis-stubs/mununu_annotations.h
+++ b/crates/mununu-core/cmsis-stubs/mununu_annotations.h
@@ -1,0 +1,57 @@
+/*
+ * mununu_annotations.h — in-source annotation markers consumed by
+ *                        `mununu codesign extract-c`.
+ *
+ * The extractor recognises calls to specific marker functions and
+ * lifts them out of the IR as semantic annotations on the
+ * surrounding code. The marker functions are declared `extern`
+ * here; they have NO definition (the firmware never links — we
+ * only need clang to parse + emit IR). Trying to link a firmware
+ * that uses these markers without a no-op definition is the
+ * caller's responsibility; suggested:
+ *
+ *     #ifdef MUNUNU_MARKERS_NOOP
+ *     void __mununu_state(const char *n) { (void)n; }
+ *     #endif
+ *
+ * SOUNDNESS: the marker calls are at the IR level just call
+ * instructions to `@__mununu_state(...)`. The extractor consumes
+ * them and they contribute NO register accesses. A real firmware
+ * compile (for the device, not for verification) would link them
+ * to the no-op definition or strip them via the optimizer.
+ */
+#ifndef MUNUNU_ANNOTATIONS_H
+#define MUNUNU_ANNOTATIONS_H
+
+/* Phase-L9 (gap 1 from the verification-stack audit): hint to the
+ * extractor that the basic block beginning here represents a state
+ * the user named `name`. The synthesised CTXDSL automaton then uses
+ * `name` instead of the default `S<N>` for the SOURCE state of
+ * every transition emitted between this marker and the next.
+ *
+ * Example:
+ *
+ *     void uart_send(uint8_t byte) {
+ *         MUNUNU_STATE("Polling");
+ *         while (UART->STATUS.bit.tx_busy);
+ *         MUNUNU_STATE("Ready");
+ *         UART->DATA.byte = byte;
+ *         MUNUNU_STATE("Sending");
+ *         UART->CTRL.bit.tx_start = 1;
+ *     }
+ *
+ * synthesises to (approximately):
+ *
+ *     transitions {
+ *         transition Polling -> Loop0 on label rd_status_tx_busy;
+ *         transition Loop0 -> Ready on label rd_status_tx_busy;
+ *         transition Ready -> Sending on label wr_data_byte;
+ *         transition Sending -> S4 on label wr_ctrl_tx_start;
+ *     }
+ *
+ * — state names the user can write properties against.
+ */
+extern void __mununu_state(const char *name);
+#define MUNUNU_STATE(name) __mununu_state(name)
+
+#endif /* MUNUNU_ANNOTATIONS_H */

--- a/crates/mununu-core/src/codesign/c_extract.rs
+++ b/crates/mununu-core/src/codesign/c_extract.rs
@@ -51,6 +51,13 @@ pub struct RegisterAccess {
     /// Control-flow context for this access.
     #[serde(default, skip_serializing_if = "AccessFlow::is_linear")]
     pub flow: AccessFlow,
+    /// Phase-L9 (gap 1 from the verification audit): user-supplied
+    /// name for the SOURCE state of this access's transition,
+    /// emitted by a `MUNUNU_STATE("Name")` marker call in the C
+    /// source. The synthesiser uses this name instead of the
+    /// default `S<i>` when rendering the transition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_state_hint: Option<String>,
 }
 
 /// Control-flow context for a [`RegisterAccess`].
@@ -138,13 +145,27 @@ pub fn synthesise_automaton_ctxdsl(
         let _ = writeln!(buf);
     }
 
+    // Phase L9 (gap 1): state-name resolution. `state_names[i]` is
+    // the name of the state reached just before access[i] (so
+    // `state_names[0]` is the initial state, and `state_names[N]` is
+    // the terminal state after the last access). The default name is
+    // `S{i}`; a `MUNUNU_STATE("Foo")` marker upstream of access[i]
+    // populates `access[i].source_state_hint` and renames
+    // `state_names[i]` to `Foo` (sanitised to a CTXDSL identifier).
+    let mut state_names: Vec<String> = (0..=accesses.len()).map(|i| format!("S{i}")).collect();
+    for (i, access) in accesses.iter().enumerate() {
+        if let Some(hint) = &access.source_state_hint {
+            state_names[i] = sanitise_state_name(hint);
+        }
+    }
+
     let _ = writeln!(buf, "            states {{");
-    let _ = writeln!(buf, "                state S0 initial;");
+    let _ = writeln!(buf, "                state {} initial;", state_names[0]);
     for (i, access) in accesses.iter().enumerate() {
         if access.flow == AccessFlow::PollingLoop {
             let _ = writeln!(buf, "                state Loop{i};");
         }
-        let _ = writeln!(buf, "                state S{idx};", idx = i + 1);
+        let _ = writeln!(buf, "                state {};", state_names[i + 1]);
     }
     let _ = writeln!(buf, "            }}");
     let _ = writeln!(buf);
@@ -152,8 +173,8 @@ pub fn synthesise_automaton_ctxdsl(
     let _ = writeln!(buf, "            transitions {{");
     for (i, access) in accesses.iter().enumerate() {
         let label = rendezvous_label_name(&access.register, access.field.as_deref(), access.kind);
-        let from = format!("S{i}");
-        let to = format!("S{next}", next = i + 1);
+        let from = &state_names[i];
+        let to = &state_names[i + 1];
         match access.flow {
             AccessFlow::Linear => {
                 let _ = writeln!(
@@ -188,6 +209,29 @@ pub fn synthesise_automaton_ctxdsl(
 
     let _ = rm; // unused — kept for parity with coupling.rs's emitter signature.
     buf
+}
+
+/// Phase L9 (gap 1): sanitise a user-supplied state-name hint from
+/// a `MUNUNU_STATE("…")` marker into a CTXDSL state identifier.
+/// CTXDSL states are parsed as plain identifiers, so any non-alnum
+/// becomes `_`; a leading digit is prefixed with `S_` so the result
+/// starts with a letter; empty input falls back to `S`.
+fn sanitise_state_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            out.push(c);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        return "S".to_string();
+    }
+    if out.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        out.insert_str(0, "S_");
+    }
+    out
 }
 
 /// Sanitise a C identifier into a CTXDSL automaton name: first
@@ -265,6 +309,7 @@ mod tests {
             accessor: "(IR)".to_string(),
             source_line: 1,
             flow: AccessFlow::Linear,
+            source_state_hint: None,
         }];
         let ctxdsl = synthesise_automaton_ctxdsl("fire", &accesses, &uart_register_map());
         assert!(ctxdsl.contains("state S0 initial"));
@@ -282,11 +327,69 @@ mod tests {
             accessor: "(IR)".to_string(),
             source_line: 1,
             flow: AccessFlow::PollingLoop,
+            source_state_hint: None,
         }];
         let ctxdsl = synthesise_automaton_ctxdsl("poll", &accesses, &uart_register_map());
         assert!(ctxdsl.contains("state Loop0"));
         assert!(ctxdsl.contains("state S1"));
         let n = ctxdsl.matches("rd_ctrl_tx_start").count();
         assert!(n >= 3, "expected ≥3 enter/iterate/exit; got {n}");
+    }
+
+    #[test]
+    fn sanitise_state_name_handles_edge_cases() {
+        assert_eq!(sanitise_state_name("Polling"), "Polling");
+        assert_eq!(sanitise_state_name("Tx Ready"), "Tx_Ready");
+        assert_eq!(sanitise_state_name("3State"), "S_3State");
+        assert_eq!(sanitise_state_name(""), "S");
+        assert_eq!(sanitise_state_name("with-dashes"), "with_dashes");
+    }
+
+    #[test]
+    fn state_hint_renames_source_states_in_synthesised_automaton() {
+        let accesses = vec![
+            RegisterAccess {
+                kind: AccessKind::Read,
+                register: "CTRL".to_string(),
+                field: Some("tx_start".to_string()),
+                accessor: "(IR)".to_string(),
+                source_line: 1,
+                flow: AccessFlow::PollingLoop,
+                source_state_hint: Some("Polling".to_string()),
+            },
+            RegisterAccess {
+                kind: AccessKind::Write,
+                register: "CTRL".to_string(),
+                field: Some("tx_start".to_string()),
+                accessor: "(IR)".to_string(),
+                source_line: 2,
+                flow: AccessFlow::Linear,
+                source_state_hint: Some("Ready".to_string()),
+            },
+        ];
+        let ctxdsl = synthesise_automaton_ctxdsl("uart_send", &accesses, &uart_register_map());
+        // Initial state is renamed by the first hint.
+        assert!(
+            ctxdsl.contains("state Polling initial"),
+            "expected initial state renamed to 'Polling'; got:\n{ctxdsl}"
+        );
+        // Second hint renames the state between the two accesses.
+        assert!(ctxdsl.contains("state Ready;"));
+        // Terminal state after the last access keeps its default
+        // name since no further hint applies.
+        assert!(ctxdsl.contains("state S2;"));
+        // Transitions reference the renamed states.
+        assert!(
+            ctxdsl.contains("Polling -> Loop0"),
+            "expected polling-loop entry from 'Polling' state; got:\n{ctxdsl}"
+        );
+        assert!(
+            ctxdsl.contains("Loop0 -> Ready"),
+            "expected polling-loop exit into 'Ready' state; got:\n{ctxdsl}"
+        );
+        assert!(
+            ctxdsl.contains("Ready -> S2"),
+            "expected linear transition Ready -> S2; got:\n{ctxdsl}"
+        );
     }
 }

--- a/crates/mununu-core/src/codesign/c_extract_llvm.rs
+++ b/crates/mununu-core/src/codesign/c_extract_llvm.rs
@@ -45,7 +45,7 @@ use crate::codesign::coupling::AccessKind;
 use crate::codesign::register_map::{Register, RegisterMap};
 use crate::llvm_ir::{GepIndex, Instruction, Module, PointerOperand, Terminator, parse_module};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -382,7 +382,14 @@ fn summarise(module: &Module, source_text: &str, options: &LlvmExtractOptions) -
         .iter()
         .map(|f| {
             let is_isr = isr_function_names.contains(&f.name);
-            summarise_function(f, options, &module_fns, is_isr, &mut warnings)
+            summarise_function(
+                f,
+                options,
+                &module_fns,
+                &module.string_constants,
+                is_isr,
+                &mut warnings,
+            )
         })
         .collect();
 
@@ -429,6 +436,7 @@ fn summarise_function(
     f: &crate::llvm_ir::Function,
     options: &LlvmExtractOptions,
     module_fns: &HashMap<&str, &crate::llvm_ir::Function>,
+    string_constants: &BTreeMap<String, String>,
     is_isr: bool,
     warnings: &mut Vec<LlvmExtractWarning>,
 ) -> LlvmFunctionSummary {
@@ -458,6 +466,7 @@ fn summarise_function(
             f,
             rm,
             module_fns,
+            string_constants,
             &mut visiting,
             HashMap::new(), // entry-point: no caller bindings yet
             warnings,
@@ -1057,6 +1066,7 @@ fn extract_register_accesses(
     f: &crate::llvm_ir::Function,
     rm: &RegisterMap,
     module_fns: &HashMap<&str, &crate::llvm_ir::Function>,
+    string_constants: &BTreeMap<String, String>,
     visiting: &mut std::collections::HashSet<String>,
     param_bindings: HashMap<String, ResolvedAddress>,
     warnings: &mut Vec<LlvmExtractWarning>,
@@ -1078,6 +1088,10 @@ fn extract_register_accesses(
 
     let mut accesses: Vec<RegisterAccess> = Vec::new();
     let mut current_line: u32 = 0;
+    // Phase L9 (gap 1): running state-name hint, updated each time we
+    // see a `call void @__mununu_state(ptr @.strN)` marker. Applied
+    // to every RegisterAccess emitted until the next marker.
+    let mut current_state_hint: Option<String> = None;
     for bb in &f.basic_blocks {
         if plan.skip_blocks.contains(&bb.label) {
             // Phase L3: skip the polling-loop's back-edge body. It
@@ -1087,19 +1101,28 @@ fn extract_register_accesses(
         // Approximate source-line ordering by basic-block traversal.
         for instr in &bb.instructions {
             current_line = current_line.saturating_add(1);
-            // Phase L5 / L5.5: when we hit a call to a function
-            // defined in the same module, build parameter bindings
-            // from the call's arguments (resolved against the
-            // caller's ctx) and recurse into the callee with those
-            // bindings. External calls fall through silently.
+            // Phase L5 / L5.5 / L9: dispatch on call instructions.
+            // Three cases: (a) marker call to `__mununu_state` —
+            // update `current_state_hint` and continue; (b) call to a
+            // function defined in the same module — recurse; (c)
+            // call to an external symbol — fall through silently.
             if let Instruction::Call { callee, args, .. } = instr {
                 let target = callee.trim_start_matches('@');
+                if target == "__mununu_state" {
+                    if let Some(arg) = args.first()
+                        && let Some(name) = lookup_state_marker_name(arg, string_constants)
+                    {
+                        current_state_hint = Some(name);
+                    }
+                    continue;
+                }
                 if let Some(callee_fn) = module_fns.get(target) {
                     let callee_bindings = build_callee_param_bindings(callee_fn, args, &ctx);
                     let callee_accesses = extract_register_accesses(
                         callee_fn,
                         rm,
                         module_fns,
+                        string_constants,
                         visiting,
                         callee_bindings,
                         warnings,
@@ -1147,7 +1170,7 @@ fn extract_register_accesses(
                         }
                         _ => AccessFlow::Linear,
                     };
-                    if let Some(access) = match_address_to_register(
+                    if let Some(mut access) = match_address_to_register(
                         &addr,
                         rm,
                         kind,
@@ -1155,6 +1178,7 @@ fn extract_register_accesses(
                         flow,
                         field_override.as_deref(),
                     ) {
+                        access.source_state_hint = current_state_hint.clone();
                         accesses.push(access);
                     } else {
                         warnings.push(LlvmExtractWarning::UnknownAccessor {
@@ -1556,7 +1580,42 @@ fn match_address_to_register(
         accessor: format!("(IR-resolved @{addr:?})"),
         source_line,
         flow,
+        source_state_hint: None,
     })
+}
+
+/// Phase L9 (gap 1): parse a single argument string from a
+/// `call void @__mununu_state(...)` instruction and resolve the
+/// referenced string-constant global to its decoded payload.
+///
+/// clang lowers `MUNUNU_STATE("Polling")` to one of two shapes
+/// (depending on optimisation level and target):
+///
+/// ```text
+/// call void @__mununu_state(ptr noundef @.str)
+/// call void @__mununu_state(ptr noundef getelementptr inbounds (...))
+/// ```
+///
+/// Both forms reference a module-level `@.strN` global whose payload
+/// the parser captured in `string_constants`. We accept the first
+/// form natively and the second form by finding `@.strN` anywhere in
+/// the argument text — the GEP indices are always `i32 0, i32 0` for
+/// `[N x i8]` strings, so the global name is the only payload-bearing
+/// component.
+fn lookup_state_marker_name(
+    arg_text: &str,
+    string_constants: &BTreeMap<String, String>,
+) -> Option<String> {
+    let at_pos = arg_text.find('@')?;
+    let after_at = &arg_text[at_pos + 1..];
+    let end = after_at
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '.'))
+        .unwrap_or(after_at.len());
+    let global_name = &after_at[..end];
+    if global_name.is_empty() {
+        return None;
+    }
+    string_constants.get(global_name).cloned()
 }
 
 #[cfg(test)]
@@ -2427,5 +2486,106 @@ define void @uart_send() {
         let parsed: LlvmExtraction = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.functions.len(), 1);
         assert_eq!(parsed.functions[0].accesses.len(), 3);
+    }
+
+    #[test]
+    fn lookup_state_marker_name_handles_clang_arg_shapes() {
+        let mut consts = BTreeMap::new();
+        consts.insert(".str".to_string(), "Polling".to_string());
+        consts.insert(".str.1".to_string(), "Ready".to_string());
+
+        // Plain `ptr noundef @.str` shape (clang -O0 default).
+        assert_eq!(
+            lookup_state_marker_name("ptr noundef @.str", &consts),
+            Some("Polling".to_string())
+        );
+        // `@.str.1` with dot in the name.
+        assert_eq!(
+            lookup_state_marker_name("ptr noundef @.str.1", &consts),
+            Some("Ready".to_string())
+        );
+        // Inline `getelementptr` constexpr shape: still finds the
+        // global because the global name has no `(` inside it.
+        assert_eq!(
+            lookup_state_marker_name(
+                "ptr noundef getelementptr inbounds ([8 x i8], ptr @.str, i32 0, i32 0)",
+                &consts
+            ),
+            Some("Polling".to_string())
+        );
+        // Missing global → None.
+        assert_eq!(
+            lookup_state_marker_name("ptr noundef @.missing", &consts),
+            None
+        );
+        // Arg with no `@` at all → None.
+        assert_eq!(lookup_state_marker_name("i32 42", &consts), None);
+    }
+
+    #[test]
+    fn mununu_state_markers_rename_synthesised_automaton_states() {
+        // Minimal IR: two volatile writes to CTRL.tx_start, separated
+        // by a `__mununu_state` marker. The marker before the second
+        // write should rename the state between the two accesses.
+        let ir = r#"; ModuleID = 'state_marker_demo.c'
+source_filename = "state_marker_demo.c"
+target triple = "x86_64-apple-macosx26.0.0"
+
+@UART = external constant ptr, align 8
+@.str = private unnamed_addr constant [8 x i8] c"Polling\00", align 1
+@.str.1 = private unnamed_addr constant [6 x i8] c"Ready\00", align 1
+
+%struct.UART_TypeDef = type { %union.anon }
+
+declare void @__mununu_state(ptr noundef)
+
+define void @demo() {
+  call void @__mununu_state(ptr noundef @.str)
+  %1 = load ptr, ptr @UART, align 8
+  %2 = getelementptr inbounds %struct.UART_TypeDef, ptr %1, i32 0, i32 0
+  store volatile i32 1, ptr %2, align 4
+  call void @__mununu_state(ptr noundef @.str.1)
+  %3 = load ptr, ptr @UART, align 8
+  %4 = getelementptr inbounds %struct.UART_TypeDef, ptr %3, i32 0, i32 0
+  store volatile i32 1, ptr %4, align 4
+  ret void
+}
+"#;
+        let opts = LlvmExtractOptions {
+            register_map: Some(uart_register_map()),
+            synthesize_automaton: true,
+            ..Default::default()
+        };
+        let ext = extract_from_ir_text_with_options(ir, &opts).unwrap();
+        assert_eq!(ext.functions.len(), 1);
+        let f = &ext.functions[0];
+        assert_eq!(f.accesses.len(), 2, "two writes expected, markers consumed");
+        assert_eq!(
+            f.accesses[0].source_state_hint.as_deref(),
+            Some("Polling"),
+            "first access should be tagged with 'Polling'"
+        );
+        assert_eq!(
+            f.accesses[1].source_state_hint.as_deref(),
+            Some("Ready"),
+            "second access should be tagged with 'Ready'"
+        );
+        let automaton = f.automaton_ctxdsl.as_ref().expect("automaton synthesised");
+        assert!(
+            automaton.contains("state Polling initial"),
+            "initial state should be 'Polling'; got:\n{automaton}"
+        );
+        assert!(
+            automaton.contains("state Ready;"),
+            "intermediate state should be 'Ready'; got:\n{automaton}"
+        );
+        assert!(
+            automaton.contains("Polling -> Ready"),
+            "first transition should be Polling -> Ready; got:\n{automaton}"
+        );
+        assert!(
+            automaton.contains("Ready -> S2"),
+            "second transition should be Ready -> S2; got:\n{automaton}"
+        );
     }
 }

--- a/crates/mununu-core/src/llvm_ir/parser.rs
+++ b/crates/mununu-core/src/llvm_ir/parser.rs
@@ -57,6 +57,7 @@ struct Regexes {
     target_triple: Regex,
     struct_type: Regex,
     global: Regex,
+    string_constant: Regex,
     define: Regex,
     bb_label: Regex,
     preds_comment: Regex,
@@ -92,6 +93,15 @@ fn regexes() -> &'static Regexes {
         struct_type: Regex::new(r#"^\s*%([\w."]+?)\s*=\s*type\s*\{(.*)\}\s*$"#).unwrap(),
         global: Regex::new(
             r"^\s*@([\w.]+)\s*=\s*((?:[\w_]+\s+)*)(constant|global)\s+(\S+)(?:.*?align\s+(\d+))?",
+        )
+        .unwrap(),
+        // Phase L9: string constants emitted by clang for C string
+        // literals — `@.str = private unnamed_addr constant [N x i8]
+        // c"…\00", align 1`. Captures the global name and the raw
+        // string body (escape sequences left as-is; the unescaper
+        // runs after capture).
+        string_constant: Regex::new(
+            r#"^\s*@([\w.]+)\s*=\s*[\w\s_]*?constant\s+\[\d+\s+x\s+i8\]\s+c"([^"]*)""#,
         )
         .unwrap(),
         define: Regex::new(r"^\s*define\s+(?:[^@]*?\s)?(\S+)\s+@([\w.]+)\((.*?)\)").unwrap(),
@@ -191,6 +201,19 @@ pub fn parse_module(ir_text: &str) -> Result<Module, ParseError> {
                     fields,
                 };
                 module.struct_types.insert(name, st);
+                continue;
+            }
+            // Phase L9: string-constant lines like
+            // `@.str = private unnamed_addr constant [8 x i8] c"Polling\00"`
+            // get recorded in `module.string_constants` so the
+            // marker-call matcher can resolve `@.str` to "Polling".
+            // Matched BEFORE the general global regex, which would
+            // otherwise consume them.
+            if let Some(caps) = r.string_constant.captures(line) {
+                let name = caps[1].to_string();
+                let raw = caps[2].to_string();
+                let unescaped = unescape_llvm_c_string(&raw);
+                module.string_constants.insert(name, unescaped);
                 continue;
             }
             if let Some(caps) = r.global.captures(line) {
@@ -634,6 +657,40 @@ fn parse_phi_incoming(text: &str) -> Vec<(ValueOperand, String)> {
 
 /// Drop trailing `!metadata, !N, !something` annotations from a line
 /// so the instruction regexes don't have to account for them.
+/// Unescape an LLVM-IR C string literal body. Handles the common
+/// escape sequences clang emits: `\NN` hex byte escapes (notably
+/// `\00` for the null terminator), `\\` for backslash. Other bytes
+/// pass through verbatim. The trailing `\00` terminator is
+/// stripped.
+fn unescape_llvm_c_string(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push(((h << 4) | l) as u8);
+                i += 3;
+                continue;
+            }
+            if bytes[i + 1] == b'\\' {
+                out.push(b'\\');
+                i += 2;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    // Strip the trailing NUL terminator clang emits.
+    while out.last() == Some(&0) {
+        out.pop();
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 fn strip_trailing_metadata(line: &str) -> &str {
     // Find ", !" — that marks the start of a metadata-annotation
     // suffix on an instruction (e.g. `br label %3, !llvm.loop !6`).

--- a/crates/mununu-core/src/llvm_ir/types.rs
+++ b/crates/mununu-core/src/llvm_ir/types.rs
@@ -29,6 +29,14 @@ pub struct Module {
     pub struct_types: BTreeMap<String, StructType>,
     /// Module-level globals: `@name = … <type>`.
     pub globals: Vec<Global>,
+    /// Module-level string constants from clang's lowering of C
+    /// string literals: `@.str = private unnamed_addr constant
+    /// [N x i8] c"…\00", align 1`. Keyed by the global name (with
+    /// the leading `@` stripped); value is the unescaped string.
+    /// Used by phase-L9 marker-call recognition (`MUNUNU_STATE("Name")`)
+    /// — the call passes `ptr @.strX` and the matcher dereferences
+    /// through this table to recover `"Name"`.
+    pub string_constants: BTreeMap<String, String>,
     /// Function definitions.
     pub functions: Vec<Function>,
 }

--- a/examples/industrial/codesign_uart/motivating_examples/example_9_state_name_annotations.c
+++ b/examples/industrial/codesign_uart/motivating_examples/example_9_state_name_annotations.c
@@ -1,0 +1,61 @@
+/*
+ * example_9_state_name_annotations.c — Plan phase L9 (gap 1).
+ *
+ * Closes verification-gap (1) from the C-extraction audit: the
+ * synthesised CTXDSL automaton names its states `S0`, `S1`, `S2`, …
+ * by default, which makes it hard for the user to write properties
+ * against meaningful state names (e.g.
+ * `mu X. (state = Sending) -> [c] X`).
+ *
+ * The fix is in-source state-name annotations via the
+ * `MUNUNU_STATE("Name")` macro declared in
+ * `crates/mununu-core/cmsis-stubs/mununu_annotations.h`. Clang lowers
+ * each invocation to a `call void @__mununu_state(ptr noundef @.str)`
+ * which mununu's IR walker recognises, records, and propagates as a
+ * `source_state_hint` on the very next emitted register access.
+ *
+ * The synthesised CTXDSL substitutes the hint for the default state
+ * name when emitting the source state of each transition. The
+ * terminal state (after the last access) keeps its default `S<N>`
+ * name unless a closing marker appears after the last access.
+ *
+ * SOUNDNESS — the marker is a pure metadata side-channel:
+ *   - clang treats `__mununu_state` as an extern function with no
+ *     side effects on register state (it never resolves to a real
+ *     symbol; mununu's extractor consumes the call and emits no
+ *     register access for it);
+ *   - state names are syntactic identifiers in the synthesised
+ *     CTXDSL, not semantic predicates — incorrect naming is a
+ *     readability issue, not a soundness issue;
+ *   - if the user's MUNUNU_STATE calls don't actually appear at
+ *     basic-block boundaries the IR walker sees, mununu falls back
+ *     to `S<N>` defaults silently.
+ *
+ * Expected lift:
+ *   transition Polling -> Loop0 on label rd_status_tx_busy;
+ *   transition Loop0   -> Loop0 on label rd_status_tx_busy;
+ *   transition Loop0   -> Ready on label rd_status_tx_busy;
+ *   transition Ready   -> Sending on label wr_data_byte;
+ *   transition Sending -> S4    on label wr_ctrl_tx_start;
+ */
+
+#include <stdint.h>
+#include "mununu_annotations.h"
+
+#define UART ((volatile UART_TypeDef *)0x40010000u)
+
+typedef struct {
+    union { volatile uint32_t reg; struct { uint32_t tx_start:1; uint32_t enable:1; uint32_t reserved:30; } bit; } CTRL;
+    union { volatile uint32_t reg; struct { uint32_t tx_busy:1; uint32_t rx_ready:1; uint32_t reserved:30; } bit; } STATUS;
+    union { volatile uint32_t reg; uint8_t byte; } DATA;
+} UART_TypeDef;
+
+void uart_send_byte(uint8_t byte) {
+    MUNUNU_STATE("Polling");
+    while (UART->STATUS.bit.tx_busy)
+        ;
+    MUNUNU_STATE("Ready");
+    UART->DATA.byte = byte;
+    MUNUNU_STATE("Sending");
+    UART->CTRL.bit.tx_start = 1;
+}

--- a/examples/industrial/codesign_uart/motivating_examples/transcript.txt
+++ b/examples/industrial/codesign_uart/motivating_examples/transcript.txt
@@ -271,7 +271,7 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
 }
 
 === Example 8: CMSIS-style struct-member access (--cmsis-stubs) ===
-$ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/motivating_examples/example_8_cmsis_struct_access.c --register-map examples/industrial/codesign_uart/register_map.json --synthesize-automaton --cmsis-stubs --include /var/folders/cp/dgzzd8w16l90rnvkvx8532m80000gn/T/tmp.P2Tsc7IqsC
+$ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/motivating_examples/example_8_cmsis_struct_access.c --register-map examples/industrial/codesign_uart/register_map.json --synthesize-automaton --cmsis-stubs --include /var/folders/cp/dgzzd8w16l90rnvkvx8532m80000gn/T/tmp.iMYGUpnfVk
 {
   "source_filename": "examples/industrial/codesign_uart/motivating_examples/example_8_cmsis_struct_access.c",
   "target_triple": "x86_64-apple-macosx26.0.0",
@@ -315,6 +315,60 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
   "external_globals": [],
   "struct_types": [
     "%struct.UART_LITE_Type",
+    "%union.anon",
+    "%union.anon.0",
+    "%union.anon.2"
+  ]
+}
+
+=== Example 9: in-source state-name annotations (MUNUNU_STATE markers) ===
+$ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/motivating_examples/example_9_state_name_annotations.c --register-map examples/industrial/codesign_uart/register_map.json --synthesize-automaton --cmsis-stubs
+{
+  "source_filename": "examples/industrial/codesign_uart/motivating_examples/example_9_state_name_annotations.c",
+  "target_triple": "x86_64-apple-macosx26.0.0",
+  "functions": [
+    {
+      "name": "uart_send_byte",
+      "return_type": "void",
+      "num_parameters": 1,
+      "num_basic_blocks": 4,
+      "num_instructions": 14,
+      "num_volatile_loads": 2,
+      "num_volatile_stores": 2,
+      "num_inttoptr": 0,
+      "accesses": [
+        {
+          "kind": "read",
+          "register": "STATUS",
+          "field": "tx_busy",
+          "accessor": "(IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 })",
+          "source_line": 5,
+          "flow": "polling_loop",
+          "source_state_hint": "Polling"
+        },
+        {
+          "kind": "write",
+          "register": "DATA",
+          "field": "byte",
+          "accessor": "(IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })",
+          "source_line": 11,
+          "source_state_hint": "Ready"
+        },
+        {
+          "kind": "write",
+          "register": "CTRL",
+          "field": "tx_start",
+          "accessor": "(IR-resolved @AbsoluteAddress(1073807360))",
+          "source_line": 16,
+          "source_state_hint": "Sending"
+        }
+      ],
+      "automaton_ctxdsl": "    automata {\n        automaton Uart_send_byte {\n            controllable {\n                wr_data_byte;\n                wr_ctrl_tx_start;\n            }\n\n            states {\n                state Polling initial;\n                state Loop0;\n                state Ready;\n                state Sending;\n                state S3;\n            }\n\n            transitions {\n                transition Polling -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (enter loop)\n                transition Loop0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (loop iteration)\n                transition Loop0 -> Ready on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (exit loop)\n                transition Ready -> Sending on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition Sending -> S3 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
+    }
+  ],
+  "external_globals": [],
+  "struct_types": [
+    "%struct.UART_TypeDef",
     "%union.anon",
     "%union.anon.0",
     "%union.anon.2"

--- a/examples/industrial/codesign_uart/motivating_examples/validate-motivating-examples.sh
+++ b/examples/industrial/codesign_uart/motivating_examples/validate-motivating-examples.sh
@@ -120,6 +120,18 @@ CMSIS_HEADER
 
     rm -rf "$L8_TMP"
 
+    # Phase L9 / gap (1) — Example 9 uses MUNUNU_STATE() markers to
+    # rename the synthesised CTXDSL states from S0/S1/… to
+    # user-supplied names (Polling, Ready, Sending). The header is
+    # shipped under crates/mununu-core/cmsis-stubs and lives on the
+    # include path under `--cmsis-stubs`.
+    run "Example 9: in-source state-name annotations (MUNUNU_STATE markers)" \
+        ./target/debug/mununu codesign extract-c \
+            "$DIR/example_9_state_name_annotations.c" \
+            --register-map "$REGISTER_MAP" \
+            --synthesize-automaton \
+            --cmsis-stubs
+
     printf '\n=== end of transcript ===\n'
 } > "$TRANSCRIPT"
 


### PR DESCRIPTION
## Summary

Closes **verification-gap (1)** from the C-extraction audit: by default the synthesised CTXDSL automaton names its states `S0`, `S1`, `S2`, … which makes properties hard to write. With this change, a `MUNUNU_STATE(\"Name\")` macro in the firmware source renames the state that begins at that marker — the user gets to write `mu X. (Sending || <> X)` against semantically meaningful state names.

The macro is defined in the bundled `crates/mununu-core/cmsis-stubs/mununu_annotations.h` (already on the include path under `--cmsis-stubs`). Clang lowers each call to `call void @__mununu_state(ptr noundef @.strN)`. mununu's IR walker:

1. Captures `@.strN = private unnamed_addr constant [N x i8] c\"…\"` globals into `Module.string_constants`.
2. Recognises the marker call, looks up the string, sets a running `current_state_hint`.
3. Tags each subsequent `RegisterAccess` with `source_state_hint`.
4. The synthesiser substitutes the hint for the default `S<i>` source-state name.

## Soundness

The marker is a pure metadata side-channel:
- clang treats `__mununu_state` as an extern function with no side effects on register state;
- mununu's extractor consumes the call and emits no register access for it;
- state names are syntactic identifiers in the synthesised CTXDSL, not semantic predicates — incorrect naming is a readability issue, not a soundness issue;
- if markers don't appear at basic-block boundaries the IR walker sees, mununu falls back to `S<N>` defaults silently.

## End-to-end demo

`examples/industrial/codesign_uart/motivating_examples/example_9_state_name_annotations.c` is the canonical UART driver with three markers (Polling / Ready / Sending). The synthesised automaton emits:

\`\`\`
transition Polling -> Loop0   on label rd_status_tx_busy;
transition Loop0   -> Loop0   on label rd_status_tx_busy;
transition Loop0   -> Ready   on label rd_status_tx_busy;
transition Ready   -> Sending on label wr_data_byte;
transition Sending -> S3      on label wr_ctrl_tx_start;
\`\`\`

The terminal state (`S3`) keeps its default name because no closing marker appears after the last access.

## Test plan

- [x] Unit tests: \`lookup_state_marker_name_handles_clang_arg_shapes\` (3 IR-arg shapes), \`mununu_state_markers_rename_synthesised_automaton_states\` (end-to-end IR→CTXDSL), \`sanitise_state_name_handles_edge_cases\`, \`state_hint_renames_source_states_in_synthesised_automaton\`.
- [x] Regression: all 1079 mununu-core unit tests pass; existing motivating examples 2/4/5/6/8 still emit \`S0/S1/…\` defaults (no markers, no change).
- [x] End-to-end: \`validate-motivating-examples.sh\` runs real clang against Example 9 and shows the renamed automaton in \`transcript.txt\`.
- [x] \`make ci\` clean (fmt + clippy + workspace tests + doctests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)