### PR TITLE
fix(sidecar-audit F1): unify sidecar abstraction-widening across verify + context-eval

### DIFF
--- a/crates/mununu-cli/src/loader.rs
+++ b/crates/mununu-cli/src/loader.rs
@@ -220,173 +220,45 @@ pub(crate) fn load_with_adapter_mode_extra(
             // skips when no sidecar exists or the schema does not
             // parse — non-blocking for fixtures that pre-date R-Y2/
             // R-S5.
+            // R-Y2 + R-S5/R-S4/R-S3/R-S7 — load the SV sidecar (if it
+            // exists next to the source) and apply the SHARED
+            // abstraction-widening via
+            // `sidecar_widening::widen_sidecar` — the same helper the
+            // verify `sv-yosys` orchestrator calls. sidecar-audit F1
+            // (2026-06-17): both entry points must produce an identical
+            // abstraction for the same `.mununu.json`; the widening logic
+            // used to live inline here only, so the verify path diverged.
+            // Silently skips when no sidecar exists / it does not parse.
             let mut widened_sidecar_json: Option<String> = None;
-            let init_policy_overrides: mununu_core::adapter::yosys::InitPolicyOverrides = {
-                let mut overrides = Vec::new();
-                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                    let candidate = path.with_file_name(format!("{stem}.mununu.json"));
-                    if candidate.exists()
-                        && let Ok(content) = fs::read_to_string(&candidate)
-                        && let Ok(mut ann) = serde_json::from_str::<
-                            mununu_core::adapter::systemverilog::annotation::SvAnnotation,
-                        >(&content)
-                    {
-                        // R-S5 — build typedef map from primary +
-                        // additional SV sources, then auto-widen any
-                        // signal that declares a `type_name`.
-                        let mut typedefs = std::collections::HashMap::new();
-                        typedefs.extend(
-                            mununu_core::adapter::systemverilog::typedef_extract::extract_typedef_enums(&source),
-                        );
-                        for (_, content) in &additional {
-                            typedefs.extend(
-                                mununu_core::adapter::systemverilog::typedef_extract::extract_typedef_enums(content),
-                            );
-                        }
-                        let widened = ann.apply_type_driven_widening(&typedefs);
-                        if !widened.is_empty() {
-                            eprintln!(
-                                "R-S5: applying type-driven widening from SV typedefs: {}",
-                                widened
-                                    .iter()
-                                    .map(|(s, t, n)| format!("{s}:{t}({n} variants)"))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            );
-                        }
-                        // R-S3 (§Phase 9 §9.1) — case-literal
-                        // seeding. Scan the primary SV source +
-                        // additional sidecar SV files for
-                        // `case (signal) <LITERAL>: …` blocks; harvest
-                        // the numeric labels per switched-on signal.
-                        // Complements R-S5 (which handles typedef-
-                        // typed signals) and R-S7 (which handles
-                        // property-referenced predicates) by
-                        // capturing designer-intended distinctions
-                        // expressed directly in case-statement
-                        // labels — typically the case for hand-
-                        // written non-typedef FSMs and decoders.
-                        let mut case_literals = std::collections::HashMap::new();
-                        for (name, value) in
-                            std::iter::once((String::from("__primary__"), source.clone()))
-                                .chain(additional.iter().map(|(n, c)| (n.clone(), c.clone())))
+            let init_policy_overrides: mununu_core::adapter::yosys::InitPolicyOverrides =
+                {
+                    let mut overrides = mununu_core::adapter::yosys::InitPolicyOverrides::new();
+                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        let candidate = path.with_file_name(format!("{stem}.mununu.json"));
+                        if candidate.exists()
+                            && let Ok(content) = fs::read_to_string(&candidate)
                         {
-                            let _ = name;
-                            for (sig, lits) in
-                                mununu_core::adapter::systemverilog::case_literal_extract::extract_case_literals(&value)
+                            let widened =
+                            mununu_core::adapter::systemverilog::sidecar_widening::widen_sidecar(
+                                &content, &source, &additional,
+                            );
+                            for line in &widened.summary {
+                                eprintln!("{line}");
+                            }
+                            // Debug aid: MUNUNU_R_S5_DUMP_PATH=/path dumps the
+                            // post-widening JSON for inspection.
+                            if let Some(json) = &widened.widened_json
+                                && let Ok(dump_path) = std::env::var("MUNUNU_R_S5_DUMP_PATH")
                             {
-                                case_literals
-                                    .entry(sig)
-                                    .or_insert_with(Vec::new)
-                                    .extend(lits);
+                                let _ = std::fs::write(&dump_path, json);
+                                eprintln!("R-S5/R-S7: dumped widened sidecar to {dump_path}");
                             }
-                        }
-                        // Dedupe per signal (multiple SV files may
-                        // reference the same signal).
-                        for v in case_literals.values_mut() {
-                            v.sort_unstable();
-                            v.dedup();
-                        }
-                        // R-S4 (§Phase 9 §9.1) — equivalence-class
-                        // seeding. Runs BEFORE R-S3 (apply_case_literal_seeding)
-                        // so signals declaring `equivalence_classes: true`
-                        // get their case literals + OTHER catch-all populated
-                        // into discovered_values; R-S3 then skips those
-                        // signals (mutually exclusive per signal).
-                        let class_seeded = ann.apply_equivalence_class_seeding(&case_literals);
-                        if !class_seeded.is_empty() {
-                            eprintln!(
-                                "R-S4: equivalence-class seeding (discriminators + OTHER catch-all): {}",
-                                class_seeded
-                                    .iter()
-                                    .map(|(s, vs)| format!(
-                                        "{s}=[{}]+OTHER",
-                                        vs.iter()
-                                            .map(|v| v.to_string())
-                                            .collect::<Vec<_>>()
-                                            .join(",")
-                                    ))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            );
-                        }
-                        let case_seeded = ann.apply_case_literal_seeding(&case_literals);
-                        if !case_seeded.is_empty() {
-                            eprintln!(
-                                "R-S3: seeding discriminators from case-statement labels: {}",
-                                case_seeded
-                                    .iter()
-                                    .map(|(s, vs)| format!(
-                                        "{s}=[{}]",
-                                        vs.iter()
-                                            .map(|v| v.to_string())
-                                            .collect::<Vec<_>>()
-                                            .join(",")
-                                    ))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            );
-                        }
-                        // R-S7 (§Phase 9 §9.1) — property-syntactic
-                        // seeding. Bridges the gap when R-S5 didn't
-                        // fire (no typedef on the signal) but a
-                        // property formula references discriminator
-                        // values like `count_3` or `mode_7`. Strictly
-                        // additive — only injects values not already
-                        // in the signal's value_map.
-                        let seeded = ann.apply_property_syntactic_seeding();
-                        if !seeded.is_empty() {
-                            eprintln!(
-                                "R-S7: seeding discriminators from property formulas: {}",
-                                seeded
-                                    .iter()
-                                    .map(|(s, vs)| format!(
-                                        "{s}=[{}]",
-                                        vs.iter()
-                                            .map(|v| v.to_string())
-                                            .collect::<Vec<_>>()
-                                            .join(",")
-                                    ))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            );
-                        }
-                        if !widened.is_empty()
-                            || !seeded.is_empty()
-                            || !case_seeded.is_empty()
-                            || !class_seeded.is_empty()
-                        {
-                            // Re-serialise so the BTOR2 lifter sees
-                            // the widened+seeded variants + value_map.
-                            // Falls back to the raw content if
-                            // serialisation fails (would only happen
-                            // on schema drift).
-                            if let Ok(json) = serde_json::to_string_pretty(&ann) {
-                                // Debug aid (shared with R-S5):
-                                // MUNUNU_R_S5_DUMP_PATH=/path dumps the
-                                // post-widening JSON for inspection.
-                                if let Ok(dump_path) = std::env::var("MUNUNU_R_S5_DUMP_PATH") {
-                                    let _ = std::fs::write(&dump_path, &json);
-                                    eprintln!("R-S5/R-S7: dumped widened sidecar to {dump_path}");
-                                }
-                                widened_sidecar_json = Some(json);
-                            }
-                        }
-                        overrides = ann.init_policy_overrides();
-                        if !overrides.is_empty() {
-                            eprintln!(
-                                "R-Y2: applying per-signal init-policy overrides from sidecar: {}",
-                                overrides
-                                    .iter()
-                                    .map(|(n, p)| format!("{n}={p:?}"))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            );
+                            widened_sidecar_json = widened.widened_json;
+                            overrides = widened.init_policy_overrides;
                         }
                     }
-                }
-                overrides
-            };
+                    overrides
+                };
             let yopts = mununu_core::adapter::yosys::YosysOptions {
                 primary_source_path: Some(path.to_string_lossy().into_owned()),
                 additional_sources: additional,

--- a/crates/mununu-core/src/adapter/sidecar/mod.rs
+++ b/crates/mununu-core/src/adapter/sidecar/mod.rs
@@ -78,6 +78,14 @@ pub fn resolve_to_field_domain(
         ),
 
         SignalAbstraction::BoundedCounter => {
+            // SOUNDNESS (sidecar-audit F3): a missing `bound` defaults to
+            // 3 (saturating {0,1,2,≥3}). A bound smaller than the
+            // property's value sensitivity UNDER-approximates the
+            // reachable value set — high values saturate into one class,
+            // so a safety property that distinguishes them can be missed.
+            // Declare an explicit `bound` for value-sensitive properties.
+            // (Legacy SV-specific variant scheduled for removal per
+            // docs/abstraction.md — not a target for a smarter default.)
             let bound = sig.bound.unwrap_or(3);
             (
                 FieldDomain {
@@ -153,6 +161,17 @@ pub fn resolve_to_field_domain(
                     value_map,
                 )
             } else {
+                // SOUNDNESS (sidecar-audit F2): a `Discover` signal with
+                // no discovered values (SMT discovery skipped, or the
+                // seeding stages R-S3/R-S4/R-S5/R-S7 did not fire)
+                // collapses to `Ignored` — the cell is pinned to one value
+                // and dropped from the state space. Over-approximation:
+                // sound for safety (the model admits every concrete value
+                // the cell could take), UNDER-approximation for liveness
+                // (a progress path that depends on the cell deviating is
+                // masked). `initial` is a placeholder — irrelevant for a
+                // dropped cell. Future refinement: emit an AdapterWarning
+                // naming the silently dropped signal.
                 (
                     FieldDomain {
                         name: sig.name.clone(),
@@ -168,6 +187,11 @@ pub fn resolve_to_field_domain(
         }
 
         SignalAbstraction::BitBlast => {
+            // SOUNDNESS (sidecar-audit F3): same direction as
+            // BoundedCounter above — a missing `bound` defaults to 15; too
+            // small under-approximates the value set (unsound for
+            // value-sensitive safety). Legacy SV-specific variant,
+            // scheduled for removal per docs/abstraction.md.
             let bound = sig.bound.unwrap_or(15);
             (
                 FieldDomain {
@@ -183,6 +207,11 @@ pub fn resolve_to_field_domain(
         }
 
         SignalAbstraction::Ignored => (
+            // SOUNDNESS (sidecar-audit F2/F4): the cell is pinned to a
+            // single value and dropped from the state space —
+            // over-approximation (sound for safety, under-approx for
+            // liveness). `initial` is a placeholder, irrelevant for a
+            // dropped cell.
             FieldDomain {
                 name: sig.name.clone(),
                 abstraction: AbstractionType::Ignored,

--- a/crates/mununu-core/src/adapter/systemverilog/mod.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/mod.rs
@@ -21,4 +21,5 @@
 pub mod annotation;
 pub mod case_literal_extract;
 pub mod emit_controller;
+pub mod sidecar_widening;
 pub mod typedef_extract;

--- a/crates/mununu-core/src/adapter/systemverilog/sidecar_widening.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/sidecar_widening.rs
@@ -1,0 +1,237 @@
+//! Shared sidecar abstraction-widening (sidecar-audit F1 fix, 2026-06-17).
+//!
+//! The CLI `context eval` loader and the verify-framework `sv-yosys`
+//! orchestrator both consume a `.mununu.json` sidecar, but before this
+//! module they diverged: the loader applied the R-S5 / R-S4 / R-S3 / R-S7
+//! abstraction-widening + R-Y2 init-policy extraction, while the verify
+//! path (the R4W-3.5 `sidecar = "..."` wiring) consumed the **raw**
+//! sidecar. For the same `.mununu.json` this yielded a *coarser*
+//! abstraction on the verify route — it dropped the typedef
+//! `UNMATCHED_<n>` widening and the per-signal `init_policy: anyconst`
+//! that bug detection (e.g. the Caliptra CWE-1245 analysis) relies on, so
+//! a bug-detecting verdict could silently become a spurious "safe".
+//! (See `.claude/reviews/sidecar-auditor/audit-2026-06-17.md` F1.)
+//!
+//! Both entry points now call [`widen_sidecar`], so the abstraction is
+//! identical regardless of which surface drives the lift.
+
+use std::collections::HashMap;
+
+use crate::adapter::systemverilog::annotation::SvAnnotation;
+use crate::adapter::systemverilog::{case_literal_extract, typedef_extract};
+use crate::adapter::yosys::InitPolicyOverrides;
+
+/// Result of applying the sidecar abstraction-widening chain.
+#[derive(Debug, Default, Clone)]
+pub struct SidecarWidening {
+    /// Re-serialised widened annotation JSON. `None` when no stage fired
+    /// (the caller keeps the raw sidecar).
+    pub widened_json: Option<String>,
+    /// R-Y2 per-signal init-policy overrides for `YosysOptions`.
+    pub init_policy_overrides: InitPolicyOverrides,
+    /// Per-stage human-readable summary (for CLI feedback / `tracing`).
+    /// Empty when nothing changed.
+    pub summary: Vec<String>,
+}
+
+/// Apply the sidecar abstraction-widening chain to `sidecar_json`, using
+/// `primary_sv` + `additional_sv` as the typedef / case-literal source:
+///
+/// - **R-S5** type-driven widening from SV typedef enums;
+/// - **R-S4** equivalence-class seeding (before R-S3; mutually exclusive
+///   per signal);
+/// - **R-S3** case-literal discriminator seeding;
+/// - **R-S7** property-syntactic discriminator seeding;
+/// - **R-Y2** per-signal init-policy override extraction.
+///
+/// Returns the re-serialised widened JSON (when any value-widening stage
+/// fired), the init-policy overrides, and a per-stage summary. Best-effort
+/// and pure (no I/O, no logging): a sidecar that does not parse yields an
+/// empty result, so the caller keeps the raw sidecar. Both the CLI loader
+/// and the verify orchestrator call this so their abstraction is identical.
+pub fn widen_sidecar(
+    sidecar_json: &str,
+    primary_sv: &str,
+    additional_sv: &[(String, String)],
+) -> SidecarWidening {
+    let Ok(mut ann) = serde_json::from_str::<SvAnnotation>(sidecar_json) else {
+        return SidecarWidening::default();
+    };
+    let mut summary = Vec::new();
+
+    // R-S5 — typedef-driven widening from the primary + additional SV.
+    let mut typedefs = HashMap::new();
+    typedefs.extend(typedef_extract::extract_typedef_enums(primary_sv));
+    for (_, content) in additional_sv {
+        typedefs.extend(typedef_extract::extract_typedef_enums(content));
+    }
+    let widened = ann.apply_type_driven_widening(&typedefs);
+    if !widened.is_empty() {
+        summary.push(format!(
+            "R-S5: type-driven widening from SV typedefs: {}",
+            widened
+                .iter()
+                .map(|(s, t, n)| format!("{s}:{t}({n} variants)"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    // Case literals (shared input for R-S4 + R-S3), deduped per signal.
+    let mut case_literals: HashMap<String, Vec<u64>> = HashMap::new();
+    for (_, value) in std::iter::once((String::new(), primary_sv.to_string()))
+        .chain(additional_sv.iter().cloned())
+    {
+        for (sig, lits) in case_literal_extract::extract_case_literals(&value) {
+            case_literals.entry(sig).or_default().extend(lits);
+        }
+    }
+    for v in case_literals.values_mut() {
+        v.sort_unstable();
+        v.dedup();
+    }
+
+    // R-S4 — equivalence-class seeding (runs before R-S3).
+    let class_seeded = ann.apply_equivalence_class_seeding(&case_literals);
+    if !class_seeded.is_empty() {
+        summary.push(format!(
+            "R-S4: equivalence-class seeding (+OTHER catch-all): {}",
+            fmt_seeds(&class_seeded)
+        ));
+    }
+    // R-S3 — case-literal discriminator seeding.
+    let case_seeded = ann.apply_case_literal_seeding(&case_literals);
+    if !case_seeded.is_empty() {
+        summary.push(format!(
+            "R-S3: case-literal discriminators: {}",
+            fmt_seeds(&case_seeded)
+        ));
+    }
+    // R-S7 — property-syntactic discriminator seeding.
+    let seeded = ann.apply_property_syntactic_seeding();
+    if !seeded.is_empty() {
+        summary.push(format!(
+            "R-S7: property-syntactic discriminators: {}",
+            fmt_seeds(&seeded)
+        ));
+    }
+
+    // Re-serialise only when a value-widening stage actually changed the
+    // annotation; the init-policy overrides are returned separately
+    // (they drive YosysOptions, not the sidecar JSON).
+    let widened_json = if !widened.is_empty()
+        || !class_seeded.is_empty()
+        || !case_seeded.is_empty()
+        || !seeded.is_empty()
+    {
+        serde_json::to_string_pretty(&ann).ok()
+    } else {
+        None
+    };
+
+    let init_policy_overrides = ann.init_policy_overrides();
+    if !init_policy_overrides.is_empty() {
+        summary.push(format!(
+            "R-Y2: per-signal init-policy overrides: {}",
+            init_policy_overrides
+                .iter()
+                .map(|(n, p)| format!("{n}={p:?}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    SidecarWidening {
+        widened_json,
+        init_policy_overrides,
+        summary,
+    }
+}
+
+fn fmt_seeds(seeds: &[(String, Vec<i64>)]) -> String {
+    seeds
+        .iter()
+        .map(|(s, vs)| {
+            format!(
+                "{s}=[{}]",
+                vs.iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A sidecar whose signal declares `type_name` must auto-widen from
+    // the SV typedef (R-S5): the widened JSON gains the enum variants +
+    // the synthetic UNMATCHED_<n> entries for the unenumerated encodings.
+    const SV_WITH_ENUM: &str = r#"
+typedef enum logic [2:0] {
+    A = 3'b000,
+    B = 3'b001,
+    C = 3'b100
+} my_state_e;
+module m(input logic clk); my_state_e st; endmodule
+"#;
+
+    const SIDECAR_TYPE_NAME: &str = r#"{
+        "$schema": "mununu_sv_annotation_v1",
+        "module": "m",
+        "source": "m.sv",
+        "signals": [
+            { "name": "st", "abstraction": "discover", "type_name": "my_state_e" }
+        ]
+    }"#;
+
+    #[test]
+    fn type_name_sidecar_widens_from_typedef() {
+        let w = widen_sidecar(SIDECAR_TYPE_NAME, SV_WITH_ENUM, &[]);
+        let json = w
+            .widened_json
+            .expect("type-driven widening must produce a widened sidecar");
+        // The widened sidecar carries the named variants + the
+        // unenumerated-encoding discriminators (3-bit type, 3 used → 5
+        // unmatched: 2,3,5,6,7 are not in {0,1,4}).
+        assert!(
+            json.contains("UNMATCHED"),
+            "expected UNMATCHED_<n> widening; got: {json}"
+        );
+        assert!(
+            w.summary.iter().any(|s| s.starts_with("R-S5")),
+            "summary must record the R-S5 stage; got {:?}",
+            w.summary
+        );
+    }
+
+    #[test]
+    fn unparseable_sidecar_yields_empty_widening() {
+        let w = widen_sidecar("{ not valid json", SV_WITH_ENUM, &[]);
+        assert!(w.widened_json.is_none());
+        assert!(w.init_policy_overrides.is_empty());
+        assert!(w.summary.is_empty());
+    }
+
+    #[test]
+    fn sidecar_with_no_wideners_returns_none_json() {
+        // A plain boolean-abstraction sidecar (no type_name, no case
+        // literals, no init policy) leaves the JSON untouched.
+        let sidecar = r#"{
+            "$schema": "mununu_sv_annotation_v1",
+            "module": "m",
+            "source": "m.sv",
+            "signals": [ { "name": "st", "abstraction": "boolean" } ]
+        }"#;
+        let w = widen_sidecar(sidecar, "module m(input logic clk); endmodule", &[]);
+        assert!(
+            w.widened_json.is_none(),
+            "no widening stage fired → keep the raw sidecar; got {:?}",
+            w.widened_json
+        );
+    }
+}

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -817,22 +817,51 @@ fn dispatch_sv_yosys(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
+    // Additional SV sources (submodules / stub packages), by basename —
+    // also the typedef / case-literal source for sidecar widening below.
+    let additional_sources: Vec<(String, String)> = additional_files
+        .iter()
+        .filter_map(|(path, body)| {
+            path.file_name()
+                .and_then(|s| s.to_str())
+                .map(|name| (name.to_string(), body.clone()))
+        })
+        .collect();
+
     // R4W-3.5 — `sidecar = "<file>.mununu.json"` (path relative to the
-    // verify.toml's base_dir) supplies the per-signal abstractions the
-    // bit-blaster needs to keep a real design under the state-bit cap
-    // and the transition fan-out tractable. Previously only
-    // `context eval --sidecar` could do this; the verify path now reads
-    // it from the source options so a `verify.toml` can drive the same
-    // abstraction the M.0–M.2 fixtures used.
+    // verify.toml's base_dir) supplies the per-signal abstractions.
+    //
+    // sidecar-audit F1 (2026-06-17) — the raw sidecar is run through the
+    // SHARED widening (`sidecar_widening::widen_sidecar`) — the SAME
+    // R-S5/R-S4/R-S3/R-S7 value widening + R-Y2 init-policy extraction the
+    // CLI `context eval` loader applies — so a `verify.toml` and a
+    // `context eval` produce an IDENTICAL abstraction for the same
+    // sidecar. Before F1 the verify path consumed the raw sidecar, which
+    // dropped the typedef `UNMATCHED_<n>` widening + per-signal
+    // `init_policy: anyconst` and could yield a coarser, bug-masking
+    // abstraction than the eval route.
+    let mut init_policy_overrides = crate::adapter::yosys::InitPolicyOverrides::new();
     let sidecar_json = match options.get("sidecar").and_then(|v| v.as_str()) {
         Some(rel) => {
             let path = resolve_path(base_dir, Path::new(rel));
-            Some(std::fs::read_to_string(&path).map_err(|source| {
-                VerifyError::SourceReadFailed {
+            let raw =
+                std::fs::read_to_string(&path).map_err(|source| VerifyError::SourceReadFailed {
                     path: path.clone(),
                     source,
-                }
-            })?)
+                })?;
+            let widened = crate::adapter::systemverilog::sidecar_widening::widen_sidecar(
+                &raw,
+                content,
+                &additional_sources,
+            );
+            for line in &widened.summary {
+                tracing::info!(source_id, "sv-yosys sidecar widening: {line}");
+            }
+            init_policy_overrides = widened.init_policy_overrides;
+            // Use the widened sidecar when any value-widening stage fired;
+            // otherwise the raw sidecar (the init-policy overrides ride
+            // YosysOptions, not the sidecar JSON).
+            Some(widened.widened_json.unwrap_or(raw))
         }
         None => None,
     };
@@ -848,14 +877,6 @@ fn dispatch_sv_yosys(
         sidecar_json,
         ..AdapterOptions::default()
     };
-    let additional_sources: Vec<(String, String)> = additional_files
-        .iter()
-        .filter_map(|(path, body)| {
-            path.file_name()
-                .and_then(|s| s.to_str())
-                .map(|name| (name.to_string(), body.clone()))
-        })
-        .collect();
 
     let is_multi_module = options
         .get("multi_module")
@@ -871,6 +892,7 @@ fn dispatch_sv_yosys(
             per_module_btor: true,
             additional_sources,
             use_sv2v,
+            init_policy_overrides: init_policy_overrides.clone(),
             ..Default::default()
         };
         let comp =
@@ -896,6 +918,7 @@ fn dispatch_sv_yosys(
     let yopts = crate::adapter::yosys::YosysOptions {
         additional_sources,
         use_sv2v,
+        init_policy_overrides,
         ..Default::default()
     };
     crate::adapter::yosys::translate_sv(content, &opts, &yopts)

--- a/examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh
+++ b/examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh
@@ -41,7 +41,13 @@ set -euo pipefail
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MUNUNU="${MUNUNU:-${THIS_DIR}/../../../target/debug/mununu}"
 SRC="${THIS_DIR}/source"
-OUT="${THIS_DIR}/build/m4"
+# Transient BTOR2/CEGAR artefacts go to a tmp dir, NOT under examples/.
+# The full Caliptra BTOR2 busts the bit-blast state-bit cap by design
+# (M.4 decides it via predicate-cube CEGAR, not the full R.2 lift), so
+# leaving it under examples/ would trip the `btor2_kmts_lift_sweep` test
+# which globs `examples/**/*.btor2`. mktemp + EXIT-trap keeps it clean.
+OUT="$(mktemp -d -t mununu-m4-XXXXXX)"
+trap 'rm -rf "${OUT}"' EXIT
 
 if [[ ! -x "${MUNUNU}" ]]; then
   echo "validate_m4_cegar.sh: mununu binary not found at ${MUNUNU}" >&2
@@ -55,7 +61,6 @@ for tool in yosys sv2v; do
   fi
 done
 
-rm -rf "${OUT}" && mkdir -p "${OUT}"
 
 echo "=== M.4 — Caliptra soc_ifc_boot_fsm predicate-abstraction CEGAR ==="
 echo "upstream: chipsalliance/caliptra-rtl @ (see source/, issue #150 bug/fix pair)"


### PR DESCRIPTION
## Sidecar-audit F1 (+ F2–F4) — unify the abstraction-widening

The sidecar-auditor session found the verify `sv-yosys` path applied **none** of the abstraction-widening the CLI `context eval` loader applies to the same `.mununu.json` (R-S5 type-driven / R-S4 equivalence-class / R-S3 case-literal / R-S7 property-syntactic widening + R-Y2 init-policy). The verify path (R4W-3.5 `sidecar = "..."` wiring) consumed the **raw** sidecar → a coarser abstraction that dropped the typedef `UNMATCHED_<n>` widening + per-signal `init_policy: anyconst` bug detection relies on. A soundness-relevant divergence (latent — the merged M.3/M.4 fixtures don't hit it, but any future widening-dependent verify.toml would).

### F1 — one helper both entry points call
- **NEW** `adapter::systemverilog::sidecar_widening::widen_sidecar` — the loader's widening chain extracted into one pure core helper (widened JSON + init-policy overrides + per-stage summary).
- `dispatch_sv_yosys` now calls it (+ threads `init_policy_overrides` into `YosysOptions` on both single- and multi-module branches).
- `mununu-cli::loader` refactored onto the same helper (−165 lines of duplicated inline widening).

**Verified end-to-end:** `mununu verify` on the Caliptra pre_fix sidecar now logs `R-S5: type-driven widening … boot_fsm_ns:boot_fsm_state_e(8 variants)` + `R-Y2: … boot_fsm_ns=Anyconst` (before: neither fired).

### F2–F4 — soundness annotations on resolver fallbacks
`Discover`→`Ignored` (F2), `BoundedCounter`/`BitBlast` default bounds (F3), `init` placeholder on dropped cells (F4).

### Also — M.4 test-hygiene (surfaced by this PR's own pre-commit hook)
`validate_m4_cegar.sh` now writes its transient (cap-busting-by-design) Caliptra BTOR2 to a `mktemp` dir instead of `build/m4/` under examples/, so it no longer trips `btor2_kmts_lift_sweep` (which globs `examples/**/*.btor2`).

### Tests
`sidecar_widening.rs` (3). 1808 lib + 57 doctests + 8 CLI + `btor2_kmts_lift_sweep` pass; M.2 context-eval `validate.sh` + `validate_m4_cegar.sh` still PASS. Audit record: `.claude/reviews/sidecar-auditor/audit-2026-06-17.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)