### PR TITLE
feat(R46-4, R.4.6): surface per-cluster verification mode in the CLI report

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1425,6 +1425,28 @@ fn handle_verify(args: VerifyArgs) -> Result<(), String> {
                     },
                 );
             }
+            // R46-4 (R.4.6) — per-cluster verification mode. Present only
+            // when the joint design busted the state-bit cap and the
+            // bit-blaster fell back to verifying each cluster separately
+            // (`PartitionSummary::cluster_routing`). Each property's
+            // per-cluster automaton is also visible in its `over` field
+            // below; this line surfaces the mode + the distinct cluster
+            // count up front.
+            if let Some(routing) = s
+                .partition_summary
+                .as_ref()
+                .and_then(|ps| ps.cluster_routing.as_ref())
+            {
+                let n_clusters = routing
+                    .values()
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .len();
+                println!(
+                    "        per-cluster verification: joint design exceeded the state-bit cap → \
+                     {n_clusters} cluster(s) verified separately ({} property route(s))",
+                    routing.len(),
+                );
+            }
         }
         println!("  properties ({}):", report.property_verdicts.len());
         for v in &report.property_verdicts {


### PR DESCRIPTION
The reporting half of R.4.6 per-cluster verification (paired with mununu-ui PR for the UI surface).

When a source was verified per-cluster (the joint design busted the state-bit cap and `PartitionSummary::cluster_routing` is populated by R46-2/R46-3), the human-readable CLI report now prints a per-source mode line:

```
per-cluster verification: joint design exceeded the state-bit cap → 2 cluster(s) verified separately (2 property route(s))
```

Each property's per-cluster automaton is also already visible in its `over = Circuit__clK` field.

**Surface parity:**
- **CLI** — this line.
- **API** — automatic: `verify_project_handler` returns the core `VerifyReport`, so `cluster_routing` already serializes on the response (no new field).
- **UI** — the typed-client field (`cluster_routing` on `VerifyPartitionSummary`) + the per-cluster badge in `VerdictTable` + en/es/pt i18n + 2 tests ship in the paired **mununu-ui** PR.

Verified on the synthetic cap-buster: the line renders with the correct distinct-cluster count alongside the existing clustered-COI reduction line and the two `SATISFIED … over = Circuit__cl{0,1}` verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)