### PR TITLE
codesign(synth): emit `label X;` in controllable block so synthesised CTXDSL parses

### DIFF
--- a/crates/mununu-core/src/codesign/c_extract.rs
+++ b/crates/mununu-core/src/codesign/c_extract.rs
@@ -137,9 +137,16 @@ pub fn synthesise_automaton_ctxdsl(
         }
     }
     if !controllable_labels.is_empty() {
+        // CTXDSL's `controllable { ... }` block expects each entry as
+        // `label NAME;` (parser at
+        // `crate::context_dsl::parser::parse_label_block` calls
+        // `expect_keyword(Keyword::Label)`). Without the `label`
+        // keyword the synthesised CTXDSL fails to parse when spliced
+        // into a `context { ... }` block — which broke the end-to-end
+        // "extract C → eval against CTXDSL" workflow before this fix.
         let _ = writeln!(buf, "            controllable {{");
         for label in &controllable_labels {
-            let _ = writeln!(buf, "                {label};");
+            let _ = writeln!(buf, "                label {label};");
         }
         let _ = writeln!(buf, "            }}");
         let _ = writeln!(buf);
@@ -390,6 +397,56 @@ mod tests {
         assert!(
             ctxdsl.contains("Ready -> S2"),
             "expected linear transition Ready -> S2; got:\n{ctxdsl}"
+        );
+    }
+
+    #[test]
+    fn synthesised_automaton_parses_back_through_ctxdsl_parser() {
+        // Regression for the missing-`label`-keyword bug: the
+        // synthesised `controllable { ... }` used to emit
+        // `wr_data_byte;` without the `label` keyword, which the
+        // CTXDSL parser rejected (it calls
+        // `expect_keyword(Keyword::Label)` on every entry). The fix
+        // emits `label wr_data_byte;` instead. This test wraps the
+        // synthesised fragment in a `context { ... }` block and
+        // confirms it round-trips through the parser.
+        let accesses = vec![
+            RegisterAccess {
+                kind: AccessKind::Read,
+                register: "CTRL".to_string(),
+                field: Some("tx_start".to_string()),
+                accessor: "(IR)".to_string(),
+                source_line: 1,
+                flow: AccessFlow::PollingLoop,
+                source_state_hint: None,
+            },
+            RegisterAccess {
+                kind: AccessKind::Write,
+                register: "CTRL".to_string(),
+                field: Some("tx_start".to_string()),
+                accessor: "(IR)".to_string(),
+                source_line: 2,
+                flow: AccessFlow::Linear,
+                source_state_hint: None,
+            },
+        ];
+        let fragment = synthesise_automaton_ctxdsl("demo", &accesses, &uart_register_map());
+        // The fragment is the `automata { ... }` block alone; wrap it
+        // in a context for the parser.
+        let full = format!("context Demo {{\n{fragment}}}\n");
+        let parsed = crate::context_dsl::parse(&full).unwrap_or_else(|e| {
+            panic!("synthesised CTXDSL failed to parse: {e:?}\n--- source ---\n{full}")
+        });
+        assert_eq!(parsed.automata.len(), 1);
+        let auto = &parsed.automata[0];
+        assert_eq!(auto.name.name, "Demo");
+        // The controllable block carries the write label.
+        assert!(
+            auto.controllable
+                .iter()
+                .any(|l| l.name.name == "wr_ctrl_tx_start"),
+            "expected wr_ctrl_tx_start in controllable block; got {:?}",
+            auto.controllable
         );
     }
 }

--- a/examples/industrial/codesign_uart/motivating_examples/transcript.txt
+++ b/examples/industrial/codesign_uart/motivating_examples/transcript.txt
@@ -29,7 +29,7 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
           "source_line": 1
         }
       ],
-      "automaton_ctxdsl": "    automata {\n        automaton Uart_status_clear {\n            controllable {\n                wr_status_tx_busy;\n            }\n\n            states {\n                state S0 initial;\n                state S1;\n            }\n\n            transitions {\n                transition S0 -> S1 on label wr_status_tx_busy; // (IR-resolved @AbsoluteAddress(1073807364))\n            }\n        }\n    }\n"
+      "automaton_ctxdsl": "    automata {\n        automaton Uart_status_clear {\n            controllable {\n                label wr_status_tx_busy;\n            }\n\n            states {\n                state S0 initial;\n                state S1;\n            }\n\n            transitions {\n                transition S0 -> S1 on label wr_status_tx_busy; // (IR-resolved @AbsoluteAddress(1073807364))\n            }\n        }\n    }\n"
     }
   ],
   "external_globals": [],
