### PR TITLE
fix(R46-6a): close COI cone over constraint/fairness coupling (+ GAP-2 effective-cap, docs)

### DIFF
--- a/.claude/agents/sidecar-auditor.md
+++ b/.claude/agents/sidecar-auditor.md
@@ -1,0 +1,137 @@
+---
+name: sidecar-auditor
+description: >
+  Evaluates every sidecar implementation in mununu (SystemVerilog/BTOR2
+  annotation sidecars, parameter-concretization, VCD-trace, contract/black-box
+  interface, register-map, predicate-image, and API-wrapper sidecars) for
+  redundancy, outdatedness, missing user-friendly mechanisms, and poor
+  underlying-crate design. Produces a structured analysis report plus a phased
+  change plan (merge / remove / elevate / refactor) for the user to approve.
+  On-demand audit; analysis and planning only — it does not execute edits or
+  commit. Use when reviewing the sidecar surface as a whole.
+model: inherit
+allowed_tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Write
+  - Agent
+  - Skill
+---
+
+> **Git safety.** Never invoke `reset --hard`, `push --force`, `checkout -- <paths>`, `clean -f`, `stash drop`, or `branch -D` without explicit user instruction in this session. See `CLAUDE.md` → Git Operations & Destructive Commands.
+>
+> **Scope policy.** This agent **analyzes and plans only**. It does not edit source, run refactors, commit, push, tag, or create branches. It writes exactly two artifacts (analysis + change plan) and then halts for the user to review. Execution, if approved, is driven by the user (manually or via `/quality-session`).
+
+You are a design auditor for the **sidecar surface** of the mununu formal verification tool (Rust workspace: `mununu-core`, `mununu-cli`, `mununu-extract`; TypeScript UI in the sibling `mununu-ui` repo).
+
+A **sidecar** in mununu is an auxiliary JSON/metadata artifact passed alongside an adapter input to steer abstraction — what to enumerate, bucket, discover, or drop. Sidecars are **soundness-load-bearing**: each field encodes an over- or under-approximation decision (see `CLAUDE.md` → Soundness Guarantees and `docs/abstraction.md`). Treat every proposal to merge, remove, or restructure a sidecar as a change that can silently flip a verdict's soundness. That bias — toward preserving semantics over tidying shape — governs the whole audit.
+
+Your job is to answer three questions for the sidecar surface as a whole, backed by evidence:
+
+1. **Redundant or outdated** — are two sidecar kinds (or two fields) expressing the same abstraction decision? Is a sidecar tied to a removed/renamed code path, an obsolete RFC item, or a format version no surface emits anymore? → candidates to **merge or remove**.
+2. **Under-served mechanism** — is a sidecar doing a job that deserves a more complete, more discoverable, more user-friendly mechanism (first-class CTXDSL syntax, a richer CLTS/IR primitive, a guided CLI subcommand, a UI panel, a schema with validation)? → candidates to **elevate**.
+3. **Symptom of poor crate design** — does a sidecar exist only to paper over a missing abstraction, a leaky module boundary, or a struct that grew by accretion across many construction sites? → candidates to trigger **refactoring or unification** of the *underlying crate*, not just the sidecar.
+
+## Operating context — agent-coauthored, accretion-prone surface
+
+Much of the sidecar surface was authored incrementally by AI agents, one RFC sub-item at a time (R-S1, R-S2b, R-S6, R-Y6, …). The characteristic failure modes you are hunting are therefore:
+
+- **Field accretion.** A struct (`SvAnnotation`, `SignalAnnotation`, `AdapterOptions`, `CegarOptions`) that gained one field per feature commit, now spanning many construction sites — the CLAUDE.md pre-push workspace-check rule lists these load-bearing types precisely because they accrete.
+- **Parallel mechanisms for one decision.** Two sidecar kinds, or a sidecar field *and* a CTXDSL form, that both express the same abstraction (e.g. a discovered-value list vs. an enum value-map; a reset-sequence sidecar vs. an inline reset directive).
+- **Stranded versions.** A `*_v1` format tag, a serde-defaulted field, or a JSON shape that no current adapter path or surface still reads.
+- **Sidecar-as-workaround.** A sidecar field that exists because the IR/CTXDSL couldn't express the thing directly — the real fix is a primitive, and the sidecar is the symptom.
+
+**Meta-rule.** When you propose merging two things that *look* alike, first name the shared invariant explicitly. Two sidecar fields that look similar but encode different abstraction directions (one over-approx, one under-approx; one on a register, one on an input port) must NOT be merged. Forced unification of accidentally-similar abstraction knobs is the most dangerous error you can make here. When in doubt, record as "review only," not "merge."
+
+## Preflight
+
+Run before anything else:
+
+1. Read `CLAUDE.md` in full — especially Soundness Guarantees, Surface Parity, Adapter / Emitter Capability Use, and the pre-push workspace-check list of load-bearing structs.
+2. Read `docs/abstraction.md` (the per-subsystem abstraction recipe) so you can judge whether a sidecar is the *right* mechanism for the decision it encodes.
+3. Confirm the three delegated skills resolve: `parity-check`, `docs-traceability`, `soundness-check`. If any is unreachable, note it in the report and continue (those axes degrade to manual inspection rather than halting).
+4. Initialize the session:
+   ```bash
+   SESSION_ID=$(date -u +%Y%m%d-%H%M%S)
+   SESSION_DIR=".claude/reviews/sidecar-audit/$SESSION_ID"
+   mkdir -p "$SESSION_DIR"
+   ```
+   Use `$SESSION_DIR` for every artifact below.
+
+## Phase 1: Inventory — enumerate every sidecar kind
+
+Build a complete census before judging anything. Sweep two ways and reconcile:
+
+- **By content:** `rg -i 'sidecar' --type rust`, plus `rg 'serde_json::from_(str|slice|reader)' --type rust` and `rg '#\[derive\([^)]*Deserialize' --type rust` to catch JSON-loaded auxiliary structs that aren't literally named "sidecar."
+- **By naming convention:** the load-bearing/auxiliary struct families — `*Annotation`, `*Concretization`, `*Config`, `ResetSequence`, `SimulateReset`, `VcdTrace*`, `*Interface`, `*Report`, `RegisterMap`, `SidecarFile`, `AdapterOptions`/`CegarOptions` sidecar fields.
+
+You may fan out this sweep to an `Explore` subagent (read-only) if it's faster, but you own the reconciled result. Record one row per **sidecar kind** in `$SESSION_DIR/inventory.md`:
+
+| Kind | Root struct (`file:line`) | Format tag / version | Loaded at (`file:line`) | Emitted at (`file:line`) | CLI flag | API field | UI client | Docs anchor | RFC item / origin |
+|---|---|---|---|---|---|---|---|---|---|
+
+Group rows by purpose. The known families (verify against current source — do not trust this list blindly, it may have drifted):
+- **Signal-abstraction** — `SvAnnotation` / `SignalAnnotation` / `SignalAbstraction` / `InputAnnotation` / `DiscoveredValues`.
+- **Parameter / reset / init** — `ParameterConcretization`, `ResetSequence`, `SimulateReset`, `ResetSimConfig`.
+- **Trace / evidence** — `VcdTraceConfig`, VCD seeding, diagnostics-DSL traces.
+- **Multi-module composition** — `MultiModuleSvAnnotation`, `ConnectionSpec`, `CompositionConfig`, `BlackboxModuleEntry`.
+- **Contract / black-box** — `BlackBoxInterface`, `GapMarkerReport`, `Phase1Output`.
+- **Codesign** — `RegisterMap`.
+- **SMT discovery** — `predicate_image` types (`Predicate`, `AbstractTransition`, `ImageOptions`).
+- **API/HTTP wrappers** — `SidecarFile`, `SvInitResponse`, `SvDiscoverResponse`.
+
+Flag any kind whose **Loaded at** or **Emitted at** column is empty — a struct that is neither produced nor consumed by a reachable path is a removal candidate on its face.
+
+## Phase 2: Delegated axis checks
+
+Run the three skills scoped to the sidecar surface and capture their raw output into `$SESSION_DIR/`:
+
+1. **`/parity-check`** — pass the sidecar-related CLI flags, API fields, and UI clients from the Phase 1 inventory. Goal: find sidecar kinds that are CLI-only (or API-only) and never reached the other surfaces, in violation of `CLAUDE.md` → Surface Parity. Capture to `parity.md`.
+2. **`/docs-traceability`** — pass the docs paths that describe sidecar formats (and any sidecar struct names). Goal: find sidecar schemas with no live `Source of truth:` anchor, or anchors pointing at renamed/removed sidecar fields. Capture to `docs.md`.
+3. **`/soundness-check`** — scoped to the adapter/sidecar-loading code. Goal: find sidecar fields that drop or bucket information without a nearby `// SOUNDNESS:` annotation, and silent under-uses of CLTS/CTXDSL primitives that a sidecar is working around. Capture to `soundness.md`.
+
+These three are evidence inputs to Phase 3 — do not restate their methodology, cite their findings.
+
+## Phase 3: Schema & versioning consistency
+
+For each sidecar kind, record in `$SESSION_DIR/schema.md`:
+
+- **Version tag** present? (`mununu_sv_annotation_v1`, `mununu_sv_multi_v1`, …) Is the tag validated on load, or accepted silently? Are there multiple live versions, and does any loader reject the wrong one?
+- **serde posture** — `#[serde(default)]` / `deny_unknown_fields` / `rename` usage. A missing `deny_unknown_fields` on a sidecar that users hand-author is a silent-typo trap; flag it. A `default` on a field that encodes an abstraction decision means "absence = some default approximation" — confirm that default is the *sound* direction and is documented.
+- **Forward/backward compat** — would adding a field break old sidecars? Would an old binary silently ignore a new field a user set, changing the verdict without warning?
+- **JSON Schema** — is there a checked-in `*.json` schema (like the `.espec.json` schema) for this sidecar, or is the Rust struct the only contract? Hand-authored sidecars with no schema are elevation candidates.
+
+## Phase 4: Synthesis — the analysis report
+
+Write `$SESSION_DIR/analysis.md` with these sections:
+
+- **Executive summary.** Traffic-light (GREEN/YELLOW/RED) per family, and the 3–5 highest-leverage findings.
+- **Census.** The Phase 1 inventory table, with the empty-column (orphan) flags called out.
+- **Findings**, each tagged with one of the three verdicts and a confidence level:
+  - `REDUNDANT/OUTDATED` → which kinds/fields overlap or are stranded, with the shared-invariant justification (per the meta-rule) or the dead-path evidence.
+  - `ELEVATE` → which sidecar deserves a first-class mechanism (CTXDSL form / IR primitive / guided CLI / UI panel / JSON schema), and what the user-facing win is.
+  - `CRATE-DESIGN` → which sidecar is a symptom of a missing abstraction or leaky boundary in `mununu-core`, naming the struct/module that should change.
+  - Each finding cites `file:line` evidence and the relevant Phase 2/3 result.
+- **Soundness risk register.** For every proposed merge/remove/elevate, the specific way it could flip a verdict's soundness, and the test that must pin the behavior before any edit. No finding is actionable without its risk-register row.
+- **Non-findings.** Things that looked redundant but are correctly distinct (record the distinguishing invariant) — this prevents a future audit from re-flagging them and prevents a careless merge.
+
+## Phase 5: The change plan
+
+Write `$SESSION_DIR/plan.md` — a phased, reviewable plan, **not** executed:
+
+- **Per change**: target struct/field/module (`file:line`), verdict it addresses, the ordered edit steps (each ≤ ~150 lines / ≤ 3 files, leaving the tree compiling and tests green), the construction sites that must be updated together (cross-reference the CLAUDE.md pre-push load-bearing-struct list when a `pub` field of `OriginalTransition` / `SignalAnnotation` / `AdapterOptions` / `CegarOptions` / `ParameterConcretization` etc. is touched), and the surface-parity work (CLI+API+UI must land together).
+- **Behavior-pin step first.** Every change that touches a sidecar's load/emit path must list the characterization test to add *before* editing, sourced from the format docs or call sites — not from an existing agent-written test that may encode the bug.
+- **Doc + schema deltas.** Which `docs/` anchors and which JSON schema (if any) each change must update in the same step.
+- **Ordering & dependencies.** Sequence changes so soundness-risky merges come last, after the safe orphan-removals and doc fixes have de-risked the surface.
+- **Stop / abort conditions.** What makes a change not worth doing (e.g. the "shared invariant" turns out not to hold), and what aborts it mid-flight (coverage regression, broken doc anchor, a soundness anchor no longer holding).
+
+## Close
+
+End your run with a short message to the user that:
+1. Points at `$SESSION_DIR/analysis.md` and `$SESSION_DIR/plan.md`.
+2. Lists the top 3 findings by leverage and the single biggest soundness risk.
+3. States explicitly that **nothing has been changed** and asks the user which plan items (if any) to execute — and whether to hand execution to `/quality-session` or drive it directly.
+
+Do not proceed to execution without explicit user approval naming the items to do.

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ secrets.toml
 bench_results/
 /.mununu_dsl_debug/
 
+# Generated verify-example build output (CEGAR run artifacts, etc.)
+examples/verify/**/build/
+
 # Reproducible-experiments scaffold: target/test-fixtures/ holds canonical
 # CLTS fixtures rebuilt from seeds, and per-EXP bench stdout is captured
 # alongside the criterion archive but the live run log shouldn't be tracked.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,314 @@
+# Onboarding — mununu
+
+> **Status: Alpha.** mununu is under active development. The fundamentals are stable; the surface keeps moving. Every section of this document is annotated with a **Stability** tag and a **Last reviewed** stamp so you can tell at a glance what to trust. If you read a section and find it stale, file a `doc` finding in `REVIEW_LOG.md` (or fix it — bumping `Last reviewed:` is the only requirement).
+
+This document is what we wish we had on day one. It is **not** a complete reference — the source tree, `CLAUDE.md`, and `docs/` are. It *is* the shortest path from "I have cloned the repo" to "I can ship a feature without breaking something subtle."
+
+## Stability key
+
+| Tag | Meaning | What you can rely on |
+|-----|---------|----------------------|
+| `stable` | Change requires a deprecation cycle. | The shape, the contract, the name. |
+| `evolving` | Shape is known, surface is shifting. **The default in mununu right now.** | The mental model; expect renames and additions. |
+| `experimental` | May be removed entirely. | Nothing — read for context, don't build on it. |
+| `planned` | Documented for context, not yet implemented. | Only the design doc it points at. |
+
+Sections may also carry `> **Expected change:** <description> — <link>` when a specific upcoming shift is known.
+
+A `Last reviewed:` stamp older than 6 months auto-downgrades the section to `stale — re-verify before relying`.
+
+---
+
+## Table of Contents
+
+1. [Getting Started](#1-getting-started)
+2. [The Mental Model](#2-the-mental-model)
+3. [Core Concepts](#3-core-concepts)
+4. [The Adapter Family](#4-the-adapter-family)
+5. [The User Surfaces](#5-the-user-surfaces)
+6. [Working in this Codebase](#6-working-in-this-codebase)
+7. [Living Architecture](#7-living-architecture)
+8. [Glossary](#8-glossary)
+9. [Recipes — "I want to add a new X"](#9-recipes)
+
+---
+
+## 1. Getting Started
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 1)
+
+*To be written during Chapter 1 of the review. Should cover: clone, build, the `make ci` contract, the three crates (`mununu-core`, `mununu-cli`, `mununu-extract`) and what each is for, the pre-commit hook setup, your first smoke test against `examples/counters/`.*
+
+---
+
+## 2. The Mental Model
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 1A)
+
+*To be written during Chapter 1A. Should cover, in your words: the three-layer model (extraction → adaptation → verification), the surface-parity rule (CLI / API / UI), the soundness directions (safety + over-approx = sound, etc.), the abstraction-posture vocabulary.*
+
+---
+
+## 3. Core Concepts
+
+> Each subsection has its own stability annotation; the parent has none.
+
+### 3.1 CLTS and KMTS
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 2)
+
+*To be written during Chapter 2. Should cover: states, labels, multi-label edges (one edge ≠ parallel edges), per-state valuations, `LabelControllability`, `Tristate`, `TransitionModality` (Sharp / MayOnly / MustHyperOnly), the `must ⊆ may` invariant. Include one minimal CTXDSL example.*
+
+### 3.2 μ-calculus — Formulas, Guards, Environments
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 3)
+
+*To be written during Chapter 3. Should cover: the `Formula` shape, the five-axis `Guard` (`labels` / `current` / `next` / `control` / `max_steps`), the `Environment` for fixpoint binding, `req_next` / `forb_next` as the under-used primitive worth knowing about.*
+
+### 3.3 μ-calculus — Evaluator
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 4)
+
+*To be written during Chapter 4. Should cover: how to read a 2-valued vs 3-valued verdict, what a witness/lasso trace looks like, the fixpoint inversion rule as a "do not negate the variable" gotcha callout.*
+
+### 3.4 LTL Translation
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 5)
+
+*To be written during Chapter 5. Should cover: which LTL fragment is accepted, where translation lives, the common patterns (`G`, `F`, `U`, response).*
+
+### 3.5 Composition
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 6)
+
+*To be written during Chapter 6. Should cover: each operator (async product / hide / minimize / controllability), the CSP synchronisation rule with a 2x2 diagram, where the `controllability` module fits.*
+
+### 3.6 Abstraction
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 7)
+
+*To be written during Chapter 7. Should cover: how to choose an abstraction posture, where to write `// SOUNDNESS:` comments, the over/under-approximation cheat-sheet for safety vs liveness.*
+
+### 3.7 CTXDSL and `RealizedContext`
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 8)
+
+*To be written during Chapter 8. Should cover: what CTXDSL is, what it is not (it is the IR-as-text, not the source language for new users), the parse → canonicalize → realize pipeline, what a `RealizedContext` carries.*
+
+### 3.8 Synthesis and Diagnostics
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 9)
+
+*To be written during Chapter 9. Should cover: how to read a synthesised controller, the three diagnostic kinds (deadlock / initial failure / vacuous), the difference between counterexamples and counterstrategies.*
+
+### 3.9 Contracts and Codesign
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 13)
+
+*To be written during Chapter 13. Should cover: assume-guarantee in mununu terms, the chaotic-stub default and its direction-dependent soundness, when codesign coupling fires.*
+
+---
+
+## 4. The Adapter Family
+
+### 4.1 Adapter IR contract
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 10)
+
+*To be written during Chapter 10. Should cover: the `AdapterIR` shape, the emit.rs contract (signal-state mode vs explicit-automaton mode), the parse → emit → parse round-trip as the canonical test pattern.*
+
+### 4.2 Per-adapter quick reference
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 11)
+
+*To be written during Chapter 11. One paragraph per adapter: input format, what it abstracts, sidecar requirements (if any), and an individual `Stability:` tag (some adapters are stable, others are evolving or experimental).*
+
+Adapters to cover: SystemVerilog (+ Yosys / BTOR2 / KMTS lift), AIGER, TLSF, Promela, xstate, crewai, langgraph, extraction (.espec.json), library templates (PLIC, watchdog, tracked-memory). The microcode adapter is `planned` — note it but link to the design doc.
+
+### 4.3 The verify orchestrator
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 12)
+
+*To be written during Chapter 12. Should cover: the `verify.toml` schema, alphabet binding rules, what happens when two sources bind the same label.*
+
+---
+
+## 5. The User Surfaces
+
+### 5.1 CLI
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 14)
+
+*To be written during Chapter 14. Should cover: every subcommand at one-line resolution, what each does, where the CLI ends and the library begins. Include the `mununu <cmd> --help`-yourself convention.*
+
+### 5.2 HTTP API
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 15)
+
+*To be written during Chapter 15. Should cover: the endpoint list, request/response shapes, the performance rule (no synthesis in summary endpoints), the timing-log discipline.*
+
+### 5.3 UI
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 16)
+
+*To be written during Chapter 16. Should cover: what the UI consumes from the API, where the typed client lives (`mununu-ui/src/api/endpoints.ts`), what counts as a valid single-surface exception.*
+
+---
+
+## 6. Working in this Codebase
+
+### 6.1 Rust idioms specific to mununu
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 0)
+
+*To be written during Chapter 0. A condensed 200-word recap of patterns 9–22 from the review plan with one canonical anchor each; cross-link to the longer list for newcomers who want all 22.*
+
+### 6.2 The CI gate
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 1)
+
+*To be written during Chapter 1. Should cover: `make ci` is the contract; what it runs; what the pre-commit hook adds; how to reproduce a CI failure locally; what to do when a hook fails (create a new commit, never `--amend`, never `--no-verify` without authorisation).*
+
+### 6.3 Testing pattern
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 10)
+
+*To be written during Chapter 10. Should cover: the three-level adapter testing requirement, the parse→emit→parse round-trip, when to write a unit test vs an integration test, where test_support lives.*
+
+### 6.4 Soundness-comment discipline
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 7)
+
+*To be written during Chapter 7. Should cover: every `eval_expr → None` needs a `// SOUNDNESS:` comment naming over- or under-approximation, why this is enforced by convention rather than the type system (and what would change if it were enforced by type — see Ch 17A verdict on AQ7.1).*
+
+### 6.5 Cross-cutting policies
+
+> **Stability:** —
+> **Last reviewed:** — (Chapter 17)
+
+*To be written during Chapter 17. One paragraph each on: Surface Parity, Documentation Traceability, Claims Integrity. Each with the relevant `/parity-check`, `/docs-traceability`, `/soundness-check` skill invocation.*
+
+---
+
+## 7. Living Architecture
+
+> **Stability:** evolving (this whole section is by definition evolving — the alpha admission)
+> **Last reviewed:** — (Chapters 1A → 17A)
+
+This section is the alpha-honesty section: it tells you which architectural claims about mununu are currently true, which are currently shifting, and which are open RFCs. **Read it before you assume any specific decomposition is permanent.**
+
+It is populated in two passes: the *initial* shape during Chapter 1A (the architectural claims under test), the *final* shape during Chapter 17A (which claims survived, which were falsified, which became RFCs).
+
+### 7.1 What is stable
+
+*Populated in Ch 17A. List each architectural claim that survived the review unchallenged, with a one-line rationale and the finding ID that confirmed it.*
+
+### 7.2 What is evolving
+
+*Populated in Ch 17A. List each architectural claim that is settled in shape but expected to shift in surface (renames, refactors, additions). For each, the expected change and the issue/RFC link.*
+
+### 7.3 What is experimental
+
+*Populated in Ch 17A. List each architectural area that may be removed or replaced. Anything here is "do not build on it" — name what to use instead.*
+
+### 7.4 What is planned
+
+*Populated in Ch 17A. List capabilities documented in `docs/design/` but not yet implemented (microcode adapter, certain KMTS R.x refinements, etc.). Link the design doc. Do not list them as if they exist.*
+
+### 7.5 Open RFCs from the review
+
+*Populated in Ch 17A. List each `arch`+`bug` finding that was deferred to an RFC, with the RFC link and a one-line description of what it would change.*
+
+---
+
+## 8. Glossary
+
+> **Stability:** —
+> **Last reviewed:** —
+
+*Built incrementally — each Core Concepts chapter adds its load-bearing terms. Maintain alphabetical order.*
+
+| Term | One-line definition | Anchor |
+|------|---------------------|--------|
+| **AdapterIR** | | |
+| **CLTS** | | |
+| **Controllability class** | | |
+| **CTXDSL** | | |
+| **Environment** (μ-calculus) | | |
+| **Formula** (μ-calculus) | | |
+| **Guard** (μ-calculus) | | |
+| **KMTS** | | |
+| **MayOnly** (transition modality) | | |
+| **MustHyperOnly** (transition modality) | | |
+| **RealizedContext** | | |
+| **Sharp** (transition modality) | | |
+| **Sidecar** | | |
+| **Soundness posture** | | |
+| **Tristate** (Kleene) | | |
+
+---
+
+## 9. Recipes
+
+> **Stability:** —
+> **Last reviewed:** —
+
+The "I have done this before, where do I start" section. Each recipe is a numbered checklist; most are 5–8 steps.
+
+### 9.1 Add a new adapter
+
+*Drafted in Chapter 11. Steps: parser → adapter IR → emit round-trip test → CLI hook → API hook → UI client → docs traceability anchor.*
+
+### 9.2 Add a new CLI subcommand
+
+*Drafted in Chapter 14.*
+
+### 9.3 Add a new property template
+
+*Drafted in Chapter 8.*
+
+### 9.4 Ship a feature across all three surfaces
+
+*Drafted in Chapter 15. The surface-parity recipe — CLI handler + API handler + UI client + docs anchor + parity-check skill pass.*
+
+### 9.5 Declare a new soundness posture
+
+*Drafted in Chapter 7. When to use `// SOUNDNESS:`, when to use `AbstractionType::Symbols([…])` in a sidecar, when to add a comment block at the top of a CTXDSL source.*
+
+### 9.6 Add an LTL pattern
+
+*Drafted in Chapter 5.*
+
+---
+
+## Stewardship
+
+This document is alive. To keep it from rotting:
+
+- Any PR that changes a load-bearing primitive, surface, or architectural claim must update the relevant section AND bump its `Last reviewed:` stamp.
+- Sections older than 6 months are auto-flagged stale.
+- The review process that built this document (see `~/.claude/plans/i-am-looking-the-declarative-snowflake.md`) can be re-run periodically to refresh.
+- Use `ShareOnboardingGuide` to publish a shareable link teammates can open without cloning the repo.
+
+When in doubt, prefer truthful "this is currently in flux" over confident-sounding fiction. Alpha software deserves alpha-honest docs.

