### PR TITLE
feat(R4W-3.5, R.4 clustered-COI): verify-path sv2v+sidecar + cone-seeding fix

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -2020,10 +2020,31 @@ fn enumerate_and_blast(
             .cluster_similarity_floor
             .unwrap_or(DEFAULT_CLUSTER_SIMILARITY_FLOOR);
         let deps = file.build();
+        // R4W-3.5b — resolve each property atom to the state/input
+        // terminals in its combinational fan-in before seeding the COI.
+        // A property typically names a combinational *output* (e.g.
+        // `main_sm_err_o`), which is neither a dep-graph key nor reached
+        // by any `next` — seeding the cone with the bare atom yields a
+        // degenerate size-1 cone. `resolve_atom_to_terminals` walks the
+        // atom's defining expression down to the registers/inputs it
+        // depends on (the same symbols `build()` keys on), giving the
+        // cone a real foothold. Atoms the BTOR2 doesn't name fall back
+        // to the bare-atom seed (pre-R4W-3.5b behaviour).
         let props: Vec<(String, std::collections::HashSet<String>)> = options
             .property_seeds
             .iter()
-            .map(|(name, atoms)| (name.clone(), atoms.iter().cloned().collect()))
+            .map(|(name, atoms)| {
+                let mut seeds = std::collections::HashSet::new();
+                for atom in atoms {
+                    match super::dep_graph::resolve_atom_to_terminals(file, atom) {
+                        Some(terminals) => seeds.extend(terminals),
+                        None => {
+                            seeds.insert(atom.clone());
+                        }
+                    }
+                }
+                (name.clone(), seeds)
+            })
             .collect();
         summary.cluster_coi = Some(coi::cluster_coi_report(&props, &deps, floor));
     }

--- a/crates/mununu-core/src/adapter/btor2/dep_graph.rs
+++ b/crates/mununu-core/src/adapter/btor2/dep_graph.rs
@@ -112,6 +112,69 @@ fn collect_operand_terminals(
     }
 }
 
+/// R4W-3.5b — resolve a property atom (a BTOR2 symbol named in a
+/// mu-calculus formula — typically a combinational *output* like
+/// `main_sm_err_o`, or a named wire) to the set of **state/input
+/// terminal symbols** in its combinational fan-in.
+///
+/// This is the seed-resolution the clustered-COI path needs.
+/// [`DepGraphBuilder::build`] keys the dep graph on **state registers**
+/// (edges to the terminals each register's `next` reaches), so seeding
+/// [`crate::adapter::partition::coi::cone_of_influence`] with a bare
+/// output atom — which is neither a key nor reached by any `next` —
+/// yields a degenerate size-1 cone. Walking the atom's defining
+/// expression down to its register/input terminals gives the COI a real
+/// foothold: the returned terminals are the same symbols `build()` keys
+/// on (both use [`parser::collect_symbols`]), so the subsequent cone
+/// walk expands through the design.
+///
+/// Returns `None` when no line carries `atom` as its symbol — the caller
+/// then falls back to seeding with the atom string itself (preserving
+/// the pre-R4W-3.5b behaviour for atoms the BTOR2 doesn't name).
+pub fn resolve_atom_to_terminals(file: &Btor2File, atom: &str) -> Option<HashSet<String>> {
+    let symbols = parser::collect_symbols(file);
+    for line in &file.lines {
+        let is_match = matches!(
+            &line.node,
+            Node::Output { symbol: Some(s), .. }
+            | Node::Op { symbol: Some(s), .. }
+            | Node::Input { symbol: Some(s), .. }
+            | Node::State { symbol: Some(s), .. } if s == atom
+        );
+        if !is_match {
+            continue;
+        }
+        let mut reached = HashSet::new();
+        let mut visited = HashSet::new();
+        match &line.node {
+            // An output / named wire: walk its defining expression to the
+            // state + input terminals it combinationally depends on.
+            Node::Output { signal, .. } => {
+                collect_operand_terminals(file, signal.nid(), &symbols, &mut reached, &mut visited);
+            }
+            Node::Op { args, .. } => {
+                for arg in args {
+                    collect_operand_terminals(
+                        file,
+                        arg.nid(),
+                        &symbols,
+                        &mut reached,
+                        &mut visited,
+                    );
+                }
+            }
+            // Already a terminal — its own symbol is the seed (a property
+            // referencing a register or input directly).
+            Node::Input { .. } | Node::State { .. } => {
+                reached.insert(atom.to_string());
+            }
+            _ => {}
+        }
+        return Some(reached);
+    }
+    None
+}
+
 /// Collect the COI seed set for a BTOR2 file from its intrinsic
 /// property declarations (`bad`, `constraint`, `justice`, `fair`).
 ///
