### PR TITLE
fix: unblock CI — microcode test fix + pre-commit hook delegates to make ci

### DIFF
--- a/crates/mununu-core/src/adapter/microcode/mod.rs
+++ b/crates/mununu-core/src/adapter/microcode/mod.rs
@@ -247,6 +247,11 @@ mod tests {
         // one memory automaton — each ops can declare a `tag` that
         // gets folded into the emitted label, so caches /
         // memories can distinguish writes by issuer.
+        //
+        // Both ops live on non-terminal steps so their labels fire:
+        // translate.rs drops ops declared on terminal steps (no
+        // `next`) with an `ApproximateTranslation` warning, which
+        // would otherwise silently elide the `rd_mem` label.
         let json = r#"
         {
           "name": "tagged",
@@ -256,7 +261,9 @@ mod tests {
               "ops": [{ "op": "write_mem", "region": "x", "tag": "core_0" }],
               "next": "b" },
             { "id": "b",
-              "ops": [{ "op": "read_mem", "region": "x", "tag": "core_1" }] }
+              "ops": [{ "op": "read_mem", "region": "x", "tag": "core_1" }],
+              "next": "halt" },
+            { "id": "halt", "ops": [] }
           ]
         }
         "#;

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,18 +1,17 @@
 #!/usr/bin/env bash
+# CLAUDE.md contract: "The gate is `make ci` — the same command runs locally,
+# in pre-commit hooks, and in GitHub Actions." Anything else drifts and lets
+# CI-failing commits land. The extra `cargo test --lib api --features api`
+# call mirrors the separate step in .github/workflows/ci.yml.
 set -e
 
-echo "Running pre-commit checks..."
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 
-echo "  [1/4] Checking formatting..."
-cargo fmt --all -- --check
+echo "Running pre-commit checks (make ci)..."
+make ci
 
-echo "  [2/4] Running clippy..."
-cargo clippy --all-targets -- -D warnings
-
-echo "  [3/4] Running tests..."
-cargo test --lib --bins --tests --examples
-
-echo "  [4/4] Testing API module..."
+echo "Testing API module..."
 cargo test --lib api --features api
 
 echo "All pre-commit checks passed."


### PR DESCRIPTION
## Summary

Two-commit fix to unblock CI on `main` and prevent the regression class from recurring.

### Commit 1 — `fix(adapter): microcode tag-folding test uses non-terminal step`

`translate.rs` drops microcode ops declared on terminal steps (no `next`) with an `ApproximateTranslation` warning. The `tag_field_folds_into_emitted_label` test had its `read_mem` op on a terminal state, so the `rd_mem_x_core_1` label was silently elided and the assertion has been failing since the microcode adapter landed. CI on `main` has been red for **4 consecutive runs** (since `16c70863` on 2026-05-18 01:59 UTC). Adding an explicit `halt` terminal state fixes the test.

### Commit 2 — `fix(scripts): pre-commit hook delegates to make ci`

The previous pre-commit hook ran `cargo clippy --all-targets` and `cargo test --lib --bins --tests --examples` **without `--workspace`**, so it only exercised the crate at the invocation directory. GitHub Actions runs `make ci` which is workspace-wide. The drift is exactly how the microcode-test regression slipped through 4 PRs.

The hook now invokes `make ci` directly — same command, three places (local, hook, CI) — matching the CLAUDE.md contract by construction.

## Test plan

- [ ] GitHub Actions `lint-and-test` job passes (it has been red on main; this is the first commit that should turn it green)
- [ ] `security-audit` job passes (unchanged behaviour)
- [ ] `cargo test --lib api --features api` extra step passes
- [ ] Local: `make ci` returns 0
- [ ] Local: `scripts/pre-commit` exits 0 against this branch's working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)