### PR TITLE
test(R46-5, R.4.6): synthetic per-cluster verification regression fixture

### DIFF
--- a/examples/verify/r46_synth_two_cones/README.md
+++ b/examples/verify/r46_synth_two_cones/README.md
@@ -1,0 +1,62 @@
+# R46-5 — synthetic "joint busts cap, clusters fit" regression
+
+> **Synthetic fixture (hand-written, NOT vendored RTL).** Unlike the
+> `m{0,1,2,3}_*` milestones — which verify real OpenTitan RTL — this
+> fixture exists to regression-test the **per-cluster verification
+> mechanism** (R.4.6) in isolation, with a design small enough to read but
+> shaped to exercise the cap-overrun → per-cluster path exactly.
+
+## What it demonstrates
+
+`source/two_cones.sv` is two **independent** 11-bit counters that share
+only `clk`/`rst`. Verified jointly the design has **22 state bits**, past
+the explicit-state cap (`MAX_STATE_BITS = 20`). Each of the two
+reachability properties reads only one counter, so their cones are
+disjoint and cluster **K=2**.
+
+`mununu verify` detects the cap overrun and falls back to **per-cluster
+verification**: it partitions the properties by cone overlap, **slices**
+the netlist down to each cluster's own 11-bit cone (removing the
+out-of-cone counter, its next-state logic, and the inputs that only fed
+it), and verifies each cluster separately. Both properties come back
+`SATISFIED` over distinct cluster automata (`Circuit__cl0` /
+`Circuit__cl1`).
+
+```
+clustered-COI: joint cone 5 signals, 2 cluster(s), max cluster cone 3 signals (reduces binding cone by 2 vs joint COI)
+per-cluster verification: joint design exceeded the state-bit cap → 2 cluster(s) verified separately (2 property route(s))
+a_max_reachable: SATISFIED (2048/2048 states, 1/1 initial) [inline, over = Circuit__cl0]
+b_max_reachable: SATISFIED (2048/2048 states, 1/1 initial) [inline, over = Circuit__cl1]
+```
+
+## Why slicing, not pinning (soundness)
+
+Per-cluster restriction is realised by **slicing** the BTOR2 to a
+cluster's cone, not by pinning out-of-cone registers to a constant.
+Pinning is a safety-only over-approximation, and because synchronous
+transitions advance every register at once, it would drop the in-cone
+counter's updates whenever the out-of-cone counter moved — making even
+this reachability property report a spurious failure. Slicing removes the
+out-of-cone state from the transition relation, so the sliced model is
+bisimilar to the (hypothetical) joint model on the cluster's atoms and the
+verdict is sound for the full mu-calculus, at every alternation depth.
+
+## Run it
+
+```bash
+cargo build -p mununu-cli
+./examples/verify/r46_synth_two_cones/validate.sh
+```
+
+Requires `yosys`, `sv2v`, and `z3` on `PATH`
+(`LIBRARY_PATH=/usr/local/opt/z3/lib` for z3). The BTOR2 is produced
+inside mununu's own temp directory; nothing is written under `examples/`.
+
+## Scope
+
+This is the *narrow-cone* case (each cluster fits once isolated). The
+*wide-field* case — a cluster carrying a register that busts the cap on
+its own (a 32-bit timer, say) — additionally needs parameter
+concretisation stacked on top of slicing; the industrial fixture that
+exercises that combination (OpenTitan `sysrst_ctrl`) is tracked
+separately.