@@ -258,5 +321,73 @@ mod tests {
             "trigger should be Kept (drives s_relevant's next), got {:?}",
             p.classes.get("trigger")
         );
+    }
+
+    #[test]
+    fn resolve_atom_output_reaches_register_and_input_terminals() {
+        // R4W-3.5b — a property atom naming a combinational *output*
+        // (`out = reg & trig`) resolves to the state/input terminals in
+        // its fan-in ({reg, trig}), not the bare atom string. This is
+        // what gives the clustered-COI seed a real dep-graph foothold.
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 input 1 trig
+4 state 1 reg
+5 init 1 4 2
+6 and 1 4 3
+7 next 1 4 3
+8 output 6 out
+"#;
+        let file = parser::parse(src).expect("parse");
+        let terminals = resolve_atom_to_terminals(&file, "out").expect("out resolves");
+        assert!(
+            terminals.contains("reg"),
+            "out's cone must include the register `reg`; got {terminals:?}"
+        );
+        assert!(
+            terminals.contains("trig"),
+            "out's cone must include the input `trig`; got {terminals:?}"
+        );
+        assert!(
+            !terminals.contains("out"),
+            "the bare output atom must NOT be the seed; got {terminals:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_atom_register_is_its_own_terminal() {
+        // A property referencing a register directly seeds with that
+        // register (it is already a dep-graph key).
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 input 1 trig
+4 state 1 reg
+5 init 1 4 2
+7 next 1 4 3
+"#;
+        let file = parser::parse(src).expect("parse");
+        let terminals = resolve_atom_to_terminals(&file, "reg").expect("reg resolves");
+        assert_eq!(
+            terminals,
+            HashSet::from(["reg".to_string()]),
+            "a register atom seeds with itself"
+        );
+    }
+
+    #[test]
+    fn resolve_atom_unknown_symbol_returns_none() {
+        // An atom the BTOR2 doesn't name → None (caller falls back to the
+        // bare-atom seed).
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+4 state 1 reg
+5 init 1 4 2
+7 next 1 4 2
+"#;
+        let file = parser::parse(src).expect("parse");
+        assert!(resolve_atom_to_terminals(&file, "nonexistent").is_none());
     }
 }

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -673,7 +673,14 @@ fn dispatch_adapter(
         // `multi_module = true` (+ optional `top`), driven from the top
         // netlist. Requires `yosys` on PATH; absence surfaces as an
         // `AdapterTranslationFailed` (locate_yosys error), not silently.
-        "sv-yosys" => dispatch_sv_yosys(source_id, content, additional_files, options, cluster_coi),
+        "sv-yosys" => dispatch_sv_yosys(
+            source_id,
+            content,
+            additional_files,
+            options,
+            base_dir,
+            cluster_coi,
+        ),
         "crewai" => {
             warn_unused_additional_files(adapter, source_id, additional_files);
             let opts = AdapterOptions::default();
@@ -795,8 +802,41 @@ fn dispatch_sv_yosys(
     content: &str,
     additional_files: &[(PathBuf, String)],
     options: &std::collections::BTreeMap<String, toml::Value>,
+    base_dir: &Path,
     cluster_coi: &ClusterCoiInputs,
 ) -> Result<(String, Option<crate::adapter::partition::PartitionSummary>), VerifyError> {
+    // R4W-3.5 — `use_sv2v = true` runs sv2v as a preprocessing pass
+    // before Yosys, unblocking the SV-2009/2012 `module M import pkg::*;`
+    // header form real OpenTitan / Caliptra / ibex RTL uses (yosys's
+    // built-in parser rejects it otherwise). Matches the API's
+    // `use_sv2v` field and the CLI's `--preprocessor sv2v`. Default
+    // false preserves the plain-Verilog behaviour existing fixtures rely
+    // on.
+    let use_sv2v = options
+        .get("use_sv2v")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    // R4W-3.5 — `sidecar = "<file>.mununu.json"` (path relative to the
+    // verify.toml's base_dir) supplies the per-signal abstractions the
+    // bit-blaster needs to keep a real design under the state-bit cap
+    // and the transition fan-out tractable. Previously only
+    // `context eval --sidecar` could do this; the verify path now reads
+    // it from the source options so a `verify.toml` can drive the same
+    // abstraction the M.0–M.2 fixtures used.
+    let sidecar_json = match options.get("sidecar").and_then(|v| v.as_str()) {
+        Some(rel) => {
+            let path = resolve_path(base_dir, Path::new(rel));
+            Some(std::fs::read_to_string(&path).map_err(|source| {
+                VerifyError::SourceReadFailed {
+                    path: path.clone(),
+                    source,
+                }
+            })?)
+        }
+        None => None,
+    };
+
     // R4W-2/R4W-3 — carry the manifest's per-property COI seeds + the
     // similarity floor into the bit-blaster so it can compute the
     // joint-vs-clustered cone comparison over its dep graph (surfaced on
@@ -805,6 +845,7 @@ fn dispatch_sv_yosys(
     let opts = AdapterOptions {
         property_seeds: cluster_coi.property_seeds.clone(),
         cluster_similarity_floor: cluster_coi.similarity_floor,
+        sidecar_json,
         ..AdapterOptions::default()
     };
     let additional_sources: Vec<(String, String)> = additional_files
@@ -829,6 +870,7 @@ fn dispatch_sv_yosys(
             top,
             per_module_btor: true,
             additional_sources,
+            use_sv2v,
             ..Default::default()
         };
         let comp =
@@ -853,6 +895,7 @@ fn dispatch_sv_yosys(
 
     let yopts = crate::adapter::yosys::YosysOptions {
         additional_sources,
+        use_sv2v,
         ..Default::default()
     };
     crate::adapter::yosys::translate_sv(content, &opts, &yopts)


### PR DESCRIPTION
## R4W-3.5 — make the verify `sv-yosys` path real-RTL-capable + fix clustered-COI cone seeding

Standing up the M.3 real-RTL fixture (next PR) surfaced two genuine gaps that blocked clustered COI on real RTL via the verify path. Both are closed here. See [`.claude/plans/milestones/M-3-blocker-2026-06-16.md`] for the empirical findings; the user chose the full enablement.

### Verify-path enablement (orchestrator)
- **`[[sources]].options use_sv2v = true`** → runs sv2v before Yosys (unblocks the `module M import pkg::*;` header form real OpenTitan/Caliptra/ibex RTL uses; previously only `context eval --preprocessor sv2v` could). Threaded into `YosysOptions` on both single- and multi-module branches.
- **`[[sources]].options sidecar = "<file>.mununu.json"`** (path relative to the verify.toml's base_dir) → loaded into `AdapterOptions.sidecar_json`, so a verify.toml can drive the same per-signal abstraction the M.0–M.2 context-eval fixtures used. `dispatch_sv_yosys` gains `base_dir` to resolve the path.

### Cone-seeding fix (the substantive R4W-2 gap)
`cluster_coi_report` seeded the COI from formula atom *strings*, but `dep_graph::build()` keys on **state registers** — so a property over a combinational *output* (`main_sm_err_o`) gave a degenerate **size-1** cone. New **`dep_graph::resolve_atom_to_terminals`** walks an atom's defining expression down to the register/input terminals in its fan-in (the same symbols `build()` keys on); the bit-blast cluster_coi path resolves each atom before clustering. Atoms the BTOR2 doesn't name fall back to the bare-atom seed.

### Measured effect (two-instance csrng_main_sm harness, via verify)
- before: `cluster_coi` = joint cone **2** / max cluster cone **1** (cosmetic, bare atoms)
- after: joint cone **5** / 2 clusters / max cluster cone **3** — a real per-cluster state-space reduction, both reachability properties **SATISFIED** (non-vacuous).

### Tests
`resolve_atom_output_reaches_register_and_input_terminals`, `resolve_atom_register_is_its_own_terminal`, `resolve_atom_unknown_symbol_returns_none`. The existing 15 cluster tests are unchanged (state-atom seeds resolve to themselves). Full pre-push gate green (check/clippy -D/fmt/doctests).

The M.3 fixture that exercises this end-to-end lands in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)