### PR TITLE
fix(mu-calculus): fixpoint binder extends right per textbook convention

### DIFF
--- a/crates/mununu-core/benches/controller.rs
+++ b/crates/mununu-core/benches/controller.rs
@@ -43,8 +43,8 @@ fn build_line_plant(state_count: usize) -> Clts<DefaultStateIdx, DefaultLabelIdx
 /// alternating fixpoint evaluation instead of the trivial `true` formula.
 fn gr1_formula() -> mununu_core::mu_calculus::Formula {
     parser::parse(
-        "((! (nu NuA. (mu MuA. (Req || <> MuA)) && ([] NuA))) \
-          || (nu NuG. (mu MuG. (Grant || <> MuG)) && ([] NuG)))",
+        "((! (nu NuA. ((mu MuA. (Req || <> MuA)) && ([] NuA)))) \
+          || (nu NuG. ((mu MuG. (Grant || <> MuG)) && ([] NuG))))",
     )
     .expect("GR(1) formula parses")
 }

--- a/crates/mununu-core/src/adapter/aiger/mod.rs
+++ b/crates/mununu-core/src/adapter/aiger/mod.rs
@@ -310,7 +310,7 @@ fn to_ir(circuit: &ast::Circuit, options: &AdapterOptions) -> Result<AdapterIR, 
 
         if !justice_states.is_empty() {
             let justice_pred = justice_states.join(" || ");
-            // G F (justice_states) encoded as nu Y. (mu X. ((pred) || <> X) && [] Y)
+            // G F (justice_states) encoded as nu Y. ((mu X. ((pred) || <> X)) && ([] Y))
             properties.push(PropertySpec {
                 name: format!("justice_{i}"),
                 kind: PropertyKind::Fairness,
@@ -349,7 +349,7 @@ fn to_ir(circuit: &ast::Circuit, options: &AdapterOptions) -> Result<AdapterIR, 
 
         if !fair_states.is_empty() {
             let fair_pred = fair_states.join(" || ");
-            // G F (fairness_states) encoded as nu Y. (mu X. ((pred) || <> X) && [] Y)
+            // G F (fairness_states) encoded as nu Y. ((mu X. ((pred) || <> X)) && ([] Y))
             properties.push(PropertySpec {
                 name: format!("fairness_{i}"),
                 kind: PropertyKind::Fairness,

--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -527,7 +527,7 @@ fn build_properties(
         }
     }
 
-    // Justice properties → liveness: nu Y. (mu X. (pred || <> X) && [] Y)
+    // Justice properties → liveness: nu Y. ((mu X. (pred || <> X)) && ([] Y))
     for (i, line) in file.justices().enumerate() {
         let signals = match &line.node {
             Node::Justice { signals } => signals.clone(),

--- a/crates/mununu-core/src/examples/sterile_batch_release.rs
+++ b/crates/mununu-core/src/examples/sterile_batch_release.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 
 const PIPELINE_NAME: &str = "pipeline";
 const SHIP_REQUIRES_RELEASE: &str =
-    "nu Safe. ((! < ( labels = {ship} ) > true) || < ( labels = {qp_sign} ) > true) && Safe";
-const COMPLETION_LEADS_TO_DISPOSITION: &str = "nu Progress. ( [ ( labels = {qc_start} ) ] mu Resolve. ( < ( labels = {qp_sign} ) > true || < ( labels = {quarantine} ) > true || < ( labels = {cancel} ) > true ) && Resolve ) && Progress";
+    "nu Safe. (((! < ( labels = {ship} ) > true) || < ( labels = {qp_sign} ) > true) && ([] Safe))";
+const COMPLETION_LEADS_TO_DISPOSITION: &str = "nu Progress. (([ ( labels = {qc_start} ) ] (mu Resolve. ((< ( labels = {qp_sign} ) > true || < ( labels = {quarantine} ) > true || < ( labels = {cancel} ) > true) || (<> Resolve)))) && ([] Progress))";
 
 #[derive(Debug, Error)]
 pub enum SterileError {

--- a/crates/mununu-core/src/mu_calculus/parser.rs
+++ b/crates/mununu-core/src/mu_calculus/parser.rs
@@ -155,7 +155,13 @@ impl<'a> Parser<'a> {
             self.expect_char('.')?;
             let var_id = self.builder.push_var(name.clone());
             self.binder_stack.push(Binder { name, id: var_id });
-            let body = self.parse_unary()?;
+            // Textbook mu-calculus convention: a fixpoint binder extends as
+            // far right as possible — `mu X. φ ∧ ψ` ≡ `mu X. (φ ∧ ψ)`. Parse
+            // the body with parse_or (the lowest-precedence parser) so the
+            // body absorbs following `&&` / `||` at the same nesting level.
+            // Existing call sites use explicit parens around the body, so
+            // their parse tree is unchanged.
+            let body = self.parse_or()?;
             self.binder_stack.pop();
             let node = self.builder.push_node(Node::Mu { var: var_id, body });
             return Ok(Some(node));
@@ -169,7 +175,7 @@ impl<'a> Parser<'a> {
             self.expect_char('.')?;
             let var_id = self.builder.push_var(name.clone());
             self.binder_stack.push(Binder { name, id: var_id });
-            let body = self.parse_unary()?;
+            let body = self.parse_or()?;
             self.binder_stack.pop();
             let node = self.builder.push_node(Node::Nu { var: var_id, body });
             return Ok(Some(node));
@@ -763,29 +769,42 @@ mod tests {
     use crate::mu_calculus::{Control, Guard, ModalKind, Node, VariableGuard};
 
     #[test]
-    fn test_failing_ai_formulas() {
-        let formulas = vec![
-            (
-                "1",
-                "nu X. ((not scoring_request_received) or (mu Y. (scoring_request_handled or [] Y))) and [] X",
-            ),
-            (
-                "2",
-                "nu X. ((not score_received_) or (mu Y. (report_delay or [] Y))) and [] X",
-            ),
-            (
-                "3",
-                "nu X. ((not Fulfill_order_exit) or (mu Y. (Order_completed or [] Y))) and [] X",
-            ),
+    fn fixpoint_binder_extends_right_through_conjunction() {
+        // Verifies that `nu X. φ and [] X` binds X across the trailing
+        // `[] X` (textbook right-extending convention). Each formula is the
+        // canonical liveness-implication body — the `[] X` references the
+        // outer nu's bound variable; if the parser bound it as a free
+        // predicate, model checking would silently miscompile.
+        let formulas = [
+            "nu X. ((not scoring_request_received) or (mu Y. (scoring_request_handled or [] Y))) and [] X",
+            "nu X. ((not score_received_) or (mu Y. (report_delay or [] Y))) and [] X",
+            "nu X. ((not Fulfill_order_exit) or (mu Y. (Order_completed or [] Y))) and [] X",
         ];
 
-        for (name, formula) in formulas {
-            match parse(formula) {
-                Ok(_) => println!("Formula {}: ✅ OK", name),
-                Err(e) => {
-                    println!("Formula {}: ❌ ERROR: {:?}", name, e);
-                    println!("  Formula text: {}", formula);
-                }
+        for formula_text in formulas {
+            let formula = parse(formula_text).unwrap_or_else(|e| {
+                panic!("formula failed to parse: {e:?}\n  text: {formula_text}")
+            });
+            let Node::Nu { var: nu_var, body } = formula.node(formula.root()) else {
+                panic!(
+                    "expected outer nu, got {:?}\n  text: {formula_text}",
+                    formula.node(formula.root())
+                );
+            };
+            let Node::And(_, rhs) = formula.node(*body) else {
+                panic!("expected `... and [] X` at nu body\n  text: {formula_text}");
+            };
+            let Node::Modal { target, .. } = formula.node(*rhs) else {
+                panic!("expected `[] X` modal at rhs\n  text: {formula_text}");
+            };
+            match formula.node(*target) {
+                Node::Variable(var) => assert_eq!(
+                    var, nu_var,
+                    "`[] X` must bind to outer nu X\n  text: {formula_text}"
+                ),
+                other => panic!(
+                    "`[] X` resolved to {other:?} instead of bound Variable\n  text: {formula_text}"
+                ),
             }
         }
     }

--- a/crates/mununu-core/tests/scalable_gr1.rs
+++ b/crates/mununu-core/tests/scalable_gr1.rs
@@ -144,14 +144,14 @@ fn build_env(clts: &Clts<DefaultStateIdx, DefaultLabelIdx>, n_pairs: usize) -> E
 /// Build the GR(1) formula for n pairs using string representation.
 ///
 /// Formula: ∧_{i=0}^{n-1} (¬GF(Req_i) ∨ GF(Grant_i))
-/// = ∧_{i=0}^{n-1} ((! nu NuAi. (mu MuAi. (Req_i || <> MuAi)) && [] NuAi)
-///                  || nu NuGi. (mu MuGi. (Grant_i || <> MuGi)) && [] NuGi)
+/// = ∧_{i=0}^{n-1} ((! (nu NuAi. ((mu MuAi. (Req_i || <> MuAi)) && ([] NuAi))))
+///                  || (nu NuGi. ((mu MuGi. (Grant_i || <> MuGi)) && ([] NuGi))))
 fn build_formula_string(n_pairs: usize) -> String {
     let pair_exprs: Vec<String> = (0..n_pairs)
         .map(|i| {
             format!(
-                "((! (nu NuA{i}. (mu MuA{i}. (Req{i} || <> MuA{i})) && ([] NuA{i})))\
-                 || (nu NuG{i}. (mu MuG{i}. (Grant{i} || <> MuG{i})) && ([] NuG{i})))"
+                "((! (nu NuA{i}. ((mu MuA{i}. (Req{i} || <> MuA{i})) && ([] NuA{i}))))\
+                 || (nu NuG{i}. ((mu MuG{i}. (Grant{i} || <> MuG{i})) && ([] NuG{i}))))"
             )
         })
         .collect();

--- a/crates/mununu-core/tests/sterile_batch_release.rs
+++ b/crates/mununu-core/tests/sterile_batch_release.rs
@@ -1,12 +1,18 @@
 //! Industrial BPM Example: Sterile Pharmaceutical Batch Release
 //!
-//! This test instantiates a regulated fill-and-finish workflow—mirroring Pfizer/Roche style
-//! pipelines under FDA 21 CFR Part 11 & EU GMP Annex 1—in four CLTS components: production,
+//! This test instantiates a regulated fill-and-finish workflow — mirroring Pfizer/Roche style
+//! pipelines under FDA 21 CFR Part 11 & EU GMP Annex 1 — in four CLTS components: production,
 //! quality control, qualified-person release, and cold-chain logistics. It documents the
 //! compliance requirement that nothing ships before QC pass + QP sign-off, and every completed
-//! batch eventually gets released or quarantined. We reuse the μ-calculus formulas to confirm the
-//! safety/liveness behaviour and show that the current process violates the safety policy (hence
-//! the controller synthesis yields the empty controller).
+//! batch eventually gets released or quarantined.
+//!
+//! The synchronous composition over these four components admits only the joint initial state
+//! as reachable (private labels do not fire alone under strict synchronous semantics), so the
+//! textbook safety invariant `nu Safe. ((¬<ship>true ∨ <qp_sign>true) ∧ [] Safe)` and the
+//! corresponding leads-to liveness property hold vacuously and controller synthesis succeeds
+//! trivially. The test asserts that observable behaviour; a richer composition (asynchronous,
+//! or one that explicitly relabels private actions to a global tick) would exercise the
+//! formulas non-vacuously.
 use mununu_core::clts::{Clts, DefaultLabelIdx, DefaultStateIdx};
 use mununu_core::context_dsl::parser;
 use mununu_core::examples::sterile_batch_release::{SterileScenario, sterile_scenario};
@@ -50,12 +56,18 @@ fn sterile_batch_release_properties_hold() -> Result<(), Box<dyn Error>> {
         .expect("pipeline registered in scenario context");
     let reachable = reachable_states(pipeline_clts);
 
+    // The synchronous composition over the four pipeline components has a
+    // single reachable joint state (private labels can't fire alone), so the
+    // textbook safety invariant holds vacuously at that single state. A
+    // non-vacuous version of this test would need an asynchronous composition
+    // or a relabeling of private actions.
     let safety = context.evaluate_mu(pipeline, &ship_requires_release, &environment, None)?;
     assert!(
-        reachable.iter().enumerate().any(|(idx, reachable_state)| {
-            *reachable_state && !safety.get(idx).is_some_and(|bit| *bit)
-        }),
-        "expected at least one reachable state to violate ship_requires_release"
+        reachable
+            .iter()
+            .enumerate()
+            .all(|(idx, &rb)| { !rb || safety.get(idx).is_some_and(|bit| *bit) }),
+        "ship_requires_release should hold at every reachable state under textbook semantics"
     );
 
     let liveness = context.evaluate_mu(
@@ -65,28 +77,18 @@ fn sterile_batch_release_properties_hold() -> Result<(), Box<dyn Error>> {
         None,
     )?;
     assert!(
-        reachable.iter().enumerate().any(|(idx, reachable_state)| {
-            *reachable_state && !liveness.get(idx).is_some_and(|bit| *bit)
-        }),
-        "expected some reachable states to require disposition handling"
+        reachable
+            .iter()
+            .enumerate()
+            .all(|(idx, &rb)| { !rb || liveness.get(idx).is_some_and(|bit| *bit) }),
+        "completion_leads_to_disposition should hold at every reachable state under textbook semantics"
     );
 
     let controller =
         context.synthesise_controller(pipeline, &ship_requires_release, &environment, None)?;
-    assert!(!controller.realizable);
-    assert_eq!(controller.controller.state_count(), 0);
-    assert_eq!(controller.diagnostics.violating_initials.len(), 1);
-    assert!(
-        controller
-            .diagnostics
-            .messages
-            .iter()
-            .any(|msg| msg.contains("Controller unrealizable"))
-    );
-    assert!(
-        controller.diagnostics.counterexample_trace.is_some(),
-        "expected a minimal counterexample trace"
-    );
+    assert!(controller.realizable);
+    assert!(controller.diagnostics.violating_initials.is_empty());
+    assert!(controller.diagnostics.counterexample_trace.is_none());
     assert!(controller.diagnostics.deadlock_traces.is_empty());
     assert!(controller.diagnostics.counterstrategy_traces.is_empty());
 

--- a/examples/agentic/handoff_protocol.ctxdsl
+++ b/examples/agentic/handoff_protocol.ctxdsl
@@ -173,8 +173,8 @@ context handoff_protocol {
         // GF(Dispatching) -> GF(Idle)
         formula no_orphaned_tasks {
             over handoff_system;
-            body = (! (nu A. (mu B. (Dispatching || <> B)) && ([] A)))
-                || (nu C. (mu D. (Idle || <> D)) && ([] C));
+            body = (! (nu A. ((mu B. (Dispatching || <> B)) && ([] A))))
+                || (nu C. ((mu D. (Idle || <> D)) && ([] C)));
         }
     }
 

--- a/examples/agentic/mcp_usecases/04_stateful_sessions.ctxdsl
+++ b/examples/agentic/mcp_usecases/04_stateful_sessions.ctxdsl
@@ -187,8 +187,8 @@ context stateful_sessions {
         // Encodes the keepalive heartbeat requirement.
         formula keepalive_liveness {
             over SessionLifecycle;
-            body = (! (nu A. (mu B. (Active || <> B)) && ([] A)))
-                || (nu C. (mu D. (Active || <> D)) && ([] C));
+            body = (! (nu A. ((mu B. (Active || <> B)) && ([] A))))
+                || (nu C. ((mu D. (Active || <> D)) && ([] C)));
         }
 
         // Safety: No tool calls from uninitialized state.

--- a/examples/agentic/mcp_usecases/05_oauth21_mcp.ctxdsl
+++ b/examples/agentic/mcp_usecases/05_oauth21_mcp.ctxdsl
@@ -223,8 +223,8 @@ context oauth21_mcp {
         // GF(TokenExpired) -> GF(TokenActive)
         formula token_refresh_liveness {
             over OAuthFlow;
-            body = (! (nu A. (mu B. (TokenExpired || <> B)) && ([] A)))
-                || (nu C. (mu D. (TokenActive || <> D)) && ([] C));
+            body = (! (nu A. ((mu B. (TokenExpired || <> B)) && ([] A))))
+                || (nu C. ((mu D. (TokenActive || <> D)) && ([] C)));
         }
     }
 

--- a/examples/agentic/mcp_usecases/07_figma_mcp.ctxdsl
+++ b/examples/agentic/mcp_usecases/07_figma_mcp.ctxdsl
@@ -156,8 +156,8 @@ context figma_mcp {
         // GF(Writing) -> GF(Idle)
         formula write_fairness {
             over DesignAccess;
-            body = (! (nu A. (mu B. (Writing || <> B)) && ([] A)))
-                || (nu C. (mu D. (Idle || <> D)) && ([] C));
+            body = (! (nu A. ((mu B. (Writing || <> B)) && ([] A))))
+                || (nu C. ((mu D. (Idle || <> D)) && ([] C)));
         }
 
         // Liveness: CacheValid is reachable from CacheStale.

--- a/examples/agentic/mcp_usecases/10_bedrock_agentcore.ctxdsl
+++ b/examples/agentic/mcp_usecases/10_bedrock_agentcore.ctxdsl
@@ -277,16 +277,16 @@ context bedrock_agentcore {
         // GF(Unbound) -> GF(BoundToA || BoundToB)
         formula gateway_availability {
             over GatewayRouter;
-            body = (! (nu A. (mu B. (Unbound || <> B)) && ([] A)))
-                || (nu C. (mu D. (BoundToA || BoundToB || <> D)) && ([] C));
+            body = (! (nu A. ((mu B. (Unbound || <> B)) && ([] A))))
+                || (nu C. ((mu D. (BoundToA || BoundToB || <> D)) && ([] C)));
         }
 
         // GR(1): IAM token refresh responsiveness.
         // GF(TokenExpired) -> GF(Authenticated)
         formula iam_refresh_liveness {
             over IAMAuth;
-            body = (! (nu A. (mu B. (TokenExpired || <> B)) && ([] A)))
-                || (nu C. (mu D. (Authenticated || <> D)) && ([] C));
+            body = (! (nu A. ((mu B. (TokenExpired || <> B)) && ([] A))))
+                || (nu C. ((mu D. (Authenticated || <> D)) && ([] C)));
         }
 
         // Liveness: Authenticated state is reachable.

--- a/examples/amba_arbiter_gr1.ctxdsl
+++ b/examples/amba_arbiter_gr1.ctxdsl
@@ -126,32 +126,32 @@ context amba_arbiter_gr1 {
         // Corresponds to GF grant_0 in the GR(1) system justice.
         formula grant0_reachable {
             over bus_system;
-            body = (! (nu X. (mu Y. (Requesting0 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Grant0 || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Requesting0 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Grant0 || <> W)) && ([] Z)));
         }
 
         // Liveness (GF guarantee): Grant1 is reachable — client 1 can be served.
         formula grant1_reachable {
             over bus_system;
-            body = (! (nu X. (mu Y. (Requesting1 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Grant1 || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Requesting1 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Grant1 || <> W)) && ([] Z)));
         }
 
         // GR(1) no starvation for client 0: GF(Grant0) → GF(Free).
         // If the arbiter grants client 0 infinitely often, it also frees the
         // bus infinitely often.
-        // GF(p) = nu X. (mu Y. (p || <> Y)) && ([] X)
+        // GF(p) = nu X. ((mu Y. (p || <> Y)) && ([] X))
         formula no_starvation_0 {
             over bus_system;
-            body = (! (nu X. (mu Y. (Grant0 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Free || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Grant0 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Free || <> W)) && ([] Z)));
         }
 
         // GR(1) no starvation for client 1: GF(Grant1) → GF(Free).
         formula no_starvation_1 {
             over bus_system;
-            body = (! (nu X. (mu Y. (Grant1 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Free || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Grant1 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Free || <> W)) && ([] Z)));
         }
     }
 

--- a/examples/amba_arbiter_gr1_synthesis.ctxdsl
+++ b/examples/amba_arbiter_gr1_synthesis.ctxdsl
@@ -212,26 +212,26 @@ context amba_arbiter_gr1_synthesis {
 
         formula grant0_reachable {
             over bus_system;
-            body = (! (nu X. (mu Y. (Requesting0 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Grant0 || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Requesting0 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Grant0 || <> W)) && ([] Z)));
         }
 
         formula grant1_reachable {
             over bus_system;
-            body = (! (nu X. (mu Y. (Requesting1 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Grant1 || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Requesting1 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Grant1 || <> W)) && ([] Z)));
         }
 
         formula grant2_reachable {
             over bus_system;
-            body = (! (nu X. (mu Y. (Requesting2 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Grant2 || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Requesting2 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Grant2 || <> W)) && ([] Z)));
         }
 
         formula grant3_reachable {
             over bus_system;
-            body = (! (nu X. (mu Y. (Requesting3 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Grant3 || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Requesting3 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Grant3 || <> W)) && ([] Z)));
         }
 
         // GR(1) no starvation: GF(GrantN) → GF(Free)
@@ -240,26 +240,26 @@ context amba_arbiter_gr1_synthesis {
 
         formula no_starvation_0 {
             over bus_system;
-            body = (! (nu X. (mu Y. (Grant0 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Free || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Grant0 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Free || <> W)) && ([] Z)));
         }
 
         formula no_starvation_1 {
             over bus_system;
-            body = (! (nu X. (mu Y. (Grant1 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Free || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Grant1 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Free || <> W)) && ([] Z)));
         }
 
         formula no_starvation_2 {
             over bus_system;
-            body = (! (nu X. (mu Y. (Grant2 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Free || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Grant2 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Free || <> W)) && ([] Z)));
         }
 
         formula no_starvation_3 {
             over bus_system;
-            body = (! (nu X. (mu Y. (Grant3 || <> Y)) && ([] X)))
-                || (nu Z. (mu W. (Free || <> W)) && ([] Z));
+            body = (! (nu X. ((mu Y. (Grant3 || <> Y)) && ([] X))))
+                || (nu Z. ((mu W. (Free || <> W)) && ([] Z)));
         }
     }
 

--- a/examples/sterile_batch_release.ctxdsl
+++ b/examples/sterile_batch_release.ctxdsl
@@ -112,12 +112,12 @@ context sterile_batch_release {
     mu_formulas {
         formula ship_requires_release {
             over pipeline;
-            body = nu Safe. ((! < ( labels = {ship} ) > true) || < ( labels = {qp_sign} ) > true) && Safe;
+            body = nu Safe. (((! < ( labels = {ship} ) > true) || < ( labels = {qp_sign} ) > true) && ([] Safe));
         }
 
         formula completion_leads_to_disposition {
             over pipeline;
-            body = nu Progress. ( [ ( labels = {qc_start} ) ] mu Resolve. ( < ( labels = {qp_sign} ) > true || < ( labels = {quarantine} ) > true || < ( labels = {cancel} ) > true ) && Resolve ) && Progress;
+            body = nu Progress. (([ ( labels = {qc_start} ) ] (mu Resolve. ((< ( labels = {qp_sign} ) > true || < ( labels = {quarantine} ) > true || < ( labels = {cancel} ) > true) || (<> Resolve)))) && ([] Progress));
         }
     }
 


### PR DESCRIPTION
## Summary

- Parser bug: `mu/nu V. body` was parsed with `parse_unary`, so a formula like `nu X. φ && [] X` silently parsed as `(nu X. φ) && [] X_pred` — the trailing `X` was a free predicate (false), not the bound variable. Verdicts were silently wrong. Surfaced via the AMBA arbiter preloaded example failing realize on `/api/v1/context/summarize`.
- Fix: parse fixpoint body with `parse_or` so binder scope extends as far right as possible (textbook μ-calculus convention).
- Every existing in-repo formula uses explicit parens around the body, so the parser flip is a no-op for current call sites. At-risk examples (AMBA GR(1) liveness, agentic GR(1) in handoff + 4 mcp_usecases, bench controller, scalable_gr1 builder) were reparenthesized to textbook form first; verified verdicts preserved under the **current** parser, then flipped.
- `sterile_batch_release` was a silent-miscompilation case: the old test passed because `(nu Safe. φ) && Safe_pred` was trivially false everywhere. Rewrote to textbook `nu Safe. (φ ∧ [] Safe)` (and a proper leads-to for the liveness formula); updated test assertions and module docstring to reflect the actual verdict (vacuous hold over the synchronous composition's single reachable state).
- Strengthened the parser fixpoint test: it previously only printed errors; now it walks the parse tree and asserts the trailing `[] X` resolves to `Node::Variable(nu_var)`.
- aiger/btor2 adapter formulas were already correctly parenthesized in code; only the misleading comments were updated.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all suites green
- [x] `./target/release/mununu context summarize examples/amba_arbiter_gr1.ctxdsl` succeeds end-to-end (formulas realize)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)