@@ -68,7 +68,7 @@ warning: uart_read_status: could not resolve pointer operand %4 of a volatile lo
           "source_line": 5
         }
       ],
-      "automaton_ctxdsl": "    automata {\n        automaton Uart_send {\n            controllable {\n                wr_data_byte;\n            }\n\n            states {\n                state S0 initial;\n                state S1;\n                state S2;\n            }\n\n            transitions {\n                transition S0 -> S1 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 })\n                transition S1 -> S2 on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n            }\n        }\n    }\n"
+      "automaton_ctxdsl": "    automata {\n        automaton Uart_send {\n            controllable {\n                label wr_data_byte;\n            }\n\n            states {\n                state S0 initial;\n                state S1;\n                state S2;\n            }\n\n            transitions {\n                transition S0 -> S1 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 })\n                transition S1 -> S2 on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n            }\n        }\n    }\n"
     },
     {
       "name": "uart_read_status",
@@ -129,7 +129,7 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
           "source_line": 8
         }
       ],
-      "automaton_ctxdsl": "    automata {\n        automaton Uart_send {\n            controllable {\n                wr_data_byte;\n                wr_ctrl_tx_start;\n            }\n\n            states {\n                state S0 initial;\n                state S1;\n                state S2;\n            }\n\n            transitions {\n                transition S0 -> S1 on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition S1 -> S2 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
+      "automaton_ctxdsl": "    automata {\n        automaton Uart_send {\n            controllable {\n                label wr_data_byte;\n                label wr_ctrl_tx_start;\n            }\n\n            states {\n                state S0 initial;\n                state S1;\n                state S2;\n            }\n\n            transitions {\n                transition S0 -> S1 on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition S1 -> S2 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
     },
     {
       "name": "UART_IRQHandler",
@@ -194,7 +194,7 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
           "source_line": 4
         }
       ],
-      "automaton_ctxdsl": "    automata {\n        automaton Uart_init {\n            controllable {\n                wr_ctrl_tx_start;\n            }\n\n            states {\n                state S0 initial;\n                state S1;\n            }\n\n            transitions {\n                transition S0 -> S1 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
+      "automaton_ctxdsl": "    automata {\n        automaton Uart_init {\n            controllable {\n                label wr_ctrl_tx_start;\n            }\n\n            states {\n                state S0 initial;\n                state S1;\n            }\n\n            transitions {\n                transition S0 -> S1 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
     },
     {
       "name": "uart_send",
@@ -229,7 +229,7 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
           "source_line": 13
         }
       ],
-      "automaton_ctxdsl": "    automata {\n        automaton Uart_send {\n            controllable {\n                wr_data_byte;\n                wr_ctrl_tx_start;\n            }\n\n            states {\n                state S0 initial;\n                state Loop0;\n                state S1;\n                state S2;\n                state S3;\n            }\n\n            transitions {\n                transition S0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (enter loop)\n                transition Loop0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (loop iteration)\n                transition Loop0 -> S1 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (exit loop)\n                transition S1 -> S2 on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition S2 -> S3 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
+      "automaton_ctxdsl": "    automata {\n        automaton Uart_send {\n            controllable {\n                label wr_data_byte;\n                label wr_ctrl_tx_start;\n            }\n\n            states {\n                state S0 initial;\n                state Loop0;\n                state S1;\n                state S2;\n                state S3;\n            }\n\n            transitions {\n                transition S0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (enter loop)\n                transition Loop0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (loop iteration)\n                transition Loop0 -> S1 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (exit loop)\n                transition S1 -> S2 on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition S2 -> S3 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
     },
     {
       "name": "uart_recv",
@@ -271,7 +271,7 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
 }
 
 === Example 8: CMSIS-style struct-member access (--cmsis-stubs) ===
-$ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/motivating_examples/example_8_cmsis_struct_access.c --register-map examples/industrial/codesign_uart/register_map.json --synthesize-automaton --cmsis-stubs --include /var/folders/cp/dgzzd8w16l90rnvkvx8532m80000gn/T/tmp.iMYGUpnfVk
+$ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/motivating_examples/example_8_cmsis_struct_access.c --register-map examples/industrial/codesign_uart/register_map.json --synthesize-automaton --cmsis-stubs --include /var/folders/cp/dgzzd8w16l90rnvkvx8532m80000gn/T/tmp.hZf13TvV5s
 {
   "source_filename": "examples/industrial/codesign_uart/motivating_examples/example_8_cmsis_struct_access.c",
   "target_triple": "x86_64-apple-macosx26.0.0",
@@ -309,7 +309,7 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
           "source_line": 13
         }
       ],
