### PR TITLE
feat(R4W-2, R.4 clustered-COI wiring): manifest property seeds → cluster_coi telemetry

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -1996,10 +1996,37 @@ fn enumerate_and_blast(
                 .map(|m| (m.symbol.clone(), m.width as usize)),
         )
         .collect();
-    let partition_summary = Some(crate::adapter::partition::PartitionSummary::from_partition(
-        &partition,
-        Some(&widths),
-    ));
+    let mut summary =
+        crate::adapter::partition::PartitionSummary::from_partition(&partition, Some(&widths));
+
+    // R4W-2 (R.4 clustered-COI wiring) — when the caller threaded the
+    // manifest's per-property COI seeds, compute the joint-vs-clustered
+    // cone comparison over *this* module's BTOR2 dep graph and surface
+    // it on the summary. Pure telemetry: it reports what a per-cluster
+    // bit-blast could save vs the naive joint COI (the M.3 reduction
+    // metric); it does not change which signals the partition keeps.
+    // Skipped entirely when `property_seeds` is empty (the legacy
+    // intrinsic-seed-only path), so there is no behaviour change for
+    // existing single-property / no-manifest runs.
+    if !options.property_seeds.is_empty() {
+        use crate::adapter::partition::{DepGraphBuilder, coi};
+        // The recommended Jaccard floor (see `coi::cluster_coi_report`
+        // docs). The configurable floor + the CLI/API/UI surface for
+        // the comparison are R4W-3; R4W-2 uses the 0.5 default.
+        const CLUSTER_SIMILARITY_FLOOR: f64 = 0.5;
+        let deps = file.build();
+        let props: Vec<(String, std::collections::HashSet<String>)> = options
+            .property_seeds
+            .iter()
+            .map(|(name, atoms)| (name.clone(), atoms.iter().cloned().collect()))
+            .collect();
+        summary.cluster_coi = Some(coi::cluster_coi_report(
+            &props,
+            &deps,
+            CLUSTER_SIMILARITY_FLOOR,
+        ));
+    }
+    let partition_summary = Some(summary);
 
     Ok(BlastOutput {
         signals,
@@ -5219,6 +5246,95 @@ mod tests {
         assert!(
             after < before,
             "expected reduction from dropping s_drop; got before={before} after={after}"
+        );
+    }
+
+    #[test]
+    fn cluster_coi_report_surfaced_when_property_seeds_present() {
+        // R4W-2 (R.4 clustered-COI wiring) — when the caller threads
+        // per-property COI seeds via `AdapterOptions::property_seeds`,
+        // the bit-blaster computes a joint-vs-clustered cone comparison
+        // over its dep graph and surfaces it on
+        // `PartitionSummary::cluster_coi`.
+        //
+        // Fixture: two independent 2-state chains. Chain A is
+        // `sa -> sa2 -> 0`; chain B is `sb -> sb2 -> 0`. The two cones
+        // are disjoint, so a per-property cluster keeps only 2 signals
+        // while the naive joint COI keeps all 4 — the M.3 reduction.
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+4 state 1 sa
+5 state 1 sa2
+6 init 1 4 2
+7 init 1 5 2
+8 next 1 4 5
+9 next 1 5 2
+10 state 1 sb
+11 state 1 sb2
+12 init 1 10 2
+13 init 1 11 2
+14 next 1 10 11
+15 next 1 11 2
+16 bad 4
+"#;
+        let options = AdapterOptions {
+            property_seeds: vec![
+                ("propA".to_string(), vec!["sa".to_string()]),
+                ("propB".to_string(), vec!["sb".to_string()]),
+            ],
+            ..AdapterOptions::default()
+        };
+        let out = translate(src, &options).expect("translate");
+        let summary = out
+            .partition_summary
+            .expect("partition_summary must be populated");
+        let report = summary
+            .cluster_coi
+            .expect("cluster_coi must be Some when property_seeds is non-empty");
+
+        // Joint COI over {sa, sb} reaches {sa, sa2, sb, sb2}.
+        assert_eq!(
+            report.joint_cone_size, 4,
+            "joint cone = {{sa, sa2, sb, sb2}}; got {report:?}"
+        );
+        // Disjoint cones at the 0.5 floor → two singleton clusters.
+        assert_eq!(
+            report.clusters.len(),
+            2,
+            "disjoint cones must yield 2 clusters; got {report:?}"
+        );
+        // Each cluster's cone is exactly 2 signals.
+        assert_eq!(
+            report.max_cluster_cone_size, 2,
+            "each per-cluster cone = 2 signals; got {report:?}"
+        );
+        // The load-bearing M.3 claim: clustering shrinks the binding cone.
+        assert!(
+            report.max_cluster_cone_size < report.joint_cone_size,
+            "clustering must reduce the max cone vs the joint cone; got {report:?}"
+        );
+    }
+
+    #[test]
+    fn cluster_coi_absent_without_property_seeds() {
+        // R4W-2 — the legacy intrinsic-seed-only path leaves
+        // `cluster_coi` as `None` (no behaviour change).
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+4 state 1 sa
+6 init 1 4 2
+8 next 1 4 2
+16 bad 4
+"#;
+        let out = translate(src, &AdapterOptions::default()).expect("translate");
+        let summary = out
+            .partition_summary
+            .expect("partition_summary must be populated");
+        assert!(
+            summary.cluster_coi.is_none(),
+            "cluster_coi must be None when property_seeds is empty; got {summary:?}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -180,6 +180,24 @@ pub struct AdapterOptions {
     /// achievable value. Default empty — the single-module path passes
     /// none, leaving the verdict-parity gate untouched.
     pub surface_output_ports: Vec<String>,
+
+    /// R4W-2 (R.4 clustered-COI wiring) — per-property COI seed atoms
+    /// harvested from the verify manifest's `[[properties]]` formulas
+    /// (`(property_name, seed_atom_names)`). The verify orchestrator
+    /// resolves each property, parses it, and runs
+    /// [`crate::adapter::partition::coi::property_seed_atoms`] to fill
+    /// this in. When non-empty, the BTOR2 bit-blaster computes a
+    /// joint-vs-clustered COI comparison
+    /// ([`crate::adapter::partition::coi::cluster_coi_report`]) over its
+    /// own dep graph and surfaces it on
+    /// [`crate::adapter::partition::PartitionSummary::cluster_coi`].
+    ///
+    /// Pure telemetry — does **not** change which signals the partition
+    /// keeps. Default empty (the legacy intrinsic-seed-only path; no
+    /// behaviour change). The configurable similarity floor + the
+    /// CLI / API / UI surface for the comparison land in R4W-3; this
+    /// field uses the recommended `0.5` default at the bit-blast layer.
+    pub property_seeds: Vec<(String, Vec<String>)>,
 }
 
 /// A sidecar file the adapter produced alongside its CTXDSL output.

--- a/crates/mununu-core/src/adapter/partition/coi.rs
+++ b/crates/mununu-core/src/adapter/partition/coi.rs
@@ -20,6 +20,8 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use serde::{Deserialize, Serialize};
+
 use crate::mu_calculus::{Formula, Node};
 
 /// BFS reachability from `seeds` through `deps`.
@@ -224,7 +226,7 @@ pub fn property_seed_atoms(formula: &Formula) -> HashSet<String> {
 }
 
 /// R4W-1 — One cluster's entry in a [`ClusterCoiReport`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClusterCoiEntry {
     /// Property identifiers merged into this cluster.
     pub members: Vec<PropertyId>,
@@ -242,7 +244,7 @@ pub struct ClusterCoiEntry {
 /// when `max_cluster_cone_size < joint_cone_size` (and, at the bit-blast
 /// layer, when the joint cone busts the state-bit cap while each cluster
 /// fits).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClusterCoiReport {
     /// Signals a naive joint COI over all properties would keep.
     pub joint_cone_size: usize,

--- a/crates/mununu-core/src/adapter/partition/mod.rs
+++ b/crates/mununu-core/src/adapter/partition/mod.rs
@@ -108,6 +108,17 @@ pub struct PartitionSummary {
     /// Total raw bit-width across kept state cells after the
     /// partition's `Dropped` signals collapsed to `Ignored`.
     pub state_bits_after: Option<usize>,
+    /// R4W-2 (R.4 clustered-COI wiring) — joint-vs-clustered cone
+    /// comparison over the manifest's per-property COI seeds. `Some`
+    /// only when the caller threaded `AdapterOptions::property_seeds`
+    /// (i.e. the verify orchestrator resolved `[[properties]]` and
+    /// harvested their seed atoms); `None` for intrinsic-seed-only
+    /// runs (the legacy default — no behaviour change). Pure telemetry:
+    /// the report does not drive which signals the partition keeps; it
+    /// reports what a per-cluster bit-blast *could* save vs the naive
+    /// joint COI (the M.3 reduction metric).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cluster_coi: Option<coi::ClusterCoiReport>,
 }
 
 impl PartitionSummary {
@@ -172,6 +183,11 @@ impl PartitionSummary {
             datapath_uf,
             state_bits_before: tracking_widths.then_some(sb_before),
             state_bits_after: tracking_widths.then_some(sb_after),
+            // R4W-2 — populated by the caller (the BTOR2 bit-blaster)
+            // when `AdapterOptions::property_seeds` is non-empty; this
+            // constructor has no access to the dep graph or the seeds,
+            // so it defaults to `None` and the caller fills it in.
+            cluster_coi: None,
         }
     }
 }

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -98,6 +98,15 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
         _ => None,
     };
 
+    // R4W-2 (R.4 clustered-COI wiring) — harvest each property's COI
+    // seed atoms *before* adapter dispatch. The BTOR2 bit-blaster owns
+    // the per-module dep graph, so the seeds must reach it through
+    // `AdapterOptions::property_seeds` for the joint-vs-clustered cone
+    // comparison to be computable. Properties are resolved again (for
+    // real) in step 5; this early pass is best-effort telemetry and
+    // never aborts the run.
+    let property_seeds = harvest_property_seeds(config);
+
     // 3. For each source: read files, dispatch adapter, apply renamings.
     // Parameterised sources (`count >= 2`) expand to N instances
     // named `<id>_0` .. `<id>_<N-1>`. Each instance substitutes
@@ -140,6 +149,7 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
                 &additional_files,
                 &source.options,
                 base_dir,
+                &property_seeds,
             )?;
 
             // Apply per-source renamings from the binding. The renamings
@@ -395,6 +405,10 @@ pub fn inspect_project(
                 .collect()
         };
         for (instance_id, content) in instances {
+            // Inspection never resolves properties (step 5 is a no-op),
+            // so there are no per-property COI seeds to harvest — pass
+            // an empty slice. The bit-blaster then skips the clustered-
+            // COI comparison (legacy intrinsic-seed-only behaviour).
             let (raw_ctxdsl, partition_summary) = dispatch_adapter(
                 &source.adapter,
                 &instance_id,
@@ -403,6 +417,7 @@ pub fn inspect_project(
                 &additional_files,
                 &source.options,
                 base_dir,
+                &[],
             )?;
             let mut rewritten = match per_source_renamings.get(&source.id) {
                 Some(renamings) if !renamings.is_empty() => {
@@ -608,6 +623,12 @@ pub fn inspect_project(
 /// `AdapterOutput`. The orchestrator threads the summary onto the
 /// source's `SourceSummary` so the `VerifyReport` surfaces COI
 /// telemetry per source.
+// R4W-2 added `property_seeds` as an 8th argument; the dispatch context
+// is a flat list of independent inputs (adapter name, ids, paths,
+// options) rather than a cohesive struct, so an allow is the right call
+// here — matching the precedent on the other multi-input dispatch /
+// realize helpers in this crate.
+#[allow(clippy::too_many_arguments)]
 fn dispatch_adapter(
     adapter: &str,
     source_id: &str,
@@ -616,6 +637,11 @@ fn dispatch_adapter(
     additional_files: &[(PathBuf, String)],
     options: &std::collections::BTreeMap<String, toml::Value>,
     base_dir: &Path,
+    // R4W-2 — manifest per-property COI seeds for the clustered-COI
+    // telemetry. Consumed only by the `sv-yosys` (BTOR2) route, which
+    // owns the dep graph; other adapters ignore it. Empty on the
+    // inspection path (no property resolution there).
+    property_seeds: &[(String, Vec<String>)],
 ) -> Result<(String, Option<crate::adapter::partition::PartitionSummary>), VerifyError> {
     let to_pair = |out: crate::adapter::AdapterOutput| (out.ctxdsl, out.partition_summary);
     let err_for = |adapter: &str, source_id: &str, err: crate::adapter::AdapterError| {
@@ -646,7 +672,13 @@ fn dispatch_adapter(
         // `multi_module = true` (+ optional `top`), driven from the top
         // netlist. Requires `yosys` on PATH; absence surfaces as an
         // `AdapterTranslationFailed` (locate_yosys error), not silently.
-        "sv-yosys" => dispatch_sv_yosys(source_id, content, additional_files, options),
+        "sv-yosys" => dispatch_sv_yosys(
+            source_id,
+            content,
+            additional_files,
+            options,
+            property_seeds,
+        ),
         "crewai" => {
             warn_unused_additional_files(adapter, source_id, additional_files);
             let opts = AdapterOptions::default();
@@ -768,8 +800,17 @@ fn dispatch_sv_yosys(
     content: &str,
     additional_files: &[(PathBuf, String)],
     options: &std::collections::BTreeMap<String, toml::Value>,
+    property_seeds: &[(String, Vec<String>)],
 ) -> Result<(String, Option<crate::adapter::partition::PartitionSummary>), VerifyError> {
-    let opts = AdapterOptions::default();
+    // R4W-2 — carry the manifest's per-property COI seeds into the
+    // bit-blaster so it can compute the joint-vs-clustered cone
+    // comparison over its dep graph (surfaced on
+    // `PartitionSummary::cluster_coi`). Empty seeds preserve the legacy
+    // intrinsic-seed-only behaviour.
+    let opts = AdapterOptions {
+        property_seeds: property_seeds.to_vec(),
+        ..AdapterOptions::default()
+    };
     let additional_sources: Vec<(String, String)> = additional_files
         .iter()
         .filter_map(|(path, body)| {
@@ -975,6 +1016,33 @@ fn dispatch_c_codesign(
 // ---------------------------------------------------------------------------
 // Property template resolution
 // ---------------------------------------------------------------------------
+
+/// R4W-2 (R.4 clustered-COI wiring) — resolve + parse each manifest
+/// property and collect its COI seed atoms as
+/// `(property_name, seed_atom_names)`.
+///
+/// The seeds feed [`crate::adapter::partition::coi::cluster_coi_report`]
+/// in the BTOR2 bit-blaster (via [`AdapterOptions::property_seeds`]),
+/// which owns the per-module dep graph the cones are walked over.
+///
+/// Best-effort telemetry: a property that fails to resolve (bad
+/// template) or fails to parse (malformed formula) contributes no
+/// seeds — its real error surfaces in step 5 / the eval phase, so this
+/// pass never aborts the verify run. Returns an empty vec when the
+/// manifest declares no properties.
+fn harvest_property_seeds(config: &VerifyConfig) -> Vec<(String, Vec<String>)> {
+    let registry = TemplateRegistry::builtin();
+    config
+        .properties
+        .iter()
+        .filter_map(|p| {
+            let (formula_text, _src) = resolve_property_formula(p, &registry).ok()?;
+            let formula = crate::mu_calculus::parser::parse(&formula_text).ok()?;
+            let atoms = crate::adapter::partition::coi::property_seed_atoms(&formula);
+            Some((p.name.clone(), atoms.into_iter().collect()))
+        })
+        .collect()
+}
 
 fn resolve_property_formula(
     p: &PropertySection,
@@ -1793,6 +1861,7 @@ formula = "true"
             &[],
             &std::collections::BTreeMap::new(),
             std::path::Path::new("."),
+            &[],
         );
         // Ok (yosys present) OR AdapterTranslationFailed (yosys absent)
         // both prove the route is wired; only UnknownAdapter fails.


### PR DESCRIPTION
## R4W-2 — wire clustered-COI onto the verify path

R4W-1 (#80) shipped the pure helpers (`property_seed_atoms` + `cluster_coi_report`). **R4W-2 makes them reachable + reported on a real verify run** — the joint-vs-clustered cone comparison (the M.3 reduction metric) now flows from the manifest's `[[properties]]` down to the BTOR2 bit-blaster and back out on the partition summary.

### What changed
- **`AdapterOptions.property_seeds: Vec<(String, Vec<String>)>`** (default empty → no behaviour change).
- **Orchestrator** harvests each property's COI seed atoms before adapter dispatch (best-effort: a property that fails to resolve/parse contributes no seeds and surfaces its real error in the eval phase) and threads them into the `sv-yosys` (BTOR2) route, which owns the per-module dep graph.
- **BTOR2 bit-blaster** computes `cluster_coi_report` over its own dep graph at the recommended `0.5` Jaccard floor when `property_seeds` is non-empty, surfacing it on the additive **`PartitionSummary.cluster_coi`** field. Pure telemetry — does **not** change which signals the partition keeps.
- **`ClusterCoiReport`/`ClusterCoiEntry`** gain `Eq` + `Serialize`/`Deserialize` so the report rides the `PartitionSummary` serialization the CLI/API already emit.

### Surface parity
R4W-2 introduces **no new user control** — `property_seeds` is auto-populated from the manifest's existing `[[properties]]`, and the telemetry field flows through the verify-report JSON the CLI + API already produce. The configurable similarity floor + the dedicated CLI flag / API field / UI panel are **R4W-3**.

### Tests
- `cluster_coi_report_surfaced_when_property_seeds_present` — BTOR2 fixture with two disjoint 2-state chains → joint cone **4**, **2** clusters, max cluster cone **2** (the reduction).
- `cluster_coi_absent_without_property_seeds` — legacy path leaves `cluster_coi = None`.

Full pre-push gate green locally: `cargo check --workspace --all-features --tests`, `cargo clippy --workspace --all-features --all-targets -D warnings`, `cargo fmt --check`, `cargo test --workspace --all-features --doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)