### PR TITLE
feat(R4W-3, R.4 clustered-COI wiring): floor control across CLI + API + verify config

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -448,6 +448,15 @@ struct VerifyArgs {
     /// byte-stable; opt-in for debugging.
     #[arg(long = "print-counterexample")]
     print_counterexample: bool,
+    /// R4W-3 (R.4 clustered-COI) — Jaccard similarity floor for the
+    /// clustered cone-of-influence comparison the BTOR2 (`sv-yosys`)
+    /// route reports per source. Overrides any `cluster_similarity_floor`
+    /// set in the `verify.toml`. Omitted → the recommended `0.5`.
+    /// Tighter (→ `1.0`) approaches per-property COI; looser (→ `0.0`)
+    /// collapses toward joint COI. Only affects `sv-yosys` sources with
+    /// declared properties; a no-op for other adapters.
+    #[arg(long = "cluster-coi-floor", value_name = "FLOAT")]
+    cluster_coi_floor: Option<f64>,
 }
 
 #[derive(Args, Debug)]
@@ -1339,8 +1348,15 @@ fn handle_verify(args: VerifyArgs) -> Result<(), String> {
 
     let body = std::fs::read_to_string(&args.config)
         .map_err(|e| format!("failed to read {}: {e}", args.config.display()))?;
-    let config = VerifyConfig::from_toml(&body)
+    let mut config = VerifyConfig::from_toml(&body)
         .map_err(|e| format!("failed to parse {} as TOML: {e}", args.config.display()))?;
+
+    // R4W-3 — the CLI flag overrides any `cluster_similarity_floor` set
+    // in the verify.toml; absent flag leaves the manifest value (or its
+    // None default) in place.
+    if args.cluster_coi_floor.is_some() {
+        config.cluster_similarity_floor = args.cluster_coi_floor;
+    }
 
     let base_dir = args.base_dir.clone().unwrap_or_else(|| {
         args.config
@@ -1385,6 +1401,30 @@ fn handle_verify(args: VerifyArgs) -> Result<(), String> {
                 adapter = s.adapter,
                 automaton = s.automaton.as_deref().unwrap_or("(unresolved)"),
             );
+            // R4W-3 — clustered cone-of-influence comparison (BTOR2 /
+            // `sv-yosys` route with declared properties). Present only
+            // when the bit-blaster computed it; absent for other
+            // adapters or property-less sources.
+            if let Some(cc) = s
+                .partition_summary
+                .as_ref()
+                .and_then(|ps| ps.cluster_coi.as_ref())
+            {
+                println!(
+                    "        clustered-COI: joint cone {joint} signals, {n} cluster(s), max cluster cone {max} signals{verdict}",
+                    joint = cc.joint_cone_size,
+                    n = cc.clusters.len(),
+                    max = cc.max_cluster_cone_size,
+                    verdict = if cc.max_cluster_cone_size < cc.joint_cone_size {
+                        format!(
+                            " (reduces binding cone by {} vs joint COI)",
+                            cc.joint_cone_size - cc.max_cluster_cone_size
+                        )
+                    } else {
+                        " (no reduction — cones overlap or single cluster)".to_string()
+                    },
+                );
+            }
         }
         println!("  properties ({}):", report.property_verdicts.len());
         for v in &report.property_verdicts {

--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -2010,21 +2010,22 @@ fn enumerate_and_blast(
     // existing single-property / no-manifest runs.
     if !options.property_seeds.is_empty() {
         use crate::adapter::partition::{DepGraphBuilder, coi};
-        // The recommended Jaccard floor (see `coi::cluster_coi_report`
-        // docs). The configurable floor + the CLI/API/UI surface for
-        // the comparison are R4W-3; R4W-2 uses the 0.5 default.
-        const CLUSTER_SIMILARITY_FLOOR: f64 = 0.5;
+        // R4W-3 — honour the caller's Jaccard floor
+        // (`AdapterOptions::cluster_similarity_floor`, threaded from
+        // `VerifyConfig` / the CLI flag / the API request field). `None`
+        // falls back to the recommended 0.5 default (R4W-2 behaviour;
+        // see `coi::cluster_coi_report` docs).
+        const DEFAULT_CLUSTER_SIMILARITY_FLOOR: f64 = 0.5;
+        let floor = options
+            .cluster_similarity_floor
+            .unwrap_or(DEFAULT_CLUSTER_SIMILARITY_FLOOR);
         let deps = file.build();
         let props: Vec<(String, std::collections::HashSet<String>)> = options
             .property_seeds
             .iter()
             .map(|(name, atoms)| (name.clone(), atoms.iter().cloned().collect()))
             .collect();
-        summary.cluster_coi = Some(coi::cluster_coi_report(
-            &props,
-            &deps,
-            CLUSTER_SIMILARITY_FLOOR,
-        ));
+        summary.cluster_coi = Some(coi::cluster_coi_report(&props, &deps, floor));
     }
     let partition_summary = Some(summary);
 
@@ -5335,6 +5336,86 @@ mod tests {
         assert!(
             summary.cluster_coi.is_none(),
             "cluster_coi must be None when property_seeds is empty; got {summary:?}"
+        );
+    }
+
+    #[test]
+    fn cluster_similarity_floor_is_honored_through_adapter_options() {
+        // R4W-3 — the bit-blaster honours
+        // `AdapterOptions::cluster_similarity_floor`, not a hardcoded
+        // 0.5. Fixture: two chains that SHARE one signal, so their cones
+        // partially overlap (Jaccard = |{shared}| / |{sa,sa2,sb,sb2,shared}|
+        // = 1/5 = 0.2):
+        //   chain A: sa' = and(sa2, shared)  → cone {sa, sa2, shared}
+        //   chain B: sb' = and(sb2, shared)  → cone {sb, sb2, shared}
+        // A floor of 0.0 (≤ 0.2) merges them into one cluster; a floor of
+        // 0.9 (> 0.2) keeps them apart. The cluster count flipping with
+        // the floor proves the override threads end-to-end.
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 state 1 shared
+4 init 1 3 2
+5 next 1 3 2
+6 state 1 sa
+7 state 1 sa2
+8 init 1 6 2
+9 init 1 7 2
+10 and 1 7 3
+11 next 1 6 10
+12 next 1 7 2
+13 state 1 sb
+14 state 1 sb2
+15 init 1 13 2
+16 init 1 14 2
+17 and 1 14 3
+18 next 1 13 17
+19 next 1 14 2
+20 bad 6
+"#;
+        let seeds = vec![
+            ("propA".to_string(), vec!["sa".to_string()]),
+            ("propB".to_string(), vec!["sb".to_string()]),
+        ];
+
+        // Loose floor (0.0): the 0.2-overlapping cones merge → 1 cluster
+        // whose cone is the full joint cone (5 signals).
+        let loose = translate(
+            src,
+            &AdapterOptions {
+                property_seeds: seeds.clone(),
+                cluster_similarity_floor: Some(0.0),
+                ..AdapterOptions::default()
+            },
+        )
+        .expect("translate")
+        .partition_summary
+        .and_then(|s| s.cluster_coi)
+        .expect("cluster_coi");
+        assert_eq!(loose.clusters.len(), 1, "floor 0.0 must merge; {loose:?}");
+        assert_eq!(
+            loose.max_cluster_cone_size, loose.joint_cone_size,
+            "merged cluster cone == joint cone; {loose:?}"
+        );
+
+        // Tight floor (0.9): 0.2 < 0.9 → the cones stay in 2 clusters,
+        // each smaller than the joint cone.
+        let tight = translate(
+            src,
+            &AdapterOptions {
+                property_seeds: seeds,
+                cluster_similarity_floor: Some(0.9),
+                ..AdapterOptions::default()
+            },
+        )
+        .expect("translate")
+        .partition_summary
+        .and_then(|s| s.cluster_coi)
+        .expect("cluster_coi");
+        assert_eq!(tight.clusters.len(), 2, "floor 0.9 must split; {tight:?}");
+        assert!(
+            tight.max_cluster_cone_size < tight.joint_cone_size,
+            "split clusters reduce the binding cone; {tight:?}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -194,10 +194,23 @@ pub struct AdapterOptions {
     ///
     /// Pure telemetry — does **not** change which signals the partition
     /// keeps. Default empty (the legacy intrinsic-seed-only path; no
-    /// behaviour change). The configurable similarity floor + the
-    /// CLI / API / UI surface for the comparison land in R4W-3; this
-    /// field uses the recommended `0.5` default at the bit-blast layer.
+    /// behaviour change). R4W-2 used the recommended `0.5` default at
+    /// the bit-blast layer; R4W-3 threads
+    /// [`Self::cluster_similarity_floor`] as the override.
     pub property_seeds: Vec<(String, Vec<String>)>,
+
+    /// R4W-3 (R.4 clustered-COI wiring) — Jaccard similarity floor for
+    /// the clustered-COI comparison (see
+    /// [`crate::adapter::partition::coi::cluster_properties_by_jaccard`]).
+    /// `None` → the bit-blaster uses the recommended `0.5` default
+    /// (R4W-2 behaviour). Tighter floors (→ `1.0`) approach
+    /// per-property COI; looser floors (→ `0.0`) collapse toward joint
+    /// COI. Only consulted when [`Self::property_seeds`] is non-empty.
+    /// The verify orchestrator populates this from
+    /// `VerifyConfig::cluster_similarity_floor` (settable in
+    /// `verify.toml`, or overridden by the CLI `--cluster-coi-floor`
+    /// flag / the API request's `cluster_similarity_floor` field).
+    pub cluster_similarity_floor: Option<f64>,
 }
 
 /// A sidecar file the adapter produced alongside its CTXDSL output.

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -2124,6 +2124,15 @@ pub struct VerifyProjectRequest {
     /// Required — the server has no implicit "client working
     /// directory" the way the CLI does.
     pub base_dir: String,
+    /// R4W-3 (R.4 clustered-COI) — Jaccard similarity floor for the
+    /// clustered cone-of-influence comparison the BTOR2 (`sv-yosys`)
+    /// route reports on each source's `partition_summary.cluster_coi`.
+    /// Overrides any `cluster_similarity_floor` in the supplied config /
+    /// config_toml. `None` (default) → the recommended `0.5`. The
+    /// comparison itself rides the response's `VerifyReport` (no extra
+    /// response field needed).
+    #[serde(default)]
+    pub cluster_similarity_floor: Option<f64>,
 }
 
 /// HTTP handler for the general verify pipeline. Mirrors
@@ -2136,7 +2145,7 @@ pub struct VerifyProjectRequest {
 pub async fn verify_project_handler(
     Json(request): Json<VerifyProjectRequest>,
 ) -> ApiResult<Json<crate::verify::report::VerifyReport>> {
-    let config = match (request.config, request.config_toml) {
+    let mut config = match (request.config, request.config_toml) {
         (Some(c), None) => c,
         (None, Some(toml_text)) => crate::verify::config::VerifyConfig::from_toml(&toml_text)
             .map_err(|e| ApiError::BadRequest {
@@ -2156,6 +2165,12 @@ pub async fn verify_project_handler(
             });
         }
     };
+    // R4W-3 — the request floor overrides any value in the config /
+    // config_toml; absent leaves the manifest value (or its None
+    // default → 0.5 at the bit-blast layer) in place.
+    if request.cluster_similarity_floor.is_some() {
+        config.cluster_similarity_floor = request.cluster_similarity_floor;
+    }
     let base_dir = std::path::PathBuf::from(&request.base_dir);
     crate::verify::verify_project(&config, &base_dir)
         .map(Json)
@@ -2584,6 +2599,7 @@ over = "Sys"
             config: None,
             config_toml: Some(toml.to_string()),
             base_dir: tmp.path().to_string_lossy().to_string(),
+            cluster_similarity_floor: None,
         };
         let Json(report) = verify_project_handler(Json(request))
             .await
@@ -2613,6 +2629,7 @@ members = ["x"]
             config: Some(cfg),
             config_toml: Some("[project]\nname = \"Y\"\n".to_string()),
             base_dir: ".".to_string(),
+            cluster_similarity_floor: None,
         };
         let err = verify_project_handler(Json(request)).await.unwrap_err();
         match err {
@@ -2881,6 +2898,7 @@ members = ["x"]
             config: None,
             config_toml: None,
             base_dir: ".".to_string(),
+            cluster_similarity_floor: None,
         };
         let err = verify_project_handler(Json(request)).await.unwrap_err();
         match err {

--- a/crates/mununu-core/src/verify/codesign_shorthand.rs
+++ b/crates/mununu-core/src/verify/codesign_shorthand.rs
@@ -136,6 +136,9 @@ pub fn codesign_to_verify(codesign: &CodesignProjectConfig) -> VerifyConfig {
         alphabet,
         composition,
         properties,
+        // R4W-3 — codesign shorthand does not tune clustered-COI; the
+        // verify path uses the recommended 0.5 default.
+        cluster_similarity_floor: None,
     }
 }
 

--- a/crates/mununu-core/src/verify/config.rs
+++ b/crates/mununu-core/src/verify/config.rs
@@ -83,6 +83,17 @@ pub struct VerifyConfig {
     /// `[[properties]]` array.
     #[serde(default)]
     pub properties: Vec<PropertySection>,
+    /// R4W-3 (R.4 clustered-COI wiring) — optional Jaccard similarity
+    /// floor for the clustered-COI comparison the BTOR2 bit-blaster
+    /// reports on each source's `PartitionSummary.cluster_coi`. `None`
+    /// (the default) → the recommended `0.5`. Settable directly in
+    /// `verify.toml` (`cluster_similarity_floor = 0.7`), and overridden
+    /// by the CLI `mununu verify --cluster-coi-floor <F>` flag or the
+    /// API verify request's `cluster_similarity_floor` field. Tighter
+    /// floors (→ `1.0`) approach per-property COI; looser (→ `0.0`)
+    /// collapse toward joint COI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cluster_similarity_floor: Option<f64>,
 }
 
 /// `[project]` block.
@@ -1417,5 +1428,41 @@ members = ["memory"]
         let toml_text = toml::to_string(&cfg).unwrap();
         let reparsed = VerifyConfig::from_toml(&toml_text).unwrap();
         assert_eq!(cfg, reparsed);
+    }
+
+    #[test]
+    fn cluster_similarity_floor_defaults_to_none_and_parses_when_set() {
+        // R4W-3 — the optional top-level `cluster_similarity_floor`
+        // defaults to None (legacy manifests unaffected) and round-trips
+        // when present. The key is top-level, so it must precede any
+        // table header in the TOML source.
+        let default_cfg = VerifyConfig::from_toml(VALID_DIRECT).unwrap();
+        assert!(
+            default_cfg.cluster_similarity_floor.is_none(),
+            "absent field must default to None"
+        );
+
+        let with_floor = r#"
+cluster_similarity_floor = 0.7
+
+[project]
+name = "floored"
+
+[[sources]]
+id = "a"
+adapter = "xstate"
+files = ["a.xstate.json"]
+
+[composition]
+semantics = "synchronous"
+members = ["a"]
+name = "Solo"
+"#;
+        let cfg = VerifyConfig::from_toml(with_floor).expect("parse with floor");
+        assert_eq!(cfg.cluster_similarity_floor, Some(0.7));
+
+        // Serde round-trip preserves it.
+        let reparsed = VerifyConfig::from_toml(&toml::to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(reparsed.cluster_similarity_floor, Some(0.7));
     }
 }

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -98,14 +98,14 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
         _ => None,
     };
 
-    // R4W-2 (R.4 clustered-COI wiring) — harvest each property's COI
-    // seed atoms *before* adapter dispatch. The BTOR2 bit-blaster owns
-    // the per-module dep graph, so the seeds must reach it through
-    // `AdapterOptions::property_seeds` for the joint-vs-clustered cone
-    // comparison to be computable. Properties are resolved again (for
-    // real) in step 5; this early pass is best-effort telemetry and
-    // never aborts the run.
-    let property_seeds = harvest_property_seeds(config);
+    // R4W-2 / R4W-3 (R.4 clustered-COI wiring) — harvest each property's
+    // COI seed atoms + read the similarity floor *before* adapter
+    // dispatch. The BTOR2 bit-blaster owns the per-module dep graph, so
+    // these must reach it through `AdapterOptions` for the
+    // joint-vs-clustered cone comparison to be computable. Properties
+    // are resolved again (for real) in step 5; this early pass is
+    // best-effort telemetry and never aborts the run.
+    let cluster_coi = ClusterCoiInputs::from_config(config);
 
     // 3. For each source: read files, dispatch adapter, apply renamings.
     // Parameterised sources (`count >= 2`) expand to N instances
@@ -149,7 +149,7 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
                 &additional_files,
                 &source.options,
                 base_dir,
-                &property_seeds,
+                &cluster_coi,
             )?;
 
             // Apply per-source renamings from the binding. The renamings
@@ -406,9 +406,9 @@ pub fn inspect_project(
         };
         for (instance_id, content) in instances {
             // Inspection never resolves properties (step 5 is a no-op),
-            // so there are no per-property COI seeds to harvest — pass
-            // an empty slice. The bit-blaster then skips the clustered-
-            // COI comparison (legacy intrinsic-seed-only behaviour).
+            // so there are no clustered-COI inputs — pass the empty
+            // default. The bit-blaster then skips the clustered-COI
+            // comparison (legacy intrinsic-seed-only behaviour).
             let (raw_ctxdsl, partition_summary) = dispatch_adapter(
                 &source.adapter,
                 &instance_id,
@@ -417,7 +417,7 @@ pub fn inspect_project(
                 &additional_files,
                 &source.options,
                 base_dir,
-                &[],
+                &ClusterCoiInputs::default(),
             )?;
             let mut rewritten = match per_source_renamings.get(&source.id) {
                 Some(renamings) if !renamings.is_empty() => {
@@ -623,11 +623,11 @@ pub fn inspect_project(
 /// `AdapterOutput`. The orchestrator threads the summary onto the
 /// source's `SourceSummary` so the `VerifyReport` surfaces COI
 /// telemetry per source.
-// R4W-2 added `property_seeds` as an 8th argument; the dispatch context
-// is a flat list of independent inputs (adapter name, ids, paths,
-// options) rather than a cohesive struct, so an allow is the right call
-// here — matching the precedent on the other multi-input dispatch /
-// realize helpers in this crate.
+// R4W-2/R4W-3 added the clustered-COI inputs as an 8th argument; the
+// dispatch context is a flat list of independent inputs (adapter name,
+// ids, paths, options) rather than a cohesive struct, so an allow is the
+// right call here — matching the precedent on the other multi-input
+// dispatch / realize helpers in this crate.
 #[allow(clippy::too_many_arguments)]
 fn dispatch_adapter(
     adapter: &str,
@@ -637,11 +637,12 @@ fn dispatch_adapter(
     additional_files: &[(PathBuf, String)],
     options: &std::collections::BTreeMap<String, toml::Value>,
     base_dir: &Path,
-    // R4W-2 — manifest per-property COI seeds for the clustered-COI
-    // telemetry. Consumed only by the `sv-yosys` (BTOR2) route, which
-    // owns the dep graph; other adapters ignore it. Empty on the
-    // inspection path (no property resolution there).
-    property_seeds: &[(String, Vec<String>)],
+    // R4W-2/R4W-3 — manifest clustered-COI inputs (per-property seeds +
+    // similarity floor) for the comparison telemetry. Consumed only by
+    // the `sv-yosys` (BTOR2) route, which owns the dep graph; other
+    // adapters ignore it. Empty default on the inspection path (no
+    // property resolution there).
+    cluster_coi: &ClusterCoiInputs,
 ) -> Result<(String, Option<crate::adapter::partition::PartitionSummary>), VerifyError> {
     let to_pair = |out: crate::adapter::AdapterOutput| (out.ctxdsl, out.partition_summary);
     let err_for = |adapter: &str, source_id: &str, err: crate::adapter::AdapterError| {
@@ -672,13 +673,7 @@ fn dispatch_adapter(
         // `multi_module = true` (+ optional `top`), driven from the top
         // netlist. Requires `yosys` on PATH; absence surfaces as an
         // `AdapterTranslationFailed` (locate_yosys error), not silently.
-        "sv-yosys" => dispatch_sv_yosys(
-            source_id,
-            content,
-            additional_files,
-            options,
-            property_seeds,
-        ),
+        "sv-yosys" => dispatch_sv_yosys(source_id, content, additional_files, options, cluster_coi),
         "crewai" => {
             warn_unused_additional_files(adapter, source_id, additional_files);
             let opts = AdapterOptions::default();
@@ -800,15 +795,16 @@ fn dispatch_sv_yosys(
     content: &str,
     additional_files: &[(PathBuf, String)],
     options: &std::collections::BTreeMap<String, toml::Value>,
-    property_seeds: &[(String, Vec<String>)],
+    cluster_coi: &ClusterCoiInputs,
 ) -> Result<(String, Option<crate::adapter::partition::PartitionSummary>), VerifyError> {
-    // R4W-2 — carry the manifest's per-property COI seeds into the
-    // bit-blaster so it can compute the joint-vs-clustered cone
-    // comparison over its dep graph (surfaced on
+    // R4W-2/R4W-3 — carry the manifest's per-property COI seeds + the
+    // similarity floor into the bit-blaster so it can compute the
+    // joint-vs-clustered cone comparison over its dep graph (surfaced on
     // `PartitionSummary::cluster_coi`). Empty seeds preserve the legacy
-    // intrinsic-seed-only behaviour.
+    // intrinsic-seed-only behaviour; a `None` floor uses the 0.5 default.
     let opts = AdapterOptions {
-        property_seeds: property_seeds.to_vec(),
+        property_seeds: cluster_coi.property_seeds.clone(),
+        cluster_similarity_floor: cluster_coi.similarity_floor,
         ..AdapterOptions::default()
     };
     let additional_sources: Vec<(String, String)> = additional_files
@@ -1016,6 +1012,35 @@ fn dispatch_c_codesign(
 // ---------------------------------------------------------------------------
 // Property template resolution
 // ---------------------------------------------------------------------------
+
+/// R4W-2 / R4W-3 (R.4 clustered-COI wiring) — the clustered-COI inputs
+/// the verify orchestrator threads from the manifest into the BTOR2
+/// adapter: the harvested per-property COI seeds + the Jaccard
+/// similarity floor. Both travel together to the
+/// `sv-yosys` (BTOR2) route, which owns the dep graph the comparison is
+/// computed over. Empty (`Default`) on the inspection path / for
+/// adapters that don't compute clustered COI.
+#[derive(Debug, Default, Clone)]
+struct ClusterCoiInputs {
+    /// R4W-2 — `(property_name, seed_atom_names)` per manifest property.
+    property_seeds: Vec<(String, Vec<String>)>,
+    /// R4W-3 — Jaccard floor override; `None` → adapter default (0.5).
+    similarity_floor: Option<f64>,
+}
+
+impl ClusterCoiInputs {
+    /// Build the clustered-COI inputs from the verify config: harvest
+    /// each property's seeds and read the manifest's
+    /// `cluster_similarity_floor` (already overridden by the CLI flag /
+    /// API request field at this point, since both inject into the
+    /// config before `verify_project` runs).
+    fn from_config(config: &VerifyConfig) -> Self {
+        Self {
+            property_seeds: harvest_property_seeds(config),
+            similarity_floor: config.cluster_similarity_floor,
+        }
+    }
+}
 
 /// R4W-2 (R.4 clustered-COI wiring) — resolve + parse each manifest
 /// property and collect its COI seed atoms as
@@ -1861,7 +1886,7 @@ formula = "true"
             &[],
             &std::collections::BTreeMap::new(),
             std::path::Path::new("."),
-            &[],
+            &ClusterCoiInputs::default(),
         );
         // Ok (yosys present) OR AdapterTranslationFailed (yosys absent)
         // both prove the route is wired; only UnknownAdapter fails.


### PR DESCRIPTION
## R4W-3 — make the clustered-COI similarity floor a first-class control (mununu side)

R4W-2 (#81) surfaced the joint-vs-clustered comparison on `PartitionSummary.cluster_coi` at a fixed `0.5` floor. **R4W-3 makes the Jaccard floor a user control across the mununu surfaces.** The UI side ships as a separate **mununu-ui** PR (this PR is CLI + API + core; `/parity-check` runs clean once both land).

### Core / config
- **`AdapterOptions.cluster_similarity_floor: Option<f64>`** — the BTOR2 bit-blaster honours it (falls back to the recommended `0.5`) instead of the hardcoded const.
- **`VerifyConfig.cluster_similarity_floor`** — optional top-level `verify.toml` field (serde-default `None` → existing manifests unaffected).
- The orchestrator bundles harvested per-property seeds + the floor into a `ClusterCoiInputs` struct threaded through `dispatch_adapter` → `dispatch_sv_yosys` → `AdapterOptions`.

### CLI
- **`mununu verify --cluster-coi-floor <FLOAT>`** overrides the manifest value.
- The human report now prints a per-source **clustered-COI line** (joint cone / cluster count / max cluster cone + the reduction) when computed. `--json` already carried it.
- `context eval` intentionally has no flag — it consumes realized CTXDSL (no BTOR2 dep graph / seed harvest), so clustered COI doesn't apply there.

### API
- **`VerifyProjectRequest.cluster_similarity_floor: Option<f64>`** overrides the config; the comparison rides the existing `VerifyReport` response (no new response field).

### Tests
- `cluster_similarity_floor_is_honored_through_adapter_options` — BTOR2 fixture with two cones sharing one signal (Jaccard 0.2): floor `0.0` merges to **1** cluster, floor `0.9` splits to **2** — proving the override threads end-to-end.
- `cluster_similarity_floor_defaults_to_none_and_parses_when_set` — `verify.toml` round-trip.

Full pre-push gate green locally: check / clippy `-D` / fmt / doctests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)