### PR TITLE
feat(verify): counterexample trace witness on violated verdicts (A3)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -212,6 +212,12 @@ struct VerifyArgs {
     /// verdicts to enforce against).
     #[arg(long = "print-alphabet")]
     print_alphabet: bool,
+    /// For every violated property, print the counterexample witness
+    /// attached by the orchestrator (initial state → labelled steps →
+    /// termination). Default off so existing transcripts stay
+    /// byte-stable; opt-in for debugging.
+    #[arg(long = "print-counterexample")]
+    print_counterexample: bool,
 }
 
 #[derive(Args, Debug)]
@@ -1120,6 +1126,29 @@ fn handle_verify(args: VerifyArgs) -> Result<(), String> {
                 source = source_str,
                 over = v.over,
             );
+            if args.print_counterexample
+                && let Some(witness) = v.counterexample.as_ref()
+            {
+                println!("      counterexample (from {}):", witness.initial_state);
+                for (i, step) in witness.steps.iter().enumerate() {
+                    println!(
+                        "        {idx}. --[{label}]--> {state}",
+                        idx = i + 1,
+                        label = step.label,
+                        state = step.successor_state,
+                    );
+                }
+                let term = match &witness.termination {
+                    mununu_core::verify::report::TraceTermination::Sink => "sink".to_string(),
+                    mununu_core::verify::report::TraceTermination::Cycle { return_to_step } => {
+                        format!("cycle back to step {return_to_step}")
+                    }
+                    mununu_core::verify::report::TraceTermination::LengthLimit => {
+                        "length-limit (truncated)".to_string()
+                    }
+                };
+                println!("        ({term})");
+            }
         }
     }
 

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -63,8 +63,8 @@ use crate::verify::binding::{AlphabetBinding, apply_renamings_to_ctxdsl};
 use crate::verify::config::{PropertySection, VerifyConfig};
 use crate::verify::register_map_rewriter::derive_sv_renamings_from_register_map;
 use crate::verify::report::{
-    CompositionInfo, PropertyFormulaSource, PropertyVerdict, SourceSummary, VerifyError,
-    VerifyReport,
+    CompositionInfo, PropertyFormulaSource, PropertyVerdict, SourceSummary, TraceStep,
+    TraceTermination, TraceWitness, VerifyError, VerifyReport,
 };
 
 // ---------------------------------------------------------------------------
