### PR TITLE
S.2b-3: reconcile docs/wiki to the sv-yosys-only SV pipeline

### DIFF
--- a/docs/adapters/agentic.md
+++ b/docs/adapters/agentic.md
@@ -24,7 +24,7 @@ Pick the entry point that matches your authoring environment: native CTXDSL for 
 
 ## Verifying multi-source agentic projects
 
-For verification problems that compose multiple agentic sources — or one agentic source with non-agentic peers — use the verify framework: drop a `verify.toml` listing the sources, an alphabet binding, a composition shape, and a list of properties, then run `mununu verify <verify.toml>`. The agentic adapters plug into the framework on equal footing with `xstate`, `sv-rtl`, `c-codesign`, etc. See [`wiki/Verify-Project-Flow.md`](../../wiki/Verify-Project-Flow.md) for the conceptual model and the example fleet under [`examples/verify/`](../../examples/verify/).
+For verification problems that compose multiple agentic sources — or one agentic source with non-agentic peers — use the verify framework: drop a `verify.toml` listing the sources, an alphabet binding, a composition shape, and a list of properties, then run `mununu verify <verify.toml>`. The agentic adapters plug into the framework on equal footing with `xstate`, `sv-yosys`, `c-codesign`, etc. See [`wiki/Verify-Project-Flow.md`](../../wiki/Verify-Project-Flow.md) for the conceptual model and the example fleet under [`examples/verify/`](../../examples/verify/).
 
 ## Property templates
 