--- a/examples/verify/r46_synth_two_cones/source/two_cones.sv
+++ b/examples/verify/r46_synth_two_cones/source/two_cones.sv
@@ -1,0 +1,34 @@
+// SYNTHETIC fixture (hand-written, NOT vendored) — R46-5 / R.4.6.
+//
+// Two INDEPENDENT 11-bit counters sharing only clk/rst. Joint state =
+// 22 bits (> MAX_STATE_BITS = 20, so the joint bit-blast busts the cap);
+// each counter's cone is 11 bits (2048 states, which fits). The two
+// counters use different increments (+1 / +3) so Yosys `opt` cannot merge
+// the registers into one.
+//
+// This is the minimal faithful "joint busts cap, clusters fit" shape: the
+// single-module verify route FLATTENS it into one BTOR2 whose dep graph
+// has two disjoint register cones, the two reachability properties
+// cluster K=2, and per-cluster verification (R46-2/R46-3) slices each
+// cluster down to its own 11-bit cone and verifies it.
+module two_cones (
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  input  logic        a_en_i,
+  input  logic        b_en_i,
+  output logic        a_max_o,
+  output logic        b_max_o
+);
+  logic [10:0] cnt_a, cnt_b;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      cnt_a <= '0;
+      cnt_b <= '0;
+    end else begin
+      if (a_en_i) cnt_a <= cnt_a + 11'd1;
+      if (b_en_i) cnt_b <= cnt_b + 11'd3;
+    end
+  end
+  assign a_max_o = (cnt_a == 11'd2047);
+  assign b_max_o = (cnt_b == 11'd2046);
+endmodule

--- a/examples/verify/r46_synth_two_cones/source/verify.toml
+++ b/examples/verify/r46_synth_two_cones/source/verify.toml
@@ -1,0 +1,45 @@
+# R46-5 / R.4.6 — synthetic "joint busts cap, clusters fit" regression.
+#
+# `two_cones.sv` has two independent 11-bit counters → 22 joint state bits,
+# which busts the bit-blast cap (MAX_STATE_BITS = 20). Each property below
+# reads only one counter, so the two cones are disjoint and cluster K=2.
+# Per-cluster verification (R46-2/R46-3) detects the cap overrun, slices
+# each cluster to its own 11-bit cone, and verifies it — both properties
+# come back SATISFIED over `Circuit__cl0` / `Circuit__cl1`.
+#
+# `over = "Circuit"` is the joint default; when per-cluster verification
+# fires the orchestrator overrides it with each property's cluster
+# automaton (visible in the report's `over =` field).
+
+[project]
+name = "R46SynthTwoCones"
+description = "Synthetic two-independent-counter design: joint cone busts the state-bit cap, per-cluster verification rescues it."
+
+[[sources]]
+id = "tc"
+files = ["two_cones.sv"]
+adapter = "sv-yosys"
+
+[sources.options]
+use_sv2v = true
+top = "two_cones"
+
+[alphabet]
+strategy = "direct"
+
+[composition]
+semantics = "synchronous"
+members = ["tc"]
+name = "TwoConesTop"
+
+[[properties]]
+# cnt_a's max encoding is reachable. Cone = {cnt_a, a_en_i} — disjoint
+# from cnt_b's, which is what drives the K=2 clustering.
+name = "a_max_reachable"
+formula = "mu X. (a_max_o || (<> X))"
+over = "Circuit"
+
+[[properties]]
+name = "b_max_reachable"
+formula = "mu X. (b_max_o || (<> X))"
+over = "Circuit"

--- a/examples/verify/r46_synth_two_cones/validate.sh
+++ b/examples/verify/r46_synth_two_cones/validate.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# validate.sh — R46-5 / R.4.6 per-cluster verification regression.
+#
+# Contract: on a SYNTHETIC design whose JOINT cone busts the bit-blast
+# state-bit cap (two independent 11-bit counters = 22 state bits > 20),
+# `mununu verify` automatically falls back to PER-CLUSTER verification —
+# it partitions the two properties by their disjoint cones, slices each
+# cluster to its own 11-bit cone, and verifies it. Both reachability
+# properties come back SATISFIED, routed to distinct cluster automata
+# (`Circuit__cl0` / `Circuit__cl1`).
+#
+# This is a mechanism regression test (NOT an M-milestone): the design is
+# hand-written, clearly labeled synthetic. It guards the end-to-end
+# "joint busts cap, clusters fit" path (R46-2/R46-3 + the cone-SLICE
+# soundness fix) against regression.
+#
+# Note: the BTOR2 is produced inside mununu's own temp dir (the yosys
+# adapter), so nothing under examples/ is written — no cap-busting
+# `.btor2` lands where the `btor2_kmts_lift_sweep` glob would trip on it.
+# This script writes only its own report JSON, to a mktemp dir.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MUNUNU="${MUNUNU:-${THIS_DIR}/../../../target/debug/mununu}"
+SRC="${THIS_DIR}/source"
+OUT="$(mktemp -d -t mununu-r46-5-XXXXXX)"
+trap 'rm -rf "${OUT}"' EXIT
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu binary not found at ${MUNUNU}" >&2
+  echo "             build it first with: cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in yosys sv2v; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "validate.sh: required tool '${tool}' not on PATH" >&2
+    exit 2
+  fi
+done
+
+echo "=== R46-5 — automatic per-cluster verification on a cap-busting design ==="
+echo "fixture: ${SRC}/two_cones.sv (SYNTHETIC; two independent 11-bit counters = 22 state bits)"
+echo
+
+cd "${SRC}"
+echo "--- mununu verify (joint busts cap → automatic per-cluster) ---"
+LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}" "${MUNUNU}" verify --json verify.toml \
+  > "${OUT}/verify.json" 2>"${OUT}/verify.err" || {
+  echo "FAIL: mununu verify exited non-zero" >&2
+  tail -15 "${OUT}/verify.err" >&2
+  exit 1
+}
+
+# Human-readable lines (for the log).
+LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}" "${MUNUNU}" verify verify.toml 2>/dev/null \
+  | grep -iE "clustered-COI|per-cluster verification|SATISFIED|VIOLATED" || true
+echo
+
+python3 - "${OUT}/verify.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+
+# Done-criterion 1: per-cluster verification fired (cluster_routing present
+# on some source — only set when the joint design busted the cap).
+routing = None
+for s in r.get("sources", []):
+    routing = (s.get("partition_summary") or {}).get("cluster_routing")
+    if routing:
+        break
+assert routing, "FAIL: no cluster_routing — per-cluster verification did not fire"
+clusters = sorted(set(routing.values()))
+assert len(clusters) >= 2, f"FAIL: expected >=2 cluster automata, got {clusters}"
+print(f"per-cluster: routed {len(routing)} properties to {len(clusters)} clusters {clusters}")
+
+# Done-criterion 2: both properties SATISFIED, non-vacuous, each routed to
+# a distinct cluster automaton.
+verds = {v["name"]: v for v in r.get("property_verdicts", [])}
+assert verds, "FAIL: no property verdicts"
+overs = set()
+for name, v in verds.items():
+    assert v["satisfied"], f"FAIL: {name} not SATISFIED"
+    assert v["total_states"] > 0, f"FAIL: vacuous verdict for {name}"
+    assert v["over"].startswith("Circuit__cl"), \
+        f"FAIL: {name} not routed to a cluster automaton (over={v['over']})"
+    overs.add(v["over"])
+    print(f"verdict {name}: SAT {v['satisfying_states']}/{v['total_states']} over {v['over']}")
+assert len(overs) >= 2, f"FAIL: properties did not route to distinct clusters: {overs}"
+print("R46-5 done-criteria met: joint cone busts the cap, per-cluster "
+      "verification rescues it, both verdicts SAT + non-vacuous over distinct clusters.")
+PY
+
+echo
+echo "=== R46-5 VALIDATION PASSED ==="