@@ -1012,6 +1012,12 @@ fn evaluate_one_property(
         .collect();
     let satisfied = !initial_states.is_empty() && initial_satisfying.len() == initial_states.len();
 
+    let counterexample = if !satisfied {
+        build_counterexample_witness(clts, &result, TRACE_WITNESS_STEP_CAP)
+    } else {
+        None
+    };
+
     Ok(PropertyVerdict {
         name: name.to_string(),
         formula_source,
@@ -1022,7 +1028,147 @@ fn evaluate_one_property(
         satisfying_states,
         initial_states,
         initial_satisfying,
+        counterexample,
     })
+}
+
+/// Maximum number of steps recorded by [`build_counterexample_witness`].
+/// 20 steps is enough to surface the typical violation in shipped
+/// fixtures (the chaotic codesign trace from `Idle` to `Sending` is
+/// ~6 steps in the worst case) without producing a wall of state
+/// names in the verify report.
+const TRACE_WITNESS_STEP_CAP: usize = 20;
+
+/// Construct a forward-walk witness from a violating initial state.
+///
+/// Picks the first initial state that does not satisfy `result`,
+/// then walks outgoing transitions for up to `max_steps`, preferring
+/// successors that also violate the property. Falls back to any
+/// unvisited successor when no violating successor is available.
+///
+/// Returns `None` when:
+/// - every initial state satisfies the property (caller should not
+///   invoke this), or
+/// - the composition has no initial states.
+fn build_counterexample_witness<S, L>(
+    clts: &crate::clts::Clts<S, L>,
+    satisfaction: &bitvec::vec::BitVec<usize, bitvec::order::Lsb0>,
+    max_steps: usize,
+) -> Option<TraceWitness>
+where
+    S: IdStorage,
+    L: IdStorage,
+{
+    use std::collections::HashSet;
+
+    let violating_initial = clts
+        .initial_states()
+        .iter()
+        .copied()
+        .find(|sid| !satisfaction.get(sid.index()).map(|b| *b).unwrap_or(false))?;
+
+    let initial_state = clts.state_name(violating_initial)?.to_string();
+
+    let mut steps: Vec<TraceStep> = Vec::new();
+    let mut visited: HashSet<usize> = HashSet::new();
+    visited.insert(violating_initial.index());
+    let mut current = violating_initial;
+    let mut termination = TraceTermination::Sink;
+    let mut path_states_by_index: Vec<usize> = vec![violating_initial.index()];
+
+    for _ in 0..max_steps {
+        let outgoing = clts.outgoing(current);
+        if outgoing.is_empty() {
+            termination = TraceTermination::Sink;
+            break;
+        }
+
+        // Prefer an unvisited violating successor.
+        let mut pick = outgoing.iter().find(|t| {
+            let idx = t.target().index();
+            !visited.contains(&idx) && !satisfaction.get(idx).map(|b| *b).unwrap_or(true)
+        });
+        // Fallback to any unvisited successor.
+        if pick.is_none() {
+            pick = outgoing
+                .iter()
+                .find(|t| !visited.contains(&t.target().index()));
+        }
+
+        let Some(transition) = pick else {
+            // Every successor visited — close the cycle on the first
+            // outgoing edge.
+            let first = &outgoing[0];
+            let succ_idx = first.target().index();
+            let succ_name = clts
+                .state_name(first.target())
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("state_{succ_idx}"));
+            let label = format_transition_label(clts, first);
+            steps.push(TraceStep {
+                label,
+                successor_state: succ_name,
+            });
+            let return_to_step = path_states_by_index
+                .iter()
+                .position(|&i| i == succ_idx)
+                .unwrap_or(0);
+            termination = TraceTermination::Cycle { return_to_step };
+            break;
+        };
+
+        let succ = transition.target();
+        let succ_idx = succ.index();
+        let succ_name = clts
+            .state_name(succ)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("state_{succ_idx}"));
+        let label = format_transition_label(clts, transition);
+        steps.push(TraceStep {
+            label,
+            successor_state: succ_name,
+        });
+        visited.insert(succ_idx);
+        path_states_by_index.push(succ_idx);
+        current = succ;
+    }
+
+    if steps.len() == max_steps && !matches!(termination, TraceTermination::Cycle { .. }) {
+        termination = TraceTermination::LengthLimit;
+    }
+
+    Some(TraceWitness {
+        initial_state,
+        steps,
+        termination,
+    })
+}
+
+/// Render one multi-label transition's label payload as a
+/// comma-joined string (`label_a,label_b`). Falls back to `"?"` when
+/// the label store cannot resolve the ID, which only happens if the
+/// CLTS is malformed.
+fn format_transition_label<S, L>(
+    clts: &crate::clts::Clts<S, L>,
+    transition: &crate::clts::Transition<S, L>,
+) -> String
+where
+    S: IdStorage,
+    L: IdStorage,
+{
+    let mut parts: Vec<String> = Vec::new();
+    for lid in transition.labels() {
+        if let Some(payload) = clts.label_payload(*lid) {
+            for sym in payload {
+                parts.push(sym.clone());
+            }
+        }
+    }
+    if parts.is_empty() {
+        "?".to_string()
+    } else {
+        parts.join(",")
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1753,5 +1899,66 @@ over = "T"
         let report = verify_project(&config, temp.path()).expect("verify pipeline succeeded");
         assert_eq!(report.property_verdicts.len(), 1);
         assert!(report.property_verdicts[0].satisfied);
+    }
+
+    #[test]
+    fn violated_property_emits_counterexample_witness() {
+        // Pin a property to `false` so every initial state violates;
+        // expect the orchestrator to attach a TraceWitness rooted at
+        // a violating initial state.
+        let temp = tempdir().unwrap();
+        let _ = write_ctxdsl_source(temp.path(), "light.ctxdsl", SIMPLE_LIGHT_CTXDSL);
+        let toml_src = r#"
+[project]
+name = "Bad"
+
+[[sources]]
+id = "light"
+adapter = "ctxdsl"
+files = ["light.ctxdsl"]
+
+[composition]
+semantics = "synchronous"
+members = ["light"]
+name = "Sys"
+
+[[properties]]
+name = "impossible"
+formula = "false"
+over = "Sys"
+"#;
+        let config = VerifyConfig::from_toml(toml_src).unwrap();
+        let report = verify_project(&config, temp.path()).expect("pipeline runs");
+        assert_eq!(report.property_verdicts.len(), 1);
+        let v = &report.property_verdicts[0];
+        assert!(!v.satisfied, "expected VIOLATED");
+        let witness = v
+            .counterexample
+            .as_ref()
+            .expect("violated verdicts carry a counterexample");
+        assert!(
+            !witness.initial_state.is_empty(),
+            "initial_state should name a violating initial"
+        );
+        // The walk should produce at least one step or terminate at a sink.
+        match &witness.termination {
+            TraceTermination::Sink
+            | TraceTermination::Cycle { .. }
+            | TraceTermination::LengthLimit => {}
+        }
+    }
+
+    #[test]
+    fn satisfied_property_does_not_emit_counterexample() {
+        let temp = tempdir().unwrap();
+        let config = build_two_source_config(temp.path());
+        let report = verify_project(&config, temp.path()).expect("pipeline runs");
+        for v in &report.property_verdicts {
+            assert!(v.satisfied);
+            assert!(
+                v.counterexample.is_none(),
+                "satisfied verdicts should not carry a counterexample"
+            );
+        }
     }
 }

