### PR TITLE
refactor: dedupe ControllerMode parser, drop dead code

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -918,23 +918,12 @@ fn parse_cli_controller_mode(
 ) -> Result<mununu_core::context::ControllerMode, String> {
     use mununu_core::context::ControllerMode;
     if let Some(name) = mode {
-        let normalized: String = name
-            .chars()
-            .filter(|c| !c.is_whitespace() && *c != '-' && *c != '_')
-            .flat_map(|c| c.to_lowercase())
-            .collect();
-        return match normalized.as_str() {
-            "projection" => Ok(ControllerMode::Projection),
-            "functional" => Ok(ControllerMode::Functional),
-            "permissive" => Ok(ControllerMode::Permissive),
-            "signaturememory" => Ok(ControllerMode::SignatureMemory),
-            "productgame" => Ok(ControllerMode::ProductGame),
-            "paritygame" => Ok(ControllerMode::ParityGame),
-            other => Err(format!(
+        return ControllerMode::from_normalized_name(name).map_err(|other| {
+            format!(
                 "unknown controller mode '{other}' \
                 (valid: projection, functional, permissive, signature-memory, product-game, parity-game)"
-            )),
-        };
+            )
+        });
     }
     Ok(if extract_strategy {
         ControllerMode::Functional

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -163,25 +163,12 @@ fn resolve_controller_mode(
 ) -> Result<crate::context::ControllerMode, ApiError> {
     use crate::context::ControllerMode;
     if let Some(name) = mode {
-        let normalized: String = name
-            .chars()
-            .filter(|c| !c.is_whitespace() && *c != '-' && *c != '_')
-            .flat_map(|c| c.to_lowercase())
-            .collect();
-        return match normalized.as_str() {
-            "projection" => Ok(ControllerMode::Projection),
-            "functional" => Ok(ControllerMode::Functional),
-            "permissive" => Ok(ControllerMode::Permissive),
-            "signaturememory" => Ok(ControllerMode::SignatureMemory),
-            "productgame" => Ok(ControllerMode::ProductGame),
-            "paritygame" => Ok(ControllerMode::ParityGame),
-            other => Err(ApiError::BadRequest {
-                message: format!("Unknown controller_mode '{other}'"),
-                details: Some(
-                    "Valid: projection, functional, permissive, signature-memory, product-game, parity-game".into(),
-                ),
-            }),
-        };
+        return ControllerMode::from_normalized_name(name).map_err(|other| ApiError::BadRequest {
+            message: format!("Unknown controller_mode '{other}'"),
+            details: Some(
+                "Valid: projection, functional, permissive, signature-memory, product-game, parity-game".into(),
+            ),
+        });
     }
     Ok(if extract_strategy {
         ControllerMode::Functional

--- a/crates/mununu-core/src/context/mod.rs
+++ b/crates/mununu-core/src/context/mod.rs
@@ -1349,6 +1349,28 @@ pub enum ControllerMode {
     ParityGame,
 }
 
+impl ControllerMode {
+    /// Parse a controller-mode name with whitespace, dashes, and underscores
+    /// stripped and case folded. Returns the variant on success, or the
+    /// normalized input on failure so callers can format their own errors.
+    pub fn from_normalized_name(name: &str) -> Result<Self, String> {
+        let normalized: String = name
+            .chars()
+            .filter(|c| !c.is_whitespace() && *c != '-' && *c != '_')
+            .flat_map(|c| c.to_lowercase())
+            .collect();
+        match normalized.as_str() {
+            "projection" => Ok(Self::Projection),
+            "functional" => Ok(Self::Functional),
+            "permissive" => Ok(Self::Permissive),
+            "signaturememory" => Ok(Self::SignatureMemory),
+            "productgame" => Ok(Self::ProductGame),
+            "paritygame" => Ok(Self::ParityGame),
+            _ => Err(normalized),
+        }
+    }
+}
+
 /// Extended controller synthesis configuration, combining evaluation, diagnostics, and post-processing knobs.
 #[derive(Debug, Default)]
 pub struct ControllerSynthesisOptions<'a> {

--- a/crates/mununu-core/src/context_dsl/realize.rs
+++ b/crates/mununu-core/src/context_dsl/realize.rs
@@ -676,12 +676,6 @@ impl EnumRegistry {
     fn is_empty(&self) -> bool {
         self.enums.is_empty()
     }
-
-    /// Returns the integer domain size for an enum type, or None if not found.
-    #[allow(dead_code)]
-    fn variant_count(&self, enum_name: &str) -> Option<usize> {
-        self.enums.get(enum_name).map(Vec::len)
-    }
 }
 
 /// Resolves enum variant names in an automaton's expressions to integer literals.

--- a/crates/mununu-core/src/verify/assemble.rs
+++ b/crates/mununu-core/src/verify/assemble.rs
@@ -355,15 +355,6 @@ fn matching_close_brace(text: &str, open_at: usize) -> Option<usize> {
     None
 }
 
-/// Scan a context body for the first `automaton <name> { ... }`
-/// declaration and return `<name>`. Kept for tests and external
-/// callers; assembly itself uses [`all_automaton_names`] directly so
-/// the wildcard expansion sees the full list.
-#[allow(dead_code)]
-fn first_automaton_name(body: &str) -> Option<&str> {
-    all_automaton_names(body).into_iter().next()
-}
-
 /// Scan a context body for **every** `automaton <name> { ... }`
 /// declaration and return the names in declaration order. Used by
 /// the `<source_id>.*` wildcard composition-member syntax: a single
@@ -468,7 +459,10 @@ mod tests {
     #[test]
     fn first_automaton_name_finds_identifier_after_keyword() {
         let body = "automata { automaton Toaster { states {} } }";
-        assert_eq!(first_automaton_name(body), Some("Toaster"));
+        assert_eq!(
+            all_automaton_names(body).into_iter().next(),
+            Some("Toaster")
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -1289,12 +1289,6 @@ fn snippet_around_error(text: &str, _err: &str) -> String {
     lines.join("\n")
 }
 
-// Silence unused-import lint for IdStorage: it's brought into scope
-// so that the closure-style generic bounds in
-// `evaluate_one_property` don't need to repeat the constraint.
-#[allow(dead_code)]
-fn _id_storage_marker<S: IdStorage, L: IdStorage>(_: &crate::clts::Clts<S, L>) {}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Output of a `/quality-session` run focused on safe, mechanical wins — no behavior change.

- **DRY (major):** Centralise controller-mode name normalisation on `ControllerMode::from_normalized_name`. The CLI's `parse_cli_controller_mode` and the API's `resolve_controller_mode` previously held two character-for-character copies of the same 30-line `match`; both now delegate. Single source of truth for accepted variant names.
- **YAGNI (minors):** Remove three dead, `#[allow(dead_code)]`-suppressed helpers:
  - `verify::assemble::first_automaton_name` (had a single test caller; inlined as `all_automaton_names(body).into_iter().next()`).
  - `context_dsl::realize::EnumRegistry::variant_count` (zero callers).
  - `verify::orchestrator::_id_storage_marker` (its rationale comment was wrong — `IdStorage` is already independently used in 4 real where-clauses in the same file).

Net: ~60 LOC removed, three dead-code suppressors eliminated, one 30-line duplicated match collapsed.

## Test plan

- [x] `make ci` green locally (fmt + clippy -D warnings + 1611 tests pass via nextest, 57 doctests, 4 skipped)
- [ ] GitHub Actions CI green
- [x] `controller_mode` flag still accepts `projection`, `functional`, `permissive`, `signature-memory`, `product-game`, `parity-game` with the same normalisation rules (whitespace / dashes / underscores / case)
- [x] Compiles against current `origin/main` (rebased onto `c53fed5`)

## Deferred for follow-up sessions

- Split `crates/mununu-cli/src/main.rs` (6,305 lines) into `cmd/`, `render/`, `loader.rs` modules (SRP, major; mechanical but large diff).
- Extract shared preamble between `context_eval` and `context_synthesize` (KISS, major).
- Extract Cytoscape state/edge builders shared between `unrolled_automata_to_cytoscape` and `dsl_automata_to_cytoscape` (KISS, major).
- Lift per-format dispatch in `context_import_handler` into `dispatch_adapter` (SRP, minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)