### PR TITLE
feat: Phase A.4 SMT predicate-image discovery (in progress)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,15 +337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,22 +2123,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "z3-src"
-version = "416.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2af0c6527de39877cf55cb87f233016573eeeb7cf77afdc1469e4b32faef832"
-dependencies = [
- "cmake",
-]
-
-[[package]]
 name = "z3-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c18b0a91a13522d21b3414847667de2b2056a721a3edcb5b6ee6858352d58db4"
 dependencies = [
  "pkg-config",
- "z3-src",
 ]
 
 [[package]]

--- a/crates/mununu-cli/Cargo.toml
+++ b/crates/mununu-cli/Cargo.toml
@@ -24,4 +24,5 @@ bitvec = "1.0"
 
 [features]
 default = []
-smt = ["mununu-core/smt"]
+# `smt` feature removed in Phase A.4 step 4.2 — Z3 is now mandatory in
+# mununu-core. See its Cargo.toml for the rationale.

--- a/crates/mununu-cli/src/loader.rs
+++ b/crates/mununu-cli/src/loader.rs
@@ -193,10 +193,20 @@ pub(crate) fn load_with_adapter_mode_extra(
                 additional.push((name, content));
             }
             let use_sv2v = matches!(preprocessor, Some("sv2v"));
+            // `MUNUNU_YOSYS_SETUNDEF_ANYSEQ=1` opt-in for CWE-1245-class
+            // bug-preserving extraction. See the SOUNDNESS comment in
+            // `adapter::yosys::build_script`. CLI-level flag is
+            // deferred — env-var lets the Caliptra PoF fixture's
+            // `validate.sh` opt in without touching every adapter
+            // call-site.
+            let setundef_anyseq = std::env::var("MUNUNU_YOSYS_SETUNDEF_ANYSEQ")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
             let yopts = mununu_core::adapter::yosys::YosysOptions {
                 primary_source_path: Some(path.to_string_lossy().into_owned()),
                 additional_sources: additional,
                 use_sv2v,
+                setundef_anyseq,
                 ..Default::default()
             };
             log_adapter_output_with_dir(

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2676,48 +2676,36 @@ fn sv_discover(args: SvDiscoverArgs) -> Result<(), String> {
 
     eprintln!("Discovering values for {} signal(s)...", discover_count);
 
-    #[cfg(not(feature = "smt"))]
-    {
-        let _ = (&_module, &annotation); // suppress unused warnings
-        Err(
-            "SMT discovery requires the 'smt' feature. Rebuild with: cargo build --features smt"
-                .to_string(),
-        )
-    }
+    let mut annotation = annotation;
+    let results = mununu_core::adapter::systemverilog::kripke_smt::discover_significant_values(
+        &_module,
+        &annotation,
+    );
 
-    #[cfg(feature = "smt")]
-    {
-        let mut annotation = annotation;
-        let results = mununu_core::adapter::systemverilog::kripke_smt::discover_significant_values(
-            &_module,
-            &annotation,
-        );
-
-        if results.is_empty() {
-            eprintln!("No significant values discovered.");
-        } else {
-            for (signal, discovered) in &results {
-                eprintln!("  {} — {} value(s):", signal, discovered.values.len());
-                for v in &discovered.values {
-                    let from = v.from.as_deref().unwrap_or("unknown");
-                    eprintln!("    {} = {} ({})", v.name, v.value, from);
-                }
+    if results.is_empty() {
+        eprintln!("No significant values discovered.");
+    } else {
+        for (signal, discovered) in &results {
+            eprintln!("  {} — {} value(s):", signal, discovered.values.len());
+            for v in &discovered.values {
+                let from = v.from.as_deref().unwrap_or("unknown");
+                eprintln!("    {} = {} ({})", v.name, v.value, from);
             }
-
-            // Merge into the annotation, preserving user-given names
-            sv_annotation::merge_discovered_values(&mut annotation.discovered_values, results);
         }
 
-        // Write the updated sidecar
-        let output_path = args.output.as_ref().unwrap_or(&sidecar_path);
-        let json = serde_json::to_string_pretty(&annotation)
-            .map_err(|e| format!("Failed to serialize annotation: {e}"))?;
-        fs::write(output_path, json)
-            .map_err(|e| format!("Failed to write '{}': {e}", output_path.display()))?;
-        eprintln!("Updated sidecar: {}", output_path.display());
-
-        Ok(())
+        // Merge into the annotation, preserving user-given names
+        sv_annotation::merge_discovered_values(&mut annotation.discovered_values, results);
     }
+
+    // Write the updated sidecar
+    let output_path = args.output.as_ref().unwrap_or(&sidecar_path);
+    let json = serde_json::to_string_pretty(&annotation)
+        .map_err(|e| format!("Failed to serialize annotation: {e}"))?;
+    fs::write(output_path, json)
+        .map_err(|e| format!("Failed to write '{}': {e}", output_path.display()))?;
+    eprintln!("Updated sidecar: {}", output_path.display());
+
+    Ok(())
 }
 
 /// Multi-module discovery: runs cross-module SMT discovery for connected
@@ -2778,15 +2766,6 @@ fn sv_discover_multi(args: SvDiscoverArgs) -> Result<(), String> {
 
     eprintln!("Discovering values for {} target(s)...", discover_count);
 
-    #[cfg(not(feature = "smt"))]
-    {
-        Err(
-            "SMT discovery requires the 'smt' feature. Rebuild with: cargo build --features smt"
-                .to_string(),
-        )
-    }
-
-    #[cfg(feature = "smt")]
     {
         // Parse all sub-modules
         let mut parsed_modules: Vec<(mununu_core::adapter::systemverilog::ast::Module, String)> =

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -98,6 +98,42 @@ enum Commands {
         #[arg(long, default_value = "127.0.0.1:8080")]
         addr: String,
     },
+    /// BTOR2-direct analysis tools (Phase A.4 predicate-image discovery).
+    Btor2 {
+        #[command(subcommand)]
+        command: Box<Btor2Command>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum Btor2Command {
+    /// Run SMT predicate-image discovery on a BTOR2 file.
+    ///
+    /// For each user-named state cell, enumerate the values reachable
+    /// in one transition step under any current state + input
+    /// combination. Writes the resulting `discovered_values` map to
+    /// the path-adjacent `<stem>.mununu.json` (or `--output` if
+    /// provided), so the existing BTOR2 bit-blast / sidecar resolver
+    /// pipeline picks the abstraction up without further wiring.
+    ///
+    /// See `docs/design/auto-extraction-architecture.md` §2 Stage 4
+    /// for the soundness contract.
+    Discover(Btor2DiscoverArgs),
+}
+
+#[derive(Args, Debug)]
+struct Btor2DiscoverArgs {
+    /// Path to the BTOR2 input file.
+    #[arg(value_name = "BTOR2_FILE")]
+    file: PathBuf,
+    /// Where to write the updated sidecar. Defaults to
+    /// `<stem>.mununu.json` next to the BTOR2 input.
+    #[arg(long, value_name = "PATH")]
+    output: Option<PathBuf>,
+    /// Maximum number of distinct values to enumerate per state cell.
+    /// Default matches `ImageOptions::default().cap_edges = 4096`.
+    #[arg(long, default_value_t = 4096)]
+    cap_edges: usize,
 }
 
 #[derive(Subcommand, Debug)]
@@ -1298,7 +1334,124 @@ fn dispatch(command: Commands) -> Result<(), String> {
                 .map_err(|e| format!("Server error: {}", e))?;
             Ok(())
         }
+        Commands::Btor2 { command } => handle_btor2(*command),
     }
+}
+
+fn handle_btor2(command: Btor2Command) -> Result<(), String> {
+    match command {
+        Btor2Command::Discover(args) => btor2_discover(args),
+    }
+}
+
+fn btor2_discover(args: Btor2DiscoverArgs) -> Result<(), String> {
+    use mununu_core::adapter::sidecar::predicate_image::{
+        ImageOptions, all_smt::discover_values_for_btor2_file,
+    };
+    use mununu_core::adapter::systemverilog::annotation::{
+        DiscoveredValues, SvAnnotation, merge_discovered_values,
+    };
+
+    if !args.file.exists() {
+        return Err(format!(
+            "BTOR2 input file does not exist: {}",
+            args.file.display()
+        ));
+    }
+    let src = fs::read_to_string(&args.file)
+        .map_err(|e| format!("Failed to read '{}': {e}", args.file.display()))?;
+    let file = mununu_core::adapter::btor2::parser::parse(&src)
+        .map_err(|e| format!("BTOR2 parse error in '{}': {e}", args.file.display()))?;
+
+    let opts = ImageOptions {
+        cap_edges: args.cap_edges,
+        ..ImageOptions::default()
+    };
+
+    eprintln!(
+        "Running predicate-image discovery on {} (cap_edges={})...",
+        args.file.display(),
+        args.cap_edges
+    );
+    let results = discover_values_for_btor2_file(&file, &opts)
+        .map_err(|e| format!("predicate-image discovery failed: {e}"))?;
+
+    if results.is_empty() {
+        eprintln!("No discovered values for any state cell.");
+    } else {
+        for (signal, discovered) in &results {
+            eprintln!("  {} — {} value(s):", signal, discovered.values.len());
+            for v in &discovered.values {
+                let from = v.from.as_deref().unwrap_or("predicate-image");
+                eprintln!("    {} = {} ({})", v.name, v.value, from);
+            }
+        }
+    }
+
+    // Resolve the output sidecar path: explicit `--output`, or
+    // `<stem>.mununu.json` next to the input.
+    let sidecar_path = match &args.output {
+        Some(p) => p.clone(),
+        None => {
+            let stem = args
+                .file
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .ok_or_else(|| {
+                    format!("Cannot derive sidecar stem from '{}'", args.file.display())
+                })?;
+            args.file.with_file_name(format!("{stem}.mununu.json"))
+        }
+    };
+
+    // Load existing sidecar if present, else start from a minimal
+    // annotation shape. Either way we merge in the discovered values.
+    let mut annotation: SvAnnotation = if sidecar_path.exists() {
+        let body = fs::read_to_string(&sidecar_path).map_err(|e| {
+            format!(
+                "Failed to read existing sidecar '{}': {e}",
+                sidecar_path.display()
+            )
+        })?;
+        serde_json::from_str(&body).map_err(|e| {
+            format!(
+                "Failed to parse existing sidecar '{}': {e}",
+                sidecar_path.display()
+            )
+        })?
+    } else {
+        SvAnnotation {
+            schema: Some("mununu_sv_annotation_v1".to_string()),
+            module: args
+                .file
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("design")
+                .to_string(),
+            source: args
+                .file
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string()),
+            signals: Vec::new(),
+            inputs: Vec::new(),
+            controllable: Vec::new(),
+            properties: Vec::new(),
+            discovered_values: std::collections::HashMap::new(),
+            parameters: std::collections::HashMap::new(),
+        }
+    };
+
+    let results_typed: std::collections::HashMap<String, DiscoveredValues> = results;
+    merge_discovered_values(&mut annotation.discovered_values, results_typed);
+
+    let json = serde_json::to_string_pretty(&annotation)
+        .map_err(|e| format!("Failed to serialise updated sidecar: {e}"))?;
+    fs::write(&sidecar_path, json)
+        .map_err(|e| format!("Failed to write sidecar '{}': {e}", sidecar_path.display()))?;
+    eprintln!("Updated sidecar: {}", sidecar_path.display());
+
+    Ok(())
 }
 
 fn handle_context(command: ContextCommand) -> Result<(), String> {

--- a/crates/mununu-core/Cargo.toml
+++ b/crates/mununu-core/Cargo.toml
@@ -48,13 +48,13 @@ tree-sitter-python = { version = "0.23", optional = true }
 tree-sitter-rust = { version = "0.23", optional = true }
 
 # SMT solver — z3 for predicate-image discovery and RTL value discovery.
-# Mandatory dependency: every build links Z3 statically via the bundled
-# feature so the `mununu` binary works the same in dev containers and
-# user installs. The historical `--features smt` opt-in was removed
-# in Phase A.4 step 4.2 — the predicate-image algorithm depends on Z3,
-# and the dual-build matrix (with-Z3 / without-Z3) had no users left
-# to justify the maintenance cost.
-z3 = { version = "0.20", features = ["bundled"] }
+# Mandatory dependency since Phase A.4 step 4.2. Uses the system Z3
+# (libz3-dev on Debian / Z3 via homebrew on macOS) by default — the
+# dev-container Dockerfile installs `libz3-dev`. To build with the
+# bundled Z3 source (slower; runner-OOM-prone in CI), enable the
+# `z3/bundled` feature explicitly:
+#   cargo build --features z3/bundled
+z3 = { version = "0.20" }
 
 # Optional / feature-gated:
 #   `test_support`: deterministic CLTS generators (chain/ring/grid/hypercube/...)

--- a/crates/mununu-core/Cargo.toml
+++ b/crates/mununu-core/Cargo.toml
@@ -47,8 +47,14 @@ tree-sitter-typescript = { version = "0.23", optional = true }
 tree-sitter-python = { version = "0.23", optional = true }
 tree-sitter-rust = { version = "0.23", optional = true }
 
-# SMT solver (optional — z3 for value discovery in RTL verification)
-z3 = { version = "0.20", optional = true, features = ["bundled"] }
+# SMT solver — z3 for predicate-image discovery and RTL value discovery.
+# Mandatory dependency: every build links Z3 statically via the bundled
+# feature so the `mununu` binary works the same in dev containers and
+# user installs. The historical `--features smt` opt-in was removed
+# in Phase A.4 step 4.2 — the predicate-image algorithm depends on Z3,
+# and the dual-build matrix (with-Z3 / without-Z3) had no users left
+# to justify the maintenance cost.
+z3 = { version = "0.20", features = ["bundled"] }
 
 # Optional / feature-gated:
 #   `test_support`: deterministic CLTS generators (chain/ring/grid/hypercube/...)
@@ -74,7 +80,6 @@ rand_chacha = "0.3"
 default = []
 api = ["dep:axum", "dep:tower", "dep:tower-http", "dep:tokio"]
 ast-extract = ["dep:tree-sitter", "dep:tree-sitter-typescript", "dep:tree-sitter-python", "dep:tree-sitter-rust"]
-smt = ["dep:z3"]
 syntcomp = []
 # Optimization-programme features (see notebook/0000-overview.md). Each is
 # additive and can be enabled per-bench, per-test, or per-CI-tier.

--- a/crates/mununu-core/src/adapter/sidecar/mod.rs
+++ b/crates/mununu-core/src/adapter/sidecar/mod.rs
@@ -197,3 +197,4 @@ pub fn resolve_to_field_domain(
 }
 
 pub mod btor2_resolver;
+pub mod predicate_image;

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/all_smt.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/all_smt.rs
@@ -1,0 +1,36 @@
+//! All-SMT predicate-tuple enumeration (Hoder–Bjørner–de Moura CAV 2006).
+//!
+//! Computes the abstract transition relation `T̂ ⊆ 2^P × 2^P` by
+//! repeatedly asking Z3 for satisfying assignments of
+//! `T(s, s') ∧ (p_i ↔ p_i(s)) ∧ (p'_i ↔ p_i(s'))` and blocking the
+//! current model after each hit. The enumeration is bounded by
+//! [`super::ImageOptions::cap_edges`] and falls through to the
+//! Bryant–Kroening under-approximation when Z3 saturates a query.
+//!
+//! **Step 4.1 status: skeleton only.** The full algorithm + the
+//! recall harness against
+//! [`examples/verify/bench_predicate_image_a4/`](../../../../../../examples/verify/bench_predicate_image_a4/)
+//! land in step 4.3.
+
+use super::{AbstractTransition, ImageOptions, Predicate};
+
+/// Placeholder signature for the all-SMT enumeration. Step 4.3 will
+/// replace this stub with the real algorithm.
+///
+/// # SOUNDNESS
+///
+/// The enumeration is sound by construction — every emitted
+/// `AbstractTransition` corresponds to a satisfying assignment of the
+/// transition relation under the predicate truth-values. The
+/// `cap_edges` bound truncates the enumeration; truncation is sound
+/// for over-approximation (missing edges only make the abstract model
+/// admit *more* behaviour than enumerated, which preserves safety
+/// verdicts).
+pub fn enumerate_abstract_edges(
+    _predicates: &[Predicate],
+    _opts: &ImageOptions,
+) -> Vec<AbstractTransition> {
+    // Step 4.1 skeleton: empty enumeration is sound-trivial (no
+    // discovered values). Step 4.3 lands the real algorithm.
+    Vec::new()
+}

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/all_smt.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/all_smt.rs
@@ -1,36 +1,248 @@
-//! All-SMT predicate-tuple enumeration (Hoder–Bjørner–de Moura CAV 2006).
+//! Predicate-image enumeration over the encoded transition relation.
 //!
-//! Computes the abstract transition relation `T̂ ⊆ 2^P × 2^P` by
-//! repeatedly asking Z3 for satisfying assignments of
-//! `T(s, s') ∧ (p_i ↔ p_i(s)) ∧ (p'_i ↔ p_i(s'))` and blocking the
-//! current model after each hit. The enumeration is bounded by
-//! [`super::ImageOptions::cap_edges`] and falls through to the
-//! Bryant–Kroening under-approximation when Z3 saturates a query.
+//! Phase A.4 step 4.3 ships a focused per-signal value enumerator
+//! built on the [`super::btor2_encode::Btor2SmtView`]: for each
+//! candidate value `k` in the cell's bit-vector range, ask Z3 whether
+//! the transition relation admits `s_next_<nid> == k` (reachability
+//! under any input). The output is a `Vec<i64>` of confirmed-reachable
+//! values, suitable for round-trip into
+//! [`crate::adapter::systemverilog::annotation::DiscoveredValues`].
 //!
-//! **Step 4.1 status: skeleton only.** The full algorithm + the
-//! recall harness against
-//! [`examples/verify/bench_predicate_image_a4/`](../../../../../../examples/verify/bench_predicate_image_a4/)
-//! land in step 4.3.
+//! This is the **brute-force flavour** of the Hoder–Bjørner–de Moura
+//! predicate-tuple enumeration. For narrow signals (≤ 8 bits) it's
+//! exact and tractable; wider signals fall under the `cap_edges`
+//! truncation. The full all-SMT tuple enumeration over multiple
+//! predicates simultaneously is left for a follow-up — the brute-
+//! force form is enough to close Phase A.4's Caliptra verdict on
+//! `boot_fsm_ns` (3 bits → 8 queries).
+//!
+//! # SOUNDNESS
+//!
+//! Each enumerated value `k` is guaranteed reachable: Z3 returned
+//! SAT on `T(s, s') ∧ s_next_<nid> == k`. Values `k` for which Z3
+//! returned UNSAT are guaranteed unreachable from *any* current
+//! state under *any* input. Unknown (timeout) verdicts are **dropped**
+//! from the output, which is conservative for safety: we may surface
+//! fewer values than reachable, but never more. Callers that need
+//! the over-approximation should treat the absent values as
+//! "unknown reachability" and consult the `Discover` fallback path.
 
-use super::{AbstractTransition, ImageOptions, Predicate};
+use std::collections::HashSet;
 
-/// Placeholder signature for the all-SMT enumeration. Step 4.3 will
-/// replace this stub with the real algorithm.
+use super::ImageOptions;
+use super::btor2_encode::{Btor2SmtView, SignalKind};
+use crate::adapter::btor2::ast::{Btor2File, Nid};
+use crate::adapter::systemverilog::annotation::{DiscoveredValue, DiscoveredValues};
+
+/// Enumerate reachable values of a single BTOR2 state cell by NID.
 ///
-/// # SOUNDNESS
+/// Returns the sorted set of `k` for which the transition relation
+/// admits `s_next_<nid> == k` under some current state + input
+/// combination. Bounded by [`ImageOptions::cap_edges`].
 ///
-/// The enumeration is sound by construction — every emitted
-/// `AbstractTransition` corresponds to a satisfying assignment of the
-/// transition relation under the predicate truth-values. The
-/// `cap_edges` bound truncates the enumeration; truncation is sound
-/// for over-approximation (missing edges only make the abstract model
-/// admit *more* behaviour than enumerated, which preserves safety
-/// verdicts).
-pub fn enumerate_abstract_edges(
-    _predicates: &[Predicate],
-    _opts: &ImageOptions,
-) -> Vec<AbstractTransition> {
-    // Step 4.1 skeleton: empty enumeration is sound-trivial (no
-    // discovered values). Step 4.3 lands the real algorithm.
-    Vec::new()
+/// Caller must hold a [`z3::with_z3_config`] scope.
+pub fn discover_values_for_state_cell(
+    view: &Btor2SmtView,
+    nid: Nid,
+    opts: &ImageOptions,
+) -> Vec<i64> {
+    let next_bv = match view.next_state(nid) {
+        Some(bv) => bv,
+        None => return Vec::new(),
+    };
+    let width = next_bv.get_size();
+    if width == 0 || width > 16 {
+        // SOUNDNESS: widths > 16 explode the brute-force enumeration
+        // (2^17 = 131 072 queries minimum). Return empty rather than
+        // melt the harness; the caller's `cap_edges` already implies
+        // this fallback. Width-aware predicate-tuple enumeration is
+        // the follow-up.
+        return Vec::new();
+    }
+
+    let solver = z3::Solver::new();
+    // Assert the transition relation once; all per-value queries
+    // share this assertion under `solver.check_assumptions`.
+    solver.assert(&view.transition);
+
+    let domain_cap = if width >= 63 {
+        opts.cap_edges as u64
+    } else {
+        (1u64 << width).min(opts.cap_edges as u64)
+    };
+
+    let mut discovered: Vec<i64> = Vec::new();
+    for k in 0..domain_cap {
+        let k_bv = z3::ast::BV::from_u64(k, width);
+        let probe = next_bv.eq(&k_bv);
+        // `check_assumptions` lets us add the `s_next == k` constraint
+        // for this iteration only without polluting the solver state.
+        let result = solver.check_assumptions(&[probe]);
+        if matches!(result, z3::SatResult::Sat) {
+            discovered.push(k as i64);
+        }
+        // UNSAT and UNKNOWN both drop `k` from the discovered set.
+        // SOUNDNESS: see module docs — UNKNOWN is conservative.
+    }
+    discovered
+}
+
+/// Run [`discover_values_for_state_cell`] on every named state cell
+/// in the design and convert the results into the existing
+/// `DiscoveredValues` sidecar shape.
+///
+/// Each entry's `name` is `VAL_<k>` (matching the convention in
+/// [`crate::adapter::systemverilog::kripke_smt::engine`]); each entry's
+/// `from` provenance string is `"predicate-image: ..."` for downstream
+/// traceability.
+pub fn discover_design_values(
+    file: &Btor2File,
+    view: &Btor2SmtView,
+    opts: &ImageOptions,
+) -> std::collections::HashMap<String, DiscoveredValues> {
+    let mut out = std::collections::HashMap::new();
+    for signal in &view.signals {
+        if signal.kind != SignalKind::State {
+            continue;
+        }
+        let Some(name) = signal.symbol.as_ref() else {
+            continue;
+        };
+        let values = discover_values_for_state_cell(view, signal.nid, opts);
+        if values.is_empty() {
+            continue;
+        }
+        let _ = file; // reserved for future seed-walking
+        let dv = DiscoveredValues {
+            values: values
+                .iter()
+                .map(|&v| DiscoveredValue {
+                    value: v,
+                    name: format!("VAL_{v}"),
+                    from: Some(format!(
+                        "predicate-image: reachable on s_next_{name} == {v}"
+                    )),
+                })
+                .collect(),
+            catch_all: "OTHER".to_string(),
+        };
+        out.insert(name.clone(), dv);
+    }
+    out
+}
+
+/// Convenience wrapper that drives the full pipeline:
+/// parse `file_path`, encode the design, enumerate, return the
+/// `DiscoveredValues` map. Owns the Z3 scope so callers don't need
+/// to deal with the thread-local context plumbing.
+pub fn discover_values_for_btor2_file(
+    file: &Btor2File,
+    opts: &ImageOptions,
+) -> Result<std::collections::HashMap<String, DiscoveredValues>, super::btor2_encode::EncodeError> {
+    let cfg = z3::Config::new();
+    z3::with_z3_config(&cfg, || {
+        let view = super::btor2_encode::encode_design(file)?;
+        Ok::<_, super::btor2_encode::EncodeError>(discover_design_values(file, &view, opts))
+    })
+}
+
+/// Helper for the recall harness: convert a discovered-values map
+/// into a `HashSet<i64>` per signal for set-intersection scoring.
+pub fn flatten_to_value_sets(
+    discovered: &std::collections::HashMap<String, DiscoveredValues>,
+) -> std::collections::HashMap<String, HashSet<i64>> {
+    discovered
+        .iter()
+        .map(|(sig, dv)| {
+            (
+                sig.clone(),
+                dv.values.iter().map(|v| v.value).collect::<HashSet<i64>>(),
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::parser::parse;
+
+    #[test]
+    fn discover_cap_overflow_cnt_finds_bad_encoding() {
+        // The 8-bit counter saturates at 200 via
+        //   next(cnt) = ite(cnt < 200, cnt + 1, cnt).
+        //
+        // Single-step reachability from *any* current state:
+        // - `s_next == 200` is reachable from cnt=199 (199+1=200) or
+        //   cnt=200 (sticky). SAT.
+        // - `s_next == 0` is unreachable in one step: cnt+1=0 needs
+        //   cnt=255, but then `cnt < 200` is false → saturation
+        //   pins cnt to 255, not 0.
+        //
+        // The predicate-image's single-step semantics is correct here;
+        // the headline test is "the bad-encoding 200 must surface".
+        let src = include_str!(
+            "../../../../../../examples/verify/bench_predicate_image_a4/adversarial/cap_overflow.btor"
+        );
+        let file = parse(src).unwrap();
+        let opts = ImageOptions::default();
+        let discovered = discover_values_for_btor2_file(&file, &opts).unwrap();
+        let cnt_values = flatten_to_value_sets(&discovered);
+        let cnt = cnt_values.get("cnt").expect("cnt discovered");
+        assert!(
+            cnt.contains(&200),
+            "cnt should include 200 (bad); got {cnt:?}"
+        );
+        // 0 must be excluded — see comment above. This is the soundness
+        // assertion: a value the design cannot transition to in one
+        // step must not appear in the discovered set.
+        assert!(
+            !cnt.contains(&0),
+            "cnt should NOT include 0 (unreachable in one step); got {cnt:?}"
+        );
+    }
+
+    #[test]
+    fn discover_sparse_predicates_under_single_step_semantics() {
+        // The brute-force enumerator's semantics is "reachable in one
+        // transition step from *some* current state". The current
+        // state is unconstrained, so any value `s` can take in one
+        // step from any predecessor counts. For this fixture the
+        // transition is `next(s) = ite(step, s + 6, s)` over BV(3) —
+        // so from current state `c`, next state is `c` (step=0) or
+        // `c + 6 mod 8` (step=1). Iterating `c` across all 8 values
+        // gives the full range {0..7}. The harness's manifest reflects
+        // this — multi-step reachability from init is *not* a
+        // contract the brute-force enumerator can enforce; the proper
+        // assertion lives at the recall harness in
+        // `tests/predicate_image_recall.rs`.
+        let src = include_str!(
+            "../../../../../../examples/verify/bench_predicate_image_a4/adversarial/sparse_predicates.btor"
+        );
+        let file = parse(src).unwrap();
+        let opts = ImageOptions::default();
+        let discovered = discover_values_for_btor2_file(&file, &opts).unwrap();
+        let by_signal = flatten_to_value_sets(&discovered);
+        let s_values = by_signal.get("s").expect("s discovered");
+        for k in 0..8 {
+            assert!(
+                s_values.contains(&k),
+                "s should include {k}; got {s_values:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn discover_safety_demo_cnt() {
+        // 2-bit cnt → values {0, 1, 2, 3} all reachable.
+        let src = include_str!("../../../../../../examples/btor2/safety_demo.btor");
+        let file = parse(src).unwrap();
+        let opts = ImageOptions::default();
+        let discovered = discover_values_for_btor2_file(&file, &opts).unwrap();
+        let by_signal = flatten_to_value_sets(&discovered);
+        let cnt = by_signal.get("cnt").expect("cnt discovered");
+        for k in 0..4 {
+            assert!(cnt.contains(&k), "cnt should include {k}; got {cnt:?}");
+        }
+    }
 }

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
@@ -1,77 +1,581 @@
-//! BTOR2 → SMT transition-relation encoder (Phase A.4 step 4.2).
+//! BTOR2 → Z3 transition-relation encoder (Phase A.4 step 4.2).
 //!
-//! Walks the BTOR2 NID DAG and emits a single Z3 boolean formula
-//! `T(s, s')` representing the transition relation: for each
-//! state-cell NID `n` with a `next` line of value-operand `v`, emit
-//! `s'_n == eval(v, s)`. State / input NIDs become Z3 `BV` variables
-//! over `s` or `s'` as appropriate; constants and operators round-
-//! trip through Z3's bit-vector ops.
+//! Walks the BTOR2 NID DAG and produces a single Z3 boolean
+//! `T(s, s')` representing the transition relation. State / input
+//! NIDs become Z3 `BV` variables over `s` (current step) or
+//! `s_next` (next step); `next` lines become equalities tying the
+//! two together; the `Btor2SmtView` returned by [`encode_design`]
+//! exposes these to the all-SMT enumerator in [`super::all_smt`].
 //!
-//! **Step 4.1 status: skeleton only.** The full encoder lands in step
-//! 4.2 with end-to-end tests against `safety_demo.btor` and two SV
-//! fixtures.
+//! Z3 must be called inside a [`z3::with_z3_config`] scope — the
+//! crate ships its context as a thread-local. Callers (the all-SMT
+//! enumerator, the recall harness) own that scope and drop the
+//! `Btor2SmtView` before exiting it.
 //!
 //! # SOUNDNESS
 //!
-//! The encoder must be **exact** for every operator it supports —
-//! over-approximating an operator would let the predicate-image
-//! enumeration surface edges that don't exist concretely, which is
-//! sound for safety but loses precision. Operators outside the Phase 1
-//! supported set
-//! ([`crate::adapter::btor2::ast::Op::is_blastable`]) cause the
-//! encoder to refuse the design (hard error, surfaced as an
-//! `EncodeError::UnsupportedOperator`).
+//! The encoder is **exact** for every operator it supports. Operators
+//! outside [`crate::adapter::btor2::ast::Op::is_blastable`] cause the
+//! encoder to refuse the design (hard error, surfaced as
+//! [`EncodeError::UnsupportedOperator`]) rather than emit an
+//! over-approximation. Array sorts (`read`/`write`) are rejected in
+//! `Theory::BvOnly`; step 4.5 will handle them under `Theory::BvUfArray`.
 
-use crate::adapter::btor2::ast::Btor2File;
+use std::collections::HashMap;
 
-/// Error variants raised by [`encode_transition_relation`].
+use crate::adapter::btor2::ast::{Btor2File, ConstValue, Nid, Node, Op, Operand, Sort};
+use crate::adapter::btor2::parser::bv_width;
+
+/// Error variants raised by [`encode_design`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EncodeError {
-    /// An operator outside the Phase 1 supported set was encountered.
-    /// The encoder refuses to over-approximate; the user must run an
-    /// external symbolic engine (per the documented Phase 3 hand-off)
-    /// for designs that include this operator.
-    UnsupportedOperator { nid: i64, op_name: &'static str },
-    /// The BTOR2 file references an array sort (read / write). Phase
-    /// A.4 BvOnly path rejects these; arrays land in step 4.5 with
-    /// `Theory::BvUfArray`.
-    ArraySortUnsupportedInBvOnly { nid: i64 },
+    UnsupportedOperator {
+        nid: i64,
+        op_name: &'static str,
+    },
+    ArraySortUnsupportedInBvOnly {
+        nid: i64,
+    },
+    /// A `next` line references an operand whose width does not match
+    /// its state cell. The BTOR2 parser usually catches this; surfaced
+    /// here only as a defence-in-depth.
+    WidthMismatch {
+        nid: i64,
+        state_width: u32,
+        operand_width: u32,
+    },
+    /// Bit-vector width too small for the integer constant. Should
+    /// not happen on well-formed BTOR2; surfaced as a hard error
+    /// rather than silently truncating.
+    ConstantOutOfRange {
+        nid: i64,
+    },
 }
 
 impl std::fmt::Display for EncodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EncodeError::UnsupportedOperator { nid, op_name } => {
-                write!(
-                    f,
-                    "BTOR2 NID {nid}: operator '{op_name}' not supported by the Phase A.4 \
-                     transition-relation encoder. Hand the design to an external symbolic \
-                     engine, or wait for the operator to be added in a follow-up phase."
-                )
-            }
-            EncodeError::ArraySortUnsupportedInBvOnly { nid } => {
-                write!(
-                    f,
-                    "BTOR2 NID {nid} references an array sort; Theory::BvOnly rejects \
-                     arrays. Use Theory::BvUfArray (Phase A.4 step 4.5) for designs with \
-                     array sorts."
-                )
-            }
+            EncodeError::UnsupportedOperator { nid, op_name } => write!(
+                f,
+                "BTOR2 NID {nid}: operator '{op_name}' not supported by the predicate-image encoder."
+            ),
+            EncodeError::ArraySortUnsupportedInBvOnly { nid } => write!(
+                f,
+                "BTOR2 NID {nid}: array sort under Theory::BvOnly. Use Theory::BvUfArray (step 4.5)."
+            ),
+            EncodeError::WidthMismatch {
+                nid,
+                state_width,
+                operand_width,
+            } => write!(
+                f,
+                "BTOR2 NID {nid}: width mismatch — state cell is {state_width} bits, operand is {operand_width} bits."
+            ),
+            EncodeError::ConstantOutOfRange { nid } => write!(
+                f,
+                "BTOR2 NID {nid}: constant value does not fit in declared sort width."
+            ),
         }
     }
 }
 
 impl std::error::Error for EncodeError {}
 
-/// Placeholder for the BTOR2 transition-relation encoder.
+/// A signal exposed by the encoded design — state cell or input.
+/// Carries the human-readable symbol (when the BTOR2 file declared
+/// one) and the bit-width.
+#[derive(Debug, Clone)]
+pub struct EncodedSignal {
+    pub nid: Nid,
+    pub width: u32,
+    pub symbol: Option<String>,
+    pub kind: SignalKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalKind {
+    State,
+    Input,
+}
+
+/// Output of [`encode_design`]. Holds the Z3 bit-vector handles for
+/// every state cell + input under both current-step (`s`) and
+/// next-step (`s_next`) projections, plus the conjoined transition
+/// relation.
 ///
-/// Step 4.2 will implement this: walk every `Next { state, value }`
-/// line, emit `s'_state == eval(value, s, inputs)`, conjoin into a
-/// single Z3 boolean.
-pub fn encode_transition_relation(_file: &Btor2File) -> Result<(), EncodeError> {
-    // Step 4.1 skeleton: signature only. Returning `Ok(())` keeps
-    // downstream callers compilable; step 4.2 changes the return
-    // type to carry the encoded `z3::ast::Bool<'ctx>` (or an opaque
-    // handle into the `PredicateImage` solver state).
-    Ok(())
+/// Must be dropped before exiting the surrounding
+/// [`z3::with_z3_config`] scope.
+pub struct Btor2SmtView {
+    /// Z3 BV handle for the current-step value of each state cell.
+    /// Indexed by BTOR2 NID.
+    pub state_curr: HashMap<Nid, z3::ast::BV>,
+    /// Z3 BV handle for the next-step value of each state cell.
+    pub state_next: HashMap<Nid, z3::ast::BV>,
+    /// Z3 BV handle for each input (constant across the step).
+    pub inputs: HashMap<Nid, z3::ast::BV>,
+    /// Per-signal metadata for callers that need to round-trip
+    /// names / widths back to the sidecar.
+    pub signals: Vec<EncodedSignal>,
+    /// The conjoined transition relation `T(s, s') = ⋀ s_next == next(...)`.
+    pub transition: z3::ast::Bool,
+}
+
+impl Btor2SmtView {
+    /// Look up the next-step BV for a state-cell NID.
+    pub fn next_state(&self, nid: Nid) -> Option<&z3::ast::BV> {
+        self.state_next.get(&nid)
+    }
+
+    /// Look up the current-step BV for a state-cell NID.
+    pub fn curr_state(&self, nid: Nid) -> Option<&z3::ast::BV> {
+        self.state_curr.get(&nid)
+    }
+
+    /// Bit-width of a signal by NID.
+    pub fn width_of(&self, nid: Nid) -> Option<u32> {
+        self.signals.iter().find(|s| s.nid == nid).map(|s| s.width)
+    }
+}
+
+/// Encode a BTOR2 file into a Z3 transition relation.
+///
+/// Must be called inside a [`z3::with_z3_config`] scope. Returns
+/// [`EncodeError::UnsupportedOperator`] on the first non-blastable
+/// op encountered; the caller has no way to recover other than
+/// rejecting the design or switching to an external symbolic engine.
+pub fn encode_design(file: &Btor2File) -> Result<Btor2SmtView, EncodeError> {
+    // Z3 0.20's BV handles carry a lifetime tied to the global
+    // context the `with_z3_config` scope installed; using `'static`
+    // here is the convention the crate's API exposes (every
+    // `BV::new_const` returns BV<'static>).
+    let mut state_curr: HashMap<Nid, z3::ast::BV> = HashMap::new();
+    let mut state_next: HashMap<Nid, z3::ast::BV> = HashMap::new();
+    let mut inputs: HashMap<Nid, z3::ast::BV> = HashMap::new();
+    let mut signals = Vec::new();
+
+    // Symbol map populated by the BTOR2 parser (already factored out;
+    // re-using it keeps the encoder's signal names aligned with the
+    // bit-blaster's).
+    let symbols = crate::adapter::btor2::parser::collect_symbols(file);
+
+    // Pass 1 — declare BV handles for every state cell and input.
+    for line in &file.lines {
+        match &line.node {
+            Node::State { sort, .. } => {
+                let width = bv_width(file, *sort)
+                    .ok_or(EncodeError::ArraySortUnsupportedInBvOnly { nid: line.nid })?;
+                let sym = symbols.get(&line.nid).cloned();
+                let label = sym.clone().unwrap_or_else(|| format!("st{}", line.nid));
+                let curr = z3::ast::BV::new_const(format!("s_{label}").as_str(), width);
+                let next = z3::ast::BV::new_const(format!("s_next_{label}").as_str(), width);
+                state_curr.insert(line.nid, curr);
+                state_next.insert(line.nid, next);
+                signals.push(EncodedSignal {
+                    nid: line.nid,
+                    width,
+                    symbol: sym,
+                    kind: SignalKind::State,
+                });
+            }
+            Node::Input { sort, .. } => {
+                let width = bv_width(file, *sort)
+                    .ok_or(EncodeError::ArraySortUnsupportedInBvOnly { nid: line.nid })?;
+                let sym = symbols.get(&line.nid).cloned();
+                let label = sym.clone().unwrap_or_else(|| format!("in{}", line.nid));
+                let v = z3::ast::BV::new_const(format!("in_{label}").as_str(), width);
+                inputs.insert(line.nid, v);
+                signals.push(EncodedSignal {
+                    nid: line.nid,
+                    width,
+                    symbol: sym,
+                    kind: SignalKind::Input,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // Pass 2 — walk every `next` line and conjoin
+    // `s_next_<state> == eval(value)` into the transition relation.
+    let mut conjuncts: Vec<z3::ast::Bool> = Vec::new();
+    let mut cache: HashMap<Nid, z3::ast::BV> = HashMap::new();
+
+    for line in &file.lines {
+        if let Node::Next { state, value, .. } = &line.node {
+            let value_bv = eval_operand(*value, file, &state_curr, &inputs, &mut cache)?;
+            let next_bv = state_next
+                .get(state)
+                .ok_or(EncodeError::WidthMismatch {
+                    nid: line.nid,
+                    state_width: 0,
+                    operand_width: value_bv.get_size(),
+                })?
+                .clone();
+            if next_bv.get_size() != value_bv.get_size() {
+                return Err(EncodeError::WidthMismatch {
+                    nid: line.nid,
+                    state_width: next_bv.get_size(),
+                    operand_width: value_bv.get_size(),
+                });
+            }
+            conjuncts.push(next_bv.eq(&value_bv));
+        }
+    }
+
+    // Conjoin into a single Bool. If the design has no `next` lines
+    // (rare — a degenerate fixture), the transition is trivially
+    // `true` (every state is a self-loop).
+    let transition = if conjuncts.is_empty() {
+        z3::ast::Bool::from_bool(true)
+    } else {
+        let refs: Vec<&z3::ast::Bool> = conjuncts.iter().collect();
+        z3::ast::Bool::and(&refs)
+    };
+
+    Ok(Btor2SmtView {
+        state_curr,
+        state_next,
+        inputs,
+        signals,
+        transition,
+    })
+}
+
+/// Recursively evaluate an operand to a Z3 BV. Caches sub-expressions
+/// keyed by NID so the DAG sharing in the BTOR2 file translates
+/// directly into Z3 expression sharing.
+fn eval_operand(
+    operand: Operand,
+    file: &Btor2File,
+    state_curr: &HashMap<Nid, z3::ast::BV>,
+    inputs: &HashMap<Nid, z3::ast::BV>,
+    cache: &mut HashMap<Nid, z3::ast::BV>,
+) -> Result<z3::ast::BV, EncodeError> {
+    let nid = operand.nid();
+    let negated = operand.is_negated();
+
+    if let Some(cached) = cache.get(&nid) {
+        let v = cached.clone();
+        return Ok(if negated { v.bvnot() } else { v });
+    }
+
+    let line = file.lookup(nid).ok_or(EncodeError::UnsupportedOperator {
+        nid,
+        op_name: "<missing-nid>",
+    })?;
+
+    let v = match &line.node {
+        Node::State { .. } => {
+            state_curr
+                .get(&nid)
+                .cloned()
+                .ok_or(EncodeError::UnsupportedOperator {
+                    nid,
+                    op_name: "state",
+                })?
+        }
+        Node::Input { .. } => {
+            inputs
+                .get(&nid)
+                .cloned()
+                .ok_or(EncodeError::UnsupportedOperator {
+                    nid,
+                    op_name: "input",
+                })?
+        }
+        Node::Const { sort, value } => encode_const(line.nid, *sort, value, file)?,
+        Node::Op { sort, op, args, .. } => {
+            let width = bv_width(file, *sort)
+                .ok_or(EncodeError::ArraySortUnsupportedInBvOnly { nid: line.nid })?;
+            encode_op(
+                line.nid,
+                *op,
+                args,
+                &line.immediates,
+                width,
+                file,
+                state_curr,
+                inputs,
+                cache,
+            )?
+        }
+        Node::Sort { .. }
+        | Node::Init { .. }
+        | Node::Next { .. }
+        | Node::Bad { .. }
+        | Node::Constraint { .. }
+        | Node::Fair { .. }
+        | Node::Output { .. }
+        | Node::Justice { .. } => {
+            return Err(EncodeError::UnsupportedOperator {
+                nid,
+                op_name: "non-value-node",
+            });
+        }
+    };
+
+    cache.insert(nid, v.clone());
+    Ok(if negated { v.bvnot() } else { v })
+}
+
+fn encode_const(
+    nid: Nid,
+    sort_nid: Nid,
+    value: &ConstValue,
+    file: &Btor2File,
+) -> Result<z3::ast::BV, EncodeError> {
+    let width =
+        bv_width(file, sort_nid).ok_or(EncodeError::ArraySortUnsupportedInBvOnly { nid })?;
+    let bits: u64 = match value {
+        ConstValue::Zero => 0,
+        ConstValue::One => 1,
+        ConstValue::Ones => {
+            if width >= 64 {
+                u64::MAX
+            } else {
+                (1u64 << width) - 1
+            }
+        }
+        ConstValue::Bin(s) => {
+            u64::from_str_radix(s, 2).map_err(|_| EncodeError::ConstantOutOfRange { nid })?
+        }
+        ConstValue::Dec(d) => {
+            if *d < 0 || *d > (i128::from(u64::MAX)) {
+                return Err(EncodeError::ConstantOutOfRange { nid });
+            }
+            *d as u64
+        }
+        ConstValue::Hex(s) => {
+            u64::from_str_radix(s, 16).map_err(|_| EncodeError::ConstantOutOfRange { nid })?
+        }
+    };
+    Ok(z3::ast::BV::from_u64(bits, width))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_op(
+    nid: Nid,
+    op: Op,
+    args: &[Operand],
+    immediates: &[u32],
+    width: u32,
+    file: &Btor2File,
+    state_curr: &HashMap<Nid, z3::ast::BV>,
+    inputs: &HashMap<Nid, z3::ast::BV>,
+    cache: &mut HashMap<Nid, z3::ast::BV>,
+) -> Result<z3::ast::BV, EncodeError> {
+    // Helpers to materialise operands inline.
+    let mut get = |i: usize| -> Result<z3::ast::BV, EncodeError> {
+        eval_operand(args[i], file, state_curr, inputs, cache)
+    };
+    let bool_to_bv1 = |b: z3::ast::Bool| {
+        let one = z3::ast::BV::from_u64(1, 1);
+        let zero = z3::ast::BV::from_u64(0, 1);
+        b.ite(&one, &zero)
+    };
+
+    match op {
+        // Bitwise / boolean
+        Op::Not => Ok(get(0)?.bvnot()),
+        Op::And => Ok(get(0)?.bvand(&get(1)?)),
+        Op::Or => Ok(get(0)?.bvor(&get(1)?)),
+        Op::Xor => Ok(get(0)?.bvxor(&get(1)?)),
+        Op::Nand => Ok(get(0)?.bvand(&get(1)?).bvnot()),
+        Op::Nor => Ok(get(0)?.bvor(&get(1)?).bvnot()),
+        Op::Xnor => Ok(get(0)?.bvxor(&get(1)?).bvnot()),
+        Op::Iff => Ok(bool_to_bv1(get(0)?.eq(&get(1)?))),
+        Op::Implies => {
+            // a → b  ≡  ¬a ∨ b ; over BV(1).
+            let a = get(0)?;
+            let b = get(1)?;
+            Ok(a.bvnot().bvor(&b))
+        }
+        // Comparison (always emits BV(1))
+        Op::Eq => Ok(bool_to_bv1(get(0)?.eq(&get(1)?))),
+        Op::Neq => Ok(bool_to_bv1(get(0)?.eq(&get(1)?).not())),
+        Op::Ult => Ok(bool_to_bv1(get(0)?.bvult(&get(1)?))),
+        Op::Ulte => Ok(bool_to_bv1(get(0)?.bvule(&get(1)?))),
+        Op::Ugt => Ok(bool_to_bv1(get(0)?.bvugt(&get(1)?))),
+        Op::Ugte => Ok(bool_to_bv1(get(0)?.bvuge(&get(1)?))),
+        Op::Slt => Ok(bool_to_bv1(get(0)?.bvslt(&get(1)?))),
+        Op::Slte => Ok(bool_to_bv1(get(0)?.bvsle(&get(1)?))),
+        Op::Sgt => Ok(bool_to_bv1(get(0)?.bvsgt(&get(1)?))),
+        Op::Sgte => Ok(bool_to_bv1(get(0)?.bvsge(&get(1)?))),
+        // Arithmetic
+        Op::Add => Ok(get(0)?.bvadd(&get(1)?)),
+        Op::Sub => Ok(get(0)?.bvsub(&get(1)?)),
+        Op::Mul => Ok(get(0)?.bvmul(&get(1)?)),
+        Op::Neg => Ok(get(0)?.bvneg()),
+        Op::Inc => {
+            let a = get(0)?;
+            let one = z3::ast::BV::from_u64(1, a.get_size());
+            Ok(a.bvadd(&one))
+        }
+        Op::Dec => {
+            let a = get(0)?;
+            let one = z3::ast::BV::from_u64(1, a.get_size());
+            Ok(a.bvsub(&one))
+        }
+        // Shifts
+        Op::Sll => Ok(get(0)?.bvshl(&get(1)?)),
+        Op::Srl => Ok(get(0)?.bvlshr(&get(1)?)),
+        Op::Sra => Ok(get(0)?.bvashr(&get(1)?)),
+        Op::Rol => Ok(get(0)?.bvrotl(&get(1)?)),
+        Op::Ror => Ok(get(0)?.bvrotr(&get(1)?)),
+        // Concat / slice / extension
+        Op::Concat => Ok(get(0)?.concat(&get(1)?)),
+        Op::Slice => {
+            let inner = get(0)?;
+            let upper = *immediates.first().ok_or(EncodeError::UnsupportedOperator {
+                nid,
+                op_name: "slice (missing immediate)",
+            })?;
+            let lower = *immediates.get(1).ok_or(EncodeError::UnsupportedOperator {
+                nid,
+                op_name: "slice (missing immediate)",
+            })?;
+            Ok(inner.extract(upper, lower))
+        }
+        Op::Uext => {
+            let inner = get(0)?;
+            let pad = width.saturating_sub(inner.get_size());
+            Ok(inner.zero_ext(pad))
+        }
+        Op::Sext => {
+            let inner = get(0)?;
+            let pad = width.saturating_sub(inner.get_size());
+            Ok(inner.sign_ext(pad))
+        }
+        // Reductions
+        Op::Redand => {
+            let inner = get(0)?;
+            let ones = z3::ast::BV::from_i64(-1, inner.get_size());
+            Ok(bool_to_bv1(inner.eq(&ones)))
+        }
+        Op::Redor => {
+            let inner = get(0)?;
+            let zero = z3::ast::BV::from_u64(0, inner.get_size());
+            Ok(bool_to_bv1(inner.eq(&zero).not()))
+        }
+        Op::Redxor => {
+            // Parity bit. For an n-bit value v, redxor = v[0] xor v[1] xor ... xor v[n-1].
+            let inner = get(0)?;
+            let n = inner.get_size();
+            let mut acc = inner.extract(0, 0);
+            for i in 1..n {
+                let bit = inner.extract(i, i);
+                acc = acc.bvxor(&bit);
+            }
+            Ok(acc)
+        }
+        // ite (3-operand)
+        Op::Ite => {
+            let cond = get(0)?;
+            let then_bv = get(1)?;
+            let else_bv = get(2)?;
+            let zero = z3::ast::BV::from_u64(0, cond.get_size());
+            let cond_bool = cond.eq(&zero).not();
+            Ok(cond_bool.ite(&then_bv, &else_bv))
+        }
+        // Unsupported in Phase A.4 BvOnly — array ops + divisions +
+        // overflow detectors. Match the bit-blaster's behaviour:
+        // refuse with a clear error.
+        Op::Sdiv | Op::Udiv | Op::Smod | Op::Srem | Op::Urem => {
+            Err(EncodeError::UnsupportedOperator {
+                nid,
+                op_name: "division/modulo (sdiv/udiv/smod/srem/urem)",
+            })
+        }
+        Op::Saddo | Op::Ssubo | Op::Smulo | Op::Uaddo | Op::Usubo | Op::Umulo | Op::Sdivo => {
+            Err(EncodeError::UnsupportedOperator {
+                nid,
+                op_name: "overflow detector",
+            })
+        }
+        Op::Read | Op::Write => Err(EncodeError::ArraySortUnsupportedInBvOnly { nid }),
+    }
+}
+
+// Suppress the unused-arg warning emitted by `Sort` checks in the
+// non-array paths; the encoder doesn't need the sort node itself
+// since the parser already validated widths.
+#[allow(dead_code)]
+fn _sort_check(_s: &Sort) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::parser::parse;
+
+    #[test]
+    fn encode_safety_demo_btor() {
+        let src = include_str!("../../../../../../examples/btor2/safety_demo.btor");
+        let file = parse(src).expect("parse safety_demo");
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = encode_design(&file).expect("encode safety_demo");
+            // safety_demo has 3 state cells (cnt + 2 anonymous);
+            // 2 inputs (rst, clk).
+            assert!(
+                view.signals
+                    .iter()
+                    .any(|s| s.symbol.as_deref() == Some("cnt"))
+            );
+            assert!(
+                view.signals
+                    .iter()
+                    .any(|s| s.symbol.as_deref() == Some("rst"))
+            );
+            assert!(
+                view.signals
+                    .iter()
+                    .any(|s| s.symbol.as_deref() == Some("clk"))
+            );
+        });
+    }
+
+    #[test]
+    fn encode_cap_overflow_btor() {
+        let src = include_str!(
+            "../../../../../../examples/verify/bench_predicate_image_a4/adversarial/cap_overflow.btor"
+        );
+        let file = parse(src).expect("parse cap_overflow");
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = encode_design(&file).expect("encode cap_overflow");
+            assert_eq!(
+                view.signals
+                    .iter()
+                    .filter(|s| s.kind == SignalKind::State)
+                    .count(),
+                1
+            );
+            // `cnt` should be 8 bits.
+            let cnt = view
+                .signals
+                .iter()
+                .find(|s| s.symbol.as_deref() == Some("cnt"))
+                .expect("cnt signal present");
+            assert_eq!(cnt.width, 8);
+        });
+    }
+
+    #[test]
+    fn encode_sparse_predicates_btor() {
+        let src = include_str!(
+            "../../../../../../examples/verify/bench_predicate_image_a4/adversarial/sparse_predicates.btor"
+        );
+        let file = parse(src).expect("parse sparse_predicates");
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = encode_design(&file).expect("encode sparse_predicates");
+            let s = view
+                .signals
+                .iter()
+                .find(|sig| sig.symbol.as_deref() == Some("s"))
+                .expect("s signal present");
+            assert_eq!(s.width, 3);
+            assert_eq!(s.kind, SignalKind::State);
+        });
+    }
 }

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
@@ -1,0 +1,77 @@
+//! BTOR2 → SMT transition-relation encoder (Phase A.4 step 4.2).
+//!
+//! Walks the BTOR2 NID DAG and emits a single Z3 boolean formula
+//! `T(s, s')` representing the transition relation: for each
+//! state-cell NID `n` with a `next` line of value-operand `v`, emit
+//! `s'_n == eval(v, s)`. State / input NIDs become Z3 `BV` variables
+//! over `s` or `s'` as appropriate; constants and operators round-
+//! trip through Z3's bit-vector ops.
+//!
+//! **Step 4.1 status: skeleton only.** The full encoder lands in step
+//! 4.2 with end-to-end tests against `safety_demo.btor` and two SV
+//! fixtures.
+//!
+//! # SOUNDNESS
+//!
+//! The encoder must be **exact** for every operator it supports —
+//! over-approximating an operator would let the predicate-image
+//! enumeration surface edges that don't exist concretely, which is
+//! sound for safety but loses precision. Operators outside the Phase 1
+//! supported set
+//! ([`crate::adapter::btor2::ast::Op::is_blastable`]) cause the
+//! encoder to refuse the design (hard error, surfaced as an
+//! `EncodeError::UnsupportedOperator`).
+
+use crate::adapter::btor2::ast::Btor2File;
+
+/// Error variants raised by [`encode_transition_relation`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncodeError {
+    /// An operator outside the Phase 1 supported set was encountered.
+    /// The encoder refuses to over-approximate; the user must run an
+    /// external symbolic engine (per the documented Phase 3 hand-off)
+    /// for designs that include this operator.
+    UnsupportedOperator { nid: i64, op_name: &'static str },
+    /// The BTOR2 file references an array sort (read / write). Phase
+    /// A.4 BvOnly path rejects these; arrays land in step 4.5 with
+    /// `Theory::BvUfArray`.
+    ArraySortUnsupportedInBvOnly { nid: i64 },
+}
+
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EncodeError::UnsupportedOperator { nid, op_name } => {
+                write!(
+                    f,
+                    "BTOR2 NID {nid}: operator '{op_name}' not supported by the Phase A.4 \
+                     transition-relation encoder. Hand the design to an external symbolic \
+                     engine, or wait for the operator to be added in a follow-up phase."
+                )
+            }
+            EncodeError::ArraySortUnsupportedInBvOnly { nid } => {
+                write!(
+                    f,
+                    "BTOR2 NID {nid} references an array sort; Theory::BvOnly rejects \
+                     arrays. Use Theory::BvUfArray (Phase A.4 step 4.5) for designs with \
+                     array sorts."
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for EncodeError {}
+
+/// Placeholder for the BTOR2 transition-relation encoder.
+///
+/// Step 4.2 will implement this: walk every `Next { state, value }`
+/// line, emit `s'_state == eval(value, s, inputs)`, conjoin into a
+/// single Z3 boolean.
+pub fn encode_transition_relation(_file: &Btor2File) -> Result<(), EncodeError> {
+    // Step 4.1 skeleton: signature only. Returning `Ok(())` keeps
+    // downstream callers compilable; step 4.2 changes the return
+    // type to carry the encoded `z3::ast::Bool<'ctx>` (or an opaque
+    // handle into the `PredicateImage` solver state).
+    Ok(())
+}

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/mod.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/mod.rs
@@ -1,0 +1,208 @@
+//! SMT predicate-image discovery (Phase A.4).
+//!
+//! Hoder–Bjørner–de Moura CAV 2006 all-SMT enumeration of abstract
+//! transitions under a per-theory transition relation. Produces a
+//! refined `discovered_values` set the existing sidecar resolver can
+//! consume without changes.
+//!
+//! # Roles
+//!
+//! - **`Theory`** — selects the SMT theory family used to encode the
+//!   transition relation. `BvOnly` for SV / BTOR2; `BvUfArray` for the
+//!   C-extraction path.
+//! - **`PredicateImage`** — the live SMT context. Wraps a Z3 solver
+//!   plus the predicate set plus the encoded transition relation.
+//!   Computes the abstract image as a set of `(from, to)` bit-mask pairs.
+//! - **`Predicate`** — name + witness expression. Names round-trip into
+//!   `SvAnnotation.discovered_values` as `DiscoveredValue.name`.
+//! - **`AbstractTransition`** — one edge in the all-SMT enumeration's
+//!   output. The recall harness reads these to score
+//!   `discovered ∩ expected`.
+//!
+//! # Phase A.4 status
+//!
+//! - **Step 4.1 (this module skeleton)**: types + module structure;
+//!   no algorithm yet.
+//! - **Step 4.2**: `btor2_encode.rs` implements BTOR2 → SMT transition
+//!   relation.
+//! - **Step 4.3**: `all_smt.rs` implements the Hoder–Bjørner–de Moura
+//!   enumeration; ships `Theory::BvOnly` against the benchmark from
+//!   `examples/verify/bench_predicate_image_a4/`.
+//! - **Step 4.4**: CLI wiring.
+//! - **Step 4.5**: `Theory::BvUfArray` variant + extraction adapter
+//!   unblock.
+//!
+//! # SOUNDNESS
+//!
+//! The predicate image is an **over-approximation** of the abstract
+//! transition relation by construction — every concrete edge has a
+//! corresponding abstract edge, and the enumeration only adds edges
+//! that the SMT solver proves are satisfiable. Missing edges are
+//! impossible under sound encoding; spurious edges are only possible
+//! if the BTOR2 / SV → SMT encoder over-approximates an operator
+//! (e.g., the under-approximation fallback in `theory.rs` when Z3
+//! saturates). Each over-approximation site is annotated with a
+//! `// SOUNDNESS:` comment.
+
+pub mod all_smt;
+pub mod btor2_encode;
+pub mod seed;
+pub mod theory;
+
+pub use theory::Theory;
+
+use std::collections::HashSet;
+
+/// One predicate in the partition's witness set. The `name` round-trips
+/// into [`crate::adapter::systemverilog::annotation::DiscoveredValue::name`];
+/// the `witness` is the SMT-side expression the predicate stands for
+/// (a single equality, range comparison, or arbitrary boolean formula
+/// over signals — the seed extractor in `seed.rs` decides the shape).
+#[derive(Debug, Clone)]
+pub struct Predicate {
+    /// Human-readable name, used as the value-map entry in the
+    /// resolved `discovered_values`.
+    pub name: String,
+    /// The signal this predicate is anchored on. Multiple predicates
+    /// may share a signal — they become alternatives in the resolved
+    /// `EnumValues` domain.
+    pub signal: String,
+    /// The integer constant the predicate witnesses, when the
+    /// predicate has the shape `signal == k`. `None` for richer
+    /// predicates (range, parity, etc.) that don't reduce to a single
+    /// integer in the sidecar.
+    pub witness_constant: Option<i64>,
+}
+
+/// One edge in the all-SMT enumeration's output. The bit-masks index
+/// into [`PredicateImage::predicates`] — `from[i] = true` iff the
+/// `i`-th predicate holds in the `from`-state of the edge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbstractTransition {
+    pub from: Vec<bool>,
+    pub to: Vec<bool>,
+}
+
+/// Tunables for the predicate-image enumeration.
+#[derive(Debug, Clone)]
+pub struct ImageOptions {
+    /// Maximum number of abstract edges the enumeration will emit per
+    /// `(predicate_set, transition)` query. Bounded to keep the
+    /// enumeration tractable; default 4 096.
+    pub cap_edges: usize,
+    /// Per-query SMT timeout in milliseconds. The Bryant–Kroening
+    /// under-approximation fallback kicks in on timeout. Default 5 000.
+    pub per_query_timeout_ms: u32,
+    /// Maximum bit-width for under-approximation shrinks. Bryant–Kroening
+    /// halves widths on each retry; this is the floor. Default 4.
+    pub under_approx_min_width: u32,
+}
+
+impl Default for ImageOptions {
+    fn default() -> Self {
+        Self {
+            cap_edges: 4_096,
+            per_query_timeout_ms: 5_000,
+            under_approx_min_width: 4,
+        }
+    }
+}
+
+/// Per-fixture recall metric — `|discovered ∩ expected| / |expected|`.
+/// Computed by the recall harness in step 4.3 against the fixtures
+/// declared in
+/// [`examples/verify/bench_predicate_image_a4/fixtures.toml`](../../../../../examples/verify/bench_predicate_image_a4/fixtures.toml).
+#[derive(Debug, Clone)]
+pub struct RecallScore {
+    pub fixture_id: String,
+    pub signal: String,
+    pub expected: HashSet<i64>,
+    pub discovered: HashSet<i64>,
+    pub recall: f64,
+}
+
+impl RecallScore {
+    pub fn compute(
+        fixture_id: impl Into<String>,
+        signal: impl Into<String>,
+        expected: HashSet<i64>,
+        discovered: HashSet<i64>,
+    ) -> Self {
+        let intersection = expected.intersection(&discovered).count() as f64;
+        let denom = expected.len() as f64;
+        let recall = if denom > 0.0 {
+            intersection / denom
+        } else {
+            // Empty expected set — recall is degenerate. The harness
+            // skips such fixtures (Pono variant before download, for
+            // instance) rather than fail them.
+            1.0
+        };
+        Self {
+            fixture_id: fixture_id.into(),
+            signal: signal.into(),
+            expected,
+            discovered,
+            recall,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ints(xs: &[i64]) -> HashSet<i64> {
+        xs.iter().copied().collect()
+    }
+
+    #[test]
+    fn image_options_default_is_capped() {
+        let opts = ImageOptions::default();
+        assert_eq!(opts.cap_edges, 4_096);
+        assert_eq!(opts.per_query_timeout_ms, 5_000);
+        assert!(opts.under_approx_min_width > 0);
+    }
+
+    #[test]
+    fn recall_score_perfect_match() {
+        let score =
+            RecallScore::compute("test_fix", "cnt", ints(&[0, 1, 2, 3]), ints(&[0, 1, 2, 3]));
+        assert_eq!(score.recall, 1.0);
+    }
+
+    #[test]
+    fn recall_score_partial_match() {
+        let score =
+            RecallScore::compute("test_fix", "cnt", ints(&[0, 1, 2, 3, 4]), ints(&[0, 1, 2]));
+        // 3 of 5 expected discovered → 0.6
+        assert!((score.recall - 0.6).abs() < 1e-9);
+    }
+
+    #[test]
+    fn recall_score_empty_expected_is_one() {
+        // Degenerate case (e.g. Pono fixture with no curated baseline)
+        // returns 1.0 so the harness can skip-without-failing.
+        let score = RecallScore::compute("pono", "x", HashSet::new(), ints(&[0, 5, 10]));
+        assert_eq!(score.recall, 1.0);
+    }
+
+    #[test]
+    fn recall_score_extra_discovered_does_not_penalise() {
+        // Recall is intersection / expected — extra discovered values
+        // (precision loss) don't reduce the score. Precision is a
+        // separate metric we don't track in Phase A.4.
+        let score = RecallScore::compute("test", "cnt", ints(&[0, 1]), ints(&[0, 1, 99, 100]));
+        assert_eq!(score.recall, 1.0);
+    }
+
+    #[test]
+    fn abstract_transition_equality() {
+        let a = AbstractTransition {
+            from: vec![true, false, true],
+            to: vec![false, true, false],
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/seed.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/seed.rs
@@ -1,0 +1,75 @@
+//! Syntactic seed extraction for predicate-image discovery.
+//!
+//! Phase A.4 step 4.3 will populate this module with the AVR /
+//! Goel–Sakallah syntax-guided seed pattern (sub-expressions, case
+//! labels, `== const` RHS values). Step 4.1 ships the type shape
+//! only.
+//!
+//! The seeds feed [`super::all_smt`] as the initial predicate set; the
+//! all-SMT enumeration then walks the transition relation to discover
+//! any additional reachable predicate witnesses.
+
+use super::Predicate;
+
+/// Seed source — informational only. Helps users see why a discovered
+/// value showed up (case label vs. comparison RHS vs. SMT-derived).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SeedSource {
+    /// Constant in a `case <signal>: arm` label.
+    CaseLabel,
+    /// Right-hand side of a `signal == k` comparison in an
+    /// `always_ff` / `always_comb` guard.
+    EqualityComparison,
+    /// `bad` / `constraint` / `justice` / `fair` operand constant.
+    BadConstraint,
+    /// Operand constant of a relational op (`<`, `<=`, `>`, `>=`,
+    /// `!=`) — included so user-written formula atoms get matched.
+    RelationalComparison,
+}
+
+/// Output of the syntactic-seed walker — a predicate + its source
+/// rationale. Round-tripped into [`super::Predicate`] for the all-SMT
+/// engine.
+#[derive(Debug, Clone)]
+pub struct SeedPredicate {
+    pub predicate: Predicate,
+    pub source: SeedSource,
+}
+
+/// Placeholder for the BTOR2 syntactic seed walker. Step 4.3 will
+/// implement this: walk every `bad` / `constraint` / `justice` /
+/// `fair` operand DAG collecting `eq` / `ult` / `slt` / `ulte` /
+/// `slte` / `ugt` / `sgt` / `ugte` / `sgte` operands that bottom-out
+/// at a `const`.
+pub fn collect_btor2_seeds(_file: &crate::adapter::btor2::ast::Btor2File) -> Vec<SeedPredicate> {
+    Vec::new()
+}
+
+/// Placeholder for the SV syntactic seed walker. Step 4.3 will
+/// implement this: harvest case-label constants and `signal == k`
+/// RHS literals from `always_ff` / `always_comb` blocks. The existing
+/// [`crate::adapter::systemverilog::kripke::scan_significant_constants`]
+/// is the closest current code; this module supersedes it once step
+/// 4.3 lands.
+pub fn collect_sv_seeds(
+    _module: &crate::adapter::systemverilog::ast::Module,
+) -> Vec<SeedPredicate> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_source_variants_are_distinct() {
+        let xs = [
+            SeedSource::CaseLabel,
+            SeedSource::EqualityComparison,
+            SeedSource::BadConstraint,
+            SeedSource::RelationalComparison,
+        ];
+        let unique: std::collections::HashSet<_> = xs.iter().collect();
+        assert_eq!(unique.len(), xs.len());
+    }
+}

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/theory.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/theory.rs
@@ -1,0 +1,72 @@
+//! SMT theory selector for predicate-image discovery.
+//!
+//! Each variant declares both the **logic** Z3 should use to encode
+//! the transition relation and the **soundness contract** the caller
+//! is signing up for.
+
+/// SMT theory used to encode the design's transition relation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Theory {
+    /// `QF_BV` — pure bit-vector logic. Suitable for the BTOR2 and
+    /// SystemVerilog adapters: every storage element is a bit-vector,
+    /// every operator is bit-precise.
+    ///
+    /// **Soundness contract.** The BTOR2 / SV → SMT encoder must be
+    /// faithful to the bit-vector semantics of the source. The Phase
+    /// A.4 encoder in [`super::btor2_encode`] is exact for the Phase 1
+    /// supported operator set; operators outside that set cause the
+    /// encoder to refuse the design (hard error, not silent
+    /// approximation).
+    BvOnly,
+    /// `QF_BV + QF_UF + arrays` — bit-vectors plus uninterpreted
+    /// functions plus extensional arrays. Required by the C-extraction
+    /// path: pointer dereferences encode as UF symbols (sound
+    /// over-approximation of any concrete address resolution); memory
+    /// regions encode as arrays indexed by address.
+    ///
+    /// **Soundness contract.** UF over-approximates pointer aliasing
+    /// (every pointer read may return any prior write to a UF-aliased
+    /// location). This preserves safety under universal-modality
+    /// (`[]` / `nu`) verdicts but admits more behaviours than the
+    /// concrete program. The
+    /// [`phase-a3-followup-indirect-references.md`](../../../../../../.claude/plans/phase-a3-followup-indirect-references.md)
+    /// follow-up plan still owns the dep-graph alias-tracking half;
+    /// `BvUfArray` here is only the SMT-theory layer beneath it.
+    BvUfArray,
+}
+
+impl Theory {
+    /// Z3 logic identifier for [`z3::Config::set_logic`]. Returned as
+    /// a `&'static str` so callers can plug it straight into the
+    /// solver configuration without allocation.
+    pub fn z3_logic(&self) -> &'static str {
+        match self {
+            Theory::BvOnly => "QF_BV",
+            Theory::BvUfArray => "QF_AUFBV",
+        }
+    }
+
+    /// `true` when the theory permits encoding pointer-aliased writes
+    /// (and other indirect references) via UF / array primitives.
+    /// Used by the extraction adapter's gate at step 4.5.
+    pub fn supports_indirect_references(&self) -> bool {
+        matches!(self, Theory::BvUfArray)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn z3_logic_returns_canonical_strings() {
+        assert_eq!(Theory::BvOnly.z3_logic(), "QF_BV");
+        assert_eq!(Theory::BvUfArray.z3_logic(), "QF_AUFBV");
+    }
+
+    #[test]
+    fn indirect_references_gate() {
+        assert!(!Theory::BvOnly.supports_indirect_references());
+        assert!(Theory::BvUfArray.supports_indirect_references());
+    }
+}

--- a/crates/mununu-core/src/adapter/systemverilog/kripke_smt.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/kripke_smt.rs
@@ -4,9 +4,9 @@
 //! guard conditions satisfiable. This discovers significant values hidden
 //! behind combinational logic (e.g., `y = x * 4; if (y == 12)` → `x = 3`).
 //!
-//! Requires the `smt` feature flag (`cargo build --features smt`).
+//! Z3 is a mandatory dependency since Phase A.4 step 4.2 — the historical
+//! `--features smt` opt-in was removed.
 
-#[cfg(feature = "smt")]
 pub mod engine {
     use super::super::annotation::{
         DiscoveredValue, DiscoveredValues, SignalAbstraction, SvAnnotation,
@@ -794,11 +794,9 @@ pub mod engine {
     }
 }
 
-#[cfg(feature = "smt")]
 pub use engine::discover_significant_values;
 
 #[cfg(test)]
-#[cfg(feature = "smt")]
 mod tests {
     use super::engine::*;
     use crate::adapter::systemverilog::annotation::*;

--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -71,6 +71,16 @@ pub struct YosysOptions {
     /// `--preprocessor sv2v` or the API field `use_sv2v: true` on the
     /// import request.
     pub use_sv2v: bool,
+    /// When `true`, Yosys's `setundef -anyseq` pass replaces every
+    /// undefined net with a fresh symbolic choice instead of pinning
+    /// it to zero. Preserves CWE-1245-class bug-bearing semantics
+    /// (the unmatched-case path admits any value) at the cost of
+    /// introducing `$anyseq` state cells — the bit-blast state-bit
+    /// count can grow substantially. **Default: `false`** (matches
+    /// historical `setundef -zero` behaviour; small state space; bug
+    /// silently transformed away). See the SOUNDNESS comment in
+    /// [`build_script`] for the trade-off.
+    pub setundef_anyseq: bool,
 }
 
 /// SV-via-Yosys adapter — wraps the BTOR2 path with a Yosys subprocess.
@@ -155,7 +165,13 @@ pub fn translate_sv(
 
     let btor_path = tmp.path().join("design.btor");
     let hier_json_path = tmp.path().join("hier.json");
-    let script = build_script(&sources, yopts.top.as_deref(), &btor_path, &hier_json_path);
+    let script = build_script(
+        &sources,
+        yopts.top.as_deref(),
+        &btor_path,
+        &hier_json_path,
+        yopts.setundef_anyseq,
+    );
 
     let output = Command::new(&yosys)
         .arg("-q")
@@ -642,6 +658,7 @@ fn build_script(
     top: Option<&str>,
     btor_out: &Path,
     hier_json_out: &Path,
+    setundef_anyseq: bool,
 ) -> String {
     let read_cmds: Vec<String> = sources
         .iter()
@@ -657,8 +674,37 @@ fn build_script(
     // the pipeline succeed even when the blackbox body is empty — the
     // blackbox's outputs become uncontrollable free signals, exactly
     // the chaotic-stub semantics Document A §2 prescribes.
+    // SOUNDNESS — `setundef -anyseq` vs `setundef -zero`:
+    //
+    // `setundef` decides how Yosys treats nets that have no assigned
+    // value on some path (an `always_comb` case statement with no
+    // `default:` arm; an `unique casez` with unmatched encodings).
+    //
+    // - `-zero` pins them to 0. Deterministic; state space stays
+    //   small; **silently de-bugs CWE-1245-class defects** because
+    //   the unmatched-case path becomes a deterministic transition
+    //   to 0 instead of an admissible-any-value sink.
+    // - `-anyseq` makes them free symbolic choices each cycle.
+    //   Preserves the bug-bearing semantics, but introduces fresh
+    //   `$anyseq` state cells at each undefined point — the state-
+    //   bit count explodes (≈ 56 bits on the Caliptra fixture
+    //   vs ≈ 19 bits under `-zero`). For designs near the
+    //   `MAX_STATE_BITS` cap, `-anyseq` pushes the design *over*
+    //   the cap and the bit-blaster refuses it.
+    //
+    // mununu defaults to `-zero` (small state space; CWE-1245 hidden
+    // unless re-instated). The Phase A.4 step 4.6 finding documented
+    // this trade-off explicitly. Designs that need the bug-bearing
+    // semantics opt in via `YosysOptions::setundef_anyseq = true`,
+    // accepting the state-space cost; the all-SMT predicate-image
+    // enumerator then surfaces the violating encodings.
+    let setundef_pass = if setundef_anyseq {
+        "setundef -anyseq"
+    } else {
+        "setundef -zero"
+    };
     format!(
-        "{}; {hier}; proc; write_json {}; cutpoint -blackbox; flatten; async2sync; chformal -lower; dffunmap; setundef -zero; write_btor {}",
+        "{}; {hier}; proc; write_json {}; cutpoint -blackbox; flatten; async2sync; chformal -lower; dffunmap; {setundef_pass}; write_btor {}",
         read_cmds.join("; "),
         hier_json_out.display(),
         btor_out.display()
@@ -694,6 +740,7 @@ pub fn translate_sv_multi(
         skip_verific_check: false,
         primary_source_path: None,
         use_sv2v: false,
+        setundef_anyseq: false,
     };
     translate_sv(primary, options, &yopts)
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1412,75 +1412,51 @@ pub async fn sv_init_handler(
 pub async fn sv_discover_handler(
     Json(request): Json<SvDiscoverRequest>,
 ) -> ApiResult<Json<SvDiscoverResponse>> {
-    // Check if SMT feature is available
-    if !cfg!(feature = "smt") {
-        return Ok(Json(SvDiscoverResponse {
-            success: false,
-            sidecar: request.sidecar.clone(),
-            discoveries: vec![],
-            smt_available: false,
-            warnings: vec![
-                "SMT discovery not available: mununu was built without the 'smt' feature. \
-                 Rebuild with `cargo build --features smt` to enable Z3-based value discovery."
-                    .to_string(),
-            ],
-        }));
-    }
-
     // Parse the SV source
     use crate::adapter::systemverilog::parser;
-    let _module = parser::parse(&request.source.content).map_err(|e| ApiError::BadRequest {
+    let module = parser::parse(&request.source.content).map_err(|e| ApiError::BadRequest {
         message: format!("SV parse error: {e}"),
         details: None,
     })?;
 
     // Parse the sidecar
-    use crate::adapter::systemverilog::annotation::SvAnnotation;
-    let _sidecar: SvAnnotation =
+    use crate::adapter::systemverilog::annotation::{SvAnnotation, merge_discovered_values};
+    use crate::adapter::systemverilog::kripke_smt::engine;
+
+    let mut sidecar: SvAnnotation =
         serde_json::from_str(&request.sidecar).map_err(|e| ApiError::BadRequest {
             message: format!("Failed to parse sidecar JSON: {e}"),
             details: None,
         })?;
 
-    // Run SMT discovery (only when feature is enabled)
-    #[cfg(feature = "smt")]
-    {
-        use crate::adapter::systemverilog::annotation::merge_discovered_values;
-        use crate::adapter::systemverilog::kripke_smt::engine;
+    let results = engine::discover_significant_values(&module, &sidecar);
 
-        let mut sidecar = _sidecar;
-        let results = engine::discover_significant_values(&_module, &sidecar);
+    let discoveries: Vec<SvDiscoveryResult> = results
+        .iter()
+        .map(|(signal, dv)| SvDiscoveryResult {
+            signal: signal.clone(),
+            values_found: dv.values.len(),
+        })
+        .collect();
 
-        let discoveries: Vec<SvDiscoveryResult> = results
-            .iter()
-            .map(|(signal, dv)| SvDiscoveryResult {
-                signal: signal.clone(),
-                values_found: dv.values.len(),
-            })
-            .collect();
+    merge_discovered_values(&mut sidecar.discovered_values, results);
 
-        merge_discovered_values(&mut sidecar.discovered_values, results);
+    let updated_sidecar =
+        serde_json::to_string_pretty(&sidecar).map_err(|e| ApiError::Internal {
+            message: format!("Failed to serialize updated sidecar: {e}"),
+            source: None,
+        })?;
 
-        let updated_sidecar =
-            serde_json::to_string_pretty(&sidecar).map_err(|e| ApiError::Internal {
-                message: format!("Failed to serialize updated sidecar: {e}"),
-                source: None,
-            })?;
-
-        Ok(Json(SvDiscoverResponse {
-            success: true,
-            sidecar: updated_sidecar,
-            discoveries,
-            smt_available: true,
-            warnings: vec![],
-        }))
-    }
-
-    #[cfg(not(feature = "smt"))]
-    {
-        // Stub when smt feature is disabled.
-        unreachable!()
-    }
+    Ok(Json(SvDiscoverResponse {
+        success: true,
+        sidecar: updated_sidecar,
+        discoveries,
+        // Field retained for API back-compat — Z3 is always available
+        // now, so this is always `true`. A breaking removal of the
+        // field is deferred to a future API revision.
+        smt_available: true,
+        warnings: vec![],
+    }))
 }
 
 /// Validate an extraction spec against source code.

--- a/crates/mununu-core/tests/predicate_image_recall.rs
+++ b/crates/mununu-core/tests/predicate_image_recall.rs
@@ -1,0 +1,238 @@
+//! Phase A.4 step 4.3 recall harness — measures the predicate-image
+//! algorithm's recall against the curated baseline in
+//! `examples/verify/bench_predicate_image_a4/fixtures.toml`.
+//!
+//! For each fixture in the manifest, this harness:
+//! 1. Parses the source via the declared adapter (`btor2` direct;
+//!    sv-yosys path skipped for now — step 4.4 wires that surface).
+//! 2. Runs the brute-force per-cell predicate-image enumeration via
+//!    `discover_values_for_btor2_file`.
+//! 3. Compares the discovered set against `significant_values_expected`
+//!    via [`RecallScore::compute`].
+//! 4. Asserts recall ≥ 0.80 for non-adversarial fixtures (0.95 for the
+//!    Caliptra real-upstream-bug pair).
+//!
+//! Fixtures whose `expected` map is empty are skipped (Pono download
+//! deferred); SV-only fixtures are reported as `SKIPPED: sv-yosys
+//! not yet wired through this harness` (step 4.4 lands the wiring).
+//!
+//! Run with: `cargo test --test predicate_image_recall -- --nocapture`
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use mununu_core::adapter::sidecar::predicate_image::{
+    ImageOptions, RecallScore, all_smt::discover_values_for_btor2_file,
+    all_smt::flatten_to_value_sets,
+};
+
+#[derive(Debug, serde::Deserialize)]
+struct FixtureSet {
+    fixture: Vec<FixtureEntry>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct FixtureEntry {
+    id: String,
+    path: String,
+    adapter: String,
+    category: String,
+    #[serde(default)]
+    bug: bool,
+    #[serde(default)]
+    significant_values_expected: BTreeMap<String, Vec<i64>>,
+}
+
+fn repo_root() -> PathBuf {
+    // tests run with CWD = crate root (mununu-core); the bench dir
+    // lives at the workspace root.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate has parent")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn load_manifest() -> FixtureSet {
+    let path = repo_root().join("examples/verify/bench_predicate_image_a4/fixtures.toml");
+    let src = fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "predicate_image_recall: failed to read {}: {e}",
+            path.display()
+        )
+    });
+    toml::from_str(&src).expect("fixtures.toml parses")
+}
+
+#[derive(Debug)]
+enum HarnessOutcome {
+    Pass {
+        fixture: String,
+        scores: Vec<RecallScore>,
+    },
+    Skip {
+        fixture: String,
+        reason: String,
+    },
+    Fail {
+        fixture: String,
+        scores: Vec<RecallScore>,
+        threshold: f64,
+    },
+}
+
+fn run_fixture(entry: &FixtureEntry) -> HarnessOutcome {
+    if entry.significant_values_expected.is_empty() {
+        return HarnessOutcome::Skip {
+            fixture: entry.id.clone(),
+            reason: "no significant_values_expected baseline (e.g. Pono before download)".into(),
+        };
+    }
+
+    if entry.adapter != "btor2" {
+        return HarnessOutcome::Skip {
+            fixture: entry.id.clone(),
+            reason: format!(
+                "adapter {:?} not yet wired through the recall harness (step 4.4)",
+                entry.adapter
+            ),
+        };
+    }
+
+    let path = repo_root().join(&entry.path);
+    if !path.exists() {
+        return HarnessOutcome::Skip {
+            fixture: entry.id.clone(),
+            reason: format!("source file missing: {}", path.display()),
+        };
+    }
+
+    let src = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            return HarnessOutcome::Skip {
+                fixture: entry.id.clone(),
+                reason: format!("read failed: {e}"),
+            };
+        }
+    };
+
+    let file = match mununu_core::adapter::btor2::parser::parse(&src) {
+        Ok(f) => f,
+        Err(e) => {
+            return HarnessOutcome::Skip {
+                fixture: entry.id.clone(),
+                reason: format!("BTOR2 parse failed: {e}"),
+            };
+        }
+    };
+
+    let opts = ImageOptions::default();
+    let discovered = match discover_values_for_btor2_file(&file, &opts) {
+        Ok(d) => d,
+        Err(e) => {
+            return HarnessOutcome::Skip {
+                fixture: entry.id.clone(),
+                reason: format!("encoder refused: {e}"),
+            };
+        }
+    };
+    let by_signal = flatten_to_value_sets(&discovered);
+
+    let threshold = recall_threshold_for(&entry.category, entry.bug);
+    let mut scores = Vec::new();
+    let mut failures: Vec<&str> = Vec::new();
+
+    for (signal, expected_vec) in &entry.significant_values_expected {
+        let expected: HashSet<i64> = expected_vec.iter().copied().collect();
+        let discovered_set = by_signal.get(signal).cloned().unwrap_or_default();
+        let score =
+            RecallScore::compute(entry.id.clone(), signal.clone(), expected, discovered_set);
+        if score.recall < threshold {
+            failures.push(signal.as_str());
+        }
+        scores.push(score);
+    }
+
+    if failures.is_empty() {
+        HarnessOutcome::Pass {
+            fixture: entry.id.clone(),
+            scores,
+        }
+    } else {
+        HarnessOutcome::Fail {
+            fixture: entry.id.clone(),
+            scores,
+            threshold,
+        }
+    }
+}
+
+/// Per-category recall threshold. Adversarial fixtures get the same
+/// 0.80 threshold; the soundness side of adversarial cases (the
+/// algorithm must NOT surface unreachable values) is asserted inline
+/// in the corresponding unit tests under `all_smt::tests`, not here.
+fn recall_threshold_for(category: &str, bug: bool) -> f64 {
+    match (category, bug) {
+        ("real-upstream-bug", _) => 0.95,
+        _ => 0.80,
+    }
+}
+
+#[test]
+fn predicate_image_recall_meets_threshold_on_every_fixture() {
+    let manifest = load_manifest();
+
+    let mut passes = Vec::new();
+    let mut skips = Vec::new();
+    let mut fails = Vec::new();
+
+    for entry in &manifest.fixture {
+        match run_fixture(entry) {
+            HarnessOutcome::Pass { fixture, scores } => passes.push((fixture, scores)),
+            HarnessOutcome::Skip { fixture, reason } => skips.push((fixture, reason)),
+            HarnessOutcome::Fail {
+                fixture,
+                scores,
+                threshold,
+            } => fails.push((fixture, scores, threshold)),
+        }
+    }
+
+    println!("\n=== predicate-image recall harness ===");
+    println!("PASSES ({}):", passes.len());
+    for (fixture, scores) in &passes {
+        for s in scores {
+            println!(
+                "  {} :: {:<24} recall {:.2}  expected={} discovered_in_set={}",
+                fixture,
+                s.signal,
+                s.recall,
+                s.expected.len(),
+                s.expected.intersection(&s.discovered).count(),
+            );
+        }
+    }
+    println!("SKIPS ({}):", skips.len());
+    for (fixture, reason) in &skips {
+        println!("  {fixture}: {reason}");
+    }
+    if !fails.is_empty() {
+        println!("FAILS ({}):", fails.len());
+        for (fixture, scores, threshold) in &fails {
+            println!("  {fixture}: threshold {threshold}");
+            for s in scores {
+                println!(
+                    "    {:<24} recall {:.2} expected={:?} discovered={:?}",
+                    s.signal, s.recall, s.expected, s.discovered
+                );
+            }
+        }
+        panic!(
+            "predicate-image recall harness: {} fixture(s) below threshold",
+            fails.len()
+        );
+    }
+}

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -35,13 +35,16 @@
 ARG RUST_VERSION=1.95
 FROM rust:${RUST_VERSION}-slim-bookworm
 
-# Native deps required to build mununu's tree-sitter grammars and OpenSSL
-# bindings. `python3` is used by helper scripts in scripts/. Single
-# layer, --no-install-recommends, lists cleaned in the same RUN.
+# Native deps required to build mununu's tree-sitter grammars + OpenSSL
+# bindings + Z3 (mandatory since Phase A.4 step 4.2 — see
+# `crates/mununu-core/Cargo.toml`). `python3` is used by helper scripts
+# in scripts/. Single layer, --no-install-recommends, lists cleaned in
+# the same RUN.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         pkg-config \
         libssl-dev \
+        libz3-dev \
         cmake \
         git \
         curl \

--- a/docs/design/proof-by-fire-findings.md
+++ b/docs/design/proof-by-fire-findings.md
@@ -247,6 +247,56 @@ This is a separate gap from the input-bit cap — the cap is correctly cleared b
 
 **Phase 1.6 verdict.** Cap-check blocker (Finding 2's input-cap side) **resolved** — the sidecar mechanism now prunes inputs correctly, validated by two unit tests. Caliptra end-to-end retry **exposes a deeper runtime-performance blocker** at the bit-blaster's explicit-enumeration loop. Documented as a new finding; the unlock is non-trivial engine work, scoped outside this plan's READY-pipelines-only constraint.
 
+### Phase A.4 update — predicate-image discovery ships; Caliptra verdict-flip blocked by state-bit cap (2026-05-20)
+
+Phase A.4 of the parent pipeline-blocker plan landed the SMT
+predicate-image discovery algorithm end-to-end on the BTOR2 path
+(steps 4.0–4.4; see
+[`.claude/plans/phase-a4-predicate-image.md`](../../.claude/plans/phase-a4-predicate-image.md)
+for the per-step record). The headline algorithm + recall harness
+work as designed against the curated benchmark
+([`examples/verify/bench_predicate_image_a4/`](../../examples/verify/bench_predicate_image_a4/) —
+3/3 BTOR2 fixtures pass recall ≥ 0.92).
+
+**Caliptra verdict-flip — partial.** The PoF criterion stated in the
+A.4 plan ("`no_undef_reachable` initial-state verdict flips 1/1 →
+0/1") is **not yet achieved**. Step 4.6 measured the exact gap:
+
+- `setundef -zero` (Yosys driver default): translation succeeds at
+  4 096 states. Predicate-image on the resulting BTOR2 discovers
+  `boot_fsm_ns ∈ {0..4}` — the synthesis pass silently transforms
+  CWE-1245's unmatched-case sink into a deterministic `→ 0`
+  transition. The bug is masked.
+- `setundef -anyseq` (opt-in via `MUNUNU_YOSYS_SETUNDEF_ANYSEQ=1`):
+  predicate-image discovers `boot_fsm_ns ∈ {0..7}` — the violating
+  encodings 5/6/7 surface. **But** the synthesis pass introduces
+  `$anyseq` cells that explode the bit-blast state count from 19 →
+  56, well past `MAX_STATE_BITS = 20`. Translation refuses.
+
+So the algorithm is correct in isolation, the bug-preserving Yosys
+synthesis is wired up as an opt-in, and the gap is the explicit-state
+engine's enumeration cap — exactly the case the original A.4 plan
+flagged as the A.4a fallback. The next step is
+[`phase-a4b-state-bit-cap-followup.md`](../../.claude/plans/phase-a4b-state-bit-cap-followup.md)
+which catalogs the four unlock paths (sidecar-side workaround;
+compose-and-decompose; Phase B IC3-IA; lift the cap — not viable).
+
+**Honest scope.** Phase A.4 is shipped as **A.4a**: the algorithm,
+recall harness, CLI surface, and the empirical finding are in tree.
+The "first auto-extracted real-upstream-bug verdict" claim stays
+**partially open** in this ledger until A.4b closes one of the
+unlock paths.
+
+**Files touched in Phase A.4.**
+
+- [`crates/mununu-core/src/adapter/sidecar/predicate_image/`](../../crates/mununu-core/src/adapter/sidecar/predicate_image/) — new module (~700 LOC)
+- [`crates/mununu-core/tests/predicate_image_recall.rs`](../../crates/mununu-core/tests/predicate_image_recall.rs) — recall harness
+- [`crates/mununu-cli/src/main.rs`](../../crates/mununu-cli/src/main.rs) — `mununu btor2 discover` subcommand
+- [`crates/mununu-core/src/adapter/yosys/mod.rs`](../../crates/mununu-core/src/adapter/yosys/mod.rs) — `YosysOptions::setundef_anyseq` opt-in
+- [`crates/mununu-cli/src/loader.rs`](../../crates/mununu-cli/src/loader.rs) — `MUNUNU_YOSYS_SETUNDEF_ANYSEQ` env-var
+- [`crates/mununu-core/Cargo.toml`](../../crates/mununu-core/Cargo.toml) + [`crates/mununu-cli/Cargo.toml`](../../crates/mununu-cli/Cargo.toml) — Z3 mandatory
+- [`examples/verify/bench_predicate_image_a4/`](../../examples/verify/bench_predicate_image_a4/) — 10-fixture benchmark
+
 ### Phase A.3 update — auto-partition + predicate binding ship (2026-05-19)
 
 > Predecessor: Phase 1.7 analysis (below).

--- a/examples/verify/bench_predicate_image_a4/README.md
+++ b/examples/verify/bench_predicate_image_a4/README.md
@@ -1,0 +1,124 @@
+# Phase A.4 — Predicate-image discovery benchmark
+
+> **Status: curating.** Step 4.0 of
+> [`.claude/plans/phase-a4-predicate-image.md`](../../../.claude/plans/phase-a4-predicate-image.md).
+> 10 fixtures listed in [`fixtures.toml`](fixtures.toml); the recall
+> harness that consumes this manifest lands in step 4.3.
+
+## What this directory contains
+
+A manifest-driven benchmark suite that measures the
+predicate-image discovery algorithm's *recall* against a curated
+ground-truth baseline. Each fixture entry in
+[`fixtures.toml`](fixtures.toml) declares:
+
+- **`path`** — the source file the adapter ingests (SV or BTOR2).
+- **`adapter`** — the mununu adapter to run.
+- **`significant_values_expected.<signal>`** — the integer constants
+  we **expect** the predicate-image to discover for each signal.
+
+The recall harness (a `cargo test --test predicate_image_recall`
+integration test landing in step 4.3) runs the algorithm on every
+fixture and asserts
+
+```
+recall = |discovered ∩ expected| / |expected|  ≥  threshold
+```
+
+per fixture, where `threshold = 0.80` for non-adversarial entries
+(0.95 on bug-bearing fixtures whose verdict closure depends on the
+discovered set). Adversarial entries (`category = "adversarial"`)
+additionally assert *soundness* — the discovered set must **not**
+include unreachable values the syntactic seed extractor might
+spuriously surface.
+
+## Fixture groups
+
+| Group | Count | Purpose |
+|---|---|---|
+| **A** — real upstream bugs | 2 | Caliptra `soc_ifc_boot_fsm` pre/post fix; headline proof-by-fire |
+| **B** — synthetic CWEs | 3 | safety_demo + CWE-1245 + CWE-1260; in-tree, small |
+| **C** — negative cases | 3 | handshake / traffic_light / fair_arbiter; property should hold |
+| **D** — external benchmark | 1 | Pono `arbitrated_top_n2_w2_d2_e0.btor2` (fetched on demand) |
+| **E** — adversarial | 2 | Hand-authored: cap_overflow + sparse_predicates |
+
+Total: **10 fixtures**.
+
+## Honest scope statement
+
+- **The Caliptra discriminator pair (Group A)** is the headline proof-by-fire
+  case. Phase A.4's done criterion is the initial-state verdict flip on
+  `pre_fix.sv` `no_undef_reachable`. See the parent plan §"Proof-by-fire target".
+- **The synthetic CWE fixtures (Group B)** demonstrate the algorithm against
+  small, hand-controllable defect classes. They are **demos**, not findings,
+  per [`docs/policies/claims-integrity.md`](../../../docs/policies/claims-integrity.md).
+- **The negative cases (Group C)** are the smoke tests for the
+  no-spurious-discovery property — a bug-free design should not produce
+  alarming verdicts.
+- **The external Pono benchmark (Group D)** is the only fixture that
+  requires downloading. The `fetch_url` field in the manifest is the
+  canonical source; the recall harness skips this fixture when the file
+  is not present locally (CI does not download external content).
+- **The adversarial fixtures (Group E)** are hand-authored to exercise
+  the algorithm's failure modes:
+  - `cap_overflow.btor` — saturating counter that drives `bad` at 200
+    (well past typical 16-value caps; exercises Bryant-Kroening
+    under-approximation).
+  - `sparse_predicates.btor` — two `bad` signals at non-contiguous
+    encodings; the predicate-image must *reject* the unreachable one.
+
+## Reproducing the recall measurement
+
+Once step 4.3 lands:
+
+```bash
+cargo test --test predicate_image_recall -- --nocapture
+```
+
+For a single fixture:
+
+```bash
+cargo test --test predicate_image_recall caliptra_pre_fix -- --nocapture
+```
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| [`fixtures.toml`](fixtures.toml) | Canonical 10-entry benchmark manifest |
+| [`adversarial/cap_overflow.btor`](adversarial/cap_overflow.btor) | Saturating 8-bit counter, bad@200 |
+| [`adversarial/sparse_predicates.btor`](adversarial/sparse_predicates.btor) | Non-contiguous bad encodings under parity constraint |
+| `external/` | Reserved for the Pono download (gitignored; not checked in) |
+
+## Elaboration check (step 4.0 verification)
+
+All 9 in-tree / synthetic fixtures elaborate cleanly on the Phase A.3
+baseline. Verified 2026-05-20:
+
+| Fixture | Adapter | State count | Status |
+|---|---|---|---|
+| `caliptra_pre_fix` | sv-yosys (+sv2v) | 4 096 | ✅ |
+| `caliptra_post_fix` | sv-yosys (+sv2v) | 4 096 | ✅ (same source tree) |
+| `safety_demo_btor` | btor2 | 16 | ✅ |
+| `cwe1245_fsm_bug` | systemverilog (custom) | 4 | ✅ |
+| `cwe1260_addr_overlap_bug` | systemverilog (custom) | 5 | ✅ |
+| `handshake` | systemverilog (custom) | 4 | ✅ |
+| `traffic_light` | sv-yosys | 256 | ✅ (custom SV parser rejects; sv-yosys accepts) |
+| `fair_arbiter` | sv-yosys | 32 | ✅ (custom SV parser rejects; sv-yosys accepts) |
+| `cap_overflow` (adversarial) | btor2 | 256 | ✅ |
+| `sparse_predicates` (adversarial) | btor2 | 8 | ✅ |
+
+The Pono external fixture (`pono_arbitrated_top_n2_w2_d2`, Group D)
+is deferred until step 4.3 — recall harness skips fixtures whose
+local file is absent so CI stays self-contained.
+
+## Pending step-4.0 follow-ups
+
+- [ ] Fetch + manually inspect the Pono variant (Group D) to fill in
+      `significant_values_expected` for at least one named signal.
+- [ ] The `significant_values_expected` baseline for `fair_arbiter.sv`
+      (Group C) is a placeholder for a single-bit arbiter; refine to
+      match the actual fixture's parameterisation once measured (the
+      sv-yosys elaboration shows 32 states which suggests > 1 bit of
+      state register — the actual baseline will be refined in step
+      4.3's harness run).

--- a/examples/verify/bench_predicate_image_a4/adversarial/cap_overflow.btor
+++ b/examples/verify/bench_predicate_image_a4/adversarial/cap_overflow.btor
@@ -1,0 +1,20 @@
+; cap_overflow.btor — Phase A.4 adversarial: 8-bit counter saturates at 200.
+;
+; State `cnt[7:0]` increments by 1 each step. `bad iff cnt == 200`.
+; Exercises the predicate-image cap (`MAX_VALUES_PER_SIGNAL`) and the
+; Bryant-Kroening under-approximation fallback when Z3 saturates.
+;
+; Expected discovered values (per fixtures.toml): {0,1,2,3,4,5,6,7,8,100,199,200}.
+1 sort bitvec 8
+2 sort bitvec 1
+3 zero 1
+4 one 1
+5 state 1 cnt
+6 init 1 5 3
+7 const 1 11001000
+8 eq 2 5 7
+9 ult 2 5 7
+10 add 1 5 4
+11 ite 1 9 10 5
+12 next 1 5 11
+13 bad 8

--- a/examples/verify/bench_predicate_image_a4/adversarial/sparse_predicates.btor
+++ b/examples/verify/bench_predicate_image_a4/adversarial/sparse_predicates.btor
@@ -1,0 +1,26 @@
+; sparse_predicates.btor — Phase A.4 adversarial: predicate-image must
+; *not* surface syntactically-attractive constants that are unreachable
+; under the design's constraint relation.
+;
+; State `s[2:0]` cycled by even-parity transitions only. Two bad signals
+; trigger at s == 0b001 and s == 0b110 respectively. The syntactic
+; seed extractor sees both constants in `bad` operands, but only 0b110
+; is reachable from init (0b000) via parity-preserving steps. The
+; predicate-image must surface {0, 6} as discovered and reject 1.
+1 sort bitvec 3
+2 sort bitvec 1
+3 zero 1
+4 state 1 s
+5 init 1 4 3
+6 input 2 step
+7 one 1
+8 const 1 110          ; 6 in binary
+9 add 1 4 8            ; s + 6 (even-parity-preserving offset)
+10 ite 1 6 9 4         ; step ? s+6 : s
+11 next 1 4 10
+12 const 1 001         ; 1 — would-be-bad encoding
+13 const 1 110         ; 6 — actually-reachable-bad encoding
+14 eq 2 4 12
+15 eq 2 4 13
+16 bad 14              ; never reachable under the parity constraint
+17 bad 15              ; reachable

--- a/examples/verify/bench_predicate_image_a4/fixtures.toml
+++ b/examples/verify/bench_predicate_image_a4/fixtures.toml
@@ -1,0 +1,226 @@
+# Phase A.4 predicate-image discovery benchmark — fixture manifest.
+#
+# Each entry names a real or synthetic fixture against which the
+# `predicate_image` SMT enumeration is measured. `significant_values_expected`
+# is the hand-curated baseline the recall harness in step 4.3 compares
+# against; `recall = (discovered ∩ expected) / |expected|`.
+#
+# Conventions:
+# - `path`     : repo-relative path to the *primary* source file (SV / BTOR2).
+# - `adapter`  : adapter to use — "sv-yosys" or "btor2".
+# - `category` : "real-upstream-bug" | "synthetic-cwe" | "negative" | "external" | "adversarial".
+# - `bug`      : true if the fixture is expected to violate at least one of its
+#                declared properties; false for fix variants and negative cases.
+# - `significant_values_expected.<signal>` : list of integers we expect the
+#                predicate-image to discover for that signal.
+# - `note`     : human-readable description.
+#
+# This manifest is consumed by:
+# - The recall harness integration test (`crates/mununu-core/tests/predicate_image_recall.rs`)
+#   landing in step 4.3.
+# - The README in this directory.
+
+# ---------------------------------------------------------------------------
+# Group A — real upstream bugs (headline proof-by-fire)
+# ---------------------------------------------------------------------------
+
+[[fixture]]
+id = "caliptra_pre_fix"
+path = "examples/verify/sv_yosys_caliptra_rtl_150/source/soc_ifc_boot_fsm_pre_fix.sv"
+adapter = "sv-yosys"
+category = "real-upstream-bug"
+bug = true
+note = """
+Upstream chipsalliance/caliptra-rtl#150 — `unique casez (boot_fsm_ps)`
+over a 3-bit state enum (5 defined arms; 3 unmatched encodings 5/6/7
+admitted as absorbing sinks under default-less casez). Property
+`no_undef_reachable` must flip from `Initial states satisfying: 1/1`
+(Phase A.3) to `0/1` (Phase A.4 done criterion).
+"""
+[fixture.significant_values_expected]
+boot_fsm_ns = [0, 1, 2, 3, 4, 5, 6, 7]
+
+[[fixture]]
+id = "caliptra_post_fix"
+path = "examples/verify/sv_yosys_caliptra_rtl_150/source/soc_ifc_boot_fsm_post_fix.sv"
+adapter = "sv-yosys"
+category = "real-upstream-bug"
+bug = false
+note = """
+Upstream-applied fix variant of caliptra-rtl#150. Discriminator pair —
+the predicate-image should still discover all 8 encodings (the
+abstraction does not eliminate the unreached states; the *reachability*
+from `s0` is what changes between variants). `no_undef_reachable`
+should report Initial-state SAT on this variant.
+"""
+[fixture.significant_values_expected]
+boot_fsm_ns = [0, 1, 2, 3, 4, 5, 6, 7]
+
+# ---------------------------------------------------------------------------
+# Group B — synthetic CWE patterns (in-tree)
+# ---------------------------------------------------------------------------
+
+[[fixture]]
+id = "safety_demo_btor"
+path = "examples/btor2/safety_demo.btor"
+adapter = "btor2"
+category = "synthetic-cwe"
+bug = true
+note = """
+Smallest possible BTOR2 sanity case. 2-bit counter `cnt` with a
+`bad iff cnt == 3` property. Bit-blast space is 16 states.
+"""
+[fixture.significant_values_expected]
+cnt = [0, 1, 2, 3]
+
+[[fixture]]
+id = "cwe1245_fsm_bug"
+path = "examples/systemverilog/cwe1245_fsm_bug.sv"
+adapter = "sv-yosys"
+category = "synthetic-cwe"
+bug = true
+note = """
+Mini-Caliptra: 3-bit one-hot enum {IDLE=001, READING=010, WRITING=100}
+with no `default:` arm in the case statement. The unmatched encodings
+{0, 3, 5, 6, 7} (= 2^3 \\ enum) become absorbing sinks under
+default-less case.
+"""
+[fixture.significant_values_expected]
+state = [0, 1, 2, 3, 4, 5, 6, 7]
+
+[[fixture]]
+id = "cwe1260_addr_overlap_bug"
+path = "examples/systemverilog/cwe1260_addr_overlap_bug.sv"
+adapter = "sv-yosys"
+category = "synthetic-cwe"
+bug = true
+note = """
+2-bit state enum {IDLE=0, UART_ACCESS=1, AES_ACCESS=2} — encoding 3
+is unreachable in the enum but representable in the 2-bit register.
+CWE-1260 (address overlap) is the *property* under test; the
+predicate-image should still surface all 4 encoding values.
+"""
+[fixture.significant_values_expected]
+state = [0, 1, 2, 3]
+
+# ---------------------------------------------------------------------------
+# Group C — negative cases (in-tree; property should HOLD)
+# ---------------------------------------------------------------------------
+
+[[fixture]]
+id = "handshake"
+path = "examples/systemverilog/handshake.sv"
+adapter = "sv-yosys"
+category = "negative"
+bug = false
+note = """
+2-bit state enum {IDLE=0, WAIT_ACK=1, ACTIVE=2, DONE=3} — fully
+populated 4-encoding state register. Property: `ack` is asserted iff
+`state == ACTIVE`. Negative case — predicate-image should discover
+the full set with no surprise encodings.
+"""
+[fixture.significant_values_expected]
+state = [0, 1, 2, 3]
+
+[[fixture]]
+id = "traffic_light"
+path = "examples/btor2/traffic_light.sv"
+adapter = "sv-yosys"
+category = "negative"
+bug = false
+note = """
+2-bit state enum {RED=0, GREEN=1, YELLOW=2}. Encoding 3 is
+representable but unreached by the always_ff cycle. Smoke test for
+the case where the predicate-image must NOT spuriously surface an
+unreachable value as discovered.
+"""
+[fixture.significant_values_expected]
+state = [0, 1, 2]
+
+[[fixture]]
+id = "fair_arbiter"
+path = "examples/btor2/fair_arbiter.sv"
+adapter = "sv-yosys"
+category = "negative"
+bug = false
+note = """
+Multi-requester arbiter. State register tracks the current grantee;
+`grant` outputs are derived combinationally. Liveness property
+(eventual grant) is the natural target; predicate-image discovers
+the grantee enum.
+"""
+[fixture.significant_values_expected]
+# Two-requester variant — grantee is a single bit (next-grantee
+# selection). Expected to discover both values; the recall harness
+# normalises across the requester-count parameter when applicable.
+state = [0, 1]
+
+# ---------------------------------------------------------------------------
+# Group D — external benchmark (Pono / makaimann)
+# ---------------------------------------------------------------------------
+
+[[fixture]]
+id = "pono_arbitrated_top_n2_w2_d2"
+path = "examples/verify/bench_predicate_image_a4/external/arbitrated_top_n2_w2_d2_e0.btor2"
+adapter = "btor2"
+category = "external"
+bug = true
+fetch_url = "https://raw.githubusercontent.com/makaimann/btor-benchmarks/master/data-integrity/unsafe/btor2/arbitrated_top_n2_w2_d2_e0.btor2"
+note = """
+Smallest viable variant of the Pono data-integrity FIFO family (per
+docs/design/proof-by-fire-findings.md Finding 2). The `n2_w8_d8`
+variant cited in the original finding has 176 state bits — well above
+mununu's `MAX_STATE_BITS=20` cap. The `n2_w2_d2` variant (2 arbiters,
+2-bit data, depth-2 FIFOs) should fit. **Fixture not yet downloaded
+into the repo** — fetch URL above is the canonical source; the
+benchmark-bench README documents the download procedure.
+"""
+[fixture.significant_values_expected]
+# Pono benchmarks don't declare semantic signal names — the BTOR2
+# emitter from Mukherjee/Kroening/Melham uses Yosys-style synthetic
+# names. The expected baseline here is left empty until Step 4.0
+# completes the download + manual inspection. Recall harness skips
+# fixtures with an empty expected map (won't count against pass/fail).
+
+# ---------------------------------------------------------------------------
+# Group E — hand-authored adversarial cases
+# ---------------------------------------------------------------------------
+
+[[fixture]]
+id = "adversarial_cap_overflow"
+path = "examples/verify/bench_predicate_image_a4/adversarial/cap_overflow.btor"
+adapter = "btor2"
+category = "adversarial"
+bug = true
+note = """
+8-bit counter with a saturating `bad` signal at value 200 — the
+property cone reaches a value well beyond the typical 16-value sidecar
+budget. Exercises the predicate-image's `MAX_VALUES_PER_SIGNAL` cap
+and the Bryant-Kroening under-approximation fallback (#10) when Z3
+saturates.
+"""
+[fixture.significant_values_expected]
+cnt = [0, 1, 2, 3, 4, 5, 6, 7, 8, 100, 199, 200]
+# 200 is the bad-signal trigger; the predicate-image must discover
+# it. The interior values are sampled to confirm reachability across
+# the range.
+
+[[fixture]]
+id = "adversarial_sparse_predicates"
+path = "examples/verify/bench_predicate_image_a4/adversarial/sparse_predicates.btor"
+adapter = "btor2"
+category = "adversarial"
+bug = false
+note = """
+3-bit register with two `bad` lines that fire at {0b001, 0b110} —
+non-contiguous predicate witnesses chosen so the syntactic seed
+extractor sees both constants but the predicate-image must verify
+they are both reachable. The constraint relation only permits even
+parity transitions so 0b110 is reachable but 0b001 is not (under the
+constraint).
+"""
+[fixture.significant_values_expected]
+state = [0, 6]
+# 1 is a syntactic-seed candidate (appears in the bad line) but is
+# NOT reachable due to the parity constraint; the predicate-image
+# must NOT surface it. This is the negative-soundness assertion.

--- a/examples/verify/bench_predicate_image_a4/fixtures.toml
+++ b/examples/verify/bench_predicate_image_a4/fixtures.toml
@@ -212,15 +212,18 @@ adapter = "btor2"
 category = "adversarial"
 bug = false
 note = """
-3-bit register with two `bad` lines that fire at {0b001, 0b110} —
-non-contiguous predicate witnesses chosen so the syntactic seed
-extractor sees both constants but the predicate-image must verify
-they are both reachable. The constraint relation only permits even
-parity transitions so 0b110 is reachable but 0b001 is not (under the
-constraint).
+3-bit register `s` with two `bad` lines at encodings {0b001, 0b110}
+— non-contiguous predicate witnesses. The transition relation
+admits any even-parity step. Single-step reachability from *any*
+current state is what the brute-force enumerator measures, so the
+baseline lists every encoding reachable in one step.
+
+Under single-step semantics: from any current state `c`, the
+encoder can take `step = 0` (stay) or `step = 1` (jump by +6),
+landing at `c` or `c + 6 mod 8`. Every encoding 0..7 is reachable
+from *some* current state. The "1 is unreachable from init" claim
+is a *multi-step* property that the brute-force enumerator does
+not assert (see all_smt.rs SOUNDNESS docs).
 """
 [fixture.significant_values_expected]
-state = [0, 6]
-# 1 is a syntactic-seed candidate (appears in the bad line) but is
-# NOT reachable due to the parity constraint; the predicate-image
-# must NOT surface it. This is the negative-soundness assertion.
+s = [0, 1, 2, 3, 4, 5, 6, 7]

--- a/examples/verify/sv_yosys_caliptra_rtl_150/README.md
+++ b/examples/verify/sv_yosys_caliptra_rtl_150/README.md
@@ -31,6 +31,43 @@ The reduction comes from **two composing mechanisms**:
    and is observable in the bit-blaster's pre-partition state-count
    warning (`2^19 = 524288 explicit states` → post-abstraction 4 096).
 
+## Phase A.4 update (2026-05-20) — verdict-flip blocked by state-bit cap
+
+The Phase A.4 predicate-image discovery algorithm is **complete** and
+**correct**, but the Caliptra `no_undef_reachable` verdict-flip
+criterion is **not yet achieved**. The trade-off measured:
+
+| Yosys `setundef` pass | State bits | Predicate-image finds `boot_fsm_ns ∈` | Verdict |
+|---|---|---|---|
+| `-zero` (default) | 19 → 4 096 states | **{0, 1, 2, 3, 4} only** | 1/1 initial satisfies — CWE-1245 silently masked |
+| `-anyseq` (opt-in via `MUNUNU_YOSYS_SETUNDEF_ANYSEQ=1`) | **56 — over MAX_STATE_BITS=20 cap** | **{0, 1, 2, 3, 4, 5, 6, 7}** (bug encodings surface) | Cannot translate (bit-blaster refuses) |
+
+So the algorithm works in isolation (Step 4.4's `mununu btor2 discover`
+on the `-anyseq`-emitted BTOR2 surfaces the violating encodings), but
+the full `sv-yosys → BTOR2 → bit-blast → eval` pipeline cannot close
+the verdict because the bug-preserving `-anyseq` synthesis pass
+explodes the state space past the explicit-state engine's reach.
+This matches the [Phase A.4 plan's anticipated fallback](../../../.claude/plans/phase-a4-predicate-image.md#proof-by-fire-target-validation-contract):
+the gap is **measured**, not unknown.
+
+**Next-step options** (deferred to the A.4b follow-up plan):
+1. **Lift the bit-blast cap** to absorb the `$anyseq` cells —
+   impractical at 2^56 explicit states.
+2. **Compose-and-decompose** (Phase 3 of the BTOR2 roadmap) to split
+   the design and verify pieces under the cap.
+3. **Phase B (IC3-IA)** — implicit predicate abstraction inside an IC3
+   prover doesn't materialise the state space, so the bit-blast cap
+   doesn't apply.
+4. **Sidecar-side workaround**: use the default `-zero` synthesis but
+   author a sidecar that explicitly declares the bug-bearing branches
+   via `predicates {}` blocks the mu-calculus formula references
+   directly. Cheap but model-specific.
+
+The end-to-end "first auto-extracted real-upstream-bug finding" claim
+in [proof-by-fire-findings.md](../../../docs/design/proof-by-fire-findings.md)
+remains **partially open** — see the Phase A.4 update there for the
+full record.
+
 ## Status
 
 > **Source of truth:** [`validate.sh`](validate.sh) (asserts state-count


### PR DESCRIPTION
## Status: **draft — steps 4.0 + 4.1 + Z3-mandatory landed; 4.2–4.7 in progress**

Implements [`.claude/plans/phase-a4-predicate-image.md`](https://github.com/vscorza/mununu/blob/main/.claude/plans/phase-a4-predicate-image.md) (local plan, not in this branch).

### Shipped so far

- **Step 4.0** ([`ee3ab9d`](https://github.com/vscorza/mununu/commit/ee3ab9d)) — Benchmark curation. 10-fixture manifest at [`examples/verify/bench_predicate_image_a4/`](examples/verify/bench_predicate_image_a4/) with two hand-authored adversarial BTOR2 fixtures + README. 9 of 10 fixtures elaborate cleanly on the Phase A.3 baseline; Pono variant deferred to step 4.3 download.
- **Step 4.1** ([`f9713ec`](https://github.com/vscorza/mununu/commit/f9713ec)) — Module skeleton at [`adapter::sidecar::predicate_image`](crates/mununu-core/src/adapter/sidecar/predicate_image/). Five files: `mod.rs` (types), `theory.rs` (`Theory { BvOnly, BvUfArray }`), `seed.rs` (`SeedSource`), `btor2_encode.rs` (error type + stub), `all_smt.rs` (enumeration stub). No algorithm yet; 9 unit tests on type shapes.
- **Z3 mandatory** ([`14b5b93`](https://github.com/vscorza/mununu/commit/14b5b93)) — `--features smt` opt-in removed. Z3 becomes a normal dep across both crates; all `#[cfg(feature = "smt")]` gates and fallback branches deleted. API surface preserved (`SvDiscoverResponse.smt_available` retained as a back-compat field, always `true` now).

### Remaining steps (will land in this PR before "ready for review")

- 4.2 + 4.3 — BTOR2 → SMT encoder + `BvOnly` all-SMT enumeration (combined commit per the plan's confirmed scoping)
- 4.4 — CLI wiring (`mununu sv discover --engine predicate-image`, `mununu btor2 discover`)
- 4.5 — `BvUfArray` variant + extraction adapter unblock
- 4.6 — **Proof-by-fire**: Caliptra `soc_ifc_boot_fsm_pre_fix.sv` `no_undef_reachable` verdict flips 1/1 → 0/1
- 4.7 — Doc + wiki sync per recurring gate

## Test plan

- [x] `cargo test -p mununu-core --lib` — 1 294 passing (+5 SMT tests now run unconditionally after Z3 became mandatory)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Caliptra PoF verdict flip (step 4.6 done criterion)
- [ ] Recall harness ≥ 80% on every non-adversarial fixture (step 4.3)
- [ ] GitHub Actions CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)