--- a/crates/mununu-core/src/verify/report.rs
+++ b/crates/mununu-core/src/verify/report.rs
@@ -70,6 +70,60 @@ pub struct PropertyVerdict {
     pub initial_states: Vec<String>,
     /// Subset of `initial_states` that satisfy the formula.
     pub initial_satisfying: Vec<String>,
+    /// Witness path from a violating initial state, when the
+    /// verdict is unsatisfied and a witness can be constructed. The
+    /// orchestrator emits this opportunistically — `None` is also
+    /// emitted for satisfied verdicts and when the walk hits a
+    /// degenerate case (no violating initials, no outgoing
+    /// transitions from violating initials). See [`TraceWitness`]
+    /// for the trace shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub counterexample: Option<TraceWitness>,
+}
+
+/// A short witness path from a violating initial state to either a
+/// sink, a cycle, or a length-capped step in the composed
+/// automaton. The trace is **not** a counterstrategy — it is a
+/// straightforward forward walk through the composition, biased
+/// toward visiting states that violate the property formula. For
+/// safety properties this surfaces "the system can reach this bad
+/// state via these transitions"; for reachability properties this
+/// surfaces "no path from here reaches the target".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceWitness {
+    /// Initial composed-state name where the trace begins.
+    pub initial_state: String,
+    /// Sequence of transitions taken. `steps[i]` records the label
+    /// fired and the state entered.
+    pub steps: Vec<TraceStep>,
+    /// Why the trace stopped.
+    pub termination: TraceTermination,
+}
+
+/// One transition in a [`TraceWitness`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceStep {
+    /// Label payload of the fired transition. A single CTXDSL
+    /// `transition s -> t on label a, label b;` produces one entry
+    /// joining the labels with `,`.
+    pub label: String,
+    /// Composed-state name entered after firing this transition.
+    pub successor_state: String,
+}
+
+/// Reason a [`TraceWitness`] stopped at a particular step.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TraceTermination {
+    /// The composed-state reached has no outgoing transitions.
+    Sink,
+    /// The walk revisited a state already in the trace; the
+    /// `return_to_step` index is the step where the cycle joins
+    /// back. `0` means the cycle closes onto the initial state.
+    Cycle { return_to_step: usize },
+    /// The orchestrator's length cap (currently 20 steps) was
+    /// reached before any other terminator fired.
+    LengthLimit,
 }
 
 /// How a property's formula was sourced.


### PR DESCRIPTION
## Summary

Stream A item A3. Every violated \`PropertyVerdict\` now carries an optional \`TraceWitness\` — a forward walk from a violating initial state through the composition, preferring violating successors, recording the multi-label payload of each transition fired, and terminating on sink / cycle / 20-step length cap.

## What's added

- **\`TraceWitness\` / \`TraceStep\` / \`TraceTermination\`** types in \`verify::report\`. Serializable, backwards-compatible (\`counterexample: Option<TraceWitness>\` with serde default).
- **\`build_counterexample_witness\`** in \`verify::orchestrator\`. Pure function over \`Clts\` + satisfaction bitset; reuses the evaluation result, no extra state-space walk.
- **\`mununu verify --print-counterexample\`** flag — off by default so existing fixture transcripts stay byte-stable; opt-in surfaces the witness inline beneath each violated verdict.
- **UI client types**: \`VerifyTraceWitness\` / \`VerifyTraceStep\` / \`VerifyTraceTermination\` + the optional \`counterexample\` field (sibling repo PR).
- **2 orchestrator unit tests**: violated property emits a witness; satisfied verdicts do not.

## Smoke test

\`\`\`
$ mununu verify /tmp/ce_smoke.toml --base-dir /tmp --print-counterexample
verify report — project \`CE_Smoke\`:
  composition: asynchronous Sys { members = [Lock, Gate] }
  ...
  properties (1):
    impossible: VIOLATED (0/4 states, 0/1 initial) [inline, over = Sys]
      counterexample (from closed|locked):
        1. --[tick_gate]--> open|locked
        2. --[open_request]--> open|unlocked
        3. --[tick_gate]--> closed|unlocked
        4. --[close_request]--> closed|locked
        (cycle back to step 0)
\`\`\`

## Out of scope (deferred)

- **Liveness lasso traces** (prefix + cycle) — \`context::diagnostics\` already supports these for controller synthesis; wiring through the verify pipeline is a follow-up when a verify fixture surfaces a real liveness violation.
- **Per-source lane attribution** — the trace surfaces only the label payload today; lane-per-source UI rendering remains an A2 concern (UI wizard panels).

## Test plan

- [x] \`make ci\` green
- [x] 16 / 16 orchestrator tests pass (2 new: \`violated_property_emits_counterexample_witness\`, \`satisfied_property_does_not_emit_counterexample\`)
- [x] UI tests green (182 / 182)
- [x] End-to-end smoke against xstate_pair fixture with \`formula = "false"\` shows a 4-step cycle counterexample
- [x] \`--print-counterexample\` opt-in; existing transcripts unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)