### PR TITLE
chore(ci): cargo-machete gate, cargo-nextest, tokei reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,31 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  unused-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+      - name: Check for unused dependencies
+        run: cargo machete
+
+  tokei:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: tokei
+      - name: Count lines of code
+        run: tokei --output json > tokei.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tokei-report
+          path: tokei.json
+
   dependency-check:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,23 +843,16 @@ name = "mununu"
 version = "0.4.0"
 dependencies = [
  "assert_cmd",
- "axum",
- "bitvec",
  "clap",
  "criterion",
  "itoa",
  "mununu-core",
  "predicates",
  "proptest",
- "regex",
  "serde",
  "serde_json",
- "smallvec",
  "tempfile",
- "thiserror",
  "tokio",
- "tower",
- "tower-http",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,22 +19,16 @@ categories = ["science", "algorithms", "development-tools"]
 mununu-core = { path = "crates/mununu-core" }
 
 # Core (still needed for main.rs until P2)
-thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-bitvec = "1.0"
-smallvec = "1.15"
-regex = "1.12"
 
 # CLI (optional)
 clap = { version = "4.5", features = ["derive"], optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3.22", optional = true, features = ["env-filter"] }
 
-# API (optional)
-axum = { version = "0.8", optional = true }
-tower = { version = "0.5", optional = true }
-tower-http = { version = "0.6", optional = true, features = ["cors", "trace"] }
+# API (optional). The axum/tower/tower-http surface lives in mununu-core;
+# the root crate only needs tokio to drive the runtime.
 tokio = { version = "1", optional = true, features = ["full"] }
 
 
@@ -50,9 +44,6 @@ predicates = "3.1"
 default = ["cli"]
 cli = ["dep:clap", "dep:tracing", "dep:tracing-subscriber"]
 api = [
-    "dep:axum",
-    "dep:tower",
-    "dep:tower-http",
     "dep:tokio",
     "mununu-core/api",
     "mununu-core/ast-extract",

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,17 @@ build:
 	$(CARGO) build --release -p mununu-cli
 	$(CARGO) build --release -p mununu-extract
 
+# Prefer cargo-nextest when available (CI's dev image installs it). nextest
+# is faster but does NOT run doctests — invoke them separately so they
+# cannot silently drop. Falling back to `cargo test --workspace` covers
+# both unit and doc tests in one shot.
 test:
-	$(CARGO) test --workspace
+	@if command -v cargo-nextest >/dev/null 2>&1; then \
+		$(CARGO) nextest run --workspace && \
+		$(CARGO) test --workspace --doc; \
+	else \
+		$(CARGO) test --workspace; \
+	fi
 
 # tier-1 + tier-2: pre-commit gate. Skips #[ignore]'d stress tests by default.
 # Eventually this will be the canonical pre-commit form; for now it is an

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -54,6 +54,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # but install explicitly so the image is robust to upstream changes.
 RUN rustup component add rustfmt clippy
 
+# cargo-nextest: the test runner `make test` selects when available. The
+# image always carries it so CI's `make ci` always exercises the nextest
+# path; doctests are invoked separately by `make test` via cargo test
+# --doc (nextest does not run doctests).
+RUN cargo install --locked cargo-nextest
+
 # Use a container-side cargo target directory so the host's target/ is
 # never touched by container builds. This avoids cargo cache thrashing
 # when host and container use different toolchain hashes (e.g., the

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -14,4 +14,9 @@ make ci
 echo "Testing API module..."
 cargo test --lib api --features api
 
+# Fast (milliseconds) — mirrors the `unused-deps` CI job. Install locally with
+#   cargo install cargo-machete --locked
+echo "Checking for unused dependencies (cargo machete)..."
+cargo machete
+
 echo "All pre-commit checks passed."


### PR DESCRIPTION
## Summary

- New gating CI job `unused-deps` runs `cargo machete`; same check is appended to `scripts/pre-commit` (fast — milliseconds).
- `cargo nextest run --workspace` replaces `cargo test --workspace` in the dev image's `make ci` path. `cargo test --workspace --doc` is invoked separately so doctests don't silently drop. Local fallback to `cargo test --workspace` when nextest isn't installed.
- New non-gating CI job `tokei` runs `tokei --output json` and uploads `tokei.json` as a workflow artifact. No gate, no PR comment.

## Tool placement

| Tool | CI | pre-commit | Gates |
|---|---|---|---|
| cargo-machete | `unused-deps` (taiki-e/install-action@v2) | yes | yes |
| cargo-nextest | inside `lint-and-test` via Dockerfile + Makefile | no | yes (replaces `cargo test --workspace` only) |
| tokei | `tokei` job uploads `tokei-report` artifact | no | no |

## Validation (local)

- `cargo machete` → clean.
- `cargo nextest run --workspace` → 1611 passed, 4 skipped.
- `cargo test --workspace --doc` → 57 passed. Sum (1668) matches the pre-change `cargo test --workspace` total of 1668.
- `make ci`, `make test`, `cargo check --features api`, `cargo test --lib api --features api` → green.
- `tokei --output json` → valid JSON with `Total` plus per-language keys.
- Pre-commit hook (including the new `cargo machete` step) → green.

## Path chosen for pre-existing unused deps (path \"a\")

`cargo machete` initially flagged seven unused deps on `main`: `axum`, `bitvec`, `regex`, `smallvec`, `thiserror`, `tower`, `tower-http`. They were vestigial in the root `mununu` crate (a thin `pub use mununu_core::*;` re-export wrapper); the real axum/tower surface already lives in `mununu-core`. Removed in this PR, including the now-dead `dep:axum`/`dep:tower`/`dep:tower-http` entries in the `api` feature. `cargo check --features api` still resolves `mununu_core::api::start_server` — feature surface unchanged.

## Surfaced for future sessions

- `dependency-check` job still uses `continue-on-error: true` and the slow `cargo install cargo-outdated --locked` pattern; candidate for migration to `taiki-e/install-action@v2` in a follow-up.
- The api-feature step `cargo test --lib api --features api` is not a `--workspace` invocation and was left on `cargo test`; could move to nextest separately.
- Doctests run only via the nextest branch of `make test`; the cargo-test fallback covers them implicitly. Acceptable today since the CI dev image always carries nextest.
- `taiki-e/install-action`'s TOOLS.md does not list `tokei` — resolves through the cargo-binstall fallback against tokei's GitHub release binaries. Works today; worth watching.
- No new config files were added: no `.config/nextest.toml`, no `.cargo-machete.toml`, no wrapper scripts.
- `.claude/agents/quality-session.md` is intentionally untouched per the task spec.

## Test plan

- [ ] CI passes on this PR (specifically: `lint-and-test`, `unused-deps`, `tokei`).
- [ ] `tokei-report` artifact is present on the workflow run page.
- [ ] After merge, deliberately introduce an unused dep in a follow-up branch and confirm `unused-deps` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)