--- a/REVIEW_LOG.md
+++ b/REVIEW_LOG.md
@@ -1,0 +1,867 @@
+# mununu Hand-Review Log
+
+Companion to `~/.claude/plans/i-am-looking-the-declarative-snowflake.md`.
+Append-only. One H2 section per chapter. Roll up `bug`-severity findings at the end when all chapters are `done`.
+
+## Conventions
+
+### Severity vocabulary (fixed)
+
+- **`bug`** — incorrect behaviour, soundness violation, or contract breach. For `arch`-category findings, `bug` means *the codebase violates a stated architectural contract* (e.g. an adapter reaches into another adapter; a summary endpoint runs synthesis). Must be filed as a follow-up before the chapter can be marked `done` (architecture `bug`s block Ch 17A, not the chapter where they were found).
+- **`concern`** — design / clarity / documentation issue that would block a new contributor; not blocking for the review itself.
+- **`note`** — observation, "huh interesting", possible future cleanup.
+
+### Category vocabulary (fixed)
+
+- **`behavior`** — code does the wrong thing (or a non-obvious right thing worth documenting). Fix near where found.
+- **`arch`** — decomposition / layering / dependency-direction / primitive-choice issue. Do *not* fix mid-review; accumulate evidence and decide in Chapter 17A.
+- **`doc`** — drift between documentation and code (anchor for `/docs-traceability`). Often a quick fix; sometimes signals an `arch` issue underneath.
+
+### Finding ID format
+
+`CC-FNN` where `CC` is the chapter number (zero-padded, `00`–`17`, or `1A` / `17A` / `11a`–`11f` for letter-suffixed chapters) and `NN` is sequential within the chapter. Examples: `02-F01`, `11a-F03`, `17A-F02`.
+
+### Status vocabulary
+
+- Chapter status: `not started` → `in-progress` → `blocked` | `done`
+- Finding status: `open` → `triaged` → `fixed in <sha>` | `wontfix (<reason>)` | `RFC <link>` (for `arch` findings deferred to 17A)
+
+### Per-chapter template
+
+```markdown
+## Chapter NN — <title>
+
+Started: YYYY-MM-DD
+Reviewer: <your name>
+Status: in-progress
+
+### Acceptance Criteria
+- [ ] Comprehension Q1: …
+- [ ] Smoke test: <command>
+- [ ] (sensitive only) Invariant I1: …
+- [ ] (sensitive only) Architecture Question AQ1: <answer in log below>
+- [ ] **Onboarding contribution**: `ONBOARDING.md` §<from plan's contribution table> updated, `Stability:` annotation set, `Last reviewed:` stamped
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Architecture Q&A (sensitive chapters only)
+- AQ1: <question> — <yes/no/tradeoff> — <evidence cite> — <action if not yes>
+
+### Decisions
+-
+
+### Follow-ups
+-
+```
+
+---
+
+## Chapter 0 — Rust Orientation Primer
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Explain patterns 9–22 in your own words
+- [ ] Smoke test: `cargo build --workspace && cargo test --workspace -- --skip slow`
+- [ ] First finding logged (even a `note`) so the log mechanism is working
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 1 — Workspace, Build, CI Gate
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] `make ci` green on `main`
+- [ ] List three crates, their bin/lib status, and feature flags from memory
+- [ ] Pre-commit hook installed and understood
+- [ ] Smoke test: `make ci`
+- [ ] Smoke test: `cargo build --workspace --release`
+- [ ] Smoke test: `mununu --help`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 1A — Architecture Baseline (opening bookend)
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] §1 Dependency DAG drawn in this entry (ASCII), back-edges flagged
+- [ ] §2 Primitive inventory written (one sentence each for `Clts`, `LabelId`, `StateId`, `LabelControllability`, `TransitionModality`, `Tristate`, `Formula`, `Guard`, `Environment`, `AdapterIR`, `RealizedContext`, `Context`, `Contract`)
+- [ ] §3 User surfaces with their contracts
+- [ ] §4 At least 6 architectural claims with a paired falsifiability hook ("how would I know this is false?")
+- [ ] §5 At least 4 open architecture questions, each with a back-pointer to the chapter that will most likely answer it
+- [ ] First `arch`-category finding logged (a `note` is fine) so the schema is exercised
+
+### §1 Dependency DAG (your reconstruction)
+
+```
+(write the DAG here after reading docs/architecture/ and crates/mununu-core/src/lib.rs)
+```
+
+Back-edges noted:
+-
+
+### §2 Primitive inventory
+
+| Type | Responsibility (one sentence) |
+|------|-------------------------------|
+| `Clts` | |
+| `LabelId` | |
+| `StateId` | |
+| `LabelControllability` | |
+| `TransitionModality` | |
+| `Tristate` | |
+| `Formula` | |
+| `Guard` | |
+| `Environment` | |
+| `AdapterIR` | |
+| `RealizedContext` | |
+| `Context` | |
+| `Contract` | |
+
+Suspected overlaps (record now; will be checked across the review):
+-
+
+### §3 User surfaces and their contracts
+
+- **CLI**:
+- **HTTP API**:
+- **UI**:
+
+### §4 Architectural claims to be tested
+
+| # | Claim | Falsifiability hook (how would I know this is false?) |
+|---|-------|--------------------------------------------------------|
+| C1 | | |
+| C2 | | |
+| C3 | | |
+| C4 | | |
+| C5 | | |
+| C6 | | |
+
+### §5 Open architecture questions
+
+| # | Question | Likely-answered-in |
+|---|----------|---------------------|
+| AQ-1.1 | | |
+| AQ-1.2 | | |
+| AQ-1.3 | | |
+| AQ-1.4 | | |
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 2 — CLTS Data Model `[SENSITIVE]`
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Comprehension Q: why is `MustHyperOnly` boxed and other variants not?
+- [ ] Comprehension Q: what does it mean for a CLTS to have *no* `state_valuation` for a given state?
+- [ ] Smoke test: `cargo test -p mununu-core clts::`
+- [ ] Smoke test: `cargo test -p mununu-core --test r3_kleene_baseline`
+- [ ] **I2.1**: no adapter / lifter constructs `TransitionModality::MustHyperOnly(_)` (only `composition::*` does) — `rg "MustHyperOnly\(" crates/mununu-core/src/adapter/` returns nothing surprising
+- [ ] **I2.2**: `must ⊆ may` invariant — no constructor produces "must without may"
+- [ ] **I2.3**: `LabelControllability` never encoded as label-name suffix (`_ctrl_`, `_unctrl_`, `_env_` grep returns only test fixtures)
+- [ ] **I2.4**: multi-label edges built as one transition (spot-check `adapter::aiger`)
+- [ ] **I2.5**: `Tristate::KleeneBot` only demoted to definite verdict via documented paths
+- [ ] **AQ2.1** answered in §Architecture Q&A
+- [ ] **AQ2.2** answered in §Architecture Q&A
+- [ ] **AQ2.3** answered in §Architecture Q&A
+- [ ] **AQ2.4** answered in §Architecture Q&A
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Architecture Q&A
+- **AQ2.1 — Module boundary**: Should `Tristate` and `TransitionModality` live inside `clts/mod.rs`, or be promoted to a sibling `kmts/` module?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ2.2 — Primitive overlap**: Do `state_variable_bitset`, `state_valuation`, and `state_3valued_predicates` represent three views of the same information, or three distinct facts?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ2.3 — Type-level vs comment-level invariants**: Could `must ⊆ may` be enforced by construction (private fields, smart constructors) rather than by absence-of-constructor?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ2.4 — `IdStorage` genericity**: Is parameterising every CLTS over `S: IdStorage` paying for itself, or is everyone using `DefaultStateIdx`?
+  - Answer:
+  - Evidence:
+  - Action:
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 3 — μ-calculus AST, Environment, Guards
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Comprehension Q: draw the set of transitions constrained by `[(labels = {a}, req_next = {active}, ctrl = controllable)] φ`
+- [ ] Comprehension Q: difference between `req_cur` and `req_next` semantically
+- [ ] Smoke test: `cargo test -p mununu-core mu_calculus::`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 4 — μ-calculus Evaluator `[SENSITIVE]`
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Comprehension Q: hand-walk `νX. p ∧ [a]X` on a 3-state automaton, then confirm against `cargo run`
+- [ ] Smoke test: `cargo test -p mununu-core --test mu_calculus_response_pattern`
+- [ ] Smoke test: `cargo test -p mununu-core --test r3_kleene_baseline`
+- [ ] Smoke test: `mununu context eval examples/counters/counters.ctxdsl --sidecar examples/counters/counters_properties.ctxdsl --formula reachability --automaton Counter`
+- [ ] **I4.1**: fixpoint inversion rule — `¬(μX. φ) → νX. ¬φ`, body's `X` references NOT negated; confirm with witness test
+- [ ] **I4.2**: witness/strategy extraction returns lasso traces (prefix + cycle); cycle non-empty for liveness witnesses, prefix may be empty
+- [ ] **I4.3**: `evaluate_tri` never silently collapses `KleeneBot`; every demotion commented
+- [ ] **I4.4**: `evaluate` over sharp-everywhere KMTS = identical results to 2-valued evaluator (semantic regression)
+- [ ] **AQ4.1** answered in §Architecture Q&A
+- [ ] **AQ4.2** answered in §Architecture Q&A
+- [ ] **AQ4.3** answered in §Architecture Q&A
+- [ ] **AQ4.4** answered in §Architecture Q&A
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Architecture Q&A
+- **AQ4.1 — Truth-domain parametricity**: Could `evaluate` and `evaluate_tri` be one function parameterised over `TruthDomain`?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ4.2 — Witness extraction coupling**: Should witness extraction and counterstrategy emission share a common abstract output, or is lasso-vs-automaton fundamental to liveness-vs-safety witnessing?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ4.3 — Fixpoint inversion as a separate pass**: Should the inversion transformation be a named single-source-of-truth function?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ4.4 — Modality five-axis guard as one type**: Are all five `Guard` axes always used together, or is the struct "wide" (common case is 1–2 axes)?
+  - Answer:
+  - Evidence:
+  - Action:
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 5 — LTL → μ-calculus Translation
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Comprehension Q: hand-translate `G(req → F grant)` and compare with translator output
+- [ ] Comprehension Q: what LTL fragment is *not* supported? (find `TranslationError` arms)
+- [ ] Smoke test: `cargo test -p mununu-core --test ltl_patterns`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 6 — Composition `[SENSITIVE]`
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Smoke test: `cargo test -p mununu-core composition::`
+- [ ] Smoke test: `mununu context eval examples/counters/counters.ctxdsl --formula reachability --automaton Counter`
+- [ ] **I6.1**: shared alphabet synchronises, independent labels interleave (CSP rule); confirm with 2x2 hand example
+- [ ] **I6.2**: `Internal` controllability mutually-exclusive between automata in composition; confirm composition test where one side has `Internal a` and the other `Controllable a`
+- [ ] **I6.3**: `TransitionModality::MustHyperOnly` placeholder from `merge` IS realized in composition layer; grep for `merge_with_hyper_targets`
+- [ ] **I6.4**: bisimulation minimization preserves μ-calculus semantics on surviving label set (regression test)
+- [ ] **AQ6.1** answered in §Architecture Q&A
+- [ ] **AQ6.2** answered in §Architecture Q&A
+- [ ] **AQ6.3** answered in §Architecture Q&A
+- [ ] **AQ6.4** answered in §Architecture Q&A
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Architecture Q&A
+- **AQ6.1 — `composition::controllability` vs top-level `controllability`**: Clean producer/consumer split or duplicated logic?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ6.2 — Operator catalogue completeness**: Is the composition operator set what CTXDSL exposes? Any user-askable operator that doesn't exist (or vice versa)?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ6.3 — `ProductStateArena` interior mutability**: Could `RefCell<HashMap<...>>` be replaced with an explicit `&mut` builder?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ6.4 — Layer position of minimization**: Should bisimulation minimization live next to `clts/` rather than under `composition/`?
+  - Answer:
+  - Evidence:
+  - Action:
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 7 — Abstraction `[SENSITIVE]`
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Smoke test: `cargo test -p mununu-core abstraction::`
+- [ ] **I7.1**: every `eval_expr → None` site in abstraction layer has nearby `// SOUNDNESS:` comment naming over/under approximation
+- [ ] **I7.2**: abstraction posture declared per adapter (spot-check three from Ch 11)
+- [ ] **AQ7.1** answered in §Architecture Q&A
+- [ ] **AQ7.2** answered in §Architecture Q&A
+- [ ] **AQ7.3** answered in §Architecture Q&A
+- [ ] **AQ7.4** answered in §Architecture Q&A
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Architecture Q&A
+- **AQ7.1 — Comment-discipline vs type-level soundness**: Could `eval_expr` return `EvalResult { value, posture }` so the posture is non-optional by construction?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ7.2 — Layer position of abstraction**: Producer, consumer, or both? If both, is the bidirectional dependency a smell?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ7.3 — Per-subsystem recipe duplication**: Are the per-subsystem recipes encoded as code (library templates) or as prose only?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ7.4 — `ExpressionEvaluator<'a>` lifetime cost**: Any callsite that would benefit from owned state?
+  - Answer:
+  - Evidence:
+  - Action:
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 8 — CTXDSL: Parser → Realize → RealizedContext
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Comprehension Q: trace one CTXDSL source from text to `RealizedContext` — which functions touch it?
+- [ ] Comprehension Q: what does the canonicalizer guarantee post-pass?
+- [ ] Smoke test: `cargo test -p mununu-core context_dsl::`
+- [ ] Smoke test: `cargo test -p mununu-core --test context_dsl_controllability`
+- [ ] Smoke test: `mununu context parse examples/counters/counters.ctxdsl`
+- [ ] Smoke test: `mununu context canonicalize examples/counters/counters.ctxdsl`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 9 — Controller Synthesis & Diagnostics `[SENSITIVE]`
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Read `docs/synthesis.md` end-to-end, especially Skolem-paradigm rules
+- [ ] Smoke test: `cargo test -p mununu-core --test diagnostics`
+- [ ] Smoke test: `cargo test -p mununu-core --test scalable_gr1`
+- [ ] Smoke test: `mununu context synth <GR1 example>` produces non-empty controller
+- [ ] **I9.1**: strategy extraction uses signature-based selection from iteration ranks
+- [ ] **I9.2**: synthesis-failure diagnostic distinguishes deadlock trace / initial-state failure / vacuous spec
+- [ ] **I9.3**: counterstrategy emission produces CLTS-like structure, not single trace
+- [ ] **I9.4**: counterexamples (lasso traces) distinct from counterstrategies (witness automata) in API response shape
+- [ ] **AQ9.1** answered in §Architecture Q&A
+- [ ] **AQ9.2** answered in §Architecture Q&A
+- [ ] **AQ9.3** answered in §Architecture Q&A
+- [ ] **AQ9.4** answered in §Architecture Q&A
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Architecture Q&A
+- **AQ9.1 — Synthesis layer placement**: Should synthesis move out of `context/mod.rs` into a sibling `synthesis/` module?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ9.2 — Parity-game solver as its own crate**: Should the Zielonka / signature-extraction code be extracted to a `mununu-parity` crate?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ9.3 — Diagnostic shape uniformity**: Sum type with one canonical encoding, or three parallel structs?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ9.4 — Witness vs counterexample vs counterstrategy**: Same underlying notion under three names, or genuinely three artefacts?
+  - Answer:
+  - Evidence:
+  - Action:
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 10 — Adapter IR + CTXDSL Emitter
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Comprehension Q: which emitter mode produces multi-label edges, which produces parallel single-label edges, and why?
+- [ ] Smoke test: `cargo test -p mununu-core --test adapter_cross_format`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 11 — Adapter Walkthrough
+
+Started:
+Reviewer:
+Status: not started
+
+> One subsection per adapter. Findings namespaced as `11a-FNN`, `11b-FNN`, etc.
+
+### Per-adapter acceptance criteria (applies to every subsection)
+- [ ] Parse a real example without error
+- [ ] Emitted CTXDSL canonicalises losslessly (parse → emit → parse → equal)
+- [ ] Multi-label edges are *one* transition where source format has multi-action (Ch 2 I2.4)
+- [ ] Abstraction posture declared somewhere reachable from the adapter (Ch 7 I7.2)
+
+### 11a — SystemVerilog → Kripke (+ Yosys → BTOR2 → KMTS)
+- [ ] Smoke test: `cargo test -p mununu-core --test btor2_kmts_lift_sweep`
+- [ ] Smoke test: `cargo test -p mununu-core --test sv_preprocess_sweep`
+- [ ] Smoke test: `mununu sv discover examples/systemverilog/alu.sv`
+- [ ] **I11a.1** (sensitive): BTOR2 KMTS lifter never emits `MustHyperOnly`
+- [ ] **I11a.2**: every cross-module register read annotated as `KleeneBot` until sidecar resolves
+
+### 11b — AIGER / TLSF
+- [ ] Smoke test: `mununu context eval examples/aiger/alarm.aag --formula safety_alarm_on --automaton Circuit`
+
+### 11c — Promela
+- [ ] Smoke test: `mununu context eval examples/promela/mutex_simple.pml --formula mutex --automaton System`
+
+### 11d — Agentic (xstate / crewai / langgraph)
+- [ ] Smoke test: walk one example from `examples/agentic/` end-to-end
+
+### 11e — Extraction (.espec.json → CTXDSL)
+- [ ] Smoke test: `mununu context import examples/ast_extract/<one>/*.espec.json`
+- [ ] Walk both directions: `mununu-extract` (producer) and `adapter::extraction` (consumer)
+
+### 11f — Library templates (PLIC, watchdog, tracked-memory)
+- [ ] Smoke test: `mununu library list`
+- [ ] Smoke test: `mununu library emit plic …`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 12 — Verify Orchestrator
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Comprehension Q: trace one `verify.toml` end-to-end — which file calls which adapter, then which composition, then which evaluator?
+- [ ] Comprehension Q: what happens if two sources bind the same label?
+- [ ] Smoke test: `find examples -name verify.toml | head -3`
+- [ ] Smoke test: `mununu verify <that path>`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 13 — Contracts, Codesign, Black-Box Modules `[SENSITIVE]`
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Smoke test: `cargo test -p mununu-core contract::`
+- [ ] Smoke test: `mununu contract validate <example>`
+- [ ] Smoke test: `mununu codesign <example>`
+- [ ] **I13.1**: chaotic-stub default is over-approximation for environment-side missing contracts, under-approximation for system-side; verify both directions
+- [ ] **I13.2**: cyclic discharge does not produce circular A/G proofs without explicit well-founded ordering
+- [ ] **AQ13.1** answered in §Architecture Q&A
+- [ ] **AQ13.2** answered in §Architecture Q&A
+- [ ] **AQ13.3** answered in §Architecture Q&A
+- [ ] **AQ13.4** answered in §Architecture Q&A
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Architecture Q&A
+- **AQ13.1 — Contract as primitive vs derived**: Is `Contract` a first-class IR or a wrapper over μ-calculus formulas + metadata?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ13.2 — Codesign in `mununu-core` vs as adapter**: Can codesign be expressed as a sequence of (contract validation + verify-orchestrator + register-map adapter) calls?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ13.3 — Black-box discharge semantics**: Is the direction-dependent soundness of chaotic-stub reflected in the type system (`EnvContract` vs `SysContract` distinct), or a runtime convention?
+  - Answer:
+  - Evidence:
+  - Action:
+- **AQ13.4 — Composition with the rest of the verification stack**: Does contract validation reuse the μ-calculus evaluator, or have its own?
+  - Answer:
+  - Evidence:
+  - Action:
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 14 — CLI Surface
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Each `--help` matches the handler (no orphan flags)
+- [ ] At least one `--help`-documented example per subcommand actually runs
+- [ ] Smoke test:
+  ```bash
+  mununu --help
+  for cmd in context extraction sv templates library contract codesign verify memory server btor2; do
+      mununu $cmd --help >/dev/null && echo "OK $cmd" || echo "FAIL $cmd"
+  done
+  ```
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 15 — HTTP API Surface
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Smoke test: start server, `curl /health`, `curl /templates`, POST `/context/summarize` with small CTXDSL
+- [ ] **I15.1**: no summary endpoint runs synthesis (grep `handlers.rs` for `synthesize` calls in non-synthesis handlers)
+- [ ] **I15.2**: every handler logs parse / realize / work phases separately via `tracing::info!` with `Instant`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 16 — UI Parity
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Every endpoint from Ch 15 has a TS client function in `mununu-ui/src/api/endpoints.ts`
+- [ ] Single-surface exceptions declared inline with `surface: CLI-only — <reason>`
+- [ ] Smoke test: run `/parity-check` skill OR hand-walk each endpoint to its UI caller
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 17 — Cross-Cutting Policies
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Each skill produces a clean report OR triaged exceptions filed as follow-ups
+- [ ] No undocumented soundness decisions remain after triage
+- [ ] Run: `/parity-check`
+- [ ] Run: `/docs-traceability`
+- [ ] Run: `/soundness-check`
+- [ ] Run: `/review-orchestrator`
+
+### Findings
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Chapter 17A — Architecture Validation (closing bookend)
+
+Started:
+Reviewer:
+Status: not started
+
+### Acceptance Criteria
+- [ ] Every architectural claim from Chapter 1A§4 has a verdict line (survived / falsified / partial / unanswered)
+- [ ] Every architecture question (1A§5 + AQ2.x + AQ4.x + AQ6.x + AQ7.x + AQ9.x + AQ13.x) has a verdict line
+- [ ] All `arch`+`bug` findings are resolved OR have a filed follow-up (RFC stub or refactor plan)
+- [ ] CLAUDE.md or `docs/architecture/` updated with each surviving rationale
+- [ ] Any theme with ≥3 findings has an RFC stub linked from this entry
+
+### §1 Verdicts on architectural claims (from 1A §4)
+
+| # | Claim | Verdict | Evidence (finding IDs / chapter refs) |
+|---|-------|---------|---------------------------------------|
+| C1 | | | |
+| C2 | | | |
+| C3 | | | |
+| C4 | | | |
+| C5 | | | |
+| C6 | | | |
+
+### §2 Verdicts on architecture questions
+
+| # | Question | Verdict | Evidence |
+|---|----------|---------|----------|
+| AQ-1.1 | | | |
+| AQ-1.2 | | | |
+| AQ-1.3 | | | |
+| AQ-1.4 | | | |
+| AQ2.1 | | | |
+| AQ2.2 | | | |
+| AQ2.3 | | | |
+| AQ2.4 | | | |
+| AQ4.1 | | | |
+| AQ4.2 | | | |
+| AQ4.3 | | | |
+| AQ4.4 | | | |
+| AQ6.1 | | | |
+| AQ6.2 | | | |
+| AQ6.3 | | | |
+| AQ6.4 | | | |
+| AQ7.1 | | | |
+| AQ7.2 | | | |
+| AQ7.3 | | | |
+| AQ7.4 | | | |
+| AQ9.1 | | | |
+| AQ9.2 | | | |
+| AQ9.3 | | | |
+| AQ9.4 | | | |
+| AQ13.1 | | | |
+| AQ13.2 | | | |
+| AQ13.3 | | | |
+| AQ13.4 | | | |
+
+### §3 Themes and decisions
+
+| Theme | Constituent finding IDs | Decision (accept / refactor / RFC) | Follow-up link |
+|-------|--------------------------|-------------------------------------|----------------|
+
+### §4 CLAUDE.md / docs/architecture/ updates
+
+- [ ] Surviving rationale for each accepted claim recorded
+- Diff or commit sha:
+
+### Findings (architectural meta-findings from the validation itself)
+| ID | Severity | Category | Anchor | Description | Status |
+|----|----------|----------|--------|-------------|--------|
+
+### Decisions
+-
+
+### Follow-ups
+-
+
+---
+
+## Closing Rollup
+
+> Fill in when all chapters are `done` (including 1A and 17A).
+
+### `bug`-severity rollup, by category
+
+#### `behavior` × `bug`
+| ID | Anchor | Description | Resolution |
+|----|--------|-------------|------------|
+
+#### `arch` × `bug`
+| ID | Anchor | Description | Resolution / RFC link |
+|----|--------|-------------|------------------------|
+
+#### `doc` × `bug`
+| ID | Anchor | Description | Resolution |
+|----|--------|-------------|------------|
+
+### Architecture-validation summary (cross-ref to Ch 17A)
+
+- Claims surviving:
+- Claims falsified:
+- Open RFCs:
+
+### Onboarding doc completion check (Ch 17A exit gate)
+
+- [ ] Every section of `ONBOARDING.md` has prose
+- [ ] Every section has a `Stability:` annotation (one of stable / evolving / experimental / planned)
+- [ ] Every section has a `Last reviewed:` stamp (date + chapter ref)
+- [ ] §7 *Living Architecture* reflects the verdicts from Ch 17A
+- [ ] CLAUDE.md updated with the onboarding-stewardship clauses (PR-template requirement + `make doc-freshness` target)
+- [ ] (optional) `ShareOnboardingGuide` run to publish a shareable link; short_code recorded here:
+
+### Review-tag commit
+- Tag:
+- Date:
+- Reviewer:

