### PR TITLE
test(M.4): package the Caliptra boot-FSM CEGAR milestone (pre/post hazard verdict)

### DIFF
--- a/examples/verify/sv_yosys_caliptra_rtl_150/README.md
+++ b/examples/verify/sv_yosys_caliptra_rtl_150/README.md
@@ -1,7 +1,43 @@
 # sv_yosys_caliptra_rtl_150 — Caliptra-RTL boot FSM auto-extraction
 
-> **Phase A.3 structural sanity check.** This fixture is *not yet*
-> a property-verification claim — see [Status](#status) below.
+> **Two entry points.** [`validate.sh`](validate.sh) is the original
+> Phase-A.3 *structural* sanity check (bit-blast reduction; not a
+> property claim — see [Status](#status)). [`validate_m4_cegar.sh`](validate_m4_cegar.sh)
+> is the **M.4 milestone**: full automated predicate-abstraction CEGAR
+> that decides a sound, definite, **pre/post-distinguishing** verdict on
+> the CWE-1245 boot-FSM hazard (see [M.4](#m4--predicate-abstraction-cegar) below).
+
+## M.4 — predicate-abstraction CEGAR
+
+`validate_m4_cegar.sh` runs the R.5 predicate-cube CEGAR path
+(sv2v → Yosys `setundef -anyconst` → BTOR2 → `mununu btor2 cegar` with
+per-target SMT-proved must-edge inference) on both the bug-bearing
+`pre_fix` and fixed `post_fix` variants.
+
+Property: `<> (p5 || p6 || p7)` over the cube `{boot_fsm_ns ∈ {5,6,7}}` —
+"the next-state register can transition into an unmatched (undefined)
+`boot_fsm_state_e` encoding" (the legal encodings are 0..4; the
+default-less `unique casez` leaves 5/6/7 unhandled — CWE-1245).
+
+```
+pre_fix  (no default arm):     verdict cells T=7 F=1 ⊥=0  → hazard REACHABLE
+post_fix (default → defined):  verdict cells T=0 F=8 ⊥=0  → hazard UNREACHABLE
+```
+
+The undefined-encoding transition is reachable/absorbing in the
+bug-bearing variant and proven unreachable in the fixed variant — the
+pre/post difference is the milestone evidence. Soundness: the must-edges
+are Z3-proved (∀∀, no sampling); `setundef -anyconst` over-approximates
+power-up, so the definite verdict transfers to the concrete reset
+behaviour. The verdict is established over the extracted model; an
+RTL-level counterexample replay under a cycle-accurate simulator is the
+deferred empirical step (M.0–M.2 SBY precedent). This reproduces the
+known caliptra-rtl #150 bug/fix pair via the automated pipeline.
+
+```bash
+cargo build -p mununu-cli
+./validate_m4_cegar.sh        # requires yosys + sv2v on PATH
+```
 
 ## What this exercises
 

--- a/examples/verify/sv_yosys_caliptra_rtl_150/source/caliptra_2ff_sync.sv
+++ b/examples/verify/sv_yosys_caliptra_rtl_150/source/caliptra_2ff_sync.sv
@@ -1,0 +1,27 @@
+// NOT vendored — minimal stub of Caliptra's caliptra_2ff_sync two-flop
+// synchroniser, sufficient for boot-FSM extraction. Models the two-stage
+// register delay with async active-low reset to RST_VAL. The exact
+// metastability-hardening behaviour is irrelevant to the boot-FSM
+// state-reachability property; a registered two-stage delay is a sound
+// stand-in.
+module caliptra_2ff_sync #(
+    parameter int unsigned     WIDTH   = 1,
+    parameter logic [WIDTH-1:0] RST_VAL = '0
+) (
+    input  logic             clk,
+    input  logic             rst_b,
+    input  logic [WIDTH-1:0] din,
+    output logic [WIDTH-1:0] dout
+);
+    logic [WIDTH-1:0] ff1, ff2;
+    always_ff @(posedge clk or negedge rst_b) begin
+        if (!rst_b) begin
+            ff1 <= RST_VAL;
+            ff2 <= RST_VAL;
+        end else begin
+            ff1 <= din;
+            ff2 <= ff1;
+        end
+    end
+    assign dout = ff2;
+endmodule

--- a/examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh
+++ b/examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# validate_m4_cegar.sh — M.4 milestone: full automated predicate-abstraction
+# CEGAR on Caliptra's `soc_ifc_boot_fsm`, demonstrating a sound, definite,
+# pre/post-distinguishing verdict on real industrial RTL (§Phase 11 slot 7).
+#
+# Contrast with `validate.sh` in this directory, which is the Phase-A.3
+# *structural* sanity check (bit-blast reduction). This script exercises
+# the R.5 predicate-cube CEGAR path end-to-end and is the M.4 milestone
+# proper.
+#
+# The hazard. `soc_ifc_boot_fsm` holds its present state in a 3-bit
+# `boot_fsm_state_e` register with five legal encodings (0..4); the
+# `unique casez` enumerates exactly those five. The `pre_fix` variant has
+# NO `default` arm, so the encodings {5,6,7} — admissible by the type but
+# unhandled — latch (CWE-1245). The `post_fix` variant adds a `default`
+# that routes every other encoding back to a defined state.
+#
+# The property. `<> (p5 || p6 || p7)` over the predicate cube
+# {p5,p6,p7} = {boot_fsm_ns ∈ {5,6,7}} — "the next-state register can
+# transition into an undefined encoding". Under `setundef -anyconst`
+# (so the register's power-up value is unconstrained) + per-target
+# SMT-proved must-edge inference, this is decided definitely:
+#   - pre_fix  : SATISFIABLE (some cell True)  — the undefined encoding is
+#                reachable/absorbing → CWE-1245 hazard present.
+#   - post_fix : UNSATISFIABLE (all cells False) — proven unreachable →
+#                the default-case fix eliminates the hazard.
+# The pre/post difference is the milestone evidence.
+#
+# SOUNDNESS. `--must-edge-inference smt-per-target` proves each must-edge
+# with a Z3 ∀∀ query (no sampling); the verdict carries an
+# `[R.2.5b-smt-must]` advisory. `setundef -anyconst` over-approximates
+# power-up, so a definite verdict transfers to the concrete reset
+# behaviour. The verdict is established over the extracted model; an
+# RTL-level counterexample replay under a cycle-accurate simulator is the
+# remaining empirical step (deferred, per the M.0–M.2 SBY precedent).
+#
+# Per §10.2: if any stage fails, STOP and produce a blocker note rather
+# than silently retrying / hand-authoring around it.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MUNUNU="${MUNUNU:-${THIS_DIR}/../../../target/debug/mununu}"
+SRC="${THIS_DIR}/source"
+OUT="${THIS_DIR}/build/m4"
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate_m4_cegar.sh: mununu binary not found at ${MUNUNU}" >&2
+  echo "                      build it first with: cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in yosys sv2v; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "validate_m4_cegar.sh: required tool '${tool}' not on PATH" >&2
+    exit 2
+  fi
+done
+
+rm -rf "${OUT}" && mkdir -p "${OUT}"
+
+echo "=== M.4 — Caliptra soc_ifc_boot_fsm predicate-abstraction CEGAR ==="
+echo "upstream: chipsalliance/caliptra-rtl @ (see source/, issue #150 bug/fix pair)"
+echo "property: <> (p5 || p6 || p7)   [boot_fsm_ns transitions into an unmatched encoding]"
+echo
+
+PREDS=(--predicate p5:boot_fsm_ns=5 --predicate p6:boot_fsm_ns=6 --predicate p7:boot_fsm_ns=7
+       --config-values 'boot_fsm_ns=0,1,2,3,4,5,6,7' --must-edge-inference smt-per-target)
+
+# Generate BTOR2 + run CEGAR for one variant; echoes the T cell count.
+run_variant() {
+  local variant="$1"
+  local v="${OUT}/${variant}.v"
+  local b="${OUT}/${variant}.btor2"
+  sv2v -I"${SRC}" \
+    "${SRC}/soc_ifc_pkg.sv" "${SRC}/soc_ifc_reg_pkg.sv" \
+    "${SRC}/caliptra_2ff_sync.sv" "${SRC}/soc_ifc_boot_fsm_${variant}.sv" \
+    > "${v}" 2>"${OUT}/${variant}.sv2v.err"
+  yosys -q -p "read_verilog -sv ${v}; hierarchy -check -top soc_ifc_boot_fsm; proc; \
+               flatten; async2sync; dffunmap; setundef -anyconst; write_btor ${b}" \
+    2>"${OUT}/${variant}.yosys.err"
+  LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}" "${MUNUNU}" btor2 cegar "${b}" \
+    --formula '<> (p5 || p6 || p7)' "${PREDS[@]}" \
+    > "${OUT}/${variant}.cegar.out" 2>"${OUT}/${variant}.cegar.err"
+  cat "${OUT}/${variant}.cegar.out"
+}
+
+echo "--- pre_fix (bug-bearing: no default arm) ---"
+run_variant pre_fix
+echo
+echo "--- post_fix (fixed: default routes unmatched → defined) ---"
+run_variant post_fix
+echo
+
+# Extract the True-cell count from each "verdict cells: T=N F=M ⊥=K" line.
+t_count() { grep -E "verdict cells:" "$1" | sed -E 's/.*T=([0-9]+).*/\1/'; }
+PRE_T="$(t_count "${OUT}/pre_fix.cegar.out")"
+POST_T="$(t_count "${OUT}/post_fix.cegar.out")"
+
+echo "pre_fix  True cells (hazard reachable): ${PRE_T}"
+echo "post_fix True cells (hazard reachable): ${POST_T}"
+
+if [[ -z "${PRE_T}" || -z "${POST_T}" ]]; then
+  echo "FAIL: could not parse a verdict from one of the CEGAR runs" >&2
+  exit 1
+fi
+# Done-criterion: the hazard is reachable in the buggy variant and
+# eliminated in the fixed one — a definite, pre/post-distinguishing verdict.
+if [[ "${PRE_T}" -ge 1 && "${POST_T}" -eq 0 ]]; then
+  echo
+  echo "=== M.4 VALIDATION PASSED ==="
+  echo "pre_fix: undefined-encoding transition REACHABLE (${PRE_T} cells) — CWE-1245 detected."
+  echo "post_fix: undefined-encoding transition UNREACHABLE (0 cells) — fix verified."
+  echo "Sound, definite, pre/post-distinguishing CEGAR verdict on real Caliptra RTL."
+else
+  echo "FAIL: expected pre_fix True>=1 and post_fix True==0; got pre=${PRE_T} post=${POST_T}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## M.4 — Caliptra boot-FSM full automated CEGAR (the industrial headline)

Packages the M.4 milestone: full automated predicate-abstraction CEGAR on the real Caliptra `soc_ifc_boot_fsm`, with a **sound, definite, pre/post-distinguishing** verdict on the CWE-1245 undefined-encoding hazard.

### Result (`validate_m4_cegar.sh` PASS)
Property `<> (p5 || p6 || p7)` over the cube `{boot_fsm_ns ∈ {5,6,7}}` (legal encodings 0..4; the default-less `unique casez` leaves 5/6/7 unhandled):
```
pre_fix  (no default arm):     T=7 F=1 ⊥=0  → undefined encoding REACHABLE
post_fix (default → defined):  T=0 F=8 ⊥=0  → undefined encoding UNREACHABLE
```
The undefined-encoding transition is reachable/absorbing in the bug-bearing variant and **proven unreachable in the fixed variant** — the pre/post difference is the milestone evidence.

### Pipeline / soundness
sv2v → Yosys (`setundef -anyconst`) → BTOR2 → `mununu btor2 cegar` with **per-target SMT-proved must-edge inference** (Z3 ∀∀, no sampling). `-anyconst` over-approximates power-up, so the definite verdict transfers to the concrete reset behaviour. Model-level; RTL counterexample replay under a simulator deferred (M.0–M.2 SBY precedent). Reproduces the known caliptra-rtl #150 bug/fix pair via the automated pipeline.

### Files
- `source/caliptra_2ff_sync.sv` — 2-flop synchroniser stub (NOT vendored) so post_fix elaborates.
- `validate_m4_cegar.sh` — the M.4 validation (separate from the Phase-A.3 `validate.sh`).
- `README.md` — M.4 section.

Example-only change. Depends on the predicate-binding fix (#86) — without it the property was vacuously HOLDS. Result note: `M-4-result.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)