### PR TITLE
refactor(cli): extract build_automaton_compound_node, drop dead state_positions

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -4626,6 +4626,40 @@ fn collect_action_info(automaton: &mununu_core::context_dsl::ast::Automaton) -> 
         .collect()
 }
 
+/// Build the Cytoscape compound node that wraps an automaton's states and edges.
+/// Shape is identical for both DSL and unrolled builders; only `id` and `label`
+/// differ at the call site.
+fn build_automaton_compound_node(
+    id: String,
+    label: String,
+    var_names: &[String],
+    action_info: &[String],
+) -> CytoscapeElement {
+    CytoscapeElement {
+        data: CytoscapeData::Node {
+            id,
+            parent: None,
+            label: Some(label),
+            vars: if var_names.is_empty() {
+                None
+            } else {
+                Some(json!(var_names))
+            },
+            actions: if action_info.is_empty() {
+                None
+            } else {
+                Some(json!(action_info))
+            },
+            valuations: None,
+            note: None,
+            isStart: None,
+            isDead: None,
+        },
+        position: None,
+        classes: None,
+    }
+}
+
 /// Classify a label as controllable/internal/uncontrollable from an automaton's
 /// declarations.  Used by both Cytoscape builders for edge `actionType`.
 fn classify_action(
@@ -4912,32 +4946,13 @@ fn dsl_automata_to_cytoscape(
 
         // Create automaton compound node
         let automaton_id = automaton_name.clone();
-        elements.push(CytoscapeElement {
-            data: CytoscapeData::Node {
-                id: automaton_id.clone(),
-                parent: None,
-                label: Some(format!("Automaton {}", automaton_name)),
-                vars: if var_names.is_empty() {
-                    None
-                } else {
-                    Some(json!(var_names))
-                },
-                actions: if action_info.is_empty() {
-                    None
-                } else {
-                    Some(json!(action_info))
-                },
-                valuations: None,
-                note: None,
-                isStart: None,
-                isDead: None,
-            },
-            position: None,
-            classes: None,
-        });
+        elements.push(build_automaton_compound_node(
+            automaton_id.clone(),
+            format!("Automaton {}", automaton_name),
+            &var_names,
+            &action_info,
+        ));
 
-        // Collect states and their positions
-        let mut state_positions: HashMap<String, (f64, f64)> = HashMap::new();
         let mut x_pos = 100.0;
 
         for state_decl in &automaton.states {
@@ -4964,8 +4979,6 @@ fn dsl_automata_to_cytoscape(
                     }
                 })
             };
-
-            state_positions.insert(state_name.clone(), (x_pos, y_offset + 100.0));
 
             let state_valuations = clts
                 .state_id(state_name)
@@ -5235,32 +5248,13 @@ fn unrolled_automata_to_cytoscape(
 
         // Create automaton compound node (with "Unrolled" suffix)
         let automaton_id = format!("{}_unrolled", automaton_name);
-        elements.push(CytoscapeElement {
-            data: CytoscapeData::Node {
-                id: automaton_id.clone(),
-                parent: None,
-                label: Some(format!("Automaton {} (Unrolled)", automaton_name)),
-                vars: if var_names.is_empty() {
-                    None
-                } else {
-                    Some(json!(var_names))
-                },
-                actions: if action_info.is_empty() {
-                    None
-                } else {
-                    Some(json!(action_info))
-                },
-                valuations: None,
-                note: None,
-                isStart: None,
-                isDead: None,
-            },
-            position: None,
-            classes: None,
-        });
+        elements.push(build_automaton_compound_node(
+            automaton_id.clone(),
+            format!("Automaton {} (Unrolled)", automaton_name),
+            &var_names,
+            &action_info,
+        ));
 
-        // Collect states and their positions
-        let mut state_positions: HashMap<String, (f64, f64)> = HashMap::new();
         let mut x_pos = 100.0;
         let mut initial_states = HashSet::new();
 
@@ -5314,8 +5308,6 @@ fn unrolled_automata_to_cytoscape(
                     .collect();
                 Some(var_parts.join(", "))
             };
-
-            state_positions.insert(state_name.clone(), (x_pos, y_offset + 100.0));
 
             elements.extend(build_state_elements(StateElementParams {
                 state_id,


### PR DESCRIPTION
## Summary

Third `/quality-session` output, targeting the KISS-major deferred from PR #67/#68: shared Cytoscape scaffolding between `dsl_automata_to_cytoscape` and `unrolled_automata_to_cytoscape`.

**Heads-up on scope.** The prior session's claim of \"~450 lines of duplicated scaffolding\" turned out to be overstated. When inventoried side-by-side, the two functions diverge fundamentally past the compound-node header: one operates on the DSL AST (guards, effects, multi-labels, CLTS-backed lookups); the other on a post-unrolling state list (guards already resolved, effects gone, different initial-state detection). The 502 combined lines hold only **~27 lines of truly identical structure**. Forcing the rest into a shared pipeline would require a single-implementation trait — the kind of premature abstraction CLAUDE.md asks reviewers to push back on.

So this PR takes only the safe, mechanical wins:

- **`build_automaton_compound_node(id, label, var_names, action_info)`** — extracted from two near-identical 23-line `CytoscapeElement::Node` literals that differ only in id and label strings. Both call sites now collapse to one 5-line call.
- **Dead `state_positions: HashMap<String, (f64, f64)>` removed** from both functions — declared, written twice, never read.

| | Before | After |
|---|---|---|
| Duplicated compound-node literal | 23 × 2 = 46 lines | 1 helper (35 lines) + 2 × 5-line calls = 45 lines |
| Dead `state_positions` decl + insert | 6 lines | 0 |
| `make ci` | green | green (1611 tests, 57 doctests, 4 skipped) |

Net diff: 46 inserted / 54 deleted.

## Test plan

- [x] `make ci` green locally
- [ ] GitHub Actions CI green
- [x] `mununu context graph` and `mununu context graph --unrolled` produce identical Cytoscape JSON (verified by type-checker preservation: the new helper populates `CytoscapeElement::Node` fields with exactly the same expressions as the inlined blocks)

## Deferred

The `crates/mununu-cli/src/main.rs` 6.3k-line split (SRP, major) is the only deferred item left from the original /quality-session findings. That belongs to its own session and PR; the mechanical-but-large diff is not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)