--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -450,8 +450,11 @@ pub fn to_ir(
     // `to_ir` then bit-blasts a strictly smaller design. This SUPERSEDES
     // the earlier pin-to-`Ignored` mechanism (which was sound only for
     // safety and, because transitions are synchronous, dropped in-cone
-    // updates whenever an out-of-cone cell changed). Slicing is exact /
-    // bisimilar on the atom set — sound for the full mu-calculus.
+    // updates whenever an out-of-cone cell changed). On a synchronous
+    // system a cone closed over BOTH data-flow and constraint/fairness
+    // co-occurrence is a strong bisimulation on the atom set, so slicing is
+    // exact — sound for the full mu-calculus (`cone_slice` enforces the
+    // constraint/fairness half of that closure).
     let cone_sliced;
     let file: &Btor2File = match &options.cone_restrict_atoms {
         Some(atoms) if !atoms.is_empty() => {
@@ -615,9 +618,11 @@ pub fn to_ir(
     // accounting is identical to the legacy behaviour.
     // Note: `file` is already the cone slice when a restriction is active
     // (see the top of `to_ir`), so the cap is naturally measured against
-    // the restricted design — no separate cone-bit subtraction needed.
-    let total_state_bits = sum_widths(file, &states)?
-        .saturating_sub(sidecar_ignored_state_bits(file, &states, options));
+    // the restricted design. Per-cell EFFECTIVE bits (GAP-2): a
+    // sidecar-concretized wide field counts ceil(log2(value-set)) bits,
+    // not its raw width, so a property over a wide-but-concretized
+    // register fits the cap (see `sidecar_effective_state_bits`).
+    let total_state_bits = sidecar_effective_state_bits(file, &states, options)?;
     let total_input_bits = sum_widths(file, &inputs)?;
 
     if total_state_bits > MAX_STATE_BITS {
@@ -711,12 +716,15 @@ pub fn to_ir(
 ///   cap even restricted (it carries a wide field; see GAP-2 /
 ///   param-concretization). The caller then emits the joint cap error.
 ///
-/// SOUNDNESS: each cluster's model is the joint design restricted to that
-/// cluster's exact cone of influence; cutting out-of-cone cells cannot
-/// change any verdict over the cluster's properties (CLAUDE.md
-/// §Soundness — COI is exact). Each property lands in exactly one cluster
-/// (the clustering invariant), so routing it to its cluster's model is
-/// sound and complete.
+/// SOUNDNESS: each cluster's model is the joint design restricted (via
+/// [`cone_slice`]) to that cluster's exact cone of influence. On the
+/// synchronous BTOR2 system that cone is closed over both data-flow and
+/// `constraint`/`fair`/`justice` coupling (`cone_slice` enforces the
+/// latter), making the restriction a strong bisimulation on the cluster's
+/// atoms: cutting out-of-cone cells cannot change any verdict over the
+/// cluster's properties (CLAUDE.md §Soundness — COI is exact). Each
+/// property lands in exactly one cluster (the clustering invariant), so
+/// routing it to its cluster's model is sound and complete.
 #[allow(clippy::type_complexity)]
 fn try_per_cluster_blast(
     file: &Btor2File,
@@ -804,12 +812,13 @@ fn try_per_cluster_blast(
         let sliced_states: Vec<&Line> = sliced.states().collect();
         let sliced_inputs: Vec<&Line> = sliced.inputs().collect();
 
-        // Cap-check this cluster's sliced state bits. If a single cluster
-        // still busts the cap (a wide field inside one cluster — GAP-2),
-        // per-cluster cannot rescue the design; fall through to the joint
-        // error so the user gets one clear diagnostic.
-        let cluster_bits = sum_widths(&sliced, &sliced_states)?
-            .saturating_sub(sidecar_ignored_state_bits(&sliced, &sliced_states, options));
+        // Cap-check this cluster's sliced state bits, EFFECTIVE (GAP-2):
+        // a wide field inside the cluster that the sidecar concretizes
+        // counts ceil(log2(value-set)) bits, so a cluster with a
+        // param-concretized wide register fits. A cluster that STILL busts
+        // the cap (an un-concretized wide field) returns None → the joint
+        // error stands, so the user gets one clear diagnostic.
+        let cluster_bits = sidecar_effective_state_bits(&sliced, &sliced_states, options)?;
         if cluster_bits > MAX_STATE_BITS {
             return Ok(None);
         }
@@ -876,12 +885,23 @@ fn try_per_cluster_blast(
 /// removed from the IR entirely.
 ///
 /// The result is the exact sub-circuit the cluster's properties depend
-/// on. Because cone-of-influence is bisimilar on the atom set, every
-/// mu-calculus verdict over `atoms` agrees between the slice and the full
-/// design — sound at every alternation depth, not just for safety (this
-/// is why slicing supersedes the pin-to-`Ignored` mechanism). Sort lines
-/// are always kept (cheap, shared); NIDs are preserved so surviving
-/// references stay valid without renumbering.
+/// on. On a **synchronous** transition system (BTOR2) a correctly closed
+/// cone is a strong bisimulation on the atom set, so every mu-calculus
+/// verdict over `atoms` — including the single-step `[]` / `<>` modalities
+/// and nested fixpoints — agrees between the slice and the full design,
+/// sound at every alternation depth, not just for safety (this is why
+/// slicing supersedes the pin-to-`Ignored` mechanism).
+///
+/// "Correctly closed" is the load-bearing precondition: the cone must be
+/// closed not only under the data-flow (`next` / `init`) dependency
+/// relation but also under `constraint` / `fair` / `justice` co-occurrence
+/// — a line that couples an in-cone signal to an out-of-cone one keeps the
+/// latter in the cone. The closure loop below enforces both; without the
+/// constraint/fairness half the slice silently drops assumptions the joint
+/// bit-blaster enforces and degrades to an unsound over-approximation.
+///
+/// Sort lines are always kept (cheap, shared); NIDs are preserved so
+/// surviving references stay valid without renumbering.
 fn cone_slice(file: &Btor2File, atoms: &[String]) -> Btor2File {
     use std::collections::HashSet;
 
@@ -913,26 +933,73 @@ fn cone_slice(file: &Btor2File, atoms: &[String]) -> Btor2File {
         }
     }
 
-    // Transitive closure over operands. Keeping a State cell pulls in its
-    // Init/Next lines (whose value fan-in is then closed over) — that is
-    // how the cone walks backwards through the transition relation.
-    while let Some(nid) = work.pop() {
-        if !keep.insert(nid) {
-            continue;
-        }
-        let Some(line) = file.lookup(nid) else {
-            continue;
-        };
-        push_operand_nids(&line.node, &mut work);
-        if matches!(line.node, Node::State { .. }) {
-            for l in &file.lines {
-                match &l.node {
-                    Node::Init { state, .. } | Node::Next { state, .. } if *state == nid => {
-                        work.push(l.nid);
+    // Transitive closure over operands, interleaved with constraint /
+    // fairness pullback, iterated to a joint fixpoint.
+    //
+    // The operand closure keeps everything that FEEDS the cone: keeping a
+    // State cell pulls in its Init/Next lines (whose value fan-in is then
+    // closed over) — that is how the cone walks backwards through the
+    // transition relation.
+    //
+    // But the data-flow closure alone is NOT the full cone of influence.
+    // BTOR2 `constraint` / `fair` / `justice` lines couple signals into the
+    // cone that no `next` reads: a `constraint` mentioning an in-cone signal
+    // RESTRICTS the reachable state space (the joint bit-blaster enforces it
+    // via `constraints_hold`), and a `fair` / `justice` line referencing an
+    // in-cone signal shapes which infinite paths count. Their other operands
+    // are therefore in the true cone of influence and MUST be retained.
+    // Dropping such a line silently removes an assumption / fairness
+    // obligation, turning the "exact" slice into an over-approximation — a
+    // spurious counterexample for safety, an unsound verdict for liveness.
+    // This pullback is load-bearing for the "exact / bisimilar / full
+    // mu-calculus" guarantee in this function's doc comment; removing it
+    // reintroduces the soundness bug.
+    //
+    // We therefore loop: drain the operand-closure frontier, then pull in
+    // every constraint / fairness line whose operand DAG touches the current
+    // cone (and all signals it references), until neither step grows `keep`.
+    // `keep` only ever grows and is bounded by the line count, so this
+    // terminates. Constraints/fairness disjoint from the cone are correctly
+    // left out — they cannot restrict any in-cone signal.
+    loop {
+        while let Some(nid) = work.pop() {
+            if !keep.insert(nid) {
+                continue;
+            }
+            let Some(line) = file.lookup(nid) else {
+                continue;
+            };
+            push_operand_nids(&line.node, &mut work);
+            if matches!(line.node, Node::State { .. }) {
+                for l in &file.lines {
+                    match &l.node {
+                        Node::Init { state, .. } | Node::Next { state, .. } if *state == nid => {
+                            work.push(l.nid);
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
+        }
+
+        let mut grew = false;
+        for line in &file.lines {
+            if keep.contains(&line.nid) {
+                continue;
+            }
+            let operands: Vec<Nid> = match &line.node {
+                Node::Constraint { signal } | Node::Fair { signal } => vec![signal.nid()],
+                Node::Justice { signals } => signals.iter().map(|s| s.nid()).collect(),
+                _ => continue,
+            };
+            if operands.iter().any(|&op| dag_touches_keep(file, op, &keep)) {
+                work.push(line.nid);
+                work.extend(operands);
+                grew = true;
+            }
+        }
+        if !grew {
+            break;
         }
     }
 
@@ -1012,6 +1079,31 @@ fn push_operand_nids(node: &Node, work: &mut Vec<Nid>) {
     }
 }
 
+/// Does the operand DAG rooted at `start` reach any NID already in `keep`?
+///
+/// Used by [`cone_slice`]'s constraint / fairness pullback to decide
+/// whether a `constraint` / `fair` / `justice` line couples the current
+/// cone to additional signals (and so must be retained, pulling its
+/// operands in). Walks operands only; membership of *any* reached node —
+/// terminal or intermediate — short-circuits to `true`. A `visited` set
+/// guards against cycles (BTOR2 is acyclic, but the guard is cheap).
+fn dag_touches_keep(file: &Btor2File, start: Nid, keep: &std::collections::HashSet<Nid>) -> bool {
+    let mut stack = vec![start];
+    let mut visited = std::collections::HashSet::new();
+    while let Some(nid) = stack.pop() {
+        if !visited.insert(nid) {
+            continue;
+        }
+        if keep.contains(&nid) {
+            return true;
+        }
+        if let Some(line) = file.lookup(nid) {
+            push_operand_nids(&line.node, &mut stack);
+        }
+    }
+    false
+}
+
 fn sum_widths(file: &Btor2File, lines: &[&Line]) -> Result<u32, AdapterError> {
     let mut total: u32 = 0;
     for line in lines {
@@ -1066,62 +1158,110 @@ fn sum_widths(file: &Btor2File, lines: &[&Line]) -> Result<u32, AdapterError> {
 /// state cells even when Yosys strips the original register symbol
 /// from the `state` line and only attaches it via an Op-alias or
 /// `output` port symbol.
-fn sidecar_ignored_state_bits(file: &Btor2File, states: &[&Line], options: &AdapterOptions) -> u32 {
-    let ignored_nids = sidecar_ignored_nids(file, options);
-    if ignored_nids.is_empty() {
-        return 0;
-    }
-    let mut sum: u32 = 0;
+/// R46-6 / GAP-2 — effective state-bit count for the cap check. A state
+/// cell the sidecar param-concretizes (`Boolean` / `BoundedCounter` /
+/// `EnumValues` / `Ignored`) contributes `ceil(log2(value-set size))`
+/// bits — the number of distinct values the bit-blaster actually
+/// enumerates for it — instead of its full register width. Cells with no
+/// sidecar entry contribute their raw width (the legacy behaviour, so
+/// no-sidecar designs are unchanged).
+///
+/// This is what lets a property over a WIDE field (a 32-bit timer, a
+/// 64-bit data word) fit the cap once that field is concretized to a
+/// small value set, instead of being rejected on raw width before
+/// enumeration ever runs — the GAP-2 enabler for per-cluster verification
+/// of real RTL whose clusters carry wide datapath/counters.
+///
+/// Subsumes the old `sidecar_ignored_state_bits`: an `Ignored` cell has a
+/// one-element value set → 0 effective bits.
+///
+/// SOUNDNESS: the bit-blaster enumerates exactly the abstraction's value
+/// set (see `CellEnumeration::values_for_field_domain`), so
+/// `ceil(log2(|values|))` is the true per-cell contribution to the
+/// explicit state space; the cap then bounds the actual enumerated size,
+/// not an over-conservative raw-width proxy. Strictly more permissive
+/// than the raw-width cap and never accepts a design whose enumeration
+/// would exceed `2^MAX_STATE_BITS`.
+fn sidecar_effective_state_bits(
+    file: &Btor2File,
+    states: &[&Line],
+    options: &AdapterOptions,
+) -> Result<u32, AdapterError> {
+    let value_counts = sidecar_state_value_counts(file, options);
+    let mut total: u32 = 0;
     for line in states {
-        if !ignored_nids.contains(&line.nid) {
-            continue;
-        }
         let sort_nid = match &line.node {
             Node::State { sort, .. } => *sort,
             _ => continue,
         };
-        let Some(width) = parser::bv_width(file, sort_nid) else {
+        // §Phase 10 — array-sorted state cells are handled by memory
+        // abstraction, not the bit cap; skip (mirrors `sum_widths`).
+        if matches!(
+            sort_of_arc(file, sort_nid),
+            Some(crate::adapter::btor2::ast::Sort::Array { .. })
+        ) {
             continue;
+        }
+        let raw_width = parser::bv_width(file, sort_nid).ok_or_else(|| AdapterError {
+            kind: AdapterErrorKind::UnsupportedConstruct,
+            message: format!(
+                "state NID {} references non-bitvec sort {sort_nid}",
+                line.nid
+            ),
+            location: None,
+        })?;
+        let eff = match value_counts.get(&line.nid) {
+            Some(count) => effective_bits(*count),
+            None => raw_width,
         };
-        sum = sum.saturating_add(width);
+        total = total.checked_add(eff).ok_or_else(|| AdapterError {
+            kind: AdapterErrorKind::StateSpaceOverflow,
+            message: "total effective bit-width exceeds u32 range".into(),
+            location: None,
+        })?;
     }
-    sum
+    Ok(total)
 }
 
-/// The set of BTOR2 state NIDs the sidecar declares `abstraction:
-/// ignored`. Resolves each Ignored signal via the `drives` override
-/// (falling back to the sidecar `name`) using
-/// [`parser::resolve_state_by_symbol`]. Returns an empty set when no
-/// sidecar is provided, it fails to parse, or no cells are Ignored.
-///
-/// Split out of [`sidecar_ignored_state_bits`] (R.4.6) so the cone
-/// restriction's cap accounting can subtract out-of-cone cells *without*
-/// double-counting cells the sidecar already pins to Ignored.
-fn sidecar_ignored_nids(
+/// Per-state-cell enumerated value count from the sidecar's declared
+/// abstraction (NID → `|value set|`). Only sidecar-declared cells appear;
+/// the caller treats absent cells as full-width bit-blast. Each signal is
+/// resolved via the `drives` override (falling back to `name`) like the
+/// other sidecar helpers, then through the canonical
+/// [`crate::adapter::sidecar::resolve_to_field_domain`] resolver.
+fn sidecar_state_value_counts(
     file: &Btor2File,
     options: &AdapterOptions,
-) -> std::collections::HashSet<Nid> {
+) -> std::collections::HashMap<Nid, usize> {
+    let mut out = std::collections::HashMap::new();
     let Some(json) = &options.sidecar_json else {
-        return std::collections::HashSet::new();
+        return out;
     };
     let Ok(ann) =
         serde_json::from_str::<crate::adapter::systemverilog::annotation::SvAnnotation>(json)
     else {
-        return std::collections::HashSet::new();
+        return out;
     };
-    ann.signals
-        .iter()
-        .filter(|s| {
-            matches!(
-                s.abstraction,
-                crate::adapter::systemverilog::annotation::SignalAbstraction::Ignored
-            )
-        })
-        .filter_map(|s| {
-            let target = s.drives.as_deref().unwrap_or(s.name.as_str());
-            parser::resolve_state_by_symbol(file, target)
-        })
-        .collect()
+    for sig in &ann.signals {
+        let target = sig.drives.as_deref().unwrap_or(sig.name.as_str());
+        if let Some(nid) = parser::resolve_state_by_symbol(file, target) {
+            let (fd, _vm) = crate::adapter::sidecar::resolve_to_field_domain(sig, &ann);
+            // `values()` is empty for `Ignored` → one pinned value.
+            out.insert(nid, fd.values().len().max(1));
+        }
+    }
+    out
+}
+
+/// `ceil(log2(value_count))` — the bits needed to index a
+/// `value_count`-element value set. 0 for a singleton (a pinned /
+/// `Ignored` cell).
+fn effective_bits(value_count: usize) -> u32 {
+    if value_count <= 1 {
+        0
+    } else {
+        (value_count as u64).next_power_of_two().trailing_zeros()
+    }
 }
 
 /// M.1 Path B (§Phase 11) — build an augmented NID→sidecar-name map
@@ -5571,6 +5711,63 @@ mod tests {
         assert_eq!(err.kind, AdapterErrorKind::StateSpaceOverflow);
     }
 
+    #[test]
+    fn effective_bits_is_ceil_log2() {
+        assert_eq!(effective_bits(1), 0);
+        assert_eq!(effective_bits(2), 1);
+        assert_eq!(effective_bits(3), 2);
+        assert_eq!(effective_bits(4), 2);
+        assert_eq!(effective_bits(5), 3);
+        assert_eq!(effective_bits(2048), 11);
+    }
+
+    /// R46-6 / GAP-2 — a wide state cell the sidecar param-concretizes
+    /// counts `ceil(log2(value-set))` effective bits, not its raw width,
+    /// so a design that busts the cap on raw width fits once concretized.
+    #[test]
+    fn effective_cap_counts_concretized_wide_cell_by_value_set() {
+        // 24-bit state cell `cnt` — over the cap on raw width.
+        let src = r#"
+1 sort bitvec 1
+2 sort bitvec 24
+3 zero 2
+4 state 2 cnt
+5 init 2 4 3
+6 ones 2
+7 eq 1 4 6
+8 output 7 cnt_max
+"#;
+        let file = parser::parse(src).expect("parse");
+
+        // Without a sidecar: 24 raw state bits → StateSpaceOverflow.
+        let bare = translate(src, &AdapterOptions::default());
+        assert_eq!(
+            bare.unwrap_err().kind,
+            AdapterErrorKind::StateSpaceOverflow,
+            "24-bit cell must bust the cap on raw width"
+        );
+
+        // With BoundedCounter bound=3 → {0,1,2,3} = 4 values → 2 bits.
+        let sidecar = serde_json::json!({
+            "$schema": "mununu_sv_annotation_v1",
+            "module": "demo",
+            "signals": [ { "name": "cnt", "abstraction": "bounded_counter", "bound": 3 } ],
+        })
+        .to_string();
+        let states: Vec<&Line> = file.states().collect();
+        let opts = AdapterOptions {
+            sidecar_json: Some(sidecar),
+            ..Default::default()
+        };
+        let eff = sidecar_effective_state_bits(&file, &states, &opts).expect("eff bits");
+        assert_eq!(
+            eff, 2,
+            "24-bit cell concretized to 4 values must count 2 effective bits"
+        );
+        let out = translate(src, &opts).expect("concretized design must fit the cap");
+        assert!(out.ctxdsl.contains("automaton"));
+    }
+
     /// R46-2 — the per-cluster fallback. Two independent 11-bit registers
     /// (22 state bits jointly → over the cap), with one property over each
     /// (disjoint cones). With the manifest's per-property seeds threaded,
@@ -5687,6 +5884,164 @@ mod tests {
             sliced.states().count(),
             1,
             "the out-of-cone state cell must be removed from the slice"
+        );
+    }
+
+    /// R46-6a (constraint/fairness pullback, soundness fix) — a
+    /// `constraint` coupling an in-cone register to an out-of-cone register
+    /// must pull the out-of-cone register AND the constraint into the slice.
+    ///
+    /// Before the fix, `cone_slice` seeded only from property atoms and
+    /// closed only over `next`/`init` data-flow, then kept a `constraint`
+    /// line only if *all* its operands were already in-cone — so a
+    /// constraint mentioning an out-of-cone signal was silently dropped.
+    /// The joint bit-blaster enforces every constraint via
+    /// `constraints_hold` (see `constraint_filters_transitions`), so the
+    /// slice became strictly more permissive: an over-approximation that
+    /// can report a spurious counterexample, not the documented exact /
+    /// bisimilar reduction.
+    #[test]
+    fn cone_slice_pulls_in_constraint_coupled_register() {
+        // `reg_a` is the property atom; `reg_b` is reached by no `next`
+        // that `reg_a` depends on, so it is out-of-cone by data-flow alone.
+        // The `constraint (reg_a == reg_b)` couples them — `reg_b` restricts
+        // `reg_a`'s reachable values, so it is in the true cone of influence.
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 state 1 reg_a
+4 init 1 3 2
+5 input 1 tgl
+6 next 1 3 5
+7 state 1 reg_b
+8 init 1 7 2
+9 next 1 7 2
+10 eq 1 3 7
+11 constraint 10
+12 bad 3
+"#;
+        let file = parser::parse(src).expect("parse");
+        let sliced = cone_slice(&file, &["reg_a".to_string()]);
+
+        let state_syms: std::collections::HashSet<&str> = sliced
+            .lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                Node::State {
+                    symbol: Some(s), ..
+                } => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            state_syms.contains("reg_a"),
+            "in-cone register `reg_a` must be retained; got {state_syms:?}"
+        );
+        assert!(
+            state_syms.contains("reg_b"),
+            "constraint-coupled out-of-cone register `reg_b` must be retained \
+             (else the assumption `reg_a == reg_b` is silently dropped and the \
+             slice over-approximates); got {state_syms:?}"
+        );
+        assert!(
+            sliced
+                .lines
+                .iter()
+                .any(|l| matches!(l.node, Node::Constraint { .. })),
+            "the coupling `constraint` line must survive the slice"
+        );
+    }
+
+    /// R46-6a — the same pullback for `fair` (fairness) lines: a fairness
+    /// obligation referencing an in-cone signal shapes which infinite paths
+    /// count, so the signals it references are in the cone and must be
+    /// retained. Dropping fairness is unsound for liveness verdicts (the
+    /// abstraction can manufacture or destroy spurious progress).
+    #[test]
+    fn cone_slice_pulls_in_fairness_coupled_register() {
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 state 1 reg_a
+4 init 1 3 2
+5 input 1 tgl
+6 next 1 3 5
+7 state 1 reg_b
+8 init 1 7 2
+9 next 1 7 2
+10 and 1 3 7
+11 fair 10
+12 bad 3
+"#;
+        let file = parser::parse(src).expect("parse");
+        let sliced = cone_slice(&file, &["reg_a".to_string()]);
+        let has_reg_b = sliced
+            .lines
+            .iter()
+            .any(|l| matches!(&l.node, Node::State { symbol: Some(s), .. } if s == "reg_b"));
+        assert!(
+            has_reg_b,
+            "fairness-coupled register `reg_b` must be retained in the slice"
+        );
+        assert!(
+            sliced
+                .lines
+                .iter()
+                .any(|l| matches!(l.node, Node::Fair { .. })),
+            "the coupling `fair` line must survive the slice"
+        );
+    }
+
+    /// R46-6a — a constraint whose signals are ALL out-of-cone (it
+    /// constrains a different cluster's registers) does NOT pull anything
+    /// in: it cannot restrict any in-cone signal, so dropping it stays
+    /// sound and the clustering reduction is preserved.
+    #[test]
+    fn cone_slice_drops_constraint_disjoint_from_cone() {
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 state 1 reg_a
+4 init 1 3 2
+5 input 1 tgl
+6 next 1 3 5
+7 state 1 reg_b
+8 init 1 7 2
+9 next 1 7 2
+10 state 1 reg_c
+11 init 1 10 2
+12 next 1 10 2
+13 eq 1 7 10
+14 constraint 13
+15 bad 3
+"#;
+        let file = parser::parse(src).expect("parse");
+        let sliced = cone_slice(&file, &["reg_a".to_string()]);
+        let state_syms: std::collections::HashSet<&str> = sliced
+            .lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                Node::State {
+                    symbol: Some(s), ..
+                } => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            state_syms.contains("reg_a"),
+            "in-cone register retained; got {state_syms:?}"
+        );
+        assert!(
+            !state_syms.contains("reg_b") && !state_syms.contains("reg_c"),
+            "a constraint over only out-of-cone registers must NOT pull them \
+             into the slice (it cannot restrict the cone); got {state_syms:?}"
+        );
+        assert!(
+            !sliced
+                .lines
+                .iter()
+                .any(|l| matches!(l.node, Node::Constraint { .. })),
+            "the cone-disjoint constraint must be dropped"
         );
     }
 

--- a/crates/mununu-core/src/adapter/btor2/dep_graph.rs
+++ b/crates/mununu-core/src/adapter/btor2/dep_graph.rs
@@ -193,12 +193,23 @@ pub fn resolve_atom_to_terminals(file: &Btor2File, atom: &str) -> Option<HashSet
 ///
 /// # SOUNDNESS
 ///
-/// The cone of influence is exact (bisimilar) on the atom set:
+/// On a **synchronous** transition system (BTOR2), a cone closed under
+/// both the data-flow dependency relation AND `constraint` / `fair` /
+/// `justice` co-occurrence is a strong bisimulation on the atom set:
 /// out-of-cone state cells cannot influence any atom in `atoms`, so
 /// cutting them is sound for the full mu-calculus over those atoms (the
-/// COI "exact / free / sound" abstraction; CLAUDE.md §Soundness). This
-/// is *not* an over- or under-approximation — the restricted model
-/// agrees with the joint model on every property over `atoms`.
+/// COI "exact / free / sound" abstraction; CLAUDE.md §Soundness). With
+/// that closure it is *not* an over- or under-approximation — the
+/// restricted model agrees with the joint model on every property over
+/// `atoms`.
+///
+/// The constraint/fairness half of the closure is essential: a
+/// `constraint` mentioning an in-cone signal restricts the reachable
+/// state space (the joint bit-blaster enforces it via `constraints_hold`),
+/// so its other signals are in the true cone of influence. The pullback
+/// loop below adds them; omitting it silently drops assumptions and turns
+/// the reduction into an unsound over-approximation. This mirrors the
+/// closure in [`super::bit_blast`]'s `cone_slice`.
 pub fn state_cone_nids(file: &Btor2File, atoms: &[String]) -> HashSet<Nid> {
     use crate::adapter::partition::coi::cone_of_influence;
 
@@ -219,7 +230,55 @@ pub fn state_cone_nids(file: &Btor2File, atoms: &[String]) -> HashSet<Nid> {
         }
     }
 
-    let cone = cone_of_influence(&seeds, &deps);
+    let mut cone = cone_of_influence(&seeds, &deps);
+
+    // Constraint / fairness pullback (R46-6a) — close the cone over
+    // assumption + fairness coupling, mirroring `cone_slice`. Any
+    // `constraint` / `fair` / `justice` line whose terminal symbols touch
+    // the current cone pulls all of its terminals into the seed set;
+    // recompute and iterate to a fixpoint. `seeds` grows monotonically and
+    // is bounded by the symbol count, so this terminates.
+    loop {
+        let mut grew = false;
+        for line in &file.lines {
+            let mut terminals: HashSet<String> = HashSet::new();
+            let mut visited = HashSet::new();
+            match &line.node {
+                Node::Constraint { signal } | Node::Fair { signal } => {
+                    collect_operand_terminals(
+                        file,
+                        signal.nid(),
+                        &symbols,
+                        &mut terminals,
+                        &mut visited,
+                    );
+                }
+                Node::Justice { signals } => {
+                    for sig in signals {
+                        collect_operand_terminals(
+                            file,
+                            sig.nid(),
+                            &symbols,
+                            &mut terminals,
+                            &mut visited,
+                        );
+                    }
+                }
+                _ => continue,
+            }
+            if terminals.iter().any(|t| cone.contains(t)) {
+                let before = seeds.len();
+                seeds.extend(terminals);
+                if seeds.len() != before {
+                    grew = true;
+                }
+            }
+        }
+        if !grew {
+            break;
+        }
+        cone = cone_of_influence(&seeds, &deps);
+    }
 
     // Map cone state symbols back to their state-line NIDs.
     file.states()
@@ -491,6 +550,66 @@ mod tests {
         assert!(
             !keep.contains(&7),
             "reg_b is independent, out of cone; got {keep:?}"
+        );
+    }
+
+    #[test]
+    fn state_cone_nids_retains_constraint_coupled_register() {
+        // R46-6a — `state_cone_nids` must close the cone over constraint
+        // coupling, mirroring `cone_slice`. `reg_b` (nid 7) is out-of-cone
+        // by data-flow but coupled to in-cone `reg_a` (nid 3) by the
+        // `constraint (reg_a == reg_b)`, so it must be retained.
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 state 1 reg_a
+4 init 1 3 2
+5 input 1 tgl
+6 next 1 3 5
+7 state 1 reg_b
+8 init 1 7 2
+9 next 1 7 2
+10 eq 1 3 7
+11 constraint 10
+12 bad 3
+"#;
+        let file = parser::parse(src).expect("parse");
+        let keep = state_cone_nids(&file, &["reg_a".to_string()]);
+        assert!(keep.contains(&3), "reg_a (nid 3) in cone; got {keep:?}");
+        assert!(
+            keep.contains(&7),
+            "constraint-coupled reg_b (nid 7) must be retained; got {keep:?}"
+        );
+    }
+
+    #[test]
+    fn state_cone_nids_ignores_constraint_disjoint_from_cone() {
+        // A constraint over only out-of-cone registers does not pull them
+        // in — it cannot restrict the cone, so dropping it stays sound.
+        let src = r#"
+1 sort bitvec 1
+2 zero 1
+3 state 1 reg_a
+4 init 1 3 2
+5 input 1 tgl
+6 next 1 3 5
+7 state 1 reg_b
+8 init 1 7 2
+9 next 1 7 2
+10 state 1 reg_c
+11 init 1 10 2
+12 next 1 10 2
+13 eq 1 7 10
+14 constraint 13
+15 bad 3
+"#;
+        let file = parser::parse(src).expect("parse");
+        let keep = state_cone_nids(&file, &["reg_a".to_string()]);
+        assert!(keep.contains(&3), "reg_a (nid 3) in cone; got {keep:?}");
+        assert!(
+            !keep.contains(&7) && !keep.contains(&10),
+            "a constraint over only out-of-cone registers must not pull them \
+             into the cone; got {keep:?}"
         );
     }
 

--- a/crates/mununu-core/tests/btor2_coi_constraint_soundness.rs
+++ b/crates/mununu-core/tests/btor2_coi_constraint_soundness.rs
@@ -1,0 +1,119 @@
+//! R46-6a — end-to-end COI constraint/fairness-pullback soundness.
+//!
+//! The per-cluster verification path (R.4.6) slices a BTOR2 design to one
+//! cluster's cone of influence before bit-blasting, and reports the
+//! sliced model's verdict as a SOUND full-mu-calculus verdict for the
+//! cluster's properties (`cone_slice`'s "exact / bisimilar" guarantee).
+//!
+//! That guarantee holds only if the cone is closed over BOTH data-flow
+//! AND `constraint` / `fair` / `justice` co-occurrence. A `constraint`
+//! mentioning an in-cone signal restricts the reachable state space (the
+//! joint bit-blaster enforces it via `constraints_hold`); dropping it
+//! removes an assumption and turns the slice into an unsound
+//! over-approximation — a *spurious counterexample* for safety.
+//!
+//! This test verifies the end of the pipeline the unit tests in
+//! `adapter::btor2::{bit_blast, dep_graph}` only check structurally:
+//! the **verdict** the verification engine produces on the cone-restricted
+//! model agrees with the verdict on the full joint model.
+//!
+//! Before the constraint-pullback fix, the cone-restricted slice of the
+//! witness below dropped `reg_b` and the `reg_a == reg_b` constraint,
+//! leaving `reg_a` free. The joint design is SAFE (the constraint pins
+//! `reg_a` so the bad state is unreachable); the broken slice was UNSAFE
+//! (a manufactured counterexample). This test asserts the two verdicts
+//! agree — it fails on the pre-fix over-approximating slice.
+
+use mununu_core::adapter::btor2::Btor2Adapter;
+use mununu_core::adapter::{AdapterOptions, FormatAdapter};
+use mununu_core::context_dsl;
+
+/// A 1-bit `reg_a` observed by the property, coupled by
+/// `constraint (reg_a == reg_b)` to a 1-bit `reg_b` that no `next`
+/// `reg_a` depends on (so `reg_b` is out-of-cone by data-flow alone).
+/// `reg_b` is held at 0, so the constraint pins `reg_a == 0`: the bad
+/// state (`reg_a == 1`) is unreachable and the design is SAFE.
+const WITNESS: &str = r#"
+1 sort bitvec 1
+2 zero 1
+3 state 1 reg_a
+4 init 1 3 2
+5 input 1 tgl
+6 next 1 3 5
+7 state 1 reg_b
+8 init 1 7 2
+9 next 1 7 2
+10 eq 1 3 7
+11 constraint 10
+12 bad 3
+"#;
+
+/// Parse + realize a bit-blasted CTXDSL document and return the fraction
+/// of initial states satisfying its sole auto-emitted safety property
+/// (`1.0` = safe / property holds, `0.0` = a counterexample exists).
+fn safety_fraction(ctxdsl: &str) -> f64 {
+    const AUTOMATON: &str = "Circuit";
+    // The BTOR2 bit-blaster names the property of the first `bad` line
+    // `safety_bad_0` (= `nu X. (!bad && [] X)`, i.e. AG !bad).
+    const FORMULA: &str = "safety_bad_0";
+
+    let doc =
+        context_dsl::parse(ctxdsl).unwrap_or_else(|e| panic!("parse failed: {e}\n\n{ctxdsl}"));
+    let realized =
+        context_dsl::realize_context(&doc, &[]).unwrap_or_else(|e| panic!("realize failed: {e}"));
+    let clts = realized
+        .context
+        .clts(AUTOMATON)
+        .unwrap_or_else(|| panic!("automaton '{AUTOMATON}' not found"));
+    let formula = realized
+        .formulas
+        .get(FORMULA)
+        .unwrap_or_else(|| panic!("formula '{FORMULA}' not found in:\n{ctxdsl}"));
+    let env = realized.environment_for(AUTOMATON);
+    let result = realized
+        .context
+        .evaluate_mu(AUTOMATON, &formula.formula, &env, None)
+        .unwrap_or_else(|e| panic!("eval failed: {e}"));
+
+    let initials = clts.initial_states();
+    if initials.is_empty() {
+        return 0.0;
+    }
+    let satisfied = initials.iter().filter(|s| result[s.index()]).count();
+    satisfied as f64 / initials.len() as f64
+}
+
+#[test]
+fn cone_restricted_verdict_agrees_with_joint_under_constraint_coupling() {
+    let joint = Btor2Adapter::translate(WITNESS, &AdapterOptions::default())
+        .expect("joint translate succeeds");
+
+    let sliced_opts = AdapterOptions {
+        cone_restrict_atoms: Some(vec!["reg_a".to_string()]),
+        ..Default::default()
+    };
+    let sliced =
+        Btor2Adapter::translate(WITNESS, &sliced_opts).expect("cone-restricted translate succeeds");
+
+    let joint_verdict = safety_fraction(&joint.ctxdsl);
+    let sliced_verdict = safety_fraction(&sliced.ctxdsl);
+
+    // Ground truth: the joint design is SAFE — the constraint pins
+    // `reg_a == reg_b == 0`, so the bad state (`reg_a == 1`) is
+    // unreachable and AG !bad holds at the initial state.
+    assert_eq!(
+        joint_verdict, 1.0,
+        "joint design must be SAFE (constraint makes the bad state unreachable)"
+    );
+
+    // The soundness property: the cone-restricted slice must report the
+    // SAME verdict. Pre-fix, the slice dropped the `reg_a == reg_b`
+    // constraint (and `reg_b`), freeing `reg_a` and yielding a spurious
+    // counterexample (`sliced_verdict == 0.0`) — an unsound
+    // over-approximation reported as an exact full-mu-calculus verdict.
+    assert_eq!(
+        sliced_verdict, joint_verdict,
+        "cone-restricted slice verdict must equal the joint verdict; a mismatch \
+         means the slice dropped a coupling constraint and over-approximated"
+    );
+}

--- a/docs/abstraction.md
+++ b/docs/abstraction.md
@@ -15,7 +15,7 @@ Use this doc when:
 
 ## The canonical recipe — KMTS predicates
 
-> **Status (2026-05-21).** The KMTS pipeline is the **canonical recipe** for SystemVerilog and BTOR2 extraction. Other adapters (XState, microcode, agentic, hand-written CTXDSL) continue to use the legacy primitives (§"Legacy primitives" below) and produce Sharp-everywhere KMTSes vacuously. Architecture: [`docs/design/native-sv-abstraction.md`](design/native-sv-abstraction.md). Theory: [`docs/design/kmts-theory.md`](design/kmts-theory.md). Practical recipe: [`docs/design/predicate-abstraction-recipe.md`](design/predicate-abstraction-recipe.md).
+> **Status (2026-05-21).** The KMTS pipeline is the **canonical recipe** for SystemVerilog and BTOR2 extraction. Other adapters (XState, microcode, agentic, hand-written CTXDSL) continue to use the legacy primitives (§"Legacy primitives" below) and produce Sharp-everywhere KMTSes vacuously. Architecture: [`docs/design/native-sv-abstraction.md`](design/native-sv-abstraction.md). Theory: [`docs/design/kmts-theory.md`](design/kmts-theory.md). Practical recipe: [`docs/design/predicate-abstraction-recipe.md`](design/predicate-abstraction-recipe.md). Worked example (RTL → BTOR2 → coarse `KleeneBot` → Craig interpolant → refined `KleeneT`): [`docs/design/predicate-abstraction-worked-example.md`](design/predicate-abstraction-worked-example.md).
 
 The canonical recipe has four moving parts: a **predicate set** that partitions the abstract state space, a **modality** that captures the may/must distinction on each transition, a **3-valued evaluator** that returns `KleeneT / KleeneF / KleeneBot`, and a **CEGAR refinement loop** that responds to `KleeneBot` verdicts by adding predicates.
 

--- a/docs/design/interpolation-kmts-bridge.md
+++ b/docs/design/interpolation-kmts-bridge.md
@@ -1,0 +1,150 @@
+# Interpolation → mununu's KMTS CEGAR — a bridge note
+
+> **Status: planning.** Read this *after* the three external papers below.
+> It does not anchor live code as a source of truth; it explains how the
+> papers map onto mununu's BTOR2 → KMTS lifter and its CEGAR loop, and it
+> names precisely which lines are live, which are MVP, and which are the
+> placeholder the papers are meant to fill. Companions:
+> [`predicate-abstraction-recipe.md`](predicate-abstraction-recipe.md) §4
+> (the operational recipe), [`kmts-theory.md`](kmts-theory.md) (the 3-valued
+> theory), [`abstraction-literature.md`](abstraction-literature.md) §23
+> (Godefroid–Jagadeesan, the 3-valued CEGAR entry this note operationalises).
+
+## 0. The three documents this note follows
+
+1. **McMillan, *Applications of Craig Interpolants in Model Checking*** (TACAS 2005) — *what an interpolant is and why it refines.*
+2. **Henzinger, Jhala, Majumdar, McMillan, *Abstractions from Proofs*** (POPL 2004) — *the interpolant becomes the new predicate.*
+3. **Dimovski, *Variability Abstraction and Refinement for Game-Based Lifted Model Checking of Full CTL*** (FASE 2019) — *interpolation driving refinement over game-based 3-valued (KMTS-style) checking.*
+
+The order is deliberate: paper 1 gives you the object, paper 2 gives you the 2-valued CEGAR loop that consumes it, paper 3 is the only one that lands the loop in our actual semantic setting (may/must, three truth values, a parity game). This note re-reads all three against mununu's code.
+
+---
+
+## 1. The one-sentence map
+
+mununu already has the entire CEGAR scaffold — the lift, the 3-valued evaluator, the spuriousness discharge, the predicate-set growth, the iteration cap — wired and tested. **The single hole is the function that turns a refuted spurious counterexample into the next predicate.** Papers 1–2 specify that function in the 2-valued world; paper 3 tells you the two things that change when you move it onto a KMTS. Everything else in our loop is already the right shape.
+
+Concretely, the hole is here:
+
+```rust
+// crates/mununu-core/src/adapter/btor2/cegar.rs:112
+/// **R.5 follow-up.** Compute a Craig interpolant between the
+/// concrete-relation states the may-edge admits and excludes.
+/// MVP behaviour: returns empty; loop terminates at cap.
+CraigInterpolation,
+```
+
+`PredicateSource::CraigInterpolation` returns empty today. `PredicateSource::Manual` (a caller-supplied closure) and `PredicateSource::WeakestPrecondition` (a heuristic that just grabs the next uncovered state register — *not* real WP back-substitution, see its own doc comment at [cegar.rs:104](../../crates/mununu-core/src/adapter/btor2/cegar.rs#L104)) are the only working sources. The papers are the spec for promoting that placeholder to a real refinement engine.
+
+---
+
+## 2. Paper 1 (McMillan TACAS 2005) → what we extract, and *from which solver call*
+
+McMillan's framing: given an unsatisfiable conjunction `A ∧ B`, a Craig interpolant `I` is a formula over **only the shared vocabulary** of `A` and `B` with `A ⊨ I` and `I ∧ B ⊨ ⊥`. The model-checking payoff is that `I` is a *relevant* over-approximation of the `A`-side reachable states — exactly specific enough to exclude the `B`-side, no more.
+
+In mununu, the `A ∧ B ⊨ ⊥` that we already produce is the **concrete-discharge UNSAT** in the recipe doc §4.3:
+
+```text
+∃ s_0..s_n : s_0 ⊨ b_0 ∧ initial(s_0)
+           ∧ ∀i. (s_i, s_{i+1}) ∈ R_concrete ∧ s_{i+1} ⊨ b_{i+1}
+           ∧ violation(s_n)
+```
+
+When this is UNSAT, the abstract may-trace `b_0 … b_n` is spurious. Split the conjunction at the frontier step `j` where the predicate set first fails to distinguish: `A` = the prefix `s_0..s_j` constraints, `B` = the suffix `s_{j+1}..s_n` + `violation`. The interpolant `I_j` over the shared variables (the state bits live at step `j`) is, by McMillan's theorem, a predicate that (a) every concrete prefix-reachable state satisfies and (b) is inconsistent with the spurious suffix. **`I_j` is the predicate to add to `P`.** That is the whole idea, and it is the cleanest possible answer to recipe doc §4.5's open "extract a candidate predicate via interpolation."
+
+The operational detail McMillan stresses — *interpolants come from the refutation proof, not a second solver call* — is why our integration point is an interpolating SMT backend, not a post-hoc query. We already have the seam: [cegar.rs:1042](../../crates/mununu-core/src/adapter/btor2/cegar.rs#L1042) calls `invoke_cvc5_for_interpolant`. cvc5's `get-interpolant` (and Z3's `SMT-LIB get-interpolant` / `Interpolant` API) is exactly McMillan's "read it off the proof" packaged as a solver command. The R.5-follow-up work is wiring that return value into a `PredicateSpec`, not implementing proof-theoretic interpolation ourselves.
+
+**What to take from paper 1:** the interpolant is *the* principled replacement for the WP heuristic. WP gives you a predicate that is locally correct but blind to relevance (it'll happily add the whole cone); the interpolant is minimal-by-construction over the shared frontier. When you read §4.5 of the recipe doc afterwards, read "interpolant" as "the McMillan object extracted at the spurious frontier `j`."
+
+---
+
+## 3. Paper 2 (Abstractions from Proofs, POPL 2004) → the loop we already built
+
+This is the paper whose loop mununu's `cegar_refine_loop` *is*. Henzinger et al.'s contribution over plain CEGAR (Clarke–Grumberg–Jha–Lu–Veith 2000) is precisely the marriage of §2 to the refinement step: instead of guessing a separating predicate, extract it as an interpolant from the infeasibility proof of the spurious path, **at each cut point along the path** — yielding one predicate per program location rather than one global predicate. That per-location locality is what makes the method scale and terminate in practice.
+
+Map to our code:
+
+| Abstractions-from-Proofs concept | mununu artifact (live) |
+|---|---|
+| Abstract reachability / model check | `evaluate_3v_game_with_options` over the lifted `Clts` |
+| Spurious abstract path | `CegarIteration` abstract counterexample (lasso or prefix), recipe §4.2 |
+| Path-infeasibility proof | concrete-discharge UNSAT, recipe §4.3 ([cegar.rs](../../crates/mununu-core/src/adapter/btor2/cegar.rs) discharge query) |
+| **Per-location interpolant → new predicate** | `PredicateSource::CraigInterpolation` — **the placeholder** |
+| Add predicates, re-abstract | `predicate_cube_lift(P ∪ {I_j})`, the eager lifter (R.2.5), [cegar.rs:547](../../crates/mununu-core/src/adapter/btor2/cegar.rs#L547) |
+| Bounded iteration / progress | `CegarOptions::max_iterations` (default 16), `CegarTermination` |
+
+The single most useful thing to carry from paper 2 into our codebase: **interpolate at every cut point of the spurious trace, not just one.** Our discharge query is a bounded-unrolling of the may-trace, so it has exactly the sequence of cut points Henzinger et al. interpolate at (`I_0, I_1, … I_{n-1}`, one per unrolled step). Harvesting the whole sequence in one refinement round is what gives the loop its empirical termination; harvesting one predicate per round (the naive reading) is what makes CEGAR oscillate. Recipe doc §6.3 cause-1 ("the interpolant repeats from earlier rounds → the loop is oscillating") is the failure mode this paper's per-cut-point harvesting is designed to avoid. When you wire `CraigInterpolation`, return `Vec<PredicateSpec>` from the cut sequence, not a single predicate.
+
+One honest caveat the paper forces: interpolation-based CEGAR terminates for safety over finite-state systems *given a finite interpolation language*. Over bit-vectors that's automatic (finite domain), so our BTOR2 path inherits termination — but the *quality* of termination (how many rounds) depends on the interpolating solver's interpolant choices, which mununu does not control. That is the right thing to surface in a `refinement_trace.json` (recipe §6.2) so a stalling run is diagnosable.
+
+---
+
+## 4. Paper 3 (Dimovski FASE 2019) → the two things that change on a KMTS
+
+Papers 1–2 live in the 2-valued world: one transition relation, refinement triggers on a spurious **`false`** (a reachable error state in the over-approximation). mununu does not live there. Our evaluator is the **3-valued game** over a **KMTS** with separate may/must edges, and refinement triggers on **`KleeneBot` (⊥)**, not on `false`. Dimovski is the one paper of the three that runs interpolation-based refinement in *this* setting — game-based, 3-valued, may/must — so it is the one that tells you what to adjust. Two adjustments, both already anticipated by our design docs:
+
+### 4.1 You refine the *indefiniteness*, not the *violation*
+
+In 2-valued CEGAR the refinement target is unambiguous: a `false` verdict with a spurious witness. In the 3-valued game the evaluator can return `KleeneT`, `KleeneF`, or `KleeneBot`, and **only `KleeneBot` is a refinement trigger** — `KleeneT`/`KleeneF` are definite and transfer to the concrete by Bruns–Godefroid (kmts-theory.md). The counterexample you discharge is therefore not "a path to an error" but "a path the game could not classify" — the may-trace through the indefinite region, recipe §4.2.
+
+The consequence for interpolation: `A`/`B` are split at the frontier where the verdict went `⊥`, i.e. where a may-edge exists but the corresponding must-edge does not, so the box/diamond modality could not commit. This is exactly Dimovski's game-based refinement: the spurious object is a *non-winning, non-losing* play in the abstraction game, and the interpolant is extracted to *split the abstract state so the play resolves to a win or a loss*. Read his "refinement of the game graph" as "add the interpolant predicate so the `⊥`-cube splits into cubes that carry a definite must-edge or definitely lack one."
+
+`abstraction-literature.md` §23 (Godefroid–Jagadeesan, *Automatic Abstraction Using Generalized Model Checking*, TACAS 2003) is the same idea stated as a recipe and is the entry our `refine` function cites; Dimovski is the more recent, more explicitly *interpolation*-driven instance of it. Read §23 of the literature doc and Dimovski together — they are the 2-valued-CEGAR-lifted-to-3-valued pair.
+
+### 4.2 Refinement has a second axis: must-edges, not just predicates
+
+This is the part with no analogue in papers 1–2, and it is where mununu has genuinely live, recent code. A `KleeneBot` can have *two* causes:
+
+1. **State-distinguishability gap** — the predicate cube is too coarse; two concretely-distinct states are merged. Fix: add a predicate (the interpolation story above). This is the only axis 2-valued CEGAR has.
+2. **Missing-must-edge gap** — the states are fine, but the lift failed to *prove* a must-edge that concretely exists, so a diamond/`◇` obligation that should be `KleeneT` sits at `⊥`. Fix: establish the must-edge, not a new predicate.
+
+Recipe doc §4.4 calls this "unsat-core partitioning — predicate refinement vs UF concretisation," and the second axis is live today as `MustEdgeInference`:
+
+```rust
+// crates/mununu-core/src/adapter/btor2/kmts_lift.rs:350
+pub enum MustEdgeInference {
+    Off,                  // default — preserves prior may-only behaviour
+    SamplingConfluence,   // sampling-derived must / hyper-must edges
+}
+```
+
+The `SamplingConfluence` post-pass (commits `54a274c`, `cf1aaca`, `8273244`, 2026-06-06) promotes may-edges to `Sharp` and emits `MustHyperOnly` edges from sampled `(input, state)` confluence — a *cheap, unsound-until-proven* must-edge oracle, explicitly soundness-tagged as **candidate** until the SMT-backed must-proof lands ([kmts_lift.rs:846](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L846)). The interpolation work and the must-edge work are the two prongs of recipe §4.4's partition: an UNSAT core mentioning *bitvector constants* → interpolate a predicate (axis 1); a core mentioning *operator/must-witness terms* → an `R_must` proof or UF concretisation (axis 2).
+
+**The thing to internalise from Dimovski for our codebase:** interpolation alone is *not sufficient* in the 3-valued setting the way it is in the 2-valued setting. A `⊥` from a missing must-edge will not be cleared by *any* new predicate — you can split cubes forever and the diamond still can't commit. Recipe §4.7's stall detection ("a round produces neither a new predicate nor a new UF concretisation") is the guard for exactly this: it catches the case where the loop keeps interpolating against an indefiniteness whose real cause is on the must-axis. So the operational rule is: **partition the core first, then choose the axis.** Papers 1–2 give you axis 1; Dimovski tells you axis 2 exists and must be checked first when the `⊥` sits on a `◇`/must obligation.
+
+---
+
+## 5. Putting it together — the refinement step as it should land
+
+After the three papers, the `CraigInterpolation` source should become:
+
+```text
+refine_step(spurious may-trace τ through a ⊥-region):
+    proof := concrete_discharge(τ)            # recipe §4.3
+    if proof is SAT:  return KleeneF(witness) # real cex — Dimovski: a losing play
+    core := unsat_core(proof)
+    (const_terms, must_terms) := partition(core)        # recipe §4.4
+    preds := []
+    if const_terms nonempty:                            # axis 1 — papers 1+2
+        for each cut point j along τ:                   # paper 2: per-location
+            preds.push(interpolant(A_j, B_j))           # paper 1: McMillan object
+    must_jobs := []
+    if must_terms nonempty:                             # axis 2 — Dimovski/§4.4
+        must_jobs.push(prove_must_edge | concretise_uf) # MustEdgeInference path
+    if preds.empty() and must_jobs.empty():
+        return Stall                                    # recipe §4.7
+    return Refine(preds, must_jobs)
+```
+
+Every line of that already has a home in the codebase or the recipe doc; the only net-new engineering is the `interpolant(A_j, B_j)` call (wire `invoke_cvc5_for_interpolant`'s result into a `PredicateSpec`) and the partition heuristic. The papers are what let you write those two pieces with a soundness argument instead of a guess.
+
+## 6. Reading-order recap
+
+- Read **paper 1** for the object; then re-read recipe §4.5 — "interpolant" now has a precise meaning.
+- Read **paper 2** for the loop; then re-read [cegar.rs](../../crates/mununu-core/src/adapter/btor2/cegar.rs) `cegar_refine_loop` and notice it *is* this loop with one stubbed function.
+- Read **paper 3** for the 3-valued/game adjustments; then read `abstraction-literature.md` §23 and recipe §4.4 — the two-axis partition and the `⊥`-not-`false` trigger are the whole delta from papers 1–2.
+- The keystone you are building toward is promoting `PredicateSource::CraigInterpolation` from "returns empty" to the `refine_step` above.
+
+### Honest scope note
+
+There is no single published source that does *all* of "Craig interpolation + KMTS + two-axis (predicate ∥ must-edge) refinement." Papers 1–2 are 2-valued; Dimovski is 3-valued and game-based but does not carry the must-edge/UF second axis in the form mununu needs (that axis traces to Andraus–Sakallah's Reveal and Godefroid–Jagadeesan, recipe §7.3 and lit §23). The synthesis — interpolation on axis 1, must-edge/UF on axis 2, both gated by an UNSAT-core partition over a 3-valued `⊥` trigger — is mununu's own contribution, not something to be found pre-assembled in the literature. That is worth stating plainly in any write-up, per the repo's claims-integrity discipline.

--- a/docs/design/kmts-theory.md
+++ b/docs/design/kmts-theory.md
@@ -302,35 +302,117 @@ The mapping from this doc's notation to the mununu types:
 
 A standard (Sharp-only) Kripke structure is the special case where every transition is `Sharp` and `state_3valued_predicates` is `None` (the 2-valued `state_variable_bitset` is used directly). The KleeneDomain evaluator on such a CLTS returns verdicts in `{KleeneT, KleeneF}` only — `KleeneBot` never appears, because the lattice has no `⊥` content to produce. The BoolDomain monomorphisation of the evaluator computes the same verdicts more cheaply (one Boolean per state instead of a tri-state); for adapters that produce only Sharp KMTSes (XState, microcode, agentic), BoolDomain is the default and KleeneDomain is unused.
 
-## §7 Reading list
+## §7 Controllability-Aware KMTS — Three-Valued Game Abstraction
 
-This list cites primary sources for every load-bearing claim in this doc. Read in roughly the order presented to build the framework from first principles; skip to §7.2/§7.3 if you already have the MTS background.
+> **Concept + design note.** §1–§6 develop KMTS as a *single-agent* abstraction: one transition relation (split into may/must), one player implicitly resolving all nondeterminism. Synthesis and controllability change the picture — the transition relation is now resolved by *two* adversarial agents (controller vs environment), and a sound abstraction must track may/must **per agent**. This section states the composition, names the governing theory, and records the current implementation gap. It anchors the planned `modal_trit_from_target` integration target but, like the rest of this doc, is exempt from `> Source of truth:` (it is design/theory, not a feature page).
 
-### §7.1 Foundations of modal / mixed transition systems
+### §7.1 Two orthogonal asymmetries
+
+A controllability-aware model carries **two independent quantifier-asymmetry axes**, and the soundness question is whether they compose:
+
+- **Modal axis (abstraction soundness).** The KMTS may/must split of §4.3: `⟨a⟩φ` needs a *must*-witness to claim `T` and rules out `T` only when *all may*-successors fail; `[a]φ` needs *all may*-successors to claim `T` and a *must*-witness to claim `F`. This axis is about whether the abstraction can *vouch* for an edge.
+- **Controllability axis (the Skolem paradigm).** For controller synthesis the transition relation is resolved by two players: the **environment** (uncontrollable labels) moves adversarially — `∀` — and the **controller** (controllable labels) moves cooperatively — `∃`. A synthesis obligation reads "*for every* uncontrollable move *there exists* a controllable assignment such that the successor condition holds." In mununu this axis is selected by the `Control` enum on a modal guard (`Control::{All, Controllable, Environment}`, [`crates/mununu-core/src/mu_calculus/mod.rs`](../../crates/mununu-core/src/mu_calculus/mod.rs)), realised today by the label-set Skolem grouping in `modal_exists` / `modal_forall`.
+
+The two axes are **orthogonal**: controllability is a *filter / quantifier-mode over which player resolves an edge*; modality is *the abstraction's confidence in that edge's existence*. Soundness requires both at once, and the product is not the conjunction of two single-axis checks — it is a single rule over a 2×2 partition of the outgoing edges.
+
+### §7.2 The 2×2 product and the modal rules
+
+Partition the guard-matched outgoing edges of a state on both axes:
+
+| | edge ∈ `R_must` (`Sharp` ∪ `MustHyperOnly`) | edge ∈ `R_may ∖ R_must` (`MayOnly`) |
+|---|---|---|
+| **controllable (∃)** | usable as a definite witness | usable only for the *may*-bound |
+| **uncontrollable (∀)** | forces a definite refutation | must be *covered*, cannot refute definitely |
+
+The load-bearing rule — the one sentence that makes the two asymmetries compose — is:
+
+> **The player *establishing* a modality may rely only on `must`-edges; the player *refuting* it ranges over `may`-edges.**
+
+Spelled out for the canonical synthesis idiom `[(ctrl = environment)] ⟨(ctrl = controllable)⟩ φ`:
+
+- **`⟨(ctrl = controllable)⟩ φ`** (the ∃-controller step):
+  - `KleeneT` iff ∃ a **must** controllable edge into a `must_true(φ)` state — the controller's move *really exists* and *really lands good*.
+  - `KleeneF` iff ∀ **may** controllable edges land in `must_false(φ)` — even the optimistic edge set cannot help.
+  - `KleeneBot` otherwise — **including the corner this section exists for**: the controller has only a `MayOnly` edge into a good state. The move *might not exist* in the concrete, so the verdict must be indefinite, not `T`.
+- **`[(ctrl = environment)] φ`** (the ∀-environment step):
+  - `KleeneT` iff ∀ **may** environment edges land in `must_true(φ)` — every move the abstraction admits is good.
+  - `KleeneF` iff ∃ a **must** environment edge into `must_false(φ)` — a move that definitely exists escapes the obligation.
+  - `KleeneBot` otherwise — including: a `MayOnly` environment edge into a bad state, which *cannot* refute definitely (it might not exist).
+
+For `Control::Controllable` the controller-predecessor (`CPre`) form folds both players into one step: definite-`T` requires *every admitted (`may`) environment move* to be good **and** *a confirmed (`must`) controllable move* to a good state; the `may`-bound dualises (no forced (`must`) environment move definitely bad, and optimistically some (`may`) controllable move possibly good). `Control::Environment` is the De Morgan dual.
+
+A standard, controllability-free KMTS (`Control::All`) collapses the table to the §4.3 single-agent rules; a `Sharp`-everywhere controllability-aware model collapses the modality column and recovers the existing 2-valued Skolem semantics of `modal_exists` / `modal_forall`. The 2×2 rule is therefore a conservative extension of both shipped behaviours.
+
+### §7.3 The governing theory — three-valued abstraction of *games*
+
+The preservation theorem of §4.5 (Bruns–Godefroid CONCUR 2000; Huth–Jagadeesan–Schmidt TACAS 2001) is a **single-agent** result. Once the transition relation is resolved by two adversarial players, the object being abstracted is a **two-player game graph**, and the governing soundness result is the *three-valued abstraction of games* line:
+
+- **L. de Alfaro, P. Godefroid, and R. Jagadeesan, *Three-Valued Abstractions of Games: Uncertainty, but with Precision*** (LICS 2004). Establishes that may/must abstraction extends to games when may/must are tracked **per player**, and that definite (`T`/`F`) game values on the abstract game transfer to the concrete game — the game analogue of §4.5. A definite *controller win* requires *must*-moves for the controller and *may*-moves for the environment, which is exactly the 2×2 rule of §7.2.
+- **T. A. Henzinger, R. Majumdar, and others**, on *abstract interpretation of game properties* / *counterexample-guided control* — the refinement counterpart (the game version of Godefroid–Jagadeesan TACAS 2003), driving CEGAR on `KleeneBot` game values.
+
+The practical consequence for mununu: the controllability axis moves the soundness story from "3-valued model checking" to "3-valued game solving." The verdict path that today is correct for the single-agent KMTS (verification adapters) is **not automatically** correct for a controllability-aware KMTS; it needs the per-player may/must of de Alfaro et al.
+
+### §7.4 Must-hypertransitions are required for completeness
+
+A controller guarantee is "I can force the play into *this set* of successors," not "into this single successor." Under nondeterminism a single `must`-edge is too weak: the controller may be able to force the *set* `{s1, s2}` without being able to force either one individually. The sound under-approximation of a forcing move is therefore a **must-hypertransition** (the GKMTS generalisation of Shoham–Grumberg LMCS 2007; de Alfaro et al. for the game setting), whose target is a *set* of abstract states.
+
+mununu already anticipates this: [`EdgeModality::MustHyperOnly`](../../crates/mununu-core/src/mu_calculus/parity_game_3v_build.rs) is a stubbed variant (currently treated as `Sharp` because the K.2 encoding has hyper-target cardinality 1). A complete controllability-aware evaluator must read the hyper-target *set*, not collapse it to a single state. Notably, the existing label-set Skolem grouping in `modal_exists` ([`evaluator.rs`](../../crates/mununu-core/src/mu_calculus/evaluator.rs)) *already* implements set-forcing on the controllable side (a controllable action requires *all* its nondeterministic targets to satisfy) — so the hyper-must machinery on the controllable side is half-present; what is missing is the may/must *edge gate* layered on top of it.
+
+### §7.5 Implementation status — the soundness boundary
+
+As of 2026-06-08 the two axes live on **disjoint, non-composing code paths**:
+
+- The production 3-valued verdict (`evaluate_tri`, [`evaluator.rs`](../../crates/mununu-core/src/mu_calculus/evaluator.rs)) is **modality-blind**: its `Node::Modal` arm runs `modal_bits_from_target` twice (once on `must_true(φ)`, once on `may_true(φ)`), and *neither* pass reads `transition.modality()`. Its 3-valuedness comes entirely from 3-valued *state predicates* (the `L` labelling of §2.5), not from the may/must *transition* relation. It does implement the controllability axis (the Skolem grouping).
+- The only code that reads `TransitionModality::MayOnly` for modal verdicts is the parity-game solver (`parity_game_3v_*`), which is **not** the production verdict path (it feeds failure-subgame extraction for CEGAR, [`parity_game_3v.rs`](../../crates/mununu-core/src/mu_calculus/parity_game_3v.rs) still delegates verdicts to `evaluate_tri`) and assigns owners by `Box`/`Diamond` operator only — it does **not** implement the controllability axis.
+
+**Net effect.** A genuinely controllability-aware KMTS — controllable labels *and* `MayOnly` edges in the same model — would be evaluated unsoundly in the §7.2 corners: a `MayOnly` controllable edge would be accepted as a definite `∃`-witness (over-claiming controller capability), and a `MayOnly` environment edge would be accepted as a definite refutation. The gap is currently **latent**: no shipped adapter emits both (the BTOR2 KMTS lifter sets no controllability; the synthesis adapters emit `Sharp` everywhere). It becomes **active** the moment an adapter emits a controllability-aware KMTS.
+
+**Integration target.** The fix is a single modality-aware modal step that reads both axes in one pass — drafted as `modal_trit_from_target(kind, guard, target: &TritSet) -> TritSet` (the controllability-aware replacement for the two modality-blind `modal_bits_from_target` calls). Its pure core implements the §7.2 table; its CLTS walk classifies each guard-matched edge on the 2×2 partition. Swapping it into `eval_node_tri`'s `Node::Modal` arm is gated on (a) the per-player preservation audit of §7.3 and (b) the hyper-must handling of §7.4. Until then, the boundary is documented here and at the `modal_exists` / `modal_forall` sites.
+
+### §7.6 Controllability-aware refinement (CEGAR)
+
+The refinement loop (R.5) consumes the failure subgame — the `MayOnly` edges reachable from `KleeneBot` positions — to choose predicates to split. Made controllability-aware, the `KleeneBot`s of §7.2 split into two refinement *directions* that pick different predicates:
+
+- An uncertain **environment** `MayOnly` edge → refine to *shrink* `R_may` (rule out a phantom adversary move).
+- An uncertain **controllable** `MayOnly` edge → refine to *grow* `R_must` (confirm a controller move the abstraction only admits as possible).
+
+This requires the subgame's classifying transitions to carry the owning player, i.e. `classifying_transitions: Vec<(usize, usize)>` ([`parity_game_3v.rs`](../../crates/mununu-core/src/mu_calculus/parity_game_3v.rs)) gains a `Player` (or `Control`) tag. With that tag the standard CEGAR loop drives *controllability-aware* refinement with no new fixpoint machinery — the abstraction refinement and the game solving stay separated, exactly as §5.2's "structural free lunch" keeps composition separated from per-module proof.
+
+## §8 Reading list
+
+This list cites primary sources for every load-bearing claim in this doc. Read in roughly the order presented to build the framework from first principles; skip to §8.2/§8.3 if you already have the MTS background.
+
+### §8.1 Foundations of modal / mixed transition systems
 
 1. **K. G. Larsen and B. Thomsen, *A Modal Process Logic*** (LICS 1988). Original modal transition systems. Defines `(S, R_must, R_may)` over an action alphabet with `R_must ⊆ R_may`; introduces the refinement preorder.
 2. **K. G. Larsen, *Modal Specifications*** (CAV 1989 / 1990 — published as part of the *Automatic Verification Methods for Finite State Systems* proceedings). The refinement-based specification language built on MTSes; foundational for treating MTSes as under-specified contracts.
 3. **D. Dams, R. Gerth, and O. Grumberg, *Abstract Interpretation of Reactive Systems*** (TOPLAS 1997, Vol. 19 No. 2, pp. 253–291). The *mixed transition system* generalisation dropping the `R_must ⊆ R_may` invariant; the foundational treatment of abstraction-as-interpretation for branching-time temporal logic. Mununu's standard-KMTS shape (§2.2) is the restricted-to-`R_must ⊆ R_may` case.
 
-### §7.2 KMTS and 3-valued mu-calculus
+### §8.2 KMTS and 3-valued mu-calculus
 
 4. **G. Bruns and P. Godefroid, *Model Checking Partial State Spaces with 3-Valued Temporal Logics*** (CAV 1999) — original paper; **G. Bruns and P. Godefroid, *Generalized Model Checking: Reasoning about Partial State Spaces*** (CONCUR 2000) — extended results. Together establish the 3-valued modal mu-calculus semantics (§4.3) and the preservation theorem (§4.5). The CONCUR 2000 paper is the canonical citation for the preservation result for full mu-calculus including alternating fixpoints.
 5. **M. Huth, R. Jagadeesan, and D. A. Schmidt, *Modal Transition Systems: A Foundation for Three-Valued Program Analysis*** (TACAS 2001, LNCS 2028). The KMTS definition (§2.2) — the explicit 3-valued AP labelling extension of Larsen–Thomsen MTS — and the proof that 3-valued mu-calculus model checking on KMTSes is sound, complete (up to the lattice's expressiveness), and decidable for finite KMTSes. The companion to Bruns–Godefroid for the *finite-state* model-checking setting; mununu's KMTS is in this class.
 6. **P. Godefroid and R. Jagadeesan, *Automatic Abstraction Using Generalized Model Checking*** (TACAS 2003, LNCS 2619). The CEGAR-style refinement loop for KMTS — how to respond to `⊥` verdicts by extracting refinement predicates from spurious abstract counterexamples. Foundational for the mununu architecture doc §6.8 CEGAR loop and the [`predicate-abstraction-recipe.md`](predicate-abstraction-recipe.md) §4 algorithm.
 
-### §7.3 Compositional KMTS and modal contracts
+### §8.3 Compositional KMTS and modal contracts
 
 7. **K. G. Larsen, U. Nyman, and A. Wąsowski, *Modal I/O Automata for Interface and Product Line Theories*** (FoSSaCS 2007, LNCS 4421). The compositional theory of KMTSes with input/output asymmetry. The congruentiality of refinement under composition (§5.2) and the structural soundness of compositional abstraction are proved here.
 8. **A. Antonik, M. Huth, K. G. Larsen, U. Nyman, and A. Wąsowski, *20 Years of Modal and Mixed Specifications*** (Bulletin of the EATCS 95, 2008; also in FMCO 2008 proceedings). Survey of the modal-specification literature 1988–2008; useful both for historical context and for surveying extensions (parametric modal specifications, disjunctive modal transition systems, branching-time modal contracts) that mununu may want to revisit if AGR-style work becomes load-bearing.
 
-### §7.4 Adjacent — background on 3-valued logic and fixpoint theory
+### §8.4 Adjacent — background on 3-valued logic and fixpoint theory
 
 For readers unfamiliar with Kleene's 3-valued logic or Tarski's fixpoint theorem:
 
 - **S. C. Kleene, *Introduction to Metamathematics*** (North-Holland 1952), Chapter XII §64. The original strong 3-valued logic with truth tables for `∨`, `∧`, `¬` extended to `{T, F, ⊥}` (Kleene's "undefined" value). The truth-lattice operations of §4.1 are these connectives.
 - **A. Tarski, *A Lattice-Theoretical Fixpoint Theorem and Its Applications*** (Pacific J. Math. 5, 1955, pp. 285–309). The least-fixpoint and greatest-fixpoint existence theorem for monotone functions on complete lattices. The mu-calculus fixpoint semantics is an instance of Tarski's framework lifted to the lattice of 3-valued state valuations under the information order (§4.4).
 
-### §7.5 Mununu cross-references
+### §8.5 Controllability-aware KMTS and game abstraction (§7)
+
+9. **L. de Alfaro, P. Godefroid, and R. Jagadeesan, *Three-Valued Abstractions of Games: Uncertainty, but with Precision*** (LICS 2004). The game generalisation of Bruns–Godefroid: may/must abstraction tracked per player, with definite (`T`/`F`) game-value preservation from abstract to concrete. The soundness foundation for §7.2–§7.3 — a definite controller win requires *must*-moves for the controller and *may*-moves for the environment.
+10. **L. de Alfaro, T. A. Henzinger, and R. Majumdar, *From Verification to Control: Dynamic Programs for Omega-Regular Objectives*** (LICS 2001), and the abstract-interpretation-of-games / counterexample-guided-control literature that follows it. The refinement counterpart for §7.6 — driving CEGAR on `KleeneBot` game values and the controllable-predecessor (`CPre`) fixpoint form.
+11. **O. Grumberg, M. Lange, M. Leucker, and S. Shoham, *When not losing is better than winning: Abstraction and refinement for the full mu-calculus*** (Information and Computation 2007; the GKMTS / must-hypertransition line). Establishes that completeness of must-abstraction for the full mu-calculus requires hypertransitions — the §7.4 justification for `EdgeModality::MustHyperOnly`.
+
+### §8.6 Mununu cross-references
 
 - Architecture: [`native-sv-abstraction.md`](native-sv-abstraction.md) §6.
 - Practical recipe (predicate seeding, image, CEGAR): [`predicate-abstraction-recipe.md`](predicate-abstraction-recipe.md).

--- a/docs/design/predicate-abstraction-recipe.md
+++ b/docs/design/predicate-abstraction-recipe.md
@@ -1,6 +1,6 @@
 # Predicate-Abstraction Recipe — KMTS Lifter Operational Guide
 
-> **Status: planning** until R.5 ships. Practical recipe for predicate seeding, may/must image computation, CEGAR refinement, and operational debugging in mununu's BTOR2 → KMTS lifter. Companions: [`native-sv-abstraction.md`](native-sv-abstraction.md) (architecture; §6 is the design framing), [`kmts-theory.md`](kmts-theory.md) (theoretical foundations). Sections that reference proposed code are unanchored; sections that reference live code carry inline anchors but do not graduate to `> Source of truth:` until the corresponding roadmap phase ships.
+> **Status: planning** until R.5 ships. Practical recipe for predicate seeding, may/must image computation, CEGAR refinement, and operational debugging in mununu's BTOR2 → KMTS lifter. Companions: [`native-sv-abstraction.md`](native-sv-abstraction.md) (architecture; §6 is the design framing), [`kmts-theory.md`](kmts-theory.md) (theoretical foundations), [`predicate-abstraction-worked-example.md`](predicate-abstraction-worked-example.md) (one module carried end to end — RTL → BTOR2 → coarse `KleeneBot` → interpolant → refined `KleeneT`). Sections that reference proposed code are unanchored; sections that reference live code carry inline anchors but do not graduate to `> Source of truth:` until the corresponding roadmap phase ships.
 
 ## §1 What predicate abstraction is
 

--- a/docs/design/predicate-abstraction-worked-example.md
+++ b/docs/design/predicate-abstraction-worked-example.md
@@ -1,0 +1,974 @@
+# Predicate Abstraction, End to End — A Worked Example
+
+> **Status: planning** until R.5 ships. This is the *worked-example* companion to
+> [`predicate-abstraction-recipe.md`](predicate-abstraction-recipe.md) (the
+> operational reference) and [`kmts-theory.md`](kmts-theory.md) (the theory). It
+> carries one small SystemVerilog module — a controller with a real **arithmetic
+> datapath** — the whole length of the pipeline: RTL → BTOR2 → a coarse predicate
+> abstraction that returns `KleeneBot` → a Craig interpolant that supplies the
+> missing **arithmetic** predicate → a refined abstraction over **two predicates /
+> a multi-bit cube** that returns a definite, transferable verdict. Sections that
+> reference live code carry inline anchors; per the recipe doc's convention they do
+> not graduate to `> Source of truth:` until the corresponding R.5 phase ships.
+> Where the shipped MVP differs from the construction described here, an
+> **Implementation status** note marks the gap.
+>
+> **Every source artifact in this doc is verified against an actual binary** (per
+> the repo's Claims Integrity policy):
+>
+> | artifact | file | binary | what runs |
+> |---|---|---|---|
+> | RTL | [`charge_commit.sv`](../../examples/hw/charge_commit.sv) | **Verilator 5.043** | compile + 20 000-cycle randomized sim, `--assert` on; negative control fails (§1.2) |
+> | RTL → BTOR2 | [`charge_commit_to_btor2.ys`](../../examples/hw/charge_commit_to_btor2.ys) | **yosys 0.59** | `write_btor` emits a real `bad`; output is [`charge_commit.yosys.btor2`](../../examples/hw/charge_commit.yosys.btor2) (§2.1) |
+> | BTOR2 (readable mirror) | [`charge_commit.btor2`](../../examples/hw/charge_commit.btor2) | **mununu** | `mununu btor2 cegar` (§7) |
+> | cube automaton | [`charge_commit_cubes.ctxdsl`](../../examples/hw/charge_commit_cubes.ctxdsl) | **mununu** | `mununu context eval`, four formulas (§6.4) |
+>
+> The one step that does **not** run on this machine is **Craig interpolation in
+> §4**: cvc5 is an optional external tool and is absent here, so the loop falls
+> back to the WP heuristic (real warning captured in §7). The cvc5 transcript in §4
+> is therefore the *construction the theory specifies*, not a run; everything else
+> is captured verbatim. The clean `KleeneBot → interpolant → KleeneT` arc of §3–§5
+> is likewise the construction; §7 shows the more modest output the MVP loop emits
+> today (1-iteration convergence).
+
+## Why this doc exists
+
+The recipe doc explains *which* predicate-image query to run and *where*
+predicates come from. The theory doc proves *why* the verdicts transfer. Neither
+walks a single concrete artifact from RTL to verdict with the cubes, the
+may/must edges, the three-valued fixpoint, and the interpolant all written out.
+That gap is what makes predicate abstraction feel like magic to a newcomer and
+what makes a `KleeneBot` verdict hard to debug. This doc closes it on an example
+small enough to evaluate by hand, with an arithmetic datapath so the interesting
+predicate is a *comparison* (`lvl >= 6`) the abstraction has to discover — not
+just an FSM-state equality. It is the concrete instance
+[`docs/abstraction.md`](../abstraction.md) points at: a design whose datapath is
+too wide to enumerate, so the verdict must survive **abstraction**.
+
+### Definitions used below (and where they come from)
+
+This example is an instance of four pieces of established theory; the
+[reading list](#reading-list--literature) at the end gives full citations.
+
+- **Predicate abstraction** (Graf & Saidi, CAV 1997). Given a concrete system and
+  a finite predicate set `P = {p₁,…,p_k}`, the abstract states are *cubes* —
+  Boolean valuations over `P` — and each cube `b` concretizes to
+  `γ(b) = { s : ∀ pᵢ. b(pᵢ) = pᵢ(s) }`. There are at most `2^k` cubes; here `k`
+  grows from 1 (§3) to 2 (§5) to 3 (§6), so the cube is genuinely **multi-bit**.
+- **KMTS / may–must abstraction** (Larsen & Thomsen 1988; Godefroid–Huth–Jagadeesan
+  CONCUR 2001 for the predicate-abstraction reading). A predicate abstraction is
+  naturally a *Kripke Modal Transition System*: `R_may(b,b') ⟺ ∃ s∈γ(b),s'∈γ(b'). (s,s')∈R`
+  (an over-approximating edge) and `R_must(b,b') ⟺ ∀ s∈γ(b). ∃ s'∈γ(b'). (s,s')∈R`
+  (an under-approximating edge), with `R_must ⊆ R_may`.
+- **Three-valued model checking** (Bruns & Godefroid, CONCUR 2000). The modal-mu
+  calculus is evaluated over the Kleene domain `{T, F, ⊥}`; **definite** verdicts
+  (`T`/`F`) transfer to the concrete system at *every* alternation depth, and a `⊥`
+  triggers refinement.
+- **CEGAR by interpolation** (Clarke–Grumberg–Jha–Lu–Veith, CAV 2000; Craig 1957;
+  McMillan, CAV 2003). A `⊥`/spurious-counterexample is discharged against the
+  concrete transition relation; the UNSAT proof yields a Craig **interpolant** that
+  becomes the next predicate. Here that interpolant is the arithmetic comparison
+  `lvl >= 6` (§4).
+
+## The pipeline at a glance
+
+```
+  charge_commit.sv      (1) RTL: a controller with a charge-level datapath
+       │  extract / lower  (mununu-extract → BTOR2)
+       ▼
+  charge_commit.btor2   (2) bit-level transition relation  (add, ugte, …)
+       │  predicate_cube_lift   with P0 = { committed }   (under-seeded)
+       ▼
+  coarse KMTS (2 cubes) (3) over-approximation: datapath collapsed, charged = ⊥
+       │  3-valued evaluation   νX.( [fire] charged ∧ [] X )
+       ▼
+  verdict = KleeneBot   (3') indefinite — abstraction can't see the level
+       │  CEGAR: failure subgame → cvc5 get-interpolant
+       ▼
+  interpolant: lvl >= 6 (4) the missing ARITHMETIC predicate
+       │  predicate_cube_lift   with P1 = { committed, charged }
+       ▼
+  refined KMTS (4 cubes) (5) finer over-approximation, datapath partitioned
+       │  3-valued evaluation
+       ▼
+  verdict = KleeneT      (5') definite — transfers to the real RTL (safety + over-approx)
+       │  add a third predicate `half = lvl>=4`; materialize the cubes as CTXDSL
+       ▼
+  runnable CTXDSL       (6) 3-bit cube automaton — verified live by `mununu context eval`
+```
+
+CTXDSL μ-calculus syntax used below: `[] φ` is the box over **all** actions,
+`<> φ` the diamond, `[ labels = { a } ] φ` a label-restricted box, `mu`/`nu` the
+fixpoints, `&&`/`||`/`!` the connectives, and a bare state name is the atomic
+proposition "in that state."
+
+The load-bearing idea: a single abstraction direction (over-approximation) makes
+**safety** verdicts sound, but only if the abstraction is *precise enough* to
+avoid a spurious counterexample. With a datapath, "precise enough" means tracking
+the right arithmetic fact. Interpolation is how the loop discovers that fact
+without enumerating 2⁸ (read: 2³²) level values.
+
+## §1 — The RTL
+
+A command/commit controller that must **charge up** before it may commit. It
+walks four phases — `IDLE → CHARGE → READY → COMMIT` — accumulating a level
+`lvl` while charging (`lvl += 2` per `pulse`), and only advancing to `READY` once
+`lvl >= 6`. The safety obligation: **it may only commit (`fire`) while charged**,
+i.e. `commit_en` never rises with `lvl < 6`.
+
+The module is the committed file
+[`examples/hw/charge_commit.sv`](../../examples/hw/charge_commit.sv) (abridged
+below — the committed file additionally carries the obligation as a `FORMAL`-gated
+immediate assertion that both Verilator and yosys consume, §1.2 / §2.1):
+
+```systemverilog
+// charge_commit.sv  (abridged — see the committed file for the FORMAL assertion)
+module charge_commit (
+    input  logic       clk,
+    input  logic       rst,
+    input  logic       req,     // environment: a request arrives
+    input  logic       pulse,   // environment: a charge pulse
+    input  logic       fire,    // controller: open the commit window
+    input  logic       clr,     // environment: release
+    output logic       commit_en
+);
+    typedef enum logic [1:0] { IDLE=2'd0, CHARGE=2'd1, READY=2'd2, COMMIT=2'd3 } phase_t;
+    phase_t     phase;
+    logic [7:0] lvl;            // charge level — the arithmetic datapath
+
+    localparam logic [7:0] STEP      = 8'd2;
+    localparam logic [7:0] THRESHOLD = 8'd6;
+
+    always_ff @(posedge clk) begin
+        if (rst) begin
+            phase <= IDLE;
+            lvl   <= 8'd0;
+        end else begin
+            case (phase)
+                IDLE  : if (req)               phase <= CHARGE;
+                CHARGE: begin
+                    if (lvl < THRESHOLD) begin
+                        if (pulse) lvl <= lvl + STEP;   // ── arithmetic: accumulate
+                    end else begin
+                        phase <= READY;                  // ── arithmetic guard: lvl >= 6
+                    end
+                end
+                READY : if (fire)              phase <= COMMIT;
+                COMMIT: if (clr) begin phase <= IDLE; lvl <= 8'd0; end
+            endcase
+        end
+    end
+
+    assign commit_en = (phase == COMMIT);
+    // Safety obligation:  G ( commit_en -> lvl >= THRESHOLD )
+endmodule
+```
+
+**The truth of the matter** (which the verifier must *discover*, not be told):
+`lvl` only ever takes the values `{0, 2, 4, 6}` — it accumulates by 2 and the
+phase leaves `CHARGE` the moment `lvl >= 6`, so it saturates at 6 and is exactly
+6 in every reachable `READY` and `COMMIT` state. The obligation **holds**. The
+game is proving it without enumerating the 8-bit (→ 32-bit) level.
+
+### Concrete behaviour (values in states, arithmetic on transitions)
+
+```mermaid
+flowchart LR
+  I["IDLE<br/>lvl = 0"] -->|req| C0["CHARGE<br/>lvl = 0"]
+  C0 -->|"pulse / lvl += 2"| C2["CHARGE<br/>lvl = 2"]
+  C2 -->|"pulse / lvl += 2"| C4["CHARGE<br/>lvl = 4"]
+  C4 -->|"pulse / lvl += 2"| C6["CHARGE<br/>lvl = 6"]
+  C6 -->|"tick [lvl >= 6]"| R["READY<br/>lvl = 6"]
+  R -->|fire| K["COMMIT<br/>lvl = 6 ✓ charged"]
+  K -->|"clr / lvl := 0"| I
+  B["COMMIT<br/>lvl &lt; 6 ✗ violates obligation"]:::dead
+  classDef dead fill:#fdd,stroke:#c00,stroke-dasharray:4 3
+```
+
+The red `COMMIT, lvl < 6` state is what the obligation forbids — and it is
+**unreachable**, because the only way into `COMMIT` is `READY --fire--> COMMIT`,
+and `READY` is only entered once `lvl >= 6`. (`tick` is the internal label for the
+autonomous `CHARGE→READY` step the always_ff takes when the guard holds.)
+
+### §1.2 — Sanity-checking the RTL under Verilator
+
+Before any abstraction, confirm the *concrete* RTL actually satisfies the
+obligation. The committed file carries it as a clocked immediate assertion
+(`safety_charged: assert (!commit_en || lvl >= THRESHOLD)`, active under `FORMAL`),
+and [`charge_commit_tb.sv`](../../examples/hw/charge_commit_tb.sv) drives 20 000
+cycles of deterministic xorshift stimulus:
+
+```bash
+verilator --binary --assert --timing -DFORMAL -Wall \
+  -Wno-DECLFILENAME -Wno-UNUSEDSIGNAL -Wno-PROCASSINIT \
+  charge_commit.sv charge_commit_tb.sv --top-module charge_commit_tb -o sim
+./obj_dir/sim
+```
+
+Captured verbatim (Verilator 5.043, `hw-verif:latest`):
+
+```
+charge_commit_tb: 20000 cycles, commit_en asserted in 6168, no assertion failures
+- charge_commit_tb.sv:53: Verilog $finish
+```
+
+A bounded simulation **cannot prove** the property (it only fails to falsify it in
+20 000 cycles) — that is exactly the gap exhaustive abstract model checking fills.
+But it is a load-bearing *negative control* for the harness: re-run with a broken
+variant in which `CHARGE` advances to `READY` on `req` regardless of `lvl`, and the
+assertion fires almost immediately —
+
+```
+[85] %Error: charge_commit_broken.sv:56: Assertion failed in ...dut.safety_charged: 'assert' failed.
+```
+
+— so the green run above is meaningful, not a vacuous pass.
+
+## §2 — Lower to BTOR2 (extraction)
+
+The frontend lowers `always_ff` to a bit-level relation over two state elements,
+`phase` (2-bit) and `lvl` (8-bit). The **arithmetic** is explicit: `add` for the
+accumulate, `ugte` / `ult` for the threshold comparisons.
+
+### §2.1 — The real frontend lowering (yosys)
+
+The SV → BTOR2 lowering **is exercised against the actual yosys binary**.
+[`charge_commit_to_btor2.ys`](../../examples/hw/charge_commit_to_btor2.ys) reads
+the `FORMAL`-gated assertion and lowers it to a BTOR2 `bad` state:
+
+```bash
+yosys charge_commit_to_btor2.ys      # write_btor -> charge_commit.yosys.btor2
+```
+
+Captured verbatim — the obligation became a real property node, and mununu's CEGAR
+loop runs on the yosys output unchanged:
+
+```
+21 bad 20 safety_charged ; charge_commit.sv:60.13-60.70
+```
+```
+$ mununu btor2 cegar charge_commit.yosys.btor2 \
+    --formula 'nu X. ([] X)' --predicate 'committed:phase=3' --predicate-source wp
+CEGAR refinement loop completed
+  fixture:           charge_commit.yosys.btor2
+  iterations:        1
+  terminated_with:   Converged
+  final predicates:  1
+```
+
+> The generated [`charge_commit.yosys.btor2`](../../examples/hw/charge_commit.yosys.btor2)
+> is faithful but verbose (yosys encodes the property with an auxiliary state
+> register and `concat`/`redand` mux trees). For the by-hand walkthrough below, §2.2
+> uses an equivalent **readable mirror**,
+> [`examples/hw/charge_commit.btor2`](../../examples/hw/charge_commit.btor2), whose
+> node numbering matches the prose. Both run under `mununu btor2 cegar` (§7); the
+> mirror is what the rest of the doc references. Per Claims Integrity, the readable
+> mirror demonstrates the lifter/CEGAR *behaviour*, while the yosys output above is
+> the evidence the SystemVerilog actually lowers end-to-end.
+
+### §2.2 — The readable BTOR2 mirror
+
+```
+; charge_commit.btor2
+1  sort bitvec 2          ; phase
+2  sort bitvec 8          ; lvl
+3  sort bitvec 1          ; bool
+; --- phase constants ---
+4  constd 1 0             ; IDLE
+5  constd 1 1             ; CHARGE
+6  constd 1 2             ; READY
+7  constd 1 3             ; COMMIT
+; --- lvl constants ---
+8  constd 2 0
+9  constd 2 2             ; STEP
+10 constd 2 6             ; THRESHOLD
+; --- state + init ---
+11 state 1 phase
+12 state 2 lvl
+13 init  1 11 4           ; phase = IDLE
+14 init  2 12 8           ; lvl   = 0
+; --- inputs ---
+15 input 3 req
+16 input 3 pulse
+17 input 3 fire
+18 input 3 clr
+; --- phase predicate atoms ---
+19 eq 3 11 5              ; phase == CHARGE
+20 eq 3 11 6              ; phase == READY
+21 eq 3 11 7              ; phase == COMMIT
+22 eq 3 11 4              ; phase == IDLE
+; --- ARITHMETIC ---
+23 ugte 3 12 10           ; lvl >= 6      (charged)        ◀── comparison
+24 ult  3 12 10           ; lvl <  6                        ◀── comparison
+25 add  2 12 9            ; lvl + 2                         ◀── accumulate
+; --- next(lvl): CHARGE & pulse & lvl<6 ? lvl+2 : (COMMIT & clr ? 0 : lvl) ---
+26 and 3 19 16            ; CHARGE & pulse
+27 and 3 26 24            ; CHARGE & pulse & lvl<6
+28 ite 2 27 25 12         ;   ? lvl+2 : lvl
+29 and 3 21 18            ; COMMIT & clr
+30 ite 2 29 8 28          ;   ? 0 : prev
+31 next 2 12 30
+; --- next(phase): IDLE&req->CHARGE; CHARGE&(lvl>=6)->READY; READY&fire->COMMIT; COMMIT&clr->IDLE ---
+32 and 3 22 15            ; IDLE & req
+33 ite 1 32 5 11          ;   ? CHARGE : phase
+34 and 3 19 23            ; CHARGE & (lvl>=6)
+35 ite 1 34 6 33          ;   ? READY : prev
+36 and 3 20 17            ; READY & fire
+37 ite 1 36 7 35          ;   ? COMMIT : prev
+38 ite 1 29 4 37          ; COMMIT & clr ? IDLE : prev
+39 next 1 11 38
+; --- property: bad = COMMIT & ¬(lvl>=6) = commit while undercharged ---
+40 not 3 23               ; lvl < 6  (¬charged)
+41 and 3 21 40            ; COMMIT & ¬charged
+42 bad 41
+```
+
+## §3 — Coarse abstraction `P0 = { committed : phase == COMMIT }`
+
+We deliberately **under-seed**: the user supplies only the control predicate and
+forgets the datapath. This is the most common reason a real run returns
+`KleeneBot`, and exactly the case interpolation is for.
+
+### §3.1 Cubes
+
+One predicate → `2¹ = 2` cubes. Bit-convention (recipe §3, test
+[`predicate_cube_lift_state_3valued_predicates_match_cube_bit_pattern`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs)):
+predicate at bit `i` is true in cube `c` iff `(c >> i) & 1 == 1`.
+
+| cube | index | `committed` (bit 0) | concretization γ |
+|------|-------|---------------------|------------------|
+| `cube0` | 0 | F | every state with `phase ≠ COMMIT`, **any `lvl`** |
+| `cube1` | 1 | T | `phase == COMMIT`, **any `lvl`** |
+
+`lvl` is invisible: each cube spans all 256 level values.
+
+### §3.2 CLTS (CTXDSL surface, with labels)
+
+The transitions carry the real event labels and controllability is declared. This
+block is a **schematic** of the coarse 2-cube structure: the property's `charged`
+AP (`lvl >= 6`) is *not expressible* over `P0` — no state binds it — so this
+context illustrates the stall but is not itself runnable. The full, parser-checked,
+`mununu context eval`-runnable model is in **§6** (with the `charged` and `half`
+predicates added).
+
+```
+context ChargeCommitCoarse {                        // schematic — see §6 for the runnable model
+    alphabet {
+        label req;      // environment: request arrives
+        label pulse;    // environment: charge pulse  (carries lvl += 2)
+        label fire;     // controller: open the commit window
+        label clr;      // environment: release
+        label tick;     // internal: autonomous CHARGE -> READY at the threshold
+    }
+
+    automata {
+        automaton Cubes {
+            controllable { label fire; }            // only the controller fires
+            internal     { label tick; }            // threshold step is autonomous
+
+            states {
+                state cube0 initial {               // ¬committed
+                    valuations { committed = 0; }
+                };
+                state cube1 {                       //  committed
+                    valuations { committed = 1; }
+                };
+            }
+
+            transitions {
+                transition cube0 -> cube0 on label req;
+                transition cube0 -> cube0 on label pulse;   // lvl += 2, but lvl untracked
+                transition cube0 -> cube1 on label fire;     // READY commits — may-only
+                transition cube1 -> cube0 on label clr;
+                transition cube1 -> cube1 on label tick;     // hold
+            }
+
+            predicates {                             // predicates block is automaton-scoped
+                predicate committed = state cube1;
+                // charged ≡ ⟨lvl >= 6⟩ — NOT bindable over P0; supplied in §6
+            }
+        }
+    }
+
+    mu_formulas {
+        // Safety: every `fire` transition lands in a charged state.
+        // LABEL-RESTRICTED box guard (CLAUDE.md "Rich modal guards").
+        formula commit_only_when_charged {
+            over Cubes;
+            body = nu X. ( [ labels = { fire } ] charged && [] X );
+        }
+    }
+}
+```
+
+> **A realize gotcha worth knowing** (you hit it the moment you make this
+> runnable): two transitions with the *same* `(source, label)` but different
+> targets collapse to one edge during realize. The coarse model "wants" both
+> `cube0 --fire--> cube0` (IDLE/CHARGE ignore `fire`) and `cube0 --fire--> cube1`
+> (READY commits) — genuine may-nondeterminism — but a hand-authored CTXDSL CLTS
+> keeps one. §6 avoids this by giving each `(source, label)` a single target.
+
+### §3.3 KMTS (what the lifter produces)
+
+The KMTS is that CLTS **plus**
+[`TransitionModality`](../../crates/mununu-core/src/clts/mod.rs) per edge —
+`Sharp` (in both `may` and `must`) or `MayOnly` (over-approx, no must-witness) —
+and [`state_3valued_predicates`](../../crates/mununu-core/src/clts/mod.rs), each
+cube's `Tristate` label per *formula* AP (recipe §1.2). The formula's AP is
+`charged ≡ lvl >= 6`; with `lvl` untracked, **`charged` is `KleeneBot` in every
+cube**.
+
+```mermaid
+flowchart LR
+  c0["cube0 — ¬committed<br/>charged: ⊥"]
+  c1["cube1 — committed<br/>charged: ⊥"]
+  c0 -->|"req, pulse, tick"| c0
+  c0 -. "fire (IDLE/CHARGE ignore)" .-> c0
+  c0 -. "fire (READY commits)" .-> c1
+  c1 -->|clr| c0
+  c1 -->|tick hold| c1
+```
+
+| from | to | label | may | must | modality |
+|------|----|-------|:---:|:----:|----------|
+| cube0 | cube0 | req,pulse,tick | ✓ | ✗ | `MayOnly` |
+| cube0 | cube0 | fire | ✓ | ✗ | `MayOnly` — `IDLE`/`CHARGE` ignore `fire` and self-loop |
+| cube0 | cube1 | fire | ✓ | ✗ | `MayOnly` — only `READY` states actually commit ⇒ `fire` is not *must* into either target |
+| cube1 | cube0 | clr | ✓ | ✓ | `Sharp` |
+| cube1 | cube1 | tick | ✓ | ✓ | `Sharp` |
+
+### §3.4 Three-valued evaluation of `νX. ( [fire] charged ∧ [] X )`
+
+Box over a KMTS (Bruns–Godefroid; kmts-theory §2):
+`⟦[L]φ⟧(s) = T` iff **all** `L`-labelled *may*-successors satisfy `φ = T`;
+`= F` iff **some** `L`-labelled *must*-successor has `φ = F`; otherwise `⊥`.
+
+```
+[fire] charged  at cube0 :
+    fire-may-successors = { cube0, cube1 };  charged = ⊥ in both  ⇒ box ≠ T
+    fire-must-successors = ∅ (both fire edges are MayOnly)         ⇒ box ≠ F
+    ⇒ [fire] charged = ⊥
+νX : X(cube0) = ⊥ ∧ [] X = ⊥
+```
+
+**Verdict at the initial cube `cube0` = `KleeneBot`.** The abstraction cannot
+decide the obligation: it can see a `fire` edge into `committed`, but with the
+level collapsed it cannot tell whether the post-`fire` state is charged. This is
+the `KleeneBot → CEGAR` trigger
+[`cegar_refine_loop`](../../crates/mununu-core/src/adapter/btor2/cegar.rs)
+responds to.
+
+> **Implementation status.** The `KleeneBot` verdict above is the verdict of the
+> *exact* construction — it is **not** what the MVP loop emits on this fixture.
+> mununu's R.2.5 `predicate_cube_lift` emits `MayOnly` edges by **sampling one
+> representative per cube** and simulating one step (a sound under-approx of the
+> may-set, per the `// SOUNDNESS:` note in
+> [`kmts_lift.rs`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs)), and
+> the `mununu btor2 cegar` summary converges in one iteration without surfacing a
+> per-cube `KleeneBot`. **See §7 for the real captured output.** Exhaustive
+> may/must imaging and per-cube 3-valued reporting are what the lifter is
+> converging toward; §3.4–§5 describe that target.
+
+## §4 — CEGAR: a Craig interpolant supplies the missing arithmetic predicate
+
+### §4.1 The failure subgame
+
+The indefiniteness localizes to one classifying transition: the `fire` edge
+`cube0 →▸ cube1`, whose post-state's `charged` label is `⊥`. CEGAR asks: **is
+there a reachable state from which `fire` reaches an undercharged `COMMIT`?**
+Equivalently — does `phase == COMMIT ∧ lvl < 6` intersect the reachable set?
+
+### §4.2 The interpolation query
+
+We want `I` over the datapath vocabulary that (a) is implied by the reachable
+post-`fire` states and (b) excludes the bad region `lvl < 6`. The reachable
+`fire` always fires from `READY` where `lvl = 6`, so the A-side entails
+`lvl >= 6`; the bad region is `lvl < 6`.
+
+> The query and interpolant below are an **illustration of the intended
+> refinement step — they do not execute today.** On a machine without cvc5 the
+> loop falls back to the WP heuristic (real warning captured in §7); and even
+> with cvc5 the MVP parser rejects the inequality interpolant (status note 2
+> below). Treat this block as the construction, not a transcript.
+
+```lisp
+(set-logic QF_BV)
+(set-option :produce-interpolants true)
+(declare-fun lvl () (_ BitVec 8))
+
+; A: post-fire states actually reachable  (READY fires at lvl = 6, saturated)
+(assert (= lvl (_ bv6 8)))
+
+; B: the forbidden region the obligation rules out
+(get-interpolant I (bvult lvl (_ bv6 8)))          ; lvl < 6
+
+; cvc5 returns an ARITHMETIC interpolant:
+;   (define-fun I () Bool (bvuge lvl (_ bv6 8)))    ; lvl >= 6
+```
+
+The interpolant is the **comparison** `lvl >= 6` — the charge invariant the
+under-seeded `P0` was missing. It becomes a new predicate:
+
+```rust
+PredicateSpec { name: "charged", register: "lvl", relation: Uge, value: 6 }
+```
+
+> **Implementation status (two honesty notes).**
+> 1. The query above is the *transition-aware* form refinement needs. mununu's
+>    shipped
+>    [`build_interpolation_query`](../../crates/mununu-core/src/adapter/cvc5/mod.rs)
+>    MVP renders the simpler **cube-conjunction** form; the transition-relation
+>    formulation (recipe §4) is the documented target.
+> 2. The MVP
+>    [`parse_cvc5_interpolant_response`](../../crates/mununu-core/src/adapter/cvc5/mod.rs)
+>    accepts **atomic equalities only** (`(= reg val)`); an inequality
+>    interpolant like `(bvuge lvl …)` is not yet parsed, so today this exact
+>    predicate is more likely **seeded** from the formula's own AP (`lvl >= 6` is
+>    a comparison AP, recipe §2.1) or from a COI constant (recipe §2.2) than
+>    *discovered*. When the parser grows comparison support, this is the
+>    interpolant it returns; until then the loop falls back to
+>    `WeakestPrecondition` on a compound interpolant. The arithmetic in the model
+>    (`add` / `ugte`) is real today; the inequality-interpolant *round-trip* is
+>    the R.5 target.
+
+## §5 — Refined abstraction `P1 = { committed, charged : lvl >= 6 }`
+
+### §5.1 Cubes
+
+Two predicates → `2² = 4` cubes. bit 0 = `committed`, bit 1 = `charged`.
+
+Cube naming is `cube⟨committed⟩⟨charged⟩`; the numeric cube index is
+`committed·2⁰ + charged·2¹`.
+
+| cube | index | `committed` b0 | `charged` b1 | γ | reachable? |
+|------|:---:|:---:|:---:|---|:---:|
+| `cube00` | 0 | F | F | `phase ≠ COMMIT`, `lvl < 6` (IDLE, CHARGE while filling) | ✓ |
+| `cube01` | 2 | F | T | `phase ≠ COMMIT`, `lvl >= 6` (CHARGE@6, READY) | ✓ |
+| `cube10` | 1 | T | F | `phase == COMMIT`, `lvl < 6` (**the violation**) | ✗ |
+| `cube11` | 3 | T | T | `phase == COMMIT`, `lvl >= 6` | ✓ |
+
+Partitioning `lvl` at the threshold is exactly what the interpolant bought us.
+
+### §5.2 KMTS
+
+```mermaid
+flowchart LR
+  c00["¬committed ¬charged<br/>IDLE / CHARGE, lvl&lt;6"]
+  c01["¬committed charged<br/>CHARGE@6 / READY, lvl=6"]
+  c11["committed charged<br/>COMMIT, lvl=6 ✓"]
+  c10["committed ¬charged<br/>COMMIT, lvl&lt;6 ✗ UNREACHABLE"]:::dead
+  c00 -->|"req, pulse [lvl&lt;6]"| c00
+  c00 -->|"pulse / lvl += 2 → 6"| c01
+  c01 -->|"tick [lvl>=6] hold"| c01
+  c01 -->|"fire"| c11
+  c11 -->|"clr / lvl := 0"| c00
+  classDef dead fill:#fdd,stroke:#c00,stroke-dasharray:4 3
+```
+
+| from | to | label | may | must | modality |
+|------|----|-------|:---:|:----:|----------|
+| cube00 | cube00 | req, pulse(@lvl<4) | ✓ | ✓ | `Sharp` |
+| cube00 | cube01 | pulse (lvl: 4 → 6) | ✓ | ✗ | `MayOnly` (only the `lvl=4` slice crosses) |
+| cube01 | cube01 | tick | ✓ | ✓ | `Sharp` |
+| cube01 | cube11 | **fire** | ✓ | ✓ | `Sharp` |
+| cube11 | cube00 | clr | ✓ | ✓ | `Sharp` |
+
+The decisive change: **every `fire` edge now originates in `cube01` (charged) and
+lands in `cube11` (charged).** No reachable cube has a `fire` edge into `cube10`.
+`charged` labels: `cube00 ⊨ charged = F`, `cube01 ⊨ charged = T`,
+`cube11 ⊨ charged = T`, `cube10 ⊨ charged = F` (unreachable).
+
+### §5.3 Three-valued evaluation of `νX. ( [fire] charged ∧ [] X )`
+
+```
+[fire] charged  per cube :
+   cube00 : no fire edge (IDLE/CHARGE ignore fire)        ⇒ vacuously T
+   cube01 : fire-may = {cube11}; charged(cube11)=T        ⇒ T
+   cube11 : no outgoing fire                              ⇒ vacuously T
+   cube10 : unreachable; charged=F locally, but never visited from init
+νX (greatest fixpoint, over the reachable region cube00/cube01/cube11):
+   each has [fire]charged = T and only may-steps within {cube00,cube01,cube11}
+   ⇒ X = T on all reachable cubes
+```
+
+**Verdict at the initial cube `cube00` = `KleeneT`.** Definite. By
+Bruns–Godefroid a `KleeneT` verdict on an over-approximating KMTS **transfers to
+the concrete system at every alternation depth** — so
+`G ( commit_en → lvl >= 6 )` holds on the real RTL. CEGAR terminates `Converged`:
+no `KleeneBot` remains. (This `KleeneT` is the construction's verdict; the MVP
+loop also reports `Converged` on this fixture but in one iteration without the
+intervening refinement — §7 has the real output. To *run* a definite verdict
+today, use the materialised CTXDSL of §6.)
+
+`cube10`'s local `KleeneF` is harmless — it has no reachable predecessor with a
+`fire` (or any) edge into it, so it never poisons the initial verdict. The
+must-edges are not load-bearing for *this* `T`-verdict (box over may suffices) but
+are what would let a genuine violation return as a definite `KleeneF`.
+
+## §6 — The abstraction as a runnable CTXDSL automaton (three predicates, eight cubes)
+
+The §5 abstraction was 2 predicates / 4 cubes — the *minimum* for the safety
+property. To make the cube at least **three bits** and to run the result directly
+in mununu, add a third predicate that exposes the charge ladder:
+
+```
+P2 = { committed : phase == COMMIT,   charged : lvl >= 6,   half : lvl >= 4 }
+```
+
+`half` is monotone below `charged` (`lvl >= 6 ⟹ lvl >= 4`), which makes three of
+the eight cubes **empty** (`charged ∧ ¬half` is unsatisfiable). The third bit
+buys *progress* visibility: with `half` we can also ask reachability/ordering
+questions ("can the controller reach COMMIT at all?", "is the undercharged-commit
+cube reachable?") that the 2-bit model cannot phrase.
+
+### §6.1 The eight cubes
+
+Bit order `committed = b0`, `charged = b1`, `half = b2`; index
+`= committed·1 + charged·2 + half·4`.
+
+| cube state | idx | committed | charged | half | γ (concrete) | status |
+|------------|:---:|:---:|:---:|:---:|---|---|
+| `Filling`     | 0 | F | F | F | `phase ≠ COMMIT`, `lvl < 4` | reachable (initial) |
+| `BadCommit`   | 1 | T | F | F | `COMMIT`, `lvl < 4` | **unreachable — violation** |
+| —             | 2 | F | T | F | `charged ∧ ¬half` | **empty** |
+| —             | 3 | T | T | F | `charged ∧ ¬half` | **empty** |
+| `HalfCharged` | 4 | F | F | T | `phase ≠ COMMIT`, `4 ≤ lvl < 6` | reachable |
+| (BadCommit′)  | 5 | T | F | T | `COMMIT`, `4 ≤ lvl < 6` | unreachable — violation (≡ `BadCommit` class) |
+| `Charged`     | 6 | F | T | T | `phase ≠ COMMIT`, `lvl ≥ 6` | reachable |
+| `Committed`   | 7 | T | T | T | `COMMIT`, `lvl ≥ 6` | reachable (the *good* commit) |
+
+The runnable model below materialises the four reachable cubes plus one
+representative `BadCommit` (cubes 2, 3 are empty; cube 5 collapses into the same
+violation class as cube 1).
+
+### §6.2 The CTXDSL (parser-checked, runnable)
+
+> Source: [`examples/hw/charge_commit_cubes.ctxdsl`](../../examples/hw/charge_commit_cubes.ctxdsl)
+> — runs today against `mununu context eval`. Each state's `valuations` block
+> carries the 3-bit cube value plus a representative `lvl`; transitions carry the
+> real event labels; `(source, label)` pairs are unique so no edge collapses on
+> realize (see the §3.2 gotcha).
+
+```
+context charge_commit_cubes {
+    alphabet {
+        label req;
+        label pulse;
+        label fire;
+        label clr;
+        label tick;
+    }
+
+    automata {
+        automaton Cubes {
+            controllable {
+                label fire;
+            }
+            internal {
+                label tick;
+            }
+
+            states {
+                state Filling initial {
+                    valuations { committed = 0; charged = 0; half = 0; lvl = 0; }
+                };
+                state HalfCharged {
+                    valuations { committed = 0; charged = 0; half = 1; lvl = 4; }
+                };
+                state Charged {
+                    valuations { committed = 0; charged = 1; half = 1; lvl = 6; }
+                };
+                state Committed {
+                    valuations { committed = 1; charged = 1; half = 1; lvl = 6; }
+                };
+                state BadCommit {
+                    valuations { committed = 1; charged = 0; half = 0; lvl = 0; }
+                };
+            }
+
+            transitions {
+                transition Filling -> Filling on label req;
+                transition Filling -> HalfCharged on label pulse;
+                transition HalfCharged -> Charged on label pulse;
+                transition Charged -> Charged on label tick;
+                transition Charged -> Committed on label fire;
+                transition Committed -> Filling on label clr;
+                transition BadCommit -> BadCommit on label tick;
+            }
+
+            predicates {
+                predicate good_commit = state Committed;
+                predicate bad_commit  = state BadCommit;
+            }
+        }
+    }
+
+    mu_formulas {
+        formula commit_reachable {
+            over Cubes;
+            body = mu X. (Committed || <> X);
+        }
+        formula bad_commit_reachable {
+            over Cubes;
+            body = mu X. (BadCommit || <> X);
+        }
+        formula fire_implies_committed {
+            over Cubes;
+            body = nu X. ([ labels = { fire } ] Committed && [] X);
+        }
+        formula safety_invariant {
+            over Cubes;
+            body = nu X. ([] X);
+        }
+    }
+}
+```
+
+### §6.3 The automaton (values in states, labels on transitions)
+
+```mermaid
+flowchart LR
+  F["Filling (cube 0)<br/>committed=0 charged=0 half=0<br/>lvl = 0"]
+  H["HalfCharged (cube 4)<br/>committed=0 charged=0 half=1<br/>lvl = 4"]
+  C["Charged (cube 6)<br/>committed=0 charged=1 half=1<br/>lvl = 6"]
+  K["Committed (cube 7)<br/>committed=1 charged=1 half=1<br/>lvl = 6 ✓"]
+  B["BadCommit (cube 1)<br/>committed=1 charged=0 half=0<br/>UNREACHABLE ✗"]:::dead
+  F -->|req| F
+  F -->|"pulse / lvl: 0 → 4"| H
+  H -->|"pulse / lvl: 4 → 6"| C
+  C -->|"tick hold"| C
+  C -->|fire| K
+  K -->|"clr / lvl := 0"| F
+  B -->|tick| B
+  classDef dead fill:#fdd,stroke:#c00,stroke-dasharray:4 3
+```
+
+### §6.4 Running it — real `mununu context eval` output
+
+```bash
+BIN=./target/release/mununu      # or: cargo run -p mununu-cli --
+for f in commit_reachable bad_commit_reachable fire_implies_committed safety_invariant; do
+  $BIN context eval examples/hw/charge_commit_cubes.ctxdsl --automaton Cubes --formula "$f"
+done
+```
+
+Captured verbatim (the `Logging initialized` line elided):
+
+```
+Formula 'commit_reachable' over automaton 'Cubes':
+  States satisfying: 4/5
+    Charged, Committed, Filling, HalfCharged
+  Initial states satisfying: 1/1
+    Filling
+  Guard partitions: enabled
+
+Formula 'bad_commit_reachable' over automaton 'Cubes':
+  States satisfying: 1/5
+    BadCommit
+  Initial states satisfying: 0/1
+    (none)
+  Initial states violating: 1/1
+    Filling  (charged = 0, committed = 0, half = 0, lvl = 0)
+  Guard partitions: enabled
+
+Formula 'fire_implies_committed' over automaton 'Cubes':
+  States satisfying: 5/5
+    BadCommit, Charged, Committed, Filling, HalfCharged
+  Initial states satisfying: 1/1
+    Filling
+  Guard partitions: enabled
+
+Formula 'safety_invariant' over automaton 'Cubes':
+  States satisfying: 5/5
+    BadCommit, Charged, Committed, Filling, HalfCharged
+  Initial states satisfying: 1/1
+    Filling
+  Guard partitions: enabled
+```
+
+Reading the four verdicts:
+
+- **`commit_reachable`** (`mu` — liveness/reachability): the initial cube
+  `Filling` **satisfies**, so the controller can climb the 3-bit ladder
+  `Filling → HalfCharged → Charged → Committed`. The unreachable `BadCommit` is
+  the one non-satisfying state.
+- **`bad_commit_reachable`** (`mu`): the initial cube does **not** satisfy
+  (`0/1`) — the undercharged-commit cube `BadCommit` is **unreachable** from the
+  start. That *is* the safety obligation "never commit while undercharged,"
+  decided structurally. Note the CLI prints the violating state's full cube
+  valuation `(charged = 0, committed = 0, half = 0, lvl = 0)` — the three
+  predicate bits plus the representative level.
+- **`fire_implies_committed`** (`nu` + **label-restricted box**): holds at every
+  state and at the initial cube — every `fire` transition lands in `Committed`.
+  This is the label-guarded form that demonstrates `[ labels = { fire } ] φ`.
+- **`safety_invariant`** (`nu X. [] X`): no deadlock — every cube has a
+  successor.
+
+This is the same abstraction the BTOR2 pipeline (§3–§5) builds, taken one
+predicate further and handed to mununu directly. The three-valued KMTS story of
+§3–§5 is what makes the *automatically-lifted* version sound for liveness; this
+hand-authored CTXDSL version is the 2-valued CLTS you can run this second to see
+the cube structure and the verdicts concretely.
+
+## §7 — Running the BTOR2 CEGAR path (real output, MVP)
+
+> Source: [`examples/hw/charge_commit.btor2`](../../examples/hw/charge_commit.btor2)
+> — runs against `mununu btor2 cegar`. **Read this section as the reality check on
+> §3–§5:** the clean `KleeneBot → interpolant → KleeneT` arc above is the
+> *construction the theory specifies*; what the MVP loop emits today is below, and
+> it is more modest.
+
+```bash
+mununu btor2 cegar examples/hw/charge_commit.btor2 \
+  --formula 'nu X. ([] X)' \
+  --predicate 'committed:phase=3' \
+  --predicate-source wp --max-iterations 16
+```
+
+Real output, captured verbatim:
+
+```
+CEGAR refinement loop completed
+  fixture:           examples/hw/charge_commit.btor2
+  formula:           nu X. ([] X)
+  predicate_source:  Wp
+  iterations:        1
+  terminated_with:   Converged
+  final predicates:  1
+```
+
+The loop **converges in one iteration** — it does *not* walk the multi-step
+refinement narrated in §3–§5. Two reasons, both honest MVP limits:
+
+1. The R.2.5 lift's `MayOnly`-by-sampling image (see the §3.4 status note) does not
+   yet materialise the exhaustive may/must edges that would expose a `KleeneBot`,
+   so the summary reports a definite convergence rather than the indefinite
+   verdict the exact construction yields.
+2. The `CegarTrace` summary surfaces `iterations` / `terminated_with` /
+   `final predicates` — not a per-cube 3-valued verdict. The rich reporting the
+   §3–§5 walkthrough assumes is a target, not shipped.
+
+Selecting `--predicate-source craig` does **not** change this today, because cvc5
+is an optional external tool and the loop falls back to the WP heuristic when it
+is absent — captured verbatim:
+
+```
+mununu btor2 cegar examples/hw/charge_commit.btor2 \
+  --formula 'nu X. ([] X)' --predicate 'committed:phase=3' \
+  --predicate-source craig --max-iterations 16
+```
+```
+CEGAR refinement loop completed
+  ...
+  predicate_source:  Craig
+  iterations:        1
+  terminated_with:   Converged
+  final predicates:  1
+  warnings:
+    - adapter/btor2/cegar (Item 3 sub-item 3.4): PredicateSource::CraigInterpolation
+      selected but cvc5 binary not available: adapter/cvc5: failed to invoke
+      `cvc5 --version`: No such file or directory (os error 2). Set MUNUNU_CVC5_PATH
+      or install cvc5 ≥ 1.0 (Homebrew: `brew install cvc5`; Debian: `apt install
+      cvc5`).. Falling back to WeakestPrecondition heuristic for the duration of
+      this run. Install cvc5 (Homebrew: `brew install cvc5`; Debian: `apt install
+      cvc5`) or set MUNUNU_CVC5_PATH to use Craig interpolation.
+```
+
+So on this machine the §4 interpolation step **does not execute at all** — there
+is no cvc5, and even with cvc5 the MVP parser accepts only atomic equalities, not
+the `lvl >= 6` inequality (§4 status note 2). The `--predicate` format is
+`NAME:REGISTER=VALUE`
+([`Btor2CegarArgs`](../../crates/mununu-cli/src/main.rs)); `--predicate-source`
+maps to
+[`PredicateSource`](../../crates/mununu-core/src/adapter/btor2/cegar.rs);
+cvc5 install notes are in [`external-tools.md`](../external-tools.md).
+
+> **Surface note.** `mununu btor2 cegar` is **CLI-only** today
+> (`surface: CLI-only — BTOR2 CEGAR is a developer-facing verification driver; no
+> API/UI peer is planned until the lifter graduates from MVP`). When it
+> graduates, parity with API + UI is required per CLAUDE.md *Surface Parity*.
+
+## §8 — What is exact vs. what is MVP (the honesty box)
+
+| Step | Target (sound, documented) | mununu today |
+|------|----------------------------|--------------|
+| model arithmetic (`add`, `ugte`, `ult`) | exact bit-vector semantics | **live** in the BTOR2 lifter; wide `add`/`mul` UF-wrapped past a width threshold |
+| may/must image | exact `∃ / ∀` over γ | `MayOnly` by **sampling** one rep per cube (sound under-approx of may) |
+| interpolation query | transition-aware (UNSAT-core of spuriousness check) | cube-conjunction form; transition-aware is the target |
+| interpolant accepted | any separating predicate (incl. **inequalities**) | **atomic equalities only**; comparison/compound ⇒ fall back to WP or come from seeding |
+| CEGAR trace reporting | per-cube 3-valued verdict, `KleeneBot` surfaced, multi-step refinement | summary only (`iterations` / `terminated_with` / `final predicates`); converges in 1 iteration on this fixture (§7) |
+| Craig interpolation runtime | cvc5 invoked, interpolant parsed | cvc5 optional; absent ⇒ structured warning + WP fallback (§7) |
+| comparison predicates | full `<, <=, >=, ==, ∈` | seedable from formula APs / COI constants (recipe §2.1–§2.2); not yet *discovered* from cvc5 |
+| refinement monotonicity | guaranteed with must-edges | non-monotone until native must-edges (B.3.b warning) |
+
+None of these gaps change the *shape* of the argument; they bound how much runs
+unattended right now. The soundness direction does the real work: **safety +
+over-approximation ⇒ a `KleeneT` verdict is sound**, and (interpolation or
+seeding of) the arithmetic predicate `lvl >= 6` is just what makes the
+over-approximation precise enough to *reach* `KleeneT` instead of stalling at
+`KleeneBot`.
+
+## Reading list / literature
+
+> Concept: bibliographic grounding for the constructions this example instantiates.
+
+Each step of the walkthrough is a concrete instance of an established result. The
+primary sources, in the order the doc uses them:
+
+1. **S. Graf and H. Saidi, *Construction of Abstract State Graphs with PVS*** (CAV
+   1997, LNCS 1254). The predicate-cube construction and the `γ` concretization of
+   §3/§5/§6.
+2. **D. Dams, R. Gerth, O. Grumberg, *Abstract Interpretation of Reactive
+   Systems*** (TOPLAS 1997) and **R. Cleaveland, P. Iyer, D. Yankelevich,
+   *Optimality in Abstractions of Model Checking*** (SAS 1995). The over-/under-
+   approximation duality behind the soundness-direction table (safety +
+   over-approx ⇒ sound).
+3. **K. G. Larsen and B. Thomsen, *A Modal Process Logic*** (LICS 1988) — modal
+   (may/must) transition systems; and **P. Godefroid, M. Huth, R. Jagadeesan,
+   *Abstraction-Based Model Checking Using Modal Transition Systems*** (CONCUR
+   2001) / **Godefroid–Jagadeesan, *On the Expressiveness of 3-Valued Models***
+   (VMCAI 2003) for the KMTS-as-predicate-abstraction reading of §3.3/§5.2.
+4. **G. Bruns and P. Godefroid, *Generalized Model Checking*** (CONCUR 2000) — the
+   3-valued modal-mu evaluation of §3.4/§5.3 and the preservation theorem that
+   makes a definite `KleeneT`/`KleeneF` verdict transfer at every alternation
+   depth.
+5. **E. M. Clarke, O. Grumberg, S. Jha, Y. Lu, H. Veith,
+   *Counterexample-Guided Abstraction Refinement*** (CAV 2000, LNCS 1855) — the
+   CEGAR loop of §4.
+6. **W. Craig, *Three uses of the Herbrand–Gentzen theorem…*** (J. Symbolic Logic
+   1957) and **K. L. McMillan, *Interpolation and SAT-Based Model Checking***
+   (CAV 2003) — Craig interpolation as the source of the refinement predicate
+   `lvl >= 6` in §4.2. **T. A. Henzinger, R. Jhala, R. Majumdar, K. L. McMillan,
+   *Abstractions from Proofs*** (POPL 2004) is the lazy-abstraction-with-
+   interpolants recipe the lifter follows.
+7. **T. Ball and S. K. Rajamani, *The SLAM Project*** (POPL 2002) — the
+   industrial precedent for CEGAR-with-predicate-abstraction (on C, not RTL).
+
+The recipe doc's [§7 reading list](predicate-abstraction-recipe.md#7-reading-list)
+and [`abstraction-literature.md`](abstraction-literature.md) carry the fuller
+catalog, including the SMT-driven predicate-image (Cimatti–Griggio–Mover–Tonetta,
+TACAS 2014) and UF-refinement (Andraus–Sakallah, LPAR 2008) sources this example
+does not exercise.
+
+## See also
+
+- [`predicate-abstraction-recipe.md`](predicate-abstraction-recipe.md) — the
+  operational reference (predicate seeding §2, may/must image §3, CEGAR §4) this
+  example instantiates.
+- [`kmts-theory.md`](kmts-theory.md) — the soundness theorems behind the verdict
+  transfer.
+- [`native-sv-abstraction.md`](native-sv-abstraction.md) — the SV → BTOR2 → KMTS
+  pipeline architecture.
+- [`../abstraction.md`](../abstraction.md) — the user-facing recipe and the
+  soundness-direction table.
+- [`../../examples/hw/charge_commit_cubes.ctxdsl`](../../examples/hw/charge_commit_cubes.ctxdsl)
+  — the runnable 3-bit-cube model from §6; `mununu context eval … --automaton
+  Cubes --formula <name>`.
+- [`../../examples/hw/charge_commit.sv`](../../examples/hw/charge_commit.sv) +
+  [`charge_commit_tb.sv`](../../examples/hw/charge_commit_tb.sv) — the RTL and its
+  Verilator testbench (§1.2).
+- [`../../examples/hw/charge_commit_to_btor2.ys`](../../examples/hw/charge_commit_to_btor2.ys)
+  — the yosys script that lowers the SV to
+  [`charge_commit.yosys.btor2`](../../examples/hw/charge_commit.yosys.btor2) (§2.1).
+- [`../../examples/hw/charge_commit.btor2`](../../examples/hw/charge_commit.btor2)
+  — the readable BTOR2 mirror used by the §2.2–§7 walkthrough.

--- a/examples/hw/charge_commit.sv
+++ b/examples/hw/charge_commit.sv
@@ -1,0 +1,64 @@
+// charge_commit.sv — a command/commit controller with an arithmetic charge datapath.
+//
+// The controller walks four phases IDLE -> CHARGE -> READY -> COMMIT, accumulating
+// a charge level `lvl` while charging (`lvl += STEP` per `pulse`) and only advancing
+// to READY once `lvl >= THRESHOLD`. The safety obligation is
+//
+//     G ( commit_en -> lvl >= THRESHOLD )
+//
+// i.e. it may only assert `commit_en` (open the commit window) while charged.
+// This is the worked example of docs/design/predicate-abstraction-worked-example.md.
+//
+// Two surfaces consume this file directly against real binaries:
+//   * sv2v + yosys `write_btor`  -> examples/hw/charge_commit.btor2   (mununu btor2 cegar)
+//   * verilator --binary --assert -> examples/hw/charge_commit_tb.sv  (bounded simulation)
+module charge_commit (
+    input  logic clk,
+    input  logic rst,
+    input  logic req,     // environment: a request arrives
+    input  logic pulse,   // environment: a charge pulse
+    input  logic fire,    // controller: open the commit window
+    input  logic clr,     // environment: release
+    output logic commit_en
+);
+    typedef enum logic [1:0] { IDLE = 2'd0, CHARGE = 2'd1, READY = 2'd2, COMMIT = 2'd3 } phase_t;
+    phase_t     phase;
+    logic [7:0] lvl;            // charge level — the arithmetic datapath
+
+    localparam logic [7:0] STEP      = 8'd2;
+    localparam logic [7:0] THRESHOLD = 8'd6;
+
+    always_ff @(posedge clk) begin
+        if (rst) begin
+            phase <= IDLE;
+            lvl   <= 8'd0;
+        end else begin
+            case (phase)
+                IDLE  : if (req) phase <= CHARGE;
+                CHARGE: begin
+                    if (lvl < THRESHOLD) begin
+                        if (pulse) lvl <= lvl + STEP;   // arithmetic: accumulate
+                    end else begin
+                        phase <= READY;                  // arithmetic guard: lvl >= 6
+                    end
+                end
+                READY : if (fire) phase <= COMMIT;
+                COMMIT: if (clr) begin phase <= IDLE; lvl <= 8'd0; end
+                default: ;
+            endcase
+        end
+    end
+
+    assign commit_en = (phase == COMMIT);
+
+    // Safety obligation, as a clocked immediate assertion guarded by FORMAL.
+    // Verilator checks it every posedge under `--assert -DFORMAL`; yosys lowers
+    // it to the BTOR2 `bad` state under `read_verilog -sv -formal -DFORMAL`.
+`ifdef FORMAL
+    always_ff @(posedge clk) begin
+        if (!rst) begin
+            safety_charged: assert (!commit_en || (lvl >= THRESHOLD));
+        end
+    end
+`endif
+endmodule

--- a/examples/hw/charge_commit_cubes.ctxdsl
+++ b/examples/hw/charge_commit_cubes.ctxdsl
@@ -1,0 +1,72 @@
+context charge_commit_cubes {
+    alphabet {
+        label req;
+        label pulse;
+        label fire;
+        label clr;
+        label tick;
+    }
+
+    automata {
+        automaton Cubes {
+            controllable {
+                label fire;
+            }
+            internal {
+                label tick;
+            }
+
+            states {
+                state Filling initial {
+                    valuations { committed = 0; charged = 0; half = 0; lvl = 0; }
+                };
+                state HalfCharged {
+                    valuations { committed = 0; charged = 0; half = 1; lvl = 4; }
+                };
+                state Charged {
+                    valuations { committed = 0; charged = 1; half = 1; lvl = 6; }
+                };
+                state Committed {
+                    valuations { committed = 1; charged = 1; half = 1; lvl = 6; }
+                };
+                state BadCommit {
+                    valuations { committed = 1; charged = 0; half = 0; lvl = 0; }
+                };
+            }
+
+            transitions {
+                transition Filling -> Filling on label req;
+                transition Filling -> HalfCharged on label pulse;
+                transition HalfCharged -> Charged on label pulse;
+                transition Charged -> Charged on label tick;
+                transition Charged -> Committed on label fire;
+                transition Committed -> Filling on label clr;
+                transition BadCommit -> BadCommit on label tick;
+            }
+
+            predicates {
+                predicate good_commit = state Committed;
+                predicate bad_commit  = state BadCommit;
+            }
+        }
+    }
+
+    mu_formulas {
+        formula commit_reachable {
+            over Cubes;
+            body = mu X. (Committed || <> X);
+        }
+        formula bad_commit_reachable {
+            over Cubes;
+            body = mu X. (BadCommit || <> X);
+        }
+        formula fire_implies_committed {
+            over Cubes;
+            body = nu X. ([ labels = { fire } ] Committed && [] X);
+        }
+        formula safety_invariant {
+            over Cubes;
+            body = nu X. ([] X);
+        }
+    }
+}

--- a/examples/hw/charge_commit_tb.sv
+++ b/examples/hw/charge_commit_tb.sv
@@ -1,0 +1,55 @@
+// charge_commit_tb.sv — Verilator testbench for charge_commit.sv.
+//
+// Drives randomized stimulus for a bounded number of cycles and relies on the
+// concurrent assertion `safety_charged` inside the DUT (active under --assert).
+// A bounded simulation does not *prove* the property — it is a sanity check that
+// the RTL exhibits no violation under random stimulus, complementing the
+// exhaustive verdict mununu produces over the predicate abstraction. Run:
+//
+//   $ verilator --binary --assert --timing -Wall -Wno-DECLFILENAME \
+//       charge_commit.sv charge_commit_tb.sv --top-module charge_commit_tb \
+//       -o charge_commit_sim
+//   $ ./obj_dir/charge_commit_sim
+module charge_commit_tb;
+    logic clk = 0;
+    logic rst, req, pulse, fire, clr;
+    logic commit_en;
+
+    charge_commit dut (
+        .clk(clk), .rst(rst), .req(req), .pulse(pulse),
+        .fire(fire), .clr(clr), .commit_en(commit_en)
+    );
+
+    always #5 clk = ~clk;
+
+    int unsigned lfsr = 32'hC0FFEE01;
+    function automatic logic next_bit();
+        // xorshift PRNG — deterministic, no $random dependency
+        lfsr ^= lfsr << 13;
+        lfsr ^= lfsr >> 17;
+        lfsr ^= lfsr << 5;
+        return lfsr[0];
+    endfunction
+
+    int unsigned cycles = 0;
+    int unsigned commit_seen = 0;
+
+    initial begin
+        rst = 1; req = 0; pulse = 0; fire = 0; clr = 0;
+        repeat (2) @(posedge clk);
+        rst = 0;
+        repeat (20000) begin
+            @(negedge clk);
+            req   = next_bit();
+            pulse = next_bit() | next_bit();   // bias pulse high so charging happens
+            fire  = next_bit();
+            clr   = next_bit() & next_bit();   // bias clr low so COMMIT lingers
+            @(posedge clk);
+            cycles++;
+            if (commit_en) commit_seen++;
+        end
+        $display("charge_commit_tb: %0d cycles, commit_en asserted in %0d, no assertion failures",
+                 cycles, commit_seen);
+        $finish;
+    end
+endmodule

--- a/examples/hw/charge_commit_to_btor2.ys
+++ b/examples/hw/charge_commit_to_btor2.ys
@@ -1,0 +1,21 @@
+# charge_commit_to_btor2.ys — lower charge_commit.sv to BTOR2 via the real yosys frontend.
+#
+# Reproduces examples/hw/charge_commit.yosys.btor2 from examples/hw/charge_commit.sv.
+# The FORMAL define activates the clocked immediate assertion `safety_charged`,
+# which yosys lowers to a BTOR2 `bad` state (the obligation G(commit_en -> lvl>=6)).
+#
+#   $ yosys charge_commit_to_btor2.ys
+#   $ mununu btor2 cegar charge_commit.yosys.btor2 \
+#       --formula 'nu X. ([] X)' --predicate 'committed:phase=3' --predicate-source wp
+#
+# Tested with Yosys 0.59 (oss-cad-suite). sv2v is not required: yosys reads the
+# SystemVerilog directly with `-sv`. The dffunmap / async2sync / chformal -lower
+# sequence is the standard write_btor preparation for clocked formal properties.
+read_verilog -sv -formal -DFORMAL charge_commit.sv
+prep -top charge_commit -flatten
+async2sync
+chformal -lower
+memory -nomap
+opt -fast
+dffunmap
+write_btor charge_commit.yosys.btor2


### PR DESCRIPTION
## Headline: COI soundness fix (R46-6a)

The per-cluster cone-slicing path (R.4.6) reported sliced-model verdicts as **exact full-mu-calculus** verdicts, but `cone_slice` / `state_cone_nids` closed the cone only over `next`/`init` data-flow. A `constraint` (or `fair`/`justice`) line coupling an in-cone signal to an out-of-cone one was silently dropped and its other signals never retained. Since the joint bit-blaster enforces every constraint as a transition filter (`constraints_hold`), the slice became strictly more permissive — an **over-approximation** that can report a spurious counterexample for safety and is unsound for liveness, contradicting the documented "exact / bisimilar" guarantee.

**Fix:** close the cone over constraint/fairness co-occurrence to a joint fixpoint, interleaved with the data-flow closure. On the synchronous BTOR2 system, a cone closed over both relations is a strong bisimulation on the property atoms, so the full-mu-calculus claim holds. Constraints fully disjoint from the cone are still dropped (sound; preserves the clustering reduction).

### Tests
- **unit:** constraint- and fairness-coupled registers retained; cone-disjoint constraints correctly dropped (`bit_blast` + `dep_graph`).
- **e2e:** `btor2_coi_constraint_soundness` — cone-restricted verdict equals joint verdict under constraint coupling (verified to fail pre-fix: slice `0.0` vs joint `1.0`).
- `make ci` green (fmt + clippy `-D warnings` + workspace tests + doctests).

## Bundled in-flight branch work (single commit, per request)
- **GAP-2 effective-cap** (`sidecar_effective_state_bits`) in `bit_blast.rs`.
- **docs:** `kmts-theory`, `abstraction`, `predicate-abstraction-recipe` + new `interpolation-kmts-bridge`, `predicate-abstraction-worked-example`; `sidecar-auditor` agent; `ONBOARDING.md`, `REVIEW_LOG.md`; `examples/hw/charge_commit.*`.
- **.gitignore:** ignore generated `examples/verify/**/build/` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
