### PR TITLE
refactor(cli): extract shared eval preamble into prepare_eval_context

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -3799,16 +3799,43 @@ fn context_predicates(args: ContextPredicatesArgs) -> Result<(), String> {
     Ok(())
 }
 
-fn context_eval(args: ContextEvalArgs) -> Result<(), String> {
-    let (context_doc, mut sidecar_docs, adapter_ctxdsl) = load_context_documents_mode(
-        &args.context,
-        &args.sidecars,
-        args.adapter.as_deref(),
-        args.mode.as_deref(),
-    )?;
+/// Shared preamble result for `context eval` and `context synthesize`.
+///
+/// Both subcommands load documents, optionally print intermediate CTXDSL,
+/// resolve a formula name, and realize the context before diverging.
+/// This struct carries the outputs of that common setup so neither caller
+/// duplicates the logic.
+struct PreparedEvalContext {
+    realized: RealizedContext,
+    formula_name: String,
+}
+
+/// Input parameters for [`prepare_eval_context`].
+///
+/// Groups the fields that are identical across `ContextEvalArgs` and
+/// `ContextSynthesizeArgs` so the helper stays under clippy's argument-count
+/// limit without introducing a builder or unrelated abstraction.
+struct EvalContextParams<'a> {
+    context: &'a Path,
+    sidecars: &'a [PathBuf],
+    adapter: Option<&'a str>,
+    mode: Option<&'a str>,
+    print_ctxdsl_path: Option<&'a Option<PathBuf>>,
+    /// Non-empty only for `context eval`; pass `&[]` for `context synthesize`.
+    stubs: &'a [PathBuf],
+    formula: &'a Option<String>,
+    template: &'a Option<String>,
+    template_args: &'a [String],
+    automaton: &'a str,
+}
+
+/// Execute the shared preamble for `context eval` and `context synthesize`.
+fn prepare_eval_context(p: EvalContextParams<'_>) -> Result<PreparedEvalContext, String> {
+    let (context_doc, mut sidecar_docs, adapter_ctxdsl) =
+        load_context_documents_mode(p.context, p.sidecars, p.adapter, p.mode)?;
 
     // Print intermediate CTXDSL if requested
-    if let Some(output_path) = &args.print_ctxdsl {
+    if let Some(output_path) = p.print_ctxdsl_path {
         if let Some(ctxdsl) = &adapter_ctxdsl {
             print_ctxdsl_output(ctxdsl, output_path.as_ref())?;
         } else {
@@ -3817,10 +3844,10 @@ fn context_eval(args: ContextEvalArgs) -> Result<(), String> {
     }
 
     // Load stub files: translate each .espec.json via extraction adapter → CTXDSL → parse as sidecar
-    for stub_path in &args.stubs {
-        let (stub_doc, _) =
-            load_with_adapter_mode(stub_path, Some("extraction"), args.mode.as_deref())
-                .map_err(|e| format!("Failed to load stub '{}': {e}", stub_path.display()))?;
+    // Only context_eval passes stubs; context_synthesize passes an empty slice.
+    for stub_path in p.stubs {
+        let (stub_doc, _) = load_with_adapter_mode(stub_path, Some("extraction"), p.mode)
+            .map_err(|e| format!("Failed to load stub '{}': {e}", stub_path.display()))?;
         eprintln!(
             "Loaded stub: {} ({} automata)",
             stub_path.display(),
@@ -3831,14 +3858,36 @@ fn context_eval(args: ContextEvalArgs) -> Result<(), String> {
 
     // Resolve formula: either --formula NAME or --template ID [--template-arg K=V]
     let formula_name = resolve_formula_name(
-        &args.formula,
-        &args.template,
-        &args.template_args,
-        &args.automaton,
+        p.formula,
+        p.template,
+        p.template_args,
+        p.automaton,
         &mut sidecar_docs,
     )?;
 
     let realized = realize_documents(&context_doc, &sidecar_docs)?;
+    Ok(PreparedEvalContext {
+        realized,
+        formula_name,
+    })
+}
+
+fn context_eval(args: ContextEvalArgs) -> Result<(), String> {
+    let PreparedEvalContext {
+        realized,
+        formula_name,
+    } = prepare_eval_context(EvalContextParams {
+        context: &args.context,
+        sidecars: &args.sidecars,
+        adapter: args.adapter.as_deref(),
+        mode: args.mode.as_deref(),
+        print_ctxdsl_path: args.print_ctxdsl.as_ref(),
+        stubs: &args.stubs,
+        formula: &args.formula,
+        template: &args.template,
+        template_args: &args.template_args,
+        automaton: &args.automaton,
+    })?;
     let formula = realized
         .formulas
         .get(&formula_name)
@@ -4058,32 +4107,21 @@ fn context_eval(args: ContextEvalArgs) -> Result<(), String> {
 }
 
 fn context_synthesize(args: ContextSynthesizeArgs) -> Result<(), String> {
-    let (context_doc, mut sidecar_docs, adapter_ctxdsl) = load_context_documents_mode(
-        &args.context,
-        &args.sidecars,
-        args.adapter.as_deref(),
-        args.mode.as_deref(),
-    )?;
-
-    // Print intermediate CTXDSL if requested
-    if let Some(output_path) = &args.print_ctxdsl {
-        if let Some(ctxdsl) = &adapter_ctxdsl {
-            print_ctxdsl_output(ctxdsl, output_path.as_ref())?;
-        } else {
-            eprintln!("No adapter translation — CTXDSL is the input file itself");
-        }
-    }
-
-    // Resolve formula: either --formula NAME or --template ID [--template-arg K=V]
-    let formula_name = resolve_formula_name(
-        &args.formula,
-        &args.template,
-        &args.template_args,
-        &args.automaton,
-        &mut sidecar_docs,
-    )?;
-
-    let realized = realize_documents(&context_doc, &sidecar_docs)?;
+    let PreparedEvalContext {
+        realized,
+        formula_name,
+    } = prepare_eval_context(EvalContextParams {
+        context: &args.context,
+        sidecars: &args.sidecars,
+        adapter: args.adapter.as_deref(),
+        mode: args.mode.as_deref(),
+        print_ctxdsl_path: args.print_ctxdsl.as_ref(),
+        stubs: &[], // context_synthesize has no --stub support
+        formula: &args.formula,
+        template: &args.template,
+        template_args: &args.template_args,
+        automaton: &args.automaton,
+    })?;
     let realized_formula = realized
         .formulas
         .get(&formula_name)


### PR DESCRIPTION
## Summary

Second `/quality-session` output. Targets the KISS-major deferred from PR #67: `context_eval` and `context_synthesize` shared ~27 lines of verbatim preamble (load documents → optional CTXDSL print → optional stub loop → resolve formula → realize).

Extraction:
- `struct PreparedEvalContext { realized, formula_name }` — output carrier, destructured at both call sites.
- `struct EvalContextParams<'a>` — parameter grouping (10 borrows). Necessary because the helper would otherwise exceed clippy's `too_many_arguments` threshold; the named-field shape is the better surface anyway.
- `fn prepare_eval_context(p: EvalContextParams<'_>) -> Result<PreparedEvalContext, String>` — runs the shared sequence.

The stub-loading step (eval-only) stays inside the helper as a guarded loop — empty stub list is a no-op for the synthesize caller. Error messages are byte-identical to before.

| Entity | Before | After | Δ |
|---|---|---|---|
| `context_eval` | 258 lines | 234 lines | −24 |
| `context_synthesize` | 211 lines | 200 lines | −11 |
| Duplicated preamble | 27 lines | 0 | −27 |
| Helper + structs (new) | — | 67 lines | +67 |
| Net file SLOC | 5236 | 5262 | +26 (the structural cost of named-field call sites in exchange for DRY=GREEN) |

## Test plan

- [x] `make ci` green locally (fmt + clippy -D warnings + 1611 tests via nextest, 4 skipped; pre-commit hook ran the same)
- [ ] GitHub Actions CI green
- [x] `mununu context eval ... --print-structure <path>` writes CTXDSL identically to before
- [x] `mununu context synthesize ...` produces the same controller files
- [x] No new behavior; this is purely an internal extraction

## Not in this PR

- The two functions are still >200 lines each — that residual length is per-function logic, not duplication, and belongs to the `main.rs` 6.3k-line split (separate session).
- Cytoscape builder dedup (`unrolled_automata_to_cytoscape` / `dsl_automata_to_cytoscape`) — separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)