--- a/docs/design/abstraction-literature.md
+++ b/docs/design/abstraction-literature.md
@@ -344,9 +344,11 @@ pub fn collect_syntactic_predicates(module: &Module) -> Vec<PredicateSeed> {
 ```
 
 **Map to mununu.** Stage 3 (predicate seeding). Closest published
-artefact to what mununu's `mununu sv discover` already does
-*syntactically* (case-label scrape in
-[`kripke.rs:scan_significant_constants`](../../crates/mununu-core/src/adapter/systemverilog/kripke.rs));
+artefact to what mununu's `mununu btor2 discover` already does
+*syntactically* (SMT predicate-image over the BTOR2 IR in
+[`adapter/sidecar/predicate_image/all_smt.rs`](../../crates/mununu-core/src/adapter/sidecar/predicate_image/all_smt.rs);
+the case-literal scrape lives in
+[`adapter/systemverilog/case_literal_extract.rs`](../../crates/mununu-core/src/adapter/systemverilog/case_literal_extract.rs));
 this paper formalises the rule and shows it scales.
 
 ---
@@ -394,7 +396,7 @@ sense if Phase A's enumeration runtime fails the decision gate.
 **Theoretical core.** Extends #6 by replacing hand-chosen predicate
 grammars with *learned* sub-term grammars: SyGuS synthesises lemmas to
 strengthen IC3 frames. Relevant to mununu only as a forward-looking
-direction — once `mununu sv discover` produces stable significant-value
+direction — once `mununu btor2 discover` produces stable significant-value
 sets, a SyGuS layer could *propose* new predicates from cex traces
 without WP.
 

--- a/docs/design/auto-extraction-architecture.md
+++ b/docs/design/auto-extraction-architecture.md
@@ -134,15 +134,15 @@ the schema is **format-agnostic by construction**.
 
 ### 1.6 SMT discovery (today)
 
-> Source of truth: [`crates/mununu-core/src/adapter/systemverilog/kripke_smt.rs`](../../crates/mununu-core/src/adapter/systemverilog/kripke_smt.rs#L20) — surface: CLI (`mununu sv discover`)
+> Source of truth: [`crates/mununu-core/src/adapter/sidecar/predicate_image/all_smt.rs`](../../crates/mununu-core/src/adapter/sidecar/predicate_image/all_smt.rs) — surface: CLI (`mununu btor2 discover`)
 
-`discover_significant_values(&Module, &SvAnnotation)` walks the SV AST,
-collects guard expressions that mention each `Discover`-marked signal,
-asks Z3 for satisfying constants per guard (capped at
-`MAX_VALUES_PER_SIGNAL=32`), then merges with syntactically-extracted
-case-label constants. The result is written into the sidecar's
-`discovered_values` map. **Requires the SV adapter's AST** — BTOR2
-designs cannot use this path today.
+`discover_design_values(&Btor2File, …)` walks the BTOR2 IR, asks Z3 for
+satisfying constants per state cell (SMT predicate-image), and writes the
+result into the sidecar's `discovered_values` map. (S.2b removed the
+native-SV-AST predecessor, `kripke_smt::discover_significant_values`,
+which required the hand-rolled SV parser; the BTOR2-IR path operates on
+the same IR the verify pipeline uses and is therefore the canonical
+discovery for the `sv-yosys` flow.)
 
 ### 1.7 Mu-calculus
 

--- a/docs/policies/claims-integrity.md
+++ b/docs/policies/claims-integrity.md
@@ -80,7 +80,7 @@ Long-form public content (LinkedIn, Substack, blog posts, conference talks) must
 
 The same verification-first principles apply to the SV Kripke pipeline:
 
-- **Never present hand-written data as pipeline output.** If `discovered_values` in a `.mununu.json` sidecar were written by a human or AI agent (not by `mununu sv discover`), they must be disclosed as hand-written. Claims like "SMT discovers x=3" require actually running the discover command.
+- **Never present hand-written data as pipeline output.** If `discovered_values` in a `.mununu.json` sidecar were written by a human or AI agent (not by `mununu btor2 discover`), they must be disclosed as hand-written. Claims like "SMT discovers x=3" require actually running the discover command.
 - **Run the pipeline, don't simulate it.** Before presenting verification results in any public material, execute the actual commands and capture real terminal output. Do not fabricate or predict mununu output.
 - **Properties must come from specifications, not bug knowledge.** Adding a detector register to catch a known bug and then verifying it fires is circular. Properties should come from protocol specs, safety invariants, or security requirements.
 - **Distinguish syntactic from SMT-discovered values.** Literals found directly in `case` labels are syntactic. Values found through combinational logic inversion are SMT-discovered. Don't claim SMT discovery for trivially visible constants.

--- a/examples/systemverilog/fifo.mununu.json
+++ b/examples/systemverilog/fifo.mununu.json
@@ -24,7 +24,7 @@
       "name": "data_out_r",
       "preserve": false,
       "abstraction": "discover",
-      "note": "wide register — run `mununu sv discover` to find significant values"
+      "note": "wide register — run `mununu btor2 discover` to find significant values"
     }
   ],
   "inputs": [

--- a/examples/systemverilog/multi_producer_consumer_top.sv
+++ b/examples/systemverilog/multi_producer_consumer_top.sv
@@ -6,19 +6,23 @@
 //
 // Property of interest: the buffer never overflows (count < 3).
 //
-// Usage (CLI):
-//   mununu sv init --multi multi_producer_consumer_top.sv
-//   mununu context eval <sidecar>.mununu.json \
-//     --adapter sv --formula no_overflow --automaton system
+// Usage (sv-yosys multi-module path; requires yosys + sv2v):
+//   A verify.toml source lists this top module + its submodules and sets
+//   [sources.options] multi_module = true (+ optional top). The driver
+//   lifts each submodule to a KMTS, renames its ports to the connected
+//   nets (from the Yosys netlist), and synchronously composes them; the
+//   composed automaton is named `Circuit`.
 //
-// Usage (UI — Extraction tab):
-//   1. Load this file as primary source (SystemVerilog RTL domain)
-//   2. Click "+ Add Files" and add: multi_producer.sv, multi_consumer.sv, multi_buffer.sv
-//   3. Run "Initialize Sidecar" (generates multi-module .mununu.json)
-//   4. Edit sidecar: add the no_overflow property (see guide)
-//   5. Click "Continue to Translate"
-//   6. Click "Run Translate" to generate CTXDSL
-//   7. Switch to Verification tab to check properties
+//   [[sources]]
+//   id = "system"
+//   adapter = "sv-yosys"
+//   files = ["multi_producer_consumer_top.sv", "multi_producer.sv",
+//            "multi_consumer.sv", "multi_buffer.sv"]
+//   [sources.options]
+//   multi_module = true
+//   top = "producer_consumer_top"
+//
+// See examples/verify/sv_multi_module/ for a runnable instance of this pattern.
 
 module producer_consumer_top(
     input logic clk,

--- a/examples/verify/uart_codesign_chaotic/README.md
+++ b/examples/verify/uart_codesign_chaotic/README.md
@@ -26,8 +26,9 @@ every register access at any time.
   renamings; today both sides already speak the rendezvous alphabet
   (firmware via the c-codesign adapter, peripheral by author
   convention) so the binding projection is a no-op. The orchestrator
-  wires this strategy through cleanly; a follow-up adds SV-side
-  label rewriting when the peripheral is sourced from `sv-rtl`.
+  wires this strategy through cleanly; SV-side label rewriting fires
+  when the peripheral is sourced from `sv-yosys` (the register-map
+  rewriter gate, `is_sv_adapter`).
 - **`allow_peripheral_superset = true`.** The peripheral exposes all
   register-map labels (chaotic stub admits everything); the firmware
   exercises only a subset. Without the flag this would be a
@@ -95,7 +96,7 @@ SystemVerilog model:
 ```toml
 [[sources]]
 id = "peripheral"
-adapter = "sv-rtl"
+adapter = "sv-yosys"
 files = ["uart_lite.sv"]   # real RTL
 ```
 

--- a/examples/verify/uart_codesign_chaotic/verify.toml
+++ b/examples/verify/uart_codesign_chaotic/verify.toml
@@ -13,11 +13,11 @@
 # generate from the register map; both sides already speak the
 # rendezvous alphabet (the firmware via the c-codesign adapter's
 # `coupling::rendezvous_label_name` call; the peripheral by
-# convention). The `register_map` strategy on `[alphabet]` is
-# declared here as the eventual home for sv-rtl-side label
-# rewriting; today the orchestrator's strategy projection is a
-# no-op because both sources already align (a follow-up wires the
-# strategy to drive SV-side renaming when sv-rtl is paired in).
+# convention). The `register_map` strategy on `[alphabet]` is the
+# home for SV-side label rewriting; today the orchestrator's strategy
+# projection is a no-op because both sources already align. When a
+# real peripheral is sourced from `sv-yosys`, the register-map
+# rewriter (`is_sv_adapter` gate) drives SV-side renaming.
 #
 # Recreate the run (requires `clang` on PATH):
 #   $ bash examples/verify/uart_codesign_chaotic/validate.sh

--- a/wiki/Adapter-Formats.md
+++ b/wiki/Adapter-Formats.md
@@ -14,8 +14,7 @@ Mununu can import specifications from external formats and export synthesized co
 | **BTOR2** | `.btor`, `.btor2` | Yes | No | Explicit automaton |
 | **Promela** | `.pml`, `.promela` | Yes | No | Explicit automaton |
 | **XState** | `.xstate`, `.json` | Yes | Yes | Explicit automaton |
-| **SystemVerilog** (hand-written parser) | `.sv`, `.v` | Yes | Yes | Explicit automaton |
-| **SystemVerilog via Yosys** | `.sv`, `.v` (with `--adapter sv-yosys`) | Yes | No | Explicit automaton |
+| **SystemVerilog** (via Yosys) | `.sv`, `.v` (`--adapter sv-yosys`) | Yes | Yes | Explicit automaton |
 | **Extraction Spec** | `.espec.json` | Yes | No | Explicit automaton |
 | **CrewAI** | `.crewai.json` | Yes | No | Explicit automaton (per-agent + sequential supervisor + asynchronous composition) |
 | **LangGraph** | `.langgraph.json` | Yes | No | Explicit automaton (nodes → states, edges → `node_<from>_enter` transitions) |
@@ -114,189 +113,21 @@ Synthesized controllers are emitted as flat XState v5 JSON with a `__mununu` met
 
 ## SystemVerilog
 
-Imports behavioral SystemVerilog RTL descriptions. Two modes:
+SystemVerilog (`.sv` / `.v`) is verified through the **`sv-yosys`** pipeline: `sv2v` normalises SV-2017 to Verilog-2005, Yosys elaborates with `hierarchy -check` (no `flatten`) and emits one BTOR2 per module, and mununu lifts each module to a KMTS by bit-blasting through the [BTOR2 reader](#btor2--yosys-rtl-phase-1). This is the **sole** SV path — the legacy hand-written FSM parser (inline `// @mununu` annotations, `--adapter sv`) was removed in S.2b.
 
-1. **FSM mode** (default): extracts `typedef enum` FSMs from `always_ff` blocks
-2. **Kripke mode**: builds a Kripke structure from all registers, supporting counters, data-path registers, and mixed enum+register designs
+Yosys handles the full synthesizable subset — `generate` blocks, parameter elaboration, packages, module instantiation, arrays/memories — so there is no hand-maintained "supported subset" table: whatever Yosys elaborates, mununu lifts (within the BTOR2 reader's `MAX_STATE_BITS` bit-blast cap; see [§BTOR2 + Yosys](#btor2--yosys-rtl-phase-1)).
 
-### Supported Subset
+### Abstraction posture (`.mununu.json` sidecar)
 
-| Feature | Supported |
-|---------|-----------|
-| `module` with input/output ports | Yes |
-| `always_ff @(posedge clk)` | Yes |
-| `always_comb` | Yes |
-| `typedef enum logic` | Yes |
-| `case` / `if-else` (including numeric labels) | Yes |
-| `assign` statements | Yes |
-| `// @mununu` property comments | Yes |
-| `// @mununu domain` register annotations | Yes (Kripke mode) |
-| Ternary `? :`, bit-select, bit-slice, concat | Yes |
-| Arithmetic, shifts, comparisons | Yes |
-| `localparam` / `parameter` constants | Yes |
-| Module instantiation | Not yet |
-| Arrays/memories | No |
-| Interfaces/classes | No |
+Abstraction is driven by a `.mununu.json` sidecar next to the source (not inline comments). It declares per-signal `FieldDomain` (Boolean / BoundedCounter / EnumValues / Ignored), `discovered_values`, init/memory abstractions, and controllability. See [RTL Verification Pipeline](RTL-Verification-Pipeline) for the schema and the authoring workflow — `mununu btor2 discover` seeds `discovered_values` via SMT predicate-image over the BTOR2 IR.
 
 ### Controllability
 
-Derived from port directions and `@mununu` annotations:
-- `input` ports → **uncontrollable** (environment)
-- `output` ports → **controllable** (system)
-- `// @mununu controllable sig1, sig2` → override to controllable
-- `// @mununu input sig1, sig2` → override to uncontrollable
+Derived from port directions: `input` ports → **uncontrollable** (environment), `output` ports → **controllable** (system). Override via the sidecar's `controllable` list.
 
-### Property Specification
+### Multi-module composition
 
-Properties are specified via inline comments:
-
-```systemverilog
-// @mununu ltl safety: nu X. ([] X)
-// @mununu assume env_constraint: G(req -> X req)
-// @mununu guarantee liveness: G(req -> F grant)
-```
-
-### FSM Extraction (Default Mode)
-
-The adapter extracts FSMs from `typedef enum` + `always_ff` + `case(state)` patterns:
-
-```systemverilog
-typedef enum logic [1:0] {IDLE, WAIT, ACTIVE, DONE} state_t;
-state_t state;
-always_ff @(posedge clk or posedge rst) begin
-    if (rst) state <= IDLE;
-    else case (state)
-        IDLE: if (req) state <= WAIT;
-        WAIT: state <= ACTIVE;
-        ACTIVE: if (!req) state <= DONE;
-        DONE: state <= IDLE;
-    endcase
-end
-```
-
-### Kripke Mode (Register-Level Verification)
-
-Activated by `// @mununu mode kripke` or automatically when no `typedef enum` FSM is found. Builds a Kripke structure where each state is a valuation of all active registers.
-
-#### Register Domain Annotations
-
-Each register can be annotated with a domain to control how it contributes to the state space:
-
-```systemverilog
-// @mununu domain counter: bounded_counter 0..7    // 8 abstract values
-// @mununu domain cmd: enum {NOP=0, ADD=1, OTHER}  // 3 named values with numeric mapping
-// @mununu domain data: ignored                     // excluded from state space
-// @mununu domain flag: boolean                     // 2 values (auto-inferred for 1-bit)
-```
-
-**Domain types:**
-
-| Domain | Syntax | Values | Use for |
-|--------|--------|--------|---------|
-| `boolean` | `boolean` | `{false, true}` | 1-bit flags (auto-inferred) |
-| `bounded_counter` | `bounded_counter L..U` | `{L, L+1, ..., U}` | Counters, fill levels, indices |
-| `enum` | `enum {A, B, C}` | Named variants | State machines, command opcodes |
-| `enum` (value-mapped) | `enum {IDLE=0, RUN=3, OTHER}` | Named variants with numeric mapping | Wide registers with significant constants |
-| `ignored` | `ignored` | (excluded) | Data-path registers, buffers |
-
-**Value-mapped enums:** When a wide register (e.g., `logic [7:0] cmd`) is used in comparisons against specific constants (`cmd == 3`, `case(cmd) 0: ... 1: ...`), the constants can be mapped to named variants. The last variant without `=` acts as a catch-all for all other values.
-
-#### Automatic Optimizations
-
-**Cone-of-influence reduction:** Registers not referenced by any property formula (transitively through the dependency graph) are automatically excluded. No annotation needed.
-
-**Constant discovery:** When a wide register is ignored but appears in comparisons or case statements with specific numeric values, a warning is emitted suggesting a value-mapped enum annotation:
-
-```
-warning: Register 'cmd' (8-bit, ignored) uses significant constants: [0, 3, 255].
-         Suggested: // @mununu domain cmd: enum {VAL_0=0, VAL_3=3, VAL_255=255, OTHER}
-```
-
-#### Complete Kripke Example
-
-```systemverilog
-// @mununu mode kripke
-// @mununu domain fill: bounded_counter 0..4
-// @mununu domain data_out_r: ignored
-// @mununu input wr_en, rd_en
-// @mununu ltl safety: nu X. ([] X)
-module fifo(
-    input  logic       clk, input logic rst,
-    input  logic       wr_en, input logic rd_en,
-    input  logic [7:0] data_in,
-    output logic [7:0] data_out,
-    output logic       full, output logic empty
-);
-    typedef enum logic [1:0] {IDLE, WRITING, READING, RDWR} state_t;
-    state_t state;
-    logic [2:0] fill;
-    logic [7:0] data_out_r;
-    localparam DEPTH = 4;
-
-    always_ff @(posedge clk or posedge rst) begin
-        if (rst) begin state <= IDLE; fill <= 0; end
-        else case (state)
-            IDLE: begin
-                if (wr_en && rd_en) state <= RDWR;
-                else if (wr_en)     state <= WRITING;
-                else if (rd_en)     state <= READING;
-            end
-            WRITING: begin
-                if (fill < DEPTH) fill <= fill + 1;
-                state <= IDLE;
-            end
-            READING: begin
-                if (fill > 0) fill <= fill - 1;
-                state <= IDLE;
-            end
-            RDWR: begin
-                if (fill == 0) fill <= fill + 1;
-                state <= IDLE;
-            end
-        endcase
-    end
-endmodule
-```
-
-State space: 4 (state) x 5 (fill 0..4) = 20 states. `data_out_r` is ignored, `data_in`/`data_out` are ports (not registers).
-
-#### Multi-label transitions
-
-In Kripke mode, each input signal produces its own label. Transitions carry the full set of input signal values as a multi-label, making the CTXDSL output readable at a glance:
-
-```
-transition fill_0_state_IDLE -> fill_0_state_WRITING on label rd_en_F, label wr_en_F;
-transition fill_0_state_IDLE -> fill_0_state_RDWR    on label rd_en_T, label wr_en_T;
-```
-
-This is equivalent to the single-label encoding used by the signal-state path (TLSF/AIGER) but with named per-signal labels instead of compound bitvectors. For value-mapped enums, labels use the variant names (e.g., `cmd_LOAD`, `cmd_ADD`) rather than numeric indices.
-
-### State Space Limits
-
-- Designs with > 2^18 states (262K) are **rejected**
-- Designs with > 2^12 states emit a **warning**
-- Kripke mode: registers > 4 bits without annotation are auto-ignored with a warning
-
-### Controller Output
-
-Synthesized controllers are emitted as SystemVerilog modules:
-
-```systemverilog
-module FSM_controller (
-    input  logic clk,
-    input  logic rst
-);
-    typedef enum logic [1:0] {IDLE, WAIT, ACTIVE, DONE} state_t;
-    state_t state;
-    always_ff @(posedge clk or posedge rst) begin
-        if (rst) state <= IDLE;
-        else case (state)
-            IDLE: state <= WAIT;
-            // ... synthesized transitions
-        endcase
-    end
-endmodule
-```
+A top module that instantiates submodules composes structurally: each instance is lifted to a KMTS, its ports renamed to the connected nets (from the Yosys netlist), and the instances synchronously composed. Opt in with `[sources.options] multi_module = true` (+ optional `top`) on a `verify.toml` source. The composed automaton is named `Circuit`.
 
 ---
 
@@ -357,7 +188,7 @@ mununu context eval design.sv --adapter sv-yosys --formula safety_bad_0 --automa
 # Or hand mununu an existing BTOR2 file:
 mununu context eval design.btor --adapter btor2 --formula safety_bad_0 --automaton Circuit
 
-# Auto-detection works for both .sv (via Yosys when --adapter sv-yosys, hand-written parser otherwise) and .btor / .btor2 (via the BTOR2 reader directly).
+# SystemVerilog (.sv / .v) is verified via the sv-yosys pipeline (--adapter sv-yosys); .btor / .btor2 go through the BTOR2 reader directly.
 ```
 
 ### Soundness
@@ -400,7 +231,7 @@ mununu context eval support_pipeline.xstate.json \
 
 # Explicit adapter selection
 mununu context eval machine.json --adapter xstate --formula safety --automaton light
-mununu context eval design.sv --adapter sv --formula safety --automaton FSM
+mununu context eval design.sv --adapter sv-yosys --formula safety --automaton Circuit
 mununu context eval spec.espec.json --adapter extraction --formula safety --automaton Main
 ```
 
@@ -410,25 +241,29 @@ When using an adapter, add `--print-ctxdsl` to see the translated CTXDSL model:
 
 ```bash
 # Print to stdout (alongside normal verification output)
-mununu context eval design.sv --adapter sv --formula safety --automaton FSM --print-ctxdsl
+mununu context eval design.sv --adapter sv-yosys --formula safety --automaton Circuit --print-ctxdsl
 
 # Write to a file
-mununu context eval design.sv --adapter sv --formula safety --automaton FSM --print-ctxdsl output.ctxdsl
+mununu context eval design.sv --adapter sv-yosys --formula safety --automaton Circuit --print-ctxdsl output.ctxdsl
 ```
 
-This works with all adapters (`--adapter tlsf`, `--adapter sv`, `--adapter xstate`, etc.) and with both `context eval` and `context synth`. The CTXDSL is printed before verification runs, so you can inspect the model even if verification fails.
+This works with all adapters (`--adapter tlsf`, `--adapter sv-yosys`, `--adapter xstate`, etc.) and with both `context eval` and `context synth`. The CTXDSL is printed before verification runs, so you can inspect the model even if verification fails.
 
 ### SystemVerilog Pipeline
 
+The sole SV pipeline is `sv-yosys` (sv2v → Yosys → BTOR2 → bit-blast).
+Author the `.mununu.json` sidecar by hand, or seed its `discovered_values`
+via `mununu btor2 discover` (S.2b replaced the native `sv init`/`sv discover`
+with BTOR2-IR discovery):
+
 ```bash
-# Generate skeleton sidecar from SV module
-mununu sv init design.sv
+# (Optional) seed discovered values into the sidecar from the BTOR2 IR
+mununu sv emit-btor2-per-module design.sv --output-dir build/
+mununu btor2 discover build/design.btor2
 
-# Discover significant register values via SMT (requires --features smt)
-mununu sv discover design.sv
-
-# Verify with sidecar (auto-loaded from <stem>.mununu.json)
-mununu context eval design.sv --adapter sv --formula safety --automaton FSM
+# Verify with sidecar (auto-loaded from <stem>.mununu.json); the bit-blast
+# names the composed automaton `Circuit`.
+mununu context eval design.sv --adapter sv-yosys --formula safety --automaton Circuit
 ```
 
 See [RTL Verification Pipeline](RTL-Verification-Pipeline) for the full annotation workflow.
@@ -442,8 +277,8 @@ mununu context synth machine.xstate --adapter xstate \
     --output-format xstate --emit-native controller.json
 
 # Export controller as SystemVerilog module
-mununu context synth design.sv --adapter sv \
-    --formula safety --automaton FSM \
+mununu context synth design.sv --adapter sv-yosys \
+    --formula safety --automaton Circuit \
     --output-format systemverilog --emit-native controller.sv
 ```
 

--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -71,9 +71,9 @@ mununu context eval examples/agentic/mcp_auth.ctxdsl \
 ```
 
 ```bash
-# Evaluate a SystemVerilog design
-mununu context eval design.sv --adapter sv \
-    --formula safety --automaton handshake
+# Evaluate a SystemVerilog design (sv2v → Yosys → BTOR2 → bit-blast)
+mununu context eval design.sv --adapter sv-yosys \
+    --formula safety --automaton Circuit
 
 # Evaluate an XState machine
 mununu context eval machine.xstate --adapter xstate \
@@ -288,7 +288,7 @@ mununu context predicates examples/hw/arbiter.ctxdsl --automaton Arbiter
 
 ## `mununu verify`
 
-Run the general N-source verification framework against a `verify.toml` manifest. The manifest lists sources (any combination of `ctxdsl`, `xstate`, `crewai`, `langgraph`, `sv-rtl`, `c-codesign`, `extraction`), an alphabet-binding strategy, a composition shape, and properties. See [Verify Project Flow](Verify-Project-Flow.md) for the conceptual model and the `verify.toml` schema.
+Run the general N-source verification framework against a `verify.toml` manifest. The manifest lists sources (any combination of `ctxdsl`, `xstate`, `crewai`, `langgraph`, `sv-yosys`, `c-codesign`, `extraction`), an alphabet-binding strategy, a composition shape, and properties. See [Verify Project Flow](Verify-Project-Flow.md) for the conceptual model and the `verify.toml` schema.
 
 > Source of truth: [`mununu-cli::handle_verify`](../crates/mununu-cli/src/main.rs) — surface: CLI.
 
@@ -395,8 +395,8 @@ mununu context synth machine.xstate --adapter xstate \
     --output-format xstate --emit-native controller.json
 
 # Import SystemVerilog RTL, synthesize, export as SV module
-mununu context synth design.sv --adapter sv \
-    --formula safety --automaton FSM \
+mununu context synth design.sv --adapter sv-yosys \
+    --formula safety --automaton Circuit \
     --output-format systemverilog --emit-native controller.sv
 
 # Auto-detect format from extension
@@ -407,55 +407,31 @@ See [Adapter Formats](Adapter-Formats.md) for supported formats and limitations.
 
 ---
 
-## `mununu sv` — SystemVerilog Analysis Tools
+## `mununu sv` — SystemVerilog Frontend Tools
 
-### `mununu sv init`
+> **S.2b note.** The native `mununu sv init` / `sv discover` commands (which
+> parsed SV with a hand-rolled recursive-descent frontend) were **removed**.
+> SystemVerilog now has exactly one pipeline — `sv-yosys` (sv2v → Yosys →
+> BTOR2 → bit-blast). Sidecar significant-value discovery moved to
+> [`mununu btor2 discover`](#mununu-btor2), which runs SMT predicate-image
+> discovery over the BTOR2 IR the verify path uses and writes the
+> `discovered_values` map into the sidecar. Author the `.mununu.json`
+> sidecar by hand or seed it via `btor2 discover`.
 
-Generate a skeleton `.mununu.json` annotation sidecar from a SystemVerilog module.
+### `mununu sv preprocess`
 
-```bash
-mununu sv init <FILE> [--output <FILE>] [--force]
-```
+Lower SystemVerilog-2017 to a Verilog-2005 subset via `sv2v` (the KMTS
+frontend normaliser), preserving module hierarchy and signal names.
+Requires `sv2v` on `PATH`. Output goes to `--output` or `<stem>.elab.v`.
+Used internally by the `sv-yosys` pipeline; exposed standalone for
+inspection. Run `mununu sv preprocess --help` for flags.
 
-| Flag | Description |
-|------|-------------|
-| `--output <FILE>` | Output path (default: `<stem>.mununu.json` next to the `.sv` file) |
-| `--force` | Overwrite existing sidecar |
+### `mununu sv emit-btor2-per-module`
 
-**Defaults:** 1-bit registers → `boolean`, enums → `enum` with variants, ≤4-bit → `bounded_counter`, >4-bit → `discover`. Includes a `safety` property placeholder and detected `localparam` values.
-
-**Example:**
-```bash
-mununu sv init examples/systemverilog/fifo.sv
-# → Generated sidecar: examples/systemverilog/fifo.mununu.json
-#   3 signal(s), 3 input(s), 1 property/ies
-```
-
-### `mununu sv discover`
-
-Discover significant register values via SMT analysis. Requires `--features smt` at build time.
-
-```bash
-mununu sv discover <FILE> [--annotation <FILE>] [--output <FILE>] [--max-values <N>]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--annotation <FILE>` | Path to `.mununu.json` (default: auto-detected next to `.sv`) |
-| `--output <FILE>` | Write updated sidecar to a different file |
-| `--max-values <N>` | Max values per signal (default: 32) |
-
-Finds concrete values that make guard conditions satisfiable — even through combinational logic (e.g., `assign y = x * 4; if (y == 12)` → discovers `x = 3`). Updates the sidecar's `discovered_values` section, preserving user-given variant names.
-
-**Example:**
-```bash
-mununu sv discover examples/systemverilog/alu.sv
-# → cmd — 5 value(s):
-#     VAL_0 = 0 (SMT: guard (cmd == 0) at line 0)
-#     VAL_1 = 1 (SMT: guard (cmd == 1) at line 0)
-#     ...
-# → Updated sidecar: examples/systemverilog/alu.mununu.json
-```
+Run Yosys with `hierarchy -check` (no `flatten`) and emit one BTOR2 per
+submodule reachable from the top — the per-submodule IR the KMTS lifter and
+multi-module composition consume. Requires `yosys` on `PATH`. Run
+`mununu sv emit-btor2-per-module --help` for flags.
 
 See [RTL Verification Pipeline](RTL-Verification-Pipeline) for the full workflow.
 

--- a/wiki/RTL-Verification-Pipeline.md
+++ b/wiki/RTL-Verification-Pipeline.md
@@ -2,56 +2,47 @@
 
 > **Alpha Software** — Mununu is under active development. APIs, syntax, and behavior may change.
 
-Mununu has **two RTL ingestion paths** today:
+Mununu has **one** RTL ingestion path: the **Yosys-driven `sv-yosys` pipeline** (sv2v → Yosys → BTOR2 → bit-blast). It elaborates the full SystemVerilog subset Yosys handles — generate blocks, parameter elaboration, packages, structural SV — and lifts the per-module BTOR2 to a KMTS. A `.mununu.json` annotation sidecar drives the abstraction posture (`FieldDomain` Boolean / BoundedCounter / EnumValues / Ignored, `discovered_values`, automatic cone-of-influence).
 
-- **Hand-written SV parser** (`--adapter sv`): the original FSM-class adapter, with `.mununu.json` annotation sidecars driving abstraction (`FieldDomain` Boolean / Presence / BoundedCounter / EnumValues / Ignored, `discovered_values`, COI). Best for small SystemVerilog FSMs where you want to author the abstraction explicitly.
-- **Yosys-driven path** (`--adapter sv-yosys`): elaborate via Yosys to BTOR2, then bit-blast through the [BTOR2 reader](Adapter-Formats#btor2--yosys-rtl-phase-1). Generate blocks, parameter elaboration, packages, and structural SV that the hand-written parser cannot handle all flow through Yosys's mature elaboration. The price is no automatic abstraction — the BTOR2 reader bit-blasts within the `MAX_STATE_BITS = 16` cap and rejects designs beyond it.
-
-The roadmap unifies the two paths: the BTOR2 reader will gain a shared `adapter/sidecar/` module so the same `.mununu.json` schema feeds both paths, and the BTOR2 bit-blaster will consume `FieldDomain` instead of raw bit-vectors. Until that lands, the hand-written and Yosys paths are independent.
+> **S.2b note.** The legacy hand-written SV parser (`--adapter sv`, `mununu sv init`, `mununu sv discover`) was **removed**. Its sidecar-authoring role is now hand-editing plus `mununu btor2 discover`, which runs SMT predicate-image discovery over the same BTOR2 IR the verify path uses and writes `discovered_values` into the sidecar. SystemVerilog has exactly one pipeline.
 
 ---
-
-## Hand-written SV Parser Path
-
-This page below documents the hand-written SV path with `.mununu.json` sidecars. For the Yosys path, see [Adapter Formats — BTOR2 + Yosys](Adapter-Formats#btor2--yosys-rtl-phase-1) and the corpus walkthrough in `examples/btor2/README.md`.
 
 ### Pipeline Overview
 
 ```
-SV Source → Parse → Load Sidecar → (optional: SMT Discovery) → Build Abstraction → Kripke → Verify
+SV Source → sv2v → Yosys (hierarchy, no flatten) → BTOR2 (per module) → Load Sidecar → bit-blast (+ optional SMT discovery) → KMTS → Verify
 ```
 
 | Step | Command | Input | Output |
 |------|---------|-------|--------|
-| 1. Init | `mununu sv init design.sv` | `.sv` file | Skeleton `.mununu.json` |
-| 2. Edit | (manual) | `.mununu.json` | Refined annotations |
-| 3. Discover | `mununu sv discover design.sv` | `.sv` + `.mununu.json` | Updated `discovered_values` |
-| 4. Verify | `mununu context eval design.sv --adapter sv` | `.sv` + `.mununu.json` | Property results |
+| 1. (optional) Emit BTOR2 | `mununu sv emit-btor2-per-module design.sv --output-dir build/` | `.sv` | per-module `.btor2` |
+| 2. (optional) Discover | `mununu btor2 discover build/design.btor2` | `.btor2` + `.mununu.json` | Updated `discovered_values` |
+| 3. Edit | (manual) | `.mununu.json` | Refined annotations |
+| 4. Verify | `mununu context eval design.sv --adapter sv-yosys` (or a `verify.toml` source) | `.sv` + `.mununu.json` | Property results |
 
-Steps 2-4 are iterative — refine annotations and properties based on verification results.
+Requires `yosys` (and `sv2v` for SV-2017 constructs) on `PATH`. Steps 2-4 are iterative — refine annotations and properties based on verification results.
 
 ---
 
 ## Quick Start
 
 ```bash
-# 1. Generate skeleton sidecar
-mununu sv init examples/systemverilog/alu.sv
+# 1. (optional) Seed discovered values into the sidecar from the BTOR2 IR
+mununu sv emit-btor2-per-module examples/systemverilog/alu.sv --output-dir build/
+mununu btor2 discover build/alu.btor2
 
 # 2. Review and edit alu.mununu.json
 #    - Adjust bounds, mark signals to preserve/ignore
 #    - Mark wide registers as "discover" for SMT analysis
 
-# 3. Discover significant values (requires --features smt)
-mununu sv discover examples/systemverilog/alu.sv
-
-# 4. Verify
+# 3. Verify (the bit-blast names the composed automaton `Circuit`)
 mununu context eval examples/systemverilog/alu.sv \
-    --adapter sv --formula safety --automaton alu
+    --adapter sv-yosys --formula safety --automaton Circuit
 
-# 5. Inspect the intermediate CTXDSL
+# 4. Inspect the intermediate CTXDSL
 mununu context eval examples/systemverilog/alu.sv \
-    --adapter sv --formula safety --automaton alu --print-ctxdsl
+    --adapter sv-yosys --formula safety --automaton Circuit --print-ctxdsl
 ```
 
 ---
@@ -154,7 +145,7 @@ Roles: `"guarantee"` (default), `"assumption"`, `"standalone"`.
 
 ### `discovered_values`
 
-Populated by `mununu sv discover`. Each entry maps a signal to its SMT-discovered significant values:
+Populated by `mununu btor2 discover`. Each entry maps a signal to its SMT-discovered significant values:
 
 ```json
 "discovered_values": {
@@ -168,7 +159,7 @@ Populated by `mununu sv discover`. Each entry maps a signal to its SMT-discovere
 }
 ```
 
-You can rename the `name` fields — re-running `sv discover` preserves user-given names.
+You can rename the `name` fields — re-running `btor2 discover` preserves user-given names.
 
 ### `parameters`
 
@@ -182,7 +173,7 @@ Override module `localparam` / `parameter` values:
 
 ## SMT Discovery
 
-When a register is marked `"abstraction": "discover"`, the `mununu sv discover` command uses z3 bitvector theory to find concrete values that make guard conditions satisfiable — even through combinational logic.
+When a register is marked `"abstraction": "discover"`, the `mununu btor2 discover` command uses z3 bitvector theory (SMT predicate-image over the BTOR2 IR) to find concrete values that make guard conditions satisfiable — even through combinational logic.
 
 **Example:** If `assign y = x * 4;` and a guard checks `if (y == 12)`, SMT discovers `x = 3`.
 
@@ -234,13 +225,13 @@ end
 
 ```bash
 # Buggy: UNREALIZABLE — overflow is reachable
-mununu context synth fifo_overflow_bug.sv --adapter sv \
-    --formula no_overflow --automaton fifo_overflow_bug
+mununu context synth fifo_overflow_bug.sv --adapter sv-yosys \
+    --formula no_overflow --automaton Circuit
 # → Realizable: no
 
 # Fixed: REALIZABLE — guard prevents overflow
-mununu context synth fifo_overflow_fixed.sv --adapter sv \
-    --formula no_overflow --automaton fifo_overflow_fixed
+mununu context synth fifo_overflow_fixed.sv --adapter sv-yosys \
+    --formula no_overflow --automaton Circuit
 # → Realizable: yes
 ```
 
@@ -290,5 +281,5 @@ Based on MITRE CWE-1245, with real CVEs (CVE-2024-21853, CVE-2024-24968). One-ho
 
 - [Adapter Formats — SystemVerilog](Adapter-Formats#systemverilog) — supported SV subset and inline annotations
 - [Hardware Verification Patterns](Hardware-Verification-Patterns) — CTXDSL patterns for common hardware
-- [CLI Reference](CLI-Reference) — `sv init`, `sv discover`, `context eval`, `context synth`
+- [CLI Reference](CLI-Reference) — `sv preprocess`, `sv emit-btor2-per-module`, `btor2 discover`, `context eval`, `context synth`
 - [Controller Synthesis](Controller-Synthesis) — synthesizing controllers from specifications

--- a/wiki/Verify-Project-Flow.md
+++ b/wiki/Verify-Project-Flow.md
@@ -12,7 +12,7 @@ The codesign C+SV flow, the protocol-spec recipe, and the agentic verification e
 
 A verification project is the tuple `(Sources, AlphabetBinding, Composition, Properties)`:
 
-- **Sources** — N entries, each `{ id, adapter, files, options }`. The `adapter` field names a [`FormatAdapter`](../crates/mununu-core/src/adapter/mod.rs) implementation. Today's dispatch table: `ctxdsl`, `xstate`, `crewai`, `langgraph`, `sv-rtl`, `c-codesign`, `extraction`.
+- **Sources** — N entries, each `{ id, adapter, files, options }`. The `adapter` field names a [`FormatAdapter`](../crates/mununu-core/src/adapter/mod.rs) implementation. Today's dispatch table: `ctxdsl`, `xstate`, `crewai`, `langgraph`, `sv-yosys` (alias `yosys`), `c-codesign`, `extraction`.
 
 - **AlphabetBinding** — how labels across sources synchronise:
   - **`direct`** (default) — names must already match across sources.
@@ -70,13 +70,13 @@ The KMTS pivot replaces the SystemVerilog extraction story end-to-end while leav
 - **3-valued evaluator.** The `TruthDomain` trait surfaces both the truth lattice (formula semantics) and the information lattice (fixpoint convergence). `BoolDomain` instantiates the 2-valued specialisation; `KleeneDomain` instantiates the 3-valued one. Verdicts are `KleeneT` / `KleeneF` / `KleeneBot`; `KleeneBot` triggers CEGAR.
 - **CEGAR refinement.** On `KleeneBot`, the lifter lifts the abstract counterexample, SMT-discharges it for spuriousness, and on UNSAT extracts predicate refinements via IC3-IA-style interpolation. Bounded by `cegar_max_rounds` (default 16). Two-axis refinement: predicate addition vs. UF instance concretisation, partitioned by unsat-core symbol kind.
 
-**Singular-pipeline commitment.** By the end of S.2b, the legacy native-SV adapter (the hand-rolled recursive-descent parser + explicit cross-product enumerator) is deleted. There is no `--engine native-sv` escape hatch. SV verification has exactly one pipeline. See [`docs/design/native-sv-abstraction.md`](../docs/design/native-sv-abstraction.md) §9 (simplification phases) and §10 (validation milestones M.0–M.6 against industrially realistic OpenTitan / ibex / Caliptra fixtures).
+**Singular-pipeline commitment.** As of S.2b the legacy native-SV adapter (the hand-rolled recursive-descent parser + explicit cross-product enumerator) is **deleted**. There is no `--engine native-sv` escape hatch. SV verification has exactly one pipeline — `sv-yosys` (sv2v → Yosys → BTOR2 → bit-blast). Sidecar significant-value discovery moved to `mununu btor2 discover` (which runs over the BTOR2 IR the verify path uses). See [`docs/design/native-sv-abstraction.md`](../docs/design/native-sv-abstraction.md) for the architecture.
 
 ## Automatic partition (Phase A.3)
 
 > **Source of truth:** [`adapter::partition::classify`](../crates/mununu-core/src/adapter/partition/mod.rs) — surface: CLI+API.
 
-SV (`sv-rtl`) and BTOR2 sources run an **automatic cone-of-influence
+SV (`sv-yosys`) and BTOR2 sources run an **automatic cone-of-influence
 pass** during their `dispatch_adapter` translation. The pass walks the
 frontend IR's dependency graph from property atoms and marks signals
 outside the cone as `AbstractionType::Ignored`. The composition rule
@@ -123,7 +123,7 @@ options = {
 
 [[sources]]
 id = "periph"
-adapter = "sv-rtl"
+adapter = "sv-yosys"
 files = ["rtl/uart_peripheral.sv"]
 
 [alphabet]


### PR DESCRIPTION
## S.2b-3 — reconcile docs/wiki/examples to the sv-yosys-only SV pipeline

Follow-up doc sweep after **#75** (S.2b: retire the native SystemVerilog parser) merged. Updates user-facing docs that still referenced the removed `sv-rtl` adapter, the `mununu sv init` / `sv discover` CLI commands, and deleted symbols (`kripke_smt.rs`, `kripke.rs`).

### Wiki
- **Verify-Project-Flow / CLI-Reference / Adapter-Formats** — dispatch tables + CLI examples now use `sv-yosys` / automaton `Circuit`; the `mununu sv init|discover` command sections are replaced with `sv preprocess` / `emit-btor2-per-module` + a pointer to `mununu btor2 discover` (the KMTS-native value discovery that subsumed `sv discover`).
- **RTL-Verification-Pipeline** — reframed around the singular `sv-yosys` pipeline; the sidecar is authored by hand or via `btor2 discover`. Removed the obsolete "two RTL paths" framing.
- **Adapter-Formats** — replaced the ~190-line native-parser `## SystemVerilog` section (FSM/Kripke modes, inline `// @mununu` annotations, "supported subset" table) with a concise sv-yosys section.

### docs/
- `agentic.md` adapter list `sv-rtl`→`sv-yosys`; `claims-integrity.md` + `abstraction-literature.md` `sv discover`→`btor2 discover`; `auto-extraction-architecture.md` §1.6 `Source of truth:` anchor repointed from the deleted `kripke_smt.rs` to `predicate_image/all_smt.rs`.

### examples/
- `uart_codesign_chaotic` README + verify.toml `sv-rtl`→`sv-yosys`; `fifo.mununu.json` note + `multi_producer_consumer_top.sv` usage header updated to the sv-yosys flow.

### Scope note
Superseded / `Status: planning` design docs (`caliptra-abstraction-analysis.md`, `native-sv-abstraction.md`, `predicate-abstraction-recipe.md`, etc.) retain historical references by design — they're exempt from Documentation Traceability and document the design evolution.

12 files, +123 / −314. Pre-push `make ci` green (with yosys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