### PR DESCRIPTION
Commits the synthetic regression fixture for R.4.6 per-cluster verification — the committed end-to-end guard for the "joint busts cap, clusters fit" path.

`examples/verify/r46_synth_two_cones/` — two independent 11-bit counters (22 joint state bits, over `MAX_STATE_BITS = 20`); each property reads one counter, so the cones are disjoint (K=2). `mununu verify` detects the cap overrun and verifies each cluster against its own sliced 11-bit cone; both reachability properties come back `SATISFIED` over distinct cluster automata (`Circuit__cl0` / `Circuit__cl1`).

`validate.sh` asserts the done-criteria from the report JSON: per-cluster verification fired (`cluster_routing` present, ≥2 clusters), both verdicts SATISFIED + non-vacuous (`total_states > 0`), each routed to a distinct cluster automaton.

**Hygiene:** hand-written, clearly labeled SYNTHETIC (not vendored RTL — it regression-tests the *mechanism*, distinct from the `m{0,1,2,3}_*` real-RTL milestones). The BTOR2 is produced in mununu's own temp dir and the script writes only to `mktemp`, so no cap-busting `.btor2` lands under `examples/` (would trip `btor2_kmts_lift_sweep`); `logs/` is gitignored. Not picked up by any sweep test (`sv_preprocess_sweep` reads only `examples/systemverilog/`).

`./examples/verify/r46_synth_two_cones/validate.sh` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)