### PR TITLE
U.0 (slot 6) parity: drop removed systemverilog input adapter from format lists

### DIFF
--- a/crates/mununu-cli/src/loader.rs
+++ b/crates/mununu-cli/src/loader.rs
@@ -438,7 +438,7 @@ pub(crate) fn load_with_adapter_mode_extra(
         ),
         Some(fmt) => {
             return Err(format!(
-                "unknown adapter format '{fmt}'. Supported: tlsf, aiger, btor2, promela, xstate, systemverilog, sv-yosys, extraction, auto"
+                "unknown adapter format '{fmt}'. Supported: tlsf, aiger, btor2, promela, xstate, sv-yosys, extraction, auto"
             ));
         }
         None => {

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -966,7 +966,7 @@ struct ContextSummarizeArgs {
     #[arg(long = "sidecar", value_name = "FILE")]
     sidecars: Vec<PathBuf>,
     /// Translate from an external format before processing
-    /// (tlsf, aiger, promela, xstate, systemverilog, extraction, auto).
+    /// (tlsf, aiger, promela, xstate, sv-yosys, extraction, auto).
     #[arg(long = "adapter", value_name = "FORMAT")]
     adapter: Option<String>,
     /// Mode for extraction adapter: "fixed" or "vulnerable".
@@ -993,7 +993,7 @@ struct ContextPredicatesArgs {
     #[arg(long = "sidecar", value_name = "FILE")]
     sidecars: Vec<PathBuf>,
     /// Translate from an external format before processing
-    /// (tlsf, aiger, promela, xstate, systemverilog, extraction, auto).
+    /// (tlsf, aiger, promela, xstate, sv-yosys, extraction, auto).
     #[arg(long = "adapter", value_name = "FORMAT")]
     adapter: Option<String>,
     /// Mode for extraction adapter: "fixed" or "vulnerable".
@@ -1018,7 +1018,7 @@ struct ContextEvalArgs {
     #[arg(long = "sidecar", value_name = "FILE")]
     sidecars: Vec<PathBuf>,
     /// Translate from an external format before processing
-    /// (tlsf, aiger, promela, xstate, systemverilog, extraction, auto).
+    /// (tlsf, aiger, promela, xstate, sv-yosys, extraction, auto).
     #[arg(long = "adapter", value_name = "FORMAT")]
     adapter: Option<String>,
     /// Mode for extraction adapter: "fixed" or "vulnerable".
@@ -1073,7 +1073,7 @@ struct ContextSynthesizeArgs {
     #[arg(long = "sidecar", value_name = "FILE")]
     sidecars: Vec<PathBuf>,
     /// Translate from an external format before processing
-    /// (tlsf, aiger, promela, xstate, systemverilog, extraction, auto).
+    /// (tlsf, aiger, promela, xstate, sv-yosys, extraction, auto).
     #[arg(long = "adapter", value_name = "FORMAT")]
     adapter: Option<String>,
     /// Mode for extraction adapter: "fixed" or "vulnerable".

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -425,7 +425,7 @@ pub async fn context_import_handler(
         other => {
             return Err(ApiError::BadRequest {
                 message: format!(
-                    "Unknown format '{other}'. Supported: auto, tlsf, aiger, btor2, promela, xstate, systemverilog, sv-yosys, extraction, crewai, langgraph, microcode"
+                    "Unknown format '{other}'. Supported: auto, tlsf, aiger, btor2, promela, xstate, sv-yosys, extraction, crewai, langgraph, microcode"
                 ),
                 details: None,
             });

--- a/src/main.rs
+++ b/src/main.rs
@@ -2397,7 +2397,7 @@ fn load_with_adapter_mode(
         }
         Some(fmt) => {
             return Err(format!(
-                "unknown adapter format '{fmt}'. Supported: tlsf, aiger, promela, xstate, systemverilog, extraction, crewai, langgraph, microcode, auto"
+                "unknown adapter format '{fmt}'. Supported: tlsf, aiger, promela, xstate, sv-yosys, extraction, crewai, langgraph, microcode, auto"
             ));
         }
         None => {


### PR DESCRIPTION
## U.0 (slot 6) — parity sweep: drop the removed `systemverilog` input adapter from format lists

First slice of slot 6 (U.0 — UI/surface parity for the singular SV pipeline). S.2b removed the native `systemverilog` / `sv` **input** adapter (`sv-yosys` is the sole SV input route), but several "supported format" lists + `--adapter` doc comments across the surfaces still advertised `systemverilog` as an input format.

### Fixed (input-format lists → drop `systemverilog`, keep `sv-yosys`)
- `crates/mununu-core/src/api/handlers.rs` — translate-handler unknown-format error.
- `crates/mununu-cli/src/loader.rs` — unknown-adapter-format error.
- `crates/mununu-cli/src/main.rs` — 4 `--adapter` doc comments (`systemverilog` → `sv-yosys`).
- `src/main.rs` (legacy root bin) — unknown-adapter-format error.

### Kept (valid — output, not input)
`--output-format systemverilog` (the `emit_controller` controller-emission path, `cli/main.rs:3984` + api models). That's emission, not an input adapter, and survives S.2b.

### Slot-6 audit findings (recorded for the rest of U.0)
- U.0 sub-items **(1) engine/pipeline selector** + **(2) BitBlast/Enum/BoundedCounter sidecar editors** are **moot** — the UI never exposed those native controls (verified by grep across `mununu-ui/src`).
- The verify→API→UI verdict vertical is **2-valued** (`evaluate_with_options` / `satisfied: bool`), and the verify-framework path produces **Sharp-everywhere** KMTSes, so KleeneBot verdicts only arise on the **CEGAR / predicate-abstraction (V.6) path** — which already has its own UI panel.
- The lone substantive remaining U.0 item is the **refinement-trace viewer** (expose the CEGAR loop's verdict + `CegarTrace` via API, render in UI) — a separate arc.

No logic changes; string/doc-comment only. Pre-push `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
