### PR TITLE
feat(R46-1, R.4.6): BTOR2 cone-restriction primitive

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -595,8 +595,17 @@ pub fn to_ir(
     // when no sidecar is provided OR no cells are Ignored, the
     // accounting is identical to the legacy behaviour.
     let raw_state_bits = sum_widths(file, &states)?;
-    let total_state_bits =
-        raw_state_bits.saturating_sub(sidecar_ignored_state_bits(file, &states, options));
+    // R.4.6 — when a per-cluster cone restriction is active, out-of-cone
+    // state cells are pinned to Ignored (below, in `enumerate_and_blast`),
+    // so they contribute zero bits. Subtract them here too so the cap
+    // check is gated on the *cluster* cone, not the joint design — this is
+    // what lets a design whose joint cone busts the cap be verified
+    // per-cluster ("joint busts cap, clusters fit"). Disjoint from
+    // `sidecar_ignored_state_bits` (see `cone_dropped_state_bits`), so no
+    // double-subtraction.
+    let total_state_bits = raw_state_bits
+        .saturating_sub(sidecar_ignored_state_bits(file, &states, options))
+        .saturating_sub(cone_dropped_state_bits(file, &states, options));
     let total_input_bits = sum_widths(file, &inputs)?;
 
     if total_state_bits > MAX_STATE_BITS {
@@ -712,18 +721,49 @@ fn sum_widths(file: &Btor2File, lines: &[&Line]) -> Result<u32, AdapterError> {
 /// from the `state` line and only attaches it via an Op-alias or
 /// `output` port symbol.
 fn sidecar_ignored_state_bits(file: &Btor2File, states: &[&Line], options: &AdapterOptions) -> u32 {
-    let Some(json) = &options.sidecar_json else {
+    let ignored_nids = sidecar_ignored_nids(file, options);
+    if ignored_nids.is_empty() {
         return 0;
+    }
+    let mut sum: u32 = 0;
+    for line in states {
+        if !ignored_nids.contains(&line.nid) {
+            continue;
+        }
+        let sort_nid = match &line.node {
+            Node::State { sort, .. } => *sort,
+            _ => continue,
+        };
+        let Some(width) = parser::bv_width(file, sort_nid) else {
+            continue;
+        };
+        sum = sum.saturating_add(width);
+    }
+    sum
+}
+
+/// The set of BTOR2 state NIDs the sidecar declares `abstraction:
+/// ignored`. Resolves each Ignored signal via the `drives` override
+/// (falling back to the sidecar `name`) using
+/// [`parser::resolve_state_by_symbol`]. Returns an empty set when no
+/// sidecar is provided, it fails to parse, or no cells are Ignored.
+///
+/// Split out of [`sidecar_ignored_state_bits`] (R.4.6) so the cone
+/// restriction's cap accounting can subtract out-of-cone cells *without*
+/// double-counting cells the sidecar already pins to Ignored.
+fn sidecar_ignored_nids(
+    file: &Btor2File,
+    options: &AdapterOptions,
+) -> std::collections::HashSet<Nid> {
+    let Some(json) = &options.sidecar_json else {
+        return std::collections::HashSet::new();
     };
     let Ok(ann) =
         serde_json::from_str::<crate::adapter::systemverilog::annotation::SvAnnotation>(json)
     else {
-        return 0;
+        return std::collections::HashSet::new();
     };
-    // Map each Ignored sidecar signal → its resolved BTOR2 state NID
-    // (drives override > sidecar name; BFS-nearest-state).
-    let ignored_nids: std::collections::HashSet<Nid> = ann
-        .signals
+    ann.signals
         .iter()
         .filter(|s| {
             matches!(
@@ -735,13 +775,38 @@ fn sidecar_ignored_state_bits(file: &Btor2File, states: &[&Line], options: &Adap
             let target = s.drives.as_deref().unwrap_or(s.name.as_str());
             parser::resolve_state_by_symbol(file, target)
         })
-        .collect();
-    if ignored_nids.is_empty() {
-        return 0;
+        .collect()
+}
+
+/// R.4.6 (per-cluster verification) — the cone keep-set of state NIDs for
+/// the current restriction, or `None` when `cone_restrict_atoms` is unset
+/// / empty (the joint single-bit-blast path). Delegates the cone
+/// computation to [`super::dep_graph::state_cone_nids`].
+fn cone_keep_state_nids(
+    file: &Btor2File,
+    options: &AdapterOptions,
+) -> Option<std::collections::HashSet<Nid>> {
+    let atoms = options.cone_restrict_atoms.as_ref()?;
+    if atoms.is_empty() {
+        return None;
     }
+    Some(super::dep_graph::state_cone_nids(file, atoms))
+}
+
+/// R.4.6 — sum the widths of state cells that the cone restriction drops
+/// (out-of-cone) but that the sidecar has *not* already pinned to Ignored
+/// (those are subtracted by [`sidecar_ignored_state_bits`]). Returns 0
+/// when no restriction is active. Subtracted from the cap-check total so
+/// a per-cluster bit-blast is gated on the *cluster* cone's bit count,
+/// not the joint design's.
+fn cone_dropped_state_bits(file: &Btor2File, states: &[&Line], options: &AdapterOptions) -> u32 {
+    let Some(keep) = cone_keep_state_nids(file, options) else {
+        return 0;
+    };
+    let already_ignored = sidecar_ignored_nids(file, options);
     let mut sum: u32 = 0;
     for line in states {
-        if !ignored_nids.contains(&line.nid) {
+        if keep.contains(&line.nid) || already_ignored.contains(&line.nid) {
             continue;
         }
         let sort_nid = match &line.node {
@@ -1381,6 +1446,24 @@ fn enumerate_and_blast(
         warnings,
         "state cell",
     );
+
+    // R.4.6 (per-cluster verification) — explicit per-cluster cone
+    // restriction. When `cone_restrict_atoms` is set, pin every state
+    // cell whose NID is NOT in the cluster's cone keep-set to `Ignored`,
+    // mirroring the auto-partition drop above but driven by the explicit
+    // cluster cone rather than the intrinsic-seed partition. The
+    // cap-check in `to_ir` subtracts the same cells' widths
+    // (`cone_dropped_state_bits`), so a design whose joint cone busts the
+    // cap can still be verified per-cluster when each cone fits. The
+    // "user wins" guard (a cell already keyed in `cell_domains`) leaves
+    // sidecar-declared cells untouched.
+    if let Some(keep) = cone_keep_state_nids(file, options) {
+        apply_cone_restriction(
+            &mut cell_domains,
+            state_meta.iter().map(|m| (m.nid, m.symbol.as_str())),
+            &keep,
+        );
+    }
 
     // R-Y3 (§Phase 8) — BTOR2 init-line smart defaults for cells
     // WITHOUT sidecar entries. Opt-in via `MUNUNU_BTOR2_SMART_INIT_DEFAULTS=1`.
@@ -2462,6 +2545,50 @@ fn apply_partition_drops<'a>(
                 // (full bit-blast) applies.
             }
         }
+    }
+}
+
+/// R.4.6 (per-cluster verification) — pin every state cell whose NID is
+/// **not** in `keep_nids` (the cluster's cone keep-set) to `Ignored`,
+/// cutting it from the enumerated state space. The "user wins" guard (a
+/// cell already keyed in `domains`) leaves sidecar-declared cells
+/// untouched, matching [`apply_partition_drops`].
+///
+/// SOUNDNESS: the cone of influence is **exact** (bisimilar) on the
+/// cluster's atom set — out-of-cone cells cannot influence those atoms,
+/// so pinning them to a single value cannot change any verdict over the
+/// cluster's properties. This is the COI "exact / free / sound"
+/// abstraction (CLAUDE.md §Soundness), *not* an over- or
+/// under-approximation; no warning is emitted because no precision is
+/// lost on the cluster's properties.
+fn apply_cone_restriction<'a>(
+    domains: &mut CellDomainMap,
+    iter: impl Iterator<Item = (i64, &'a str)>,
+    keep_nids: &std::collections::HashSet<Nid>,
+) {
+    use crate::adapter::domain::{AbstractValue, AbstractionType, FieldDomain};
+
+    for (nid, symbol) in iter {
+        if keep_nids.contains(&nid) {
+            continue; // in the cluster cone → keep (full bit-blast / sidecar domain)
+        }
+        if domains.contains_key(&nid) {
+            continue; // user wins — sidecar already declared this cell
+        }
+        domains.insert(
+            nid,
+            (
+                FieldDomain {
+                    name: symbol.to_string(),
+                    abstraction: AbstractionType::Ignored,
+                    bound: None,
+                    lower_bound: None,
+                    variants: None,
+                    initial: AbstractValue::Counter(0),
+                },
+                Vec::new(),
+            ),
+        );
     }
 }
 
@@ -5123,6 +5250,79 @@ mod tests {
             src.push_str(&format!("{} state 1 s{}\n", i + 2, i));
         }
         let err = translate(&src, &AdapterOptions::default()).unwrap_err();
+        assert_eq!(err.kind, AdapterErrorKind::StateSpaceOverflow);
+    }
+
+    /// R.4.6 — the "joint busts cap, clusters fit" capability at the
+    /// bit-blast layer. Two independent 11-bit registers (22 state bits
+    /// jointly, > MAX_STATE_BITS = 20). `a_hot = (reg_a == 1)` so reg_a
+    /// is in the cone and reg_b is not. Without a restriction the design
+    /// busts the cap; restricting to `a_hot`'s cone drops reg_b's 11 bits
+    /// and the cluster (11 bits) fits + translates.
+    #[test]
+    fn cone_restriction_unlocks_cap_busting_design_per_cluster() {
+        let src = r#"
+1 sort bitvec 1
+2 sort bitvec 11
+3 zero 2
+4 state 2 reg_a
+5 init 2 4 3
+6 state 2 reg_b
+7 init 2 6 3
+8 one 2
+9 eq 1 4 8
+10 output 9 a_hot
+"#;
+        // 1) Joint — both 11-bit registers → 22 state bits → cap-bust.
+        let joint = translate(src, &AdapterOptions::default());
+        assert!(
+            joint.is_err(),
+            "joint design (22 state bits) must bust the cap"
+        );
+        assert_eq!(
+            joint.unwrap_err().kind,
+            AdapterErrorKind::StateSpaceOverflow
+        );
+
+        // 2) Per-cluster — restrict to a_hot's cone {reg_a}; reg_b's
+        // 11 bits are cut, leaving 11 ≤ MAX_STATE_BITS → translates.
+        let opts = AdapterOptions {
+            cone_restrict_atoms: Some(vec!["a_hot".to_string()]),
+            ..Default::default()
+        };
+        let out = translate(src, &opts)
+            .expect("cone-restricted cluster (11 state bits) must fit the cap");
+        assert!(
+            out.ctxdsl.contains("automaton"),
+            "restricted cluster must produce an automaton; ctxdsl:\n{}",
+            out.ctxdsl
+        );
+    }
+
+    /// R.4.6 — a restriction whose cone covers *every* state cell is a
+    /// no-op: nothing is dropped, so a design that already busts the cap
+    /// still busts it (the restriction cannot manufacture headroom it has
+    /// no out-of-cone cells to reclaim).
+    #[test]
+    fn cone_restriction_covering_all_cells_does_not_unlock_cap() {
+        // Two registers, but the atom's cone reaches BOTH (out = reg_a ==
+        // reg_b), so neither is droppable.
+        let src = r#"
+1 sort bitvec 1
+2 sort bitvec 11
+3 zero 2
+4 state 2 reg_a
+5 init 2 4 3
+6 state 2 reg_b
+7 init 2 6 3
+8 eq 1 4 6
+9 output 8 both_hot
+"#;
+        let opts = AdapterOptions {
+            cone_restrict_atoms: Some(vec!["both_hot".to_string()]),
+            ..Default::default()
+        };
+        let err = translate(src, &opts).expect_err("cone covers both regs → still 22 bits");
         assert_eq!(err.kind, AdapterErrorKind::StateSpaceOverflow);
     }
 

--- a/crates/mununu-core/src/adapter/btor2/dep_graph.rs
+++ b/crates/mununu-core/src/adapter/btor2/dep_graph.rs
@@ -175,6 +175,64 @@ pub fn resolve_atom_to_terminals(file: &Btor2File, atom: &str) -> Option<HashSet
     None
 }
 
+/// R.4.6 (per-cluster verification) — the set of **state-cell NIDs** in
+/// the cone of influence of `atoms` (one cluster's property atoms). This
+/// is the keep-set a per-cluster bit-blast restricts to: every state cell
+/// whose NID is in the returned set is kept; every other state cell is
+/// out-of-cone and can be cut (pinned to `Ignored`) without affecting the
+/// cluster's verdicts.
+///
+/// Pipeline: each atom → its terminal symbols
+/// ([`resolve_atom_to_terminals`], falling back to the bare atom string
+/// when the BTOR2 doesn't name it) → union → transitive cone over the
+/// register dep graph ([`cone_of_influence`] on
+/// [`DepGraphBuilder::build`]) → map the resulting state symbols back to
+/// their state-line NIDs.
+///
+/// [`cone_of_influence`]: crate::adapter::partition::coi::cone_of_influence
+///
+/// # SOUNDNESS
+///
+/// The cone of influence is exact (bisimilar) on the atom set:
+/// out-of-cone state cells cannot influence any atom in `atoms`, so
+/// cutting them is sound for the full mu-calculus over those atoms (the
+/// COI "exact / free / sound" abstraction; CLAUDE.md §Soundness). This
+/// is *not* an over- or under-approximation — the restricted model
+/// agrees with the joint model on every property over `atoms`.
+pub fn state_cone_nids(file: &Btor2File, atoms: &[String]) -> HashSet<Nid> {
+    use crate::adapter::partition::coi::cone_of_influence;
+
+    let symbols = parser::collect_symbols(file);
+    let deps = file.build();
+
+    // Seed the cone with each atom's terminal symbols. An atom the BTOR2
+    // doesn't name (no `output`/`state`/`input`/`op` symbol matches)
+    // falls back to seeding with the bare atom string — matching the
+    // cluster-COI seed-resolution convention (R4W-3.5b).
+    let mut seeds: HashSet<String> = HashSet::new();
+    for atom in atoms {
+        match resolve_atom_to_terminals(file, atom) {
+            Some(terminals) => seeds.extend(terminals),
+            None => {
+                seeds.insert(atom.clone());
+            }
+        }
+    }
+
+    let cone = cone_of_influence(&seeds, &deps);
+
+    // Map cone state symbols back to their state-line NIDs.
+    file.states()
+        .filter(|l| {
+            symbols
+                .get(&l.nid)
+                .map(|sym| cone.contains(sym))
+                .unwrap_or(false)
+        })
+        .map(|l| l.nid)
+        .collect()
+}
+
 /// Collect the COI seed set for a BTOR2 file from its intrinsic
 /// property declarations (`bad`, `constraint`, `justice`, `fair`).
 ///
@@ -373,6 +431,66 @@ mod tests {
             terminals,
             HashSet::from(["reg".to_string()]),
             "a register atom seeds with itself"
+        );
+    }
+
+    #[test]
+    fn state_cone_nids_keeps_only_cone_register() {
+        // R.4.6 — two independent registers. `a_hot = (reg_a == 1)` so
+        // the cone of `a_hot` is {reg_a}; `reg_b` is never reached and
+        // must be excluded from the keep-set. This is the minimal
+        // "joint busts cap, clusters fit" shape at the cone level.
+        let src = r#"
+1 sort bitvec 1
+2 sort bitvec 4
+3 zero 2
+4 state 2 reg_a
+5 init 2 4 3
+6 state 2 reg_b
+7 init 2 6 3
+8 one 2
+9 eq 1 4 8
+10 output 9 a_hot
+"#;
+        let file = parser::parse(src).expect("parse");
+        let keep = state_cone_nids(&file, &["a_hot".to_string()]);
+        assert!(
+            keep.contains(&4),
+            "reg_a (nid 4) is in a_hot's cone; got {keep:?}"
+        );
+        assert!(
+            !keep.contains(&6),
+            "reg_b (nid 6) is independent, out of cone; got {keep:?}"
+        );
+    }
+
+    #[test]
+    fn state_cone_nids_follows_next_dependency() {
+        // The cone is transitive through `next` functions: `out = reg_a`,
+        // and `reg_a`'s next reads `reg_mid`, so the cone is
+        // {reg_a, reg_mid}; the independent `reg_b` is excluded.
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 state 1 reg_a
+4 init 1 3 2
+5 state 1 reg_mid
+6 init 1 5 2
+7 state 1 reg_b
+8 init 1 7 2
+9 next 1 3 5
+10 output 3 out
+"#;
+        let file = parser::parse(src).expect("parse");
+        let keep = state_cone_nids(&file, &["out".to_string()]);
+        assert!(keep.contains(&3), "reg_a in cone; got {keep:?}");
+        assert!(
+            keep.contains(&5),
+            "reg_mid feeds reg_a's next, must be in cone; got {keep:?}"
+        );
+        assert!(
+            !keep.contains(&7),
+            "reg_b is independent, out of cone; got {keep:?}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -211,6 +211,25 @@ pub struct AdapterOptions {
     /// `verify.toml`, or overridden by the CLI `--cluster-coi-floor`
     /// flag / the API request's `cluster_similarity_floor` field).
     pub cluster_similarity_floor: Option<f64>,
+
+    /// R.4.6 (per-cluster verification) — when `Some`, restrict the BTOR2
+    /// bit-blast to the cone of influence of these property atoms (one
+    /// cluster's members). Every state cell **not** in the cone is pinned
+    /// to `Ignored` (cut from the state space), and its width is
+    /// subtracted from the `MAX_STATE_BITS` cap check — so a design whose
+    /// JOINT cone busts the cap can still be verified per-cluster when
+    /// each cluster's cone fits ("joint busts cap, clusters fit").
+    ///
+    /// SOUNDNESS: the cone of influence is exact (bisimilar) on the atom
+    /// set, so cutting out-of-cone cells cannot change any verdict over
+    /// those atoms (CLAUDE.md §Soundness — COI is the exact / free /
+    /// sound abstraction). This is *not* an approximation. `None`
+    /// (default) preserves the joint single-bit-blast behaviour. The
+    /// verify orchestrator (R46-2 / R46-3) sets this per cluster from
+    /// [`crate::adapter::partition::coi::PropertyCluster::members`]'
+    /// resolved atoms. The cone itself is computed by
+    /// [`crate::adapter::btor2::dep_graph::state_cone_nids`].
+    pub cone_restrict_atoms: Option<Vec<String>>,
 }
 
 /// A sidecar file the adapter produced alongside its CTXDSL output.


### PR DESCRIPTION
First sub-item of **R.4.6 — per-cluster verification** ("joint busts cap, clusters fit"): a sound, self-contained capability to restrict a BTOR2 bit-blast to one property cluster's cone of influence. A design whose **joint** cone busts `MAX_STATE_BITS` can then be verified per-cluster when each cluster's cone fits. No pipeline wiring yet (that is R46-2/R46-3).

## What's in this PR
- `dep_graph::state_cone_nids(file, atoms) -> HashSet<Nid>` — the state-cell nids in a cluster's cone, reusing the existing symbol-based machinery (`resolve_atom_to_terminals` + bare-atom fallback → `cone_of_influence` → state-symbol→nid map).
- `AdapterOptions.cone_restrict_atoms: Option<Vec<String>>` — default `None` → joint single-bit-blast behaviour unchanged.
- bit_blast: `cone_keep_state_nids` + `cone_dropped_state_bits` subtract out-of-cone state bits from the `to_ir` cap check (refactored `sidecar_ignored_nids` out of `sidecar_ignored_state_bits` so the two drop sources never double-subtract); `apply_cone_restriction` pins out-of-cone cells to `Ignored` inside `enumerate_and_blast`.

## Soundness
The cone of influence is **exact** (bisimilar) on the cluster's atom set — out-of-cone cells cannot influence those atoms, so cutting them cannot change any verdict over the cluster's properties (CLAUDE.md §Soundness — COI is the exact/free/sound abstraction). Not an approximation; no warning emitted.

## Tests
4 new tests, including the headline `cone_restriction_unlocks_cap_busting_design_per_cluster` (22-bit joint design errors at the cap; the 11-bit cone-restricted cluster translates). Full pre-push gate green: `fmt` + `clippy -D warnings --all-targets` + 57 doctests + btor2 (234) and partition (27) module suites, no regression.

## Context
Empirically grounded by the R46-0 scoping: a synthetic two-11-bit-counter design errors jointly (22 bits) and verifies per-cluster (11 bits each, SAT 2048/2048). Next: R46-2 wires K bit-blasts per source (trigger on cap-bust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)