-      "automaton_ctxdsl": "    automata {\n        automaton Uart_send_byte {\n            controllable {\n                wr_data_byte;\n                wr_ctrl_tx_start;\n            }\n\n            states {\n                state S0 initial;\n                state Loop0;\n                state S1;\n                state S2;\n                state S3;\n            }\n\n            transitions {\n                transition S0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (enter loop)\n                transition Loop0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (loop iteration)\n                transition Loop0 -> S1 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (exit loop)\n                transition S1 -> S2 on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition S2 -> S3 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
+      "automaton_ctxdsl": "    automata {\n        automaton Uart_send_byte {\n            controllable {\n                label wr_data_byte;\n                label wr_ctrl_tx_start;\n            }\n\n            states {\n                state S0 initial;\n                state Loop0;\n                state S1;\n                state S2;\n                state S3;\n            }\n\n            transitions {\n                transition S0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (enter loop)\n                transition Loop0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (loop iteration)\n                transition Loop0 -> S1 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (exit loop)\n                transition S1 -> S2 on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition S2 -> S3 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
     }
   ],
   "external_globals": [],
@@ -363,7 +363,7 @@ $ ./target/debug/mununu codesign extract-c examples/industrial/codesign_uart/mot
           "source_state_hint": "Sending"
         }
       ],
-      "automaton_ctxdsl": "    automata {\n        automaton Uart_send_byte {\n            controllable {\n                wr_data_byte;\n                wr_ctrl_tx_start;\n            }\n\n            states {\n                state Polling initial;\n                state Loop0;\n                state Ready;\n                state Sending;\n                state S3;\n            }\n\n            transitions {\n                transition Polling -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (enter loop)\n                transition Loop0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (loop iteration)\n                transition Loop0 -> Ready on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (exit loop)\n                transition Ready -> Sending on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition Sending -> S3 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
+      "automaton_ctxdsl": "    automata {\n        automaton Uart_send_byte {\n            controllable {\n                label wr_data_byte;\n                label wr_ctrl_tx_start;\n            }\n\n            states {\n                state Polling initial;\n                state Loop0;\n                state Ready;\n                state Sending;\n                state S3;\n            }\n\n            transitions {\n                transition Polling -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (enter loop)\n                transition Loop0 -> Loop0 on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (loop iteration)\n                transition Loop0 -> Ready on label rd_status_tx_busy; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 1 }) (exit loop)\n                transition Ready -> Sending on label wr_data_byte; // (IR-resolved @InlineConstexprGep { base_addr: 1073807360, field_index: 2 })\n                transition Sending -> S3 on label wr_ctrl_tx_start; // (IR-resolved @AbsoluteAddress(1073807360))\n            }\n        }\n    }\n"
     }
   ],
   "external_globals": [],


### PR DESCRIPTION
## Summary

Pre-existing bug: `synthesise_automaton_ctxdsl` emitted a `controllable { … }` block without the `label` keyword on each entry, which the CTXDSL parser rejects (`parse_label_block` calls `expect_keyword(Keyword::Label)`). End-to-end *extract C → splice into context → eval* was effectively broken — every consumer had to insert `label` prefixes manually.

## Fix

- Emit `label NAME;` for each controllable label.
- Add a regression test (`synthesised_automaton_parses_back_through_ctxdsl_parser`) that wraps the synthesised fragment in a `context { ... }` block and parses it. The existing unit tests checked structural shape via `contains(...)` but never round-tripped through the parser, which is how the bug shipped silently.
- Regenerate the motivating-examples transcript so the recorded JSON output reflects the new spelling.

## Test plan

- [x] Unit tests: 49 c_extract tests pass; new round-trip test exercises the parser.
- [x] `make ci` clean (fmt + clippy + workspace tests + doctests).
- [x] Manual: `./target/debug/mununu codesign extract-c .../firmware.c --register-map .../register_map.json --synthesize-automaton` now emits a `controllable { label wr_…; }` block, which pastes into a context block without manual fix-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)