### PR TITLE
test(R4W-4, M.3): clustered-COI milestone fixture on real OpenTitan RTL

### DIFF
--- a/examples/verify/m3_clustered_coi_csrng_pair/README.md
+++ b/examples/verify/m3_clustered_coi_csrng_pair/README.md
@@ -1,0 +1,77 @@
+# M.3 — Clustered cone-of-influence on real OpenTitan RTL
+
+> Status: milestone fixture (§Phase 11 slot 7, R4W-4 / R4W-5). Validates
+> R.4 **property-clustered COI** end-to-end on real RTL through the
+> automated `sv-yosys` verify pipeline.
+
+## What this demonstrates
+
+Two **independent** instances of the real OpenTitan
+[`csrng_main_sm`](source/csrng_main_sm.sv) sparse FSM are wired by a thin
+harness ([`csrng_main_sm_pair.sv`](source/csrng_main_sm_pair.sv)) so each
+instance has its own primary inputs and the two share only `clk`/`rst`.
+The single-module `sv-yosys` route flattens the harness into one BTOR2
+whose dependency graph has **two disjoint state-register cones**.
+
+A property over instance 0's error output (`u0_main_sm_err_o`) has a cone
+disjoint from a property over instance 1's, so partitioning the two
+properties by Jaccard similarity yields **two clusters**, each bit-blasting
+a cone strictly smaller than the naive joint cone-of-influence over both:
+
+```
+clustered-COI: joint cone 5 signals, 2 cluster(s), max cluster cone 3 signals
+               (reduces binding cone by 2 vs joint COI)
+verdict u0_err_reachable: SAT 4096/4096
+verdict u1_err_reachable: SAT 4096/4096
+```
+
+The verdicts are non-vacuous (each `μ`-reachability property is evaluated
+over the full bit-blast state space and reaches a definite verdict). The
+headline is the **measured cone reduction** (5 → 3) — the M.3
+done-criterion: clustered cones reduce state space vs the naive joint COI
+on a real fixture.
+
+## How to run
+
+```bash
+cargo build -p mununu-cli          # build the binary
+./validate.sh                      # runs the full pipeline + checks the criteria
+```
+
+Requires `yosys` and `sv2v` on `PATH` (the KMTS frontend), and
+`LIBRARY_PATH=/usr/local/opt/z3/lib` for the z3 link (handled by
+`validate.sh`).
+
+## Fixture provenance (M-milestone pattern)
+
+| File | Origin |
+|---|---|
+| [`source/csrng_main_sm.sv`](source/csrng_main_sm.sv) | **Vendored** from lowRISC/opentitan, pinned by [`source/UPSTREAM_COMMIT.txt`](source/UPSTREAM_COMMIT.txt). The real sparse-FSM being verified. |
+| [`source/csrng_main_sm_pair.sv`](source/csrng_main_sm_pair.sv) | **NOT vendored** — hand-written test harness instantiating two real `csrng_main_sm` instances with independent I/O. Ties off every wide / non-essential input internally, leaving 2 free 1-bit inputs so the explicit bit-blast stays tiny. |
+| [`source/csrng_pkg.sv`](source/csrng_pkg.sv) | **NOT vendored** — minimal stub package (the `acmd_e` + `main_sm_state_e` enums + widths the FSM consumes), shared with the M.2 fixture. |
+| [`source/prim_assert.sv`](source/prim_assert.sv) | **NOT vendored** — empty-SVA-macro stub + `PRIM_FLOP_SPARSE_FSM` expanded as a plain `always_ff`, shared with the M.2 fixture. |
+
+The harness is a test wrapper, not a hand-authored model: the automated
+pipeline still extracts the real `csrng_main_sm` FSM logic from upstream
+RTL; the harness only fixes the I/O boundary (exactly as the M.0–M.2
+stub packages do).
+
+## Why a two-instance harness
+
+`csrng_main_sm` alone is a single FSM whose cone is connected — it cannot
+exhibit a clustered-COI *reduction* (there is only one cone). Clustered
+COI is about **independent properties over independent subsystems**; two
+instances of a real module with independent inputs is the minimal faithful
+realization (the same shape as OpenTitan `pattgen`'s two channels). The
+richer multi-detector fixtures (`pattgen`, `sysrst_ctrl`) are deferred —
+see [`docs/design/native-sv-abstraction.md`](../../../docs/design/native-sv-abstraction.md)
+§10.3 M.3 and the R4W breakdown.
+
+## Soundness
+
+The properties are reachability (`μX. (err || ◇X)`); the verdicts are
+definite over the bit-blast model. Clustered COI is a *partitioning of
+the verification work*, not an abstraction of behaviour — it does not
+change which signals each property's verdict depends on, only how many
+are bit-blasted together. The per-cluster cones are exact sub-cones of
+the joint COI.

--- a/examples/verify/m3_clustered_coi_csrng_pair/source/UPSTREAM_COMMIT.txt
+++ b/examples/verify/m3_clustered_coi_csrng_pair/source/UPSTREAM_COMMIT.txt
@@ -1,0 +1,1 @@
+558921ccc8aeefab652b45c1402c10bceb63accc

--- a/examples/verify/m3_clustered_coi_csrng_pair/source/csrng_main_sm.sv
+++ b/examples/verify/m3_clustered_coi_csrng_pair/source/csrng_main_sm.sv
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: csrng app cmd request state machine module
+//
+//  - handles all app cmd requests from all requesting interfaces
+
+`include "prim_assert.sv"
+
+module csrng_main_sm import csrng_pkg::*; (
+  input  logic                        clk_i,
+  input  logic                        rst_ni,
+  input  logic                        enable_i,
+
+  input  logic                        acmd_avail_i,
+  output logic                        acmd_accept_o,
+  input  acmd_e                       acmd_i,
+  input  logic                        acmd_eop_i,
+
+  input  logic                        flag0_i,
+
+  output logic                        cmd_entropy_req_o,
+  input  logic                        cmd_entropy_avail_i,
+
+  output logic                        cmd_vld_o,
+  input  logic                        cmd_rdy_i,
+  output logic                        clr_adata_packer_o,
+  input  logic                        cmd_complete_i,
+
+  input  logic                        local_escalate_i,
+
+  output logic [MainSmStateWidth-1:0] main_sm_state_o,
+  output logic                        main_sm_err_o
+);
+
+  // SEC_CM: MAIN_SM.FSM.SPARSE
+  main_sm_state_e state_d, state_q;
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, main_sm_state_e, MainSmIdle)
+
+  assign main_sm_state_o = {state_q};
+
+  always_comb begin
+    state_d            = state_q;
+    acmd_accept_o      = 1'b0;
+    cmd_entropy_req_o  = 1'b0;
+    cmd_vld_o          = 1'b0;
+    clr_adata_packer_o = 1'b0;
+    main_sm_err_o      = 1'b0;
+
+    if (state_q == MainSmError) begin
+      // In case we are in the Error state we must ignore the local escalate and enable signals.
+      main_sm_err_o = 1'b1;
+    end else if (local_escalate_i) begin
+      // In case local escalate is high we must transition to the error state.
+      state_d = MainSmError;
+    end else if (!enable_i && state_q inside {MainSmIdle, MainSmParseCmd, MainSmEntropyReq,
+                                              MainSmCmdPrep, MainSmCmdVld,
+                                              MainSmClrAData, MainSmCmdCompWait}) begin
+      // In case the module is disabled and we are in a legal state we must go into idle state.
+      state_d = MainSmIdle;
+    end else begin
+      // Otherwise do the state machine as normal.
+      unique case (state_q)
+        MainSmIdle: begin
+          // Signal the arbiter to grant this request.
+          if (acmd_avail_i) begin
+            acmd_accept_o = 1'b1;
+            state_d = MainSmParseCmd;
+          end
+        end
+        MainSmParseCmd: begin
+          if (acmd_eop_i) begin
+            unique case (acmd_i)
+              INS, RES:      state_d = MainSmEntropyReq; // Command may require entropy
+              GEN, UPD, UNI: state_d = MainSmCmdPrep;    // Command does not require entropy
+              default:       state_d = MainSmIdle;       // Command was not supported
+            endcase
+          end
+        end
+        MainSmEntropyReq: begin
+          if (flag0_i) begin
+            // With flag0 set, no entropy is required.
+            state_d = MainSmCmdVld;
+          end else begin
+            // Delay one clock to fix timing issue.
+            cmd_entropy_req_o = 1'b1;
+            if (cmd_entropy_avail_i) begin
+              state_d = MainSmCmdVld;
+            end
+          end
+        end
+        MainSmCmdPrep: begin
+          // Assumes all adata is present now.
+          state_d = MainSmCmdVld;
+        end
+        MainSmCmdVld: begin
+          cmd_vld_o = 1'b1;
+          if (cmd_rdy_i) begin
+            if (cmd_complete_i) begin
+              clr_adata_packer_o = 1'b1;
+              state_d = MainSmIdle;
+            end else begin
+              state_d = MainSmClrAData;
+            end
+          end
+        end
+        MainSmClrAData: begin
+          clr_adata_packer_o = 1'b1;
+          if (cmd_complete_i) begin
+            state_d = MainSmIdle;
+          end else begin
+            state_d = MainSmCmdCompWait;
+          end
+        end
+        MainSmCmdCompWait: begin
+          if (cmd_complete_i) begin
+            state_d = MainSmIdle;
+          end
+        end
+        // Error: The error state is now covered by the if statement above.
+        default: begin
+          state_d = MainSmError;
+          main_sm_err_o = 1'b1;
+        end
+      endcase
+    end
+  end
+
+  // Make sure that the state machine has a stable error state. This means that after the error
+  // state is entered it will not exit it unless a reset signal is received.
+  `ASSERT(CsrngMainErrorStStable_A, state_q == MainSmError |=> $stable(state_q))
+  // If in error state, the error output must be high.
+  `ASSERT(CsrngMainErrorOutput_A,   state_q == MainSmError |-> main_sm_err_o)
+
+endmodule

--- a/examples/verify/m3_clustered_coi_csrng_pair/source/csrng_main_sm_pair.sv
+++ b/examples/verify/m3_clustered_coi_csrng_pair/source/csrng_main_sm_pair.sv
@@ -1,0 +1,62 @@
+// NOT vendored — R4W-4 / M.3 harness (clustered cone-of-influence).
+// Two independent real csrng_main_sm instances. To keep the explicit
+// bit-blast tiny, every input except `local_escalate_i` is tied to a
+// constant inside the harness; each instance keeps exactly one free
+// primary input, and the two instances share no free input. The
+// verified behaviour (the csrng_main_sm sparse FSM) is real upstream
+// RTL; the harness only fixes the I/O boundary.
+module csrng_main_sm_pair
+  import csrng_pkg::*;
+(
+  input  logic   clk_i,
+  input  logic   rst_ni,
+  input  logic   u0_local_escalate_i,
+  input  logic   u1_local_escalate_i,
+
+  output logic [MainSmStateWidth-1:0] u0_main_sm_state_o,
+  output logic                        u0_main_sm_err_o,
+  output logic [MainSmStateWidth-1:0] u1_main_sm_state_o,
+  output logic                        u1_main_sm_err_o
+);
+
+  csrng_main_sm u0 (
+    .clk_i,
+    .rst_ni,
+    .enable_i            (1'b1),
+    .acmd_avail_i        (1'b1),
+    .acmd_accept_o       (),
+    .acmd_i              (GEN),
+    .acmd_eop_i          (1'b1),
+    .flag0_i             (1'b0),
+    .cmd_entropy_req_o   (),
+    .cmd_entropy_avail_i (1'b1),
+    .cmd_vld_o           (),
+    .cmd_rdy_i           (1'b1),
+    .clr_adata_packer_o  (),
+    .cmd_complete_i      (1'b1),
+    .local_escalate_i    (u0_local_escalate_i),
+    .main_sm_state_o     (u0_main_sm_state_o),
+    .main_sm_err_o       (u0_main_sm_err_o)
+  );
+
+  csrng_main_sm u1 (
+    .clk_i,
+    .rst_ni,
+    .enable_i            (1'b1),
+    .acmd_avail_i        (1'b1),
+    .acmd_accept_o       (),
+    .acmd_i              (GEN),
+    .acmd_eop_i          (1'b1),
+    .flag0_i             (1'b0),
+    .cmd_entropy_req_o   (),
+    .cmd_entropy_avail_i (1'b1),
+    .cmd_vld_o           (),
+    .cmd_rdy_i           (1'b1),
+    .clr_adata_packer_o  (),
+    .cmd_complete_i      (1'b1),
+    .local_escalate_i    (u1_local_escalate_i),
+    .main_sm_state_o     (u1_main_sm_state_o),
+    .main_sm_err_o       (u1_main_sm_err_o)
+  );
+
+endmodule

--- a/examples/verify/m3_clustered_coi_csrng_pair/source/csrng_pkg.sv
+++ b/examples/verify/m3_clustered_coi_csrng_pair/source/csrng_pkg.sv
@@ -1,0 +1,46 @@
+// Minimal hand-written stub of OpenTitan's `csrng_pkg` for M.2.
+//
+// The upstream `csrng_pkg.sv` pulls in `csrng_reg_pkg::NumApps` and
+// `entropy_src_pkg::FIPS_BUS_WIDTH` (a transitive package chain
+// running into prim_secded / lc_ctrl / lifecycle types we don't
+// need for the M.2 control-FSM property). This stub defines ONLY
+// the two enums `csrng_main_sm` actually consumes:
+//   - `acmd_e`         — the 3-bit application-command opcode.
+//   - `main_sm_state_e` — the 6-bit sparse FSM state encoding.
+//
+// Values match the upstream definitions verbatim (verified against
+// `hw/ip/csrng/rtl/csrng_pkg.sv` at the same UPSTREAM_COMMIT pin).
+// The stub is shipped in this repo (not vendored) because the
+// upstream package's transitive dependencies would force vendoring
+// of ~10 additional packages whose contents are irrelevant to the
+// FSM property the M.2 milestone verifies.
+//
+// SOUNDNESS: identical enum values + identical type widths ⇒ the
+// stub is observationally equivalent to the upstream package for
+// every BTOR2 line the FSM emits. The dropped parameters
+// (BlkLen, KeyLen, SeedLen, etc.) are never referenced by
+// `csrng_main_sm.sv`.
+
+package csrng_pkg;
+
+  typedef enum logic [2:0] {
+    INS = 3'h1,
+    RES = 3'h2,
+    GEN = 3'h3,
+    UPD = 3'h4,
+    UNI = 3'h5
+  } acmd_e;
+
+  parameter int unsigned MainSmStateWidth = 6;
+  typedef enum logic [MainSmStateWidth-1:0] {
+    MainSmIdle        = 6'b110111,
+    MainSmParseCmd    = 6'b011101,
+    MainSmEntropyReq  = 6'b001110,
+    MainSmCmdPrep     = 6'b000011,
+    MainSmCmdVld      = 6'b010000,
+    MainSmClrAData    = 6'b111010,
+    MainSmCmdCompWait = 6'b100100,
+    MainSmError       = 6'b101001
+  } main_sm_state_e;
+
+endpackage

--- a/examples/verify/m3_clustered_coi_csrng_pair/source/prim_assert.sv
+++ b/examples/verify/m3_clustered_coi_csrng_pair/source/prim_assert.sv
@@ -1,0 +1,43 @@
+// Stub `prim_assert.sv` for sv2v + Yosys ingestion of OpenTitan RTL.
+//
+// All SVA macros expand to empty — synthesis-equivalent to
+// OpenTitan's `prim_assert_dummy_macros.svh` (Apache 2.0).
+//
+// Also defines `PRIM_FLOP_SPARSE_FSM` as a plain `always_ff` register
+// (the upstream definition wraps a `prim_sparse_fsm_flop` submodule
+// for FPV / runtime-encoding hardening, neither of which matters for
+// the synthesised KMTS lift). The plain `always_ff` form preserves
+// the FSM's functional semantics — `state_q` updates to `state_d`
+// each clock unless reset is asserted, then `state_q` becomes the
+// reset value.
+//
+// SOUNDNESS: dropping the sparse-FSM hardening removes only the
+// runtime "alert if state_q is not one of the legal encodings"
+// behaviour; the property the M.2 milestone verifies (idle is
+// reachable from every reachable state) doesn't depend on the
+// hardening — the FSM transitions remain identical.
+
+`define ASSERT_I(__name, __prop)
+`define ASSERT_INIT(__name, __prop)
+`define ASSERT_INIT_NET(__name, __prop)
+`define ASSERT_FINAL(__name, __prop)
+`define ASSERT_AT_RESET(__name, __prop, __rst = 0)
+`define ASSERT_AT_RESET_AND_FINAL(__name, __prop, __rst = 0)
+`define ASSERT(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_NEVER(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_KNOWN(__name, __sig, __clk = 0, __rst = 0)
+`define COVER(__name, __prop, __clk = 0, __rst = 0)
+`define ASSUME(__name, __prop, __clk = 0, __rst = 0)
+`define ASSUME_I(__name, __prop)
+`define ASSERT_PULSE(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_IF(__name, __prop, __enable, __clk = 0, __rst = 0)
+`define ASSERT_KNOWN_IF(__name, __sig, __enable, __clk = 0, __rst = 0)
+
+`define PRIM_FLOP_SPARSE_FSM(__name, __d, __q, __type, __resval = '0, __clk = clk_i, __rst_n = rst_ni, __alert_trigger_sva_en = 1) \
+  always_ff @(posedge __clk or negedge __rst_n) begin                                                                              \
+    if (!__rst_n) begin                                                                                                            \
+      __q <= __resval;                                                                                                             \
+    end else begin                                                                                                                 \
+      __q <= __d;                                                                                                                  \
+    end                                                                                                                            \
+  end

--- a/examples/verify/m3_clustered_coi_csrng_pair/source/verify.toml
+++ b/examples/verify/m3_clustered_coi_csrng_pair/source/verify.toml
@@ -1,0 +1,63 @@
+# M.3 — clustered cone-of-influence on real OpenTitan RTL (R4W-4).
+#
+# Two independent instances of the real OpenTitan `csrng_main_sm` sparse
+# FSM, wired by a thin harness so each instance has its own primary
+# inputs (they share only clk/rst). The single-module `sv-yosys` route
+# FLATTENS the harness into one BTOR2 whose dep graph has two disjoint
+# state-register cones — the structure clustered COI exploits: a property
+# over u0's error output has a cone disjoint from a property over u1's,
+# so the max per-cluster cone is strictly smaller than the naive joint COI.
+#
+# R4W-3.5 made this runnable through the verify path:
+#   - `use_sv2v = true`  — sv2v lowers the `import csrng_pkg::*;` header
+#     form yosys's parser rejects.
+#   - (no sidecar needed here — the harness ties off every wide/
+#     non-essential input internally, leaving 2 free 1-bit inputs.)
+# and fixed the cone seeding so a property over a combinational *output*
+# (`u0_main_sm_err_o`) seeds the COI from the register/input terminals in
+# its fan-in instead of the bare atom (which gave a degenerate size-1 cone).
+#
+# Done-criterion (R4W-5 / §10.3 M.3): clustered cones reduce state space
+# vs the naive joint COI on a real fixture (measured), verdicts non-vacuous.
+
+[project]
+name = "M3ClusteredCoiCsrngPair"
+description = "Two independent OpenTitan csrng_main_sm instances — clustered COI K=2 on real RTL."
+
+[[sources]]
+id = "pair"
+# Primary = the harness; the rest are the real module + its stub deps.
+files = [
+    "csrng_main_sm_pair.sv",
+    "csrng_main_sm.sv",
+    "csrng_pkg.sv",
+    "prim_assert.sv",
+]
+adapter = "sv-yosys"
+
+[sources.options]
+use_sv2v = true
+top = "csrng_main_sm_pair"
+
+[alphabet]
+strategy = "direct"
+
+[composition]
+semantics = "synchronous"
+members = ["pair"]
+# Must differ from the bit-blast automaton name "Circuit" (else the
+# composition would reference itself → circular-dependency error).
+name = "PairTop"
+
+[[properties]]
+# u0's error encoding is reachable (a least-fixpoint reachability check).
+# Property atom `u0_main_sm_err_o` seeds the COI from u0's register cone,
+# disjoint from u1's — this is what drives the K=2 clustering.
+name = "u0_err_reachable"
+formula = "mu X. (u0_main_sm_err_o || (<> X))"
+over = "Circuit"
+
+[[properties]]
+name = "u1_err_reachable"
+formula = "mu X. (u1_main_sm_err_o || (<> X))"
+over = "Circuit"

--- a/examples/verify/m3_clustered_coi_csrng_pair/validate.sh
+++ b/examples/verify/m3_clustered_coi_csrng_pair/validate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# validate.sh — M.3 clustered-cone-of-influence milestone on real
+# OpenTitan RTL (§Phase 11 slot 7, R4W-4 / R4W-5).
+#
+# Contract: the verify `sv-yosys` route runs the automated pipeline
+# (sv2v → Yosys-no-flatten-then-flatten → BTOR2 → bit-blast → 3-valued
+# eval) on two independent instances of the real OpenTitan
+# `csrng_main_sm` sparse FSM, and the report carries a clustered
+# cone-of-influence comparison whose max per-cluster cone is strictly
+# smaller than the naive joint COI (the M.3 reduction), with non-vacuous
+# property verdicts.
+#
+# Fixture shape (M-milestone pattern): the verified behaviour
+# (`csrng_main_sm`) is real upstream RTL, vendored + pinned by
+# UPSTREAM_COMMIT.txt; the harness `csrng_main_sm_pair.sv` and the stub
+# packages `csrng_pkg.sv` / `prim_assert.sv` are hand-written, clearly
+# labeled NOT vendored.
+#
+# OUT OF SCOPE: SBY oracle cross-check (deferred per the M.0-M.2
+# precedent; done-criterion is a non-vacuous sound verdict + a measured
+# cone reduction, not an SBY cross-check).
+#
+# Per §10.2 milestone blocker protocol: if any stage fails, STOP and
+# produce a blocker note rather than silently retrying / hand-authoring.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MUNUNU="${MUNUNU:-${THIS_DIR}/../../../target/debug/mununu}"
+SRC="${THIS_DIR}/source"
+OUT="${THIS_DIR}/build"
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu binary not found at ${MUNUNU}" >&2
+  echo "             build it first with: cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in yosys sv2v; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "validate.sh: required tool '${tool}' not on PATH" >&2
+    exit 2
+  fi
+done
+
+rm -rf "${OUT}" && mkdir -p "${OUT}"
+
+echo "=== M.3 — clustered COI on two OpenTitan csrng_main_sm instances ==="
+echo "fixture:  ${SRC}/csrng_main_sm_pair.sv (harness) + csrng_main_sm.sv (vendored)"
+echo "upstream: lowRISC/opentitan @ $(cat "${SRC}/UPSTREAM_COMMIT.txt")"
+echo
+
+cd "${SRC}"
+echo "--- mununu verify (sv2v + flatten + bit-blast + clustered COI) ---"
+LIBRARY_PATH=/usr/local/opt/z3/lib "${MUNUNU}" verify --json verify.toml > "${OUT}/verify.json" 2>"${OUT}/verify.err" || {
+  echo "FAIL: mununu verify exited non-zero" >&2
+  tail -15 "${OUT}/verify.err" >&2
+  exit 1
+}
+
+echo "(verify finished; clustered-COI comparison + verdicts:)"
+LIBRARY_PATH=/usr/local/opt/z3/lib "${MUNUNU}" verify verify.toml 2>/dev/null | grep -iE "clustered-COI|SATISFIED|VIOLATED" || true
+echo
+
+# Done-criterion 1: a clustered-COI comparison is present with a real
+# reduction (max cluster cone < joint cone).
+python3 - "${OUT}/verify.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+cc = None
+for s in r.get("sources", []):
+    cc = (s.get("partition_summary") or {}).get("cluster_coi")
+    if cc:
+        break
+assert cc, "FAIL: no cluster_coi in the verify report"
+joint = cc["joint_cone_size"]
+mx = cc["max_cluster_cone_size"]
+nclusters = len(cc["clusters"])
+print(f"clustered-COI: joint cone {joint}, {nclusters} cluster(s), max cluster cone {mx}")
+assert nclusters >= 2, f"FAIL: expected >=2 clusters, got {nclusters}"
+assert mx < joint, f"FAIL: no reduction (max {mx} !< joint {joint})"
+# Done-criterion 2: non-vacuous verdicts (the model is real; every
+# property evaluated over a non-empty state space).
+verds = r.get("property_verdicts", [])
+assert verds, "FAIL: no property verdicts"
+for v in verds:
+    assert v["total_states"] > 0, f"FAIL: vacuous verdict for {v['name']}"
+    print(f"verdict {v['name']}: {'SAT' if v['satisfied'] else 'VIOL'} "
+          f"{v['satisfying_states']}/{v['total_states']}")
+print("M.3 done-criteria met: clustered cones reduce the binding cone "
+      f"({joint} -> {mx}) on real RTL, verdicts non-vacuous.")
+PY
+
+echo
+echo "=== M.3 VALIDATION PASSED ==="
+echo "report: ${OUT}/verify.json"


### PR DESCRIPTION
## R4W-4 / M.3 — clustered-COI milestone fixture (completes the R.4 arc)

`examples/verify/m3_clustered_coi_csrng_pair/` — exercises R.4 property-clustered COI end-to-end through the automated `sv-yosys` verify pipeline (enabled by R4W-3.5, #83).

Two **independent** instances of the real OpenTitan `csrng_main_sm` sparse FSM (vendored + pinned), wired by a thin harness so each has its own inputs and they share only clk/rst. The single-module route flattens them into one BTOR2 with two **disjoint state-register cones**.

### `validate.sh` result
```
clustered-COI: joint cone 5, 2 cluster(s), max cluster cone 3
verdict u0_err_reachable: SAT 4096/4096
verdict u1_err_reachable: SAT 4096/4096
M.3 done-criteria met: clustered cones reduce the binding cone (5 -> 3)
on real RTL, verdicts non-vacuous.
```

### M.3 done-criteria (§10.3)
- ✅ clustered cones reduce state space vs naive joint COI on a real fixture (joint cone 5 → max cluster cone 3, measured)
- ✅ non-vacuous verdicts (both μ-reachability properties SATISFIED over the full 4096-state model)
- ✅ real RTL + automated pipeline, no hand-authored model (harness + stubs are the only hand-written pieces, M-fixture pattern)

### Provenance
- `source/csrng_main_sm.sv` — **vendored** (lowRISC/opentitan @ `UPSTREAM_COMMIT.txt`)
- `source/csrng_main_sm_pair.sv` — harness (**NOT vendored**)
- `source/csrng_pkg.sv` + `prim_assert.sv` — stubs (**NOT vendored**, shared with M.2)

Example-only change (SV/toml/sh/md) — no Rust. Closes the R.4 "wire clustered COI then M.3" arc (R4W-1 … R4W-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)