### PR TITLE
fix(R46-6, soundness): exempt OOB sink marker from the realize numericity gate

### DIFF
--- a/crates/mununu-core/src/context_dsl/realize.rs
+++ b/crates/mununu-core/src/context_dsl/realize.rs
@@ -375,12 +375,32 @@ impl RealizedContext {
     }
 }
 
-/// Return `true` when every valuation string on every CLTS state
-/// parses as an `i64`. The scope guard for the Phase A.3 follow-up
+/// The BTOR2 bit-blaster's absorbing out-of-bounds sink carries the
+/// single non-numeric marker valuation `__mununu_oob__ = "true"` (see
+/// `adapter::btor2::bit_blast::OOB_SINK_KEY`). The evaluator masks the
+/// sink out of every formula via this same key
+/// (`mu_calculus::evaluator::compute_oob_bits`). The numericity gate
+/// below must IGNORE this marker — it is not a design valuation and its
+/// presence (whenever a `BoundedCounter` / `EnumValues`-subset transition
+/// escapes its declared value set) must not disable numeric atom binding
+/// for the model's real, fully-numeric states.
+const OOB_SINK_MARKER_KEY: &str = "__mununu_oob__";
+
+/// Return `true` when every (non-marker) valuation string on every CLTS
+/// state parses as an `i64`. The scope guard for the Phase A.3 follow-up
 /// abstract-states wiring above — only the BTOR2 bit-blaster's
 /// decimal-encoded valuations qualify, so semantic SV-adapter
 /// encodings (variant names like `T`/`F`/`IDLE`) are left to the
 /// existing pre-computed-predicate path.
+///
+/// The OOB sink's `__mununu_oob__` marker (see [`OOB_SINK_MARKER_KEY`])
+/// is exempt: a single escaped transition would otherwise add a
+/// non-numeric valuation and trip the gate, disabling numeric binding
+/// for every real state — the cause of the R46-6 spurious-`VIOLATED`
+/// divergence between a `BoundedCounter` model that escapes to OOB and
+/// the otherwise-identical full bit-blast model. The wiring loop already
+/// skips per-value non-numeric strings (`if let Ok(n) = parse()`), so
+/// the marker contributes no variables to the sink's abstract state.
 fn clts_valuations_are_numeric<S, L>(clts: &crate::clts::Clts<S, L>) -> bool
 where
     S: crate::clts::IdStorage,
@@ -389,7 +409,10 @@ where
     let mut any_value = false;
     for state_id in clts.states() {
         if let Some(vals) = clts.state_valuation(state_id) {
-            for v in vals.values() {
+            for (key, v) in vals {
+                if key == OOB_SINK_MARKER_KEY {
+                    continue;
+                }
                 any_value = true;
                 if v.parse::<i64>().is_err() {
                     return false;
@@ -3296,6 +3319,59 @@ mod tests {
         assert!(!is_simple_identifier("123abc"));
         assert!(!is_simple_identifier("with spaces"));
         assert!(!is_simple_identifier("dot.notation"));
+    }
+
+    /// R46-6 regression — the OOB sink's `__mununu_oob__` marker must NOT
+    /// trip the numericity gate. A `BoundedCounter` (or `EnumValues`-subset)
+    /// model whose transition escapes its declared value set gains an
+    /// absorbing OOB sink carrying `{__mununu_oob__: "true"}`; before the
+    /// fix that single non-numeric marker made `clts_valuations_are_numeric`
+    /// return `false`, disabling abstract-states wiring for every real
+    /// (fully numeric) state — which flipped reachability verdicts from
+    /// SATISFIED to a spurious VIOLATED relative to the otherwise-identical
+    /// full bit-blast model.
+    #[test]
+    fn oob_sink_marker_does_not_trip_numericity_gate() {
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        let s0 = b.state_id_or_insert("s0").expect("s0");
+        let s1 = b.state_id_or_insert("s1").expect("s1");
+        let oob = b.state_id_or_insert(OOB_SINK_MARKER_KEY).expect("oob");
+        b.initial("s0");
+        b.with_valuation_for_state(s0, BTreeMap::from([("timer".to_string(), "0".to_string())]));
+        b.with_valuation_for_state(s1, BTreeMap::from([("timer".to_string(), "1".to_string())]));
+        // The bit-blaster's exact OOB-sink valuation (key == value-marker).
+        b.with_valuation_for_state(
+            oob,
+            BTreeMap::from([(OOB_SINK_MARKER_KEY.to_string(), "true".to_string())]),
+        );
+        let clts = b.build().expect("clts builds");
+
+        // Real states are all numeric; the OOB marker is exempt → gate passes.
+        assert!(
+            clts_valuations_are_numeric(&clts),
+            "OOB sink marker must be exempt from the numericity gate"
+        );
+    }
+
+    /// Complement to the R46-6 regression: a genuinely non-numeric *real*
+    /// valuation (e.g. the SV adapter's semantic `state == IDLE` / `T`/`F`
+    /// encodings) must still trip the gate, leaving those models on the
+    /// pre-computed-predicate path. Exempting the OOB marker must not widen
+    /// the exemption to real design valuations.
+    #[test]
+    fn non_numeric_real_valuation_still_trips_numericity_gate() {
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        let s0 = b.state_id_or_insert("s0").expect("s0");
+        b.initial("s0");
+        b.with_valuation_for_state(
+            s0,
+            BTreeMap::from([("state".to_string(), "IDLE".to_string())]),
+        );
+        let clts = b.build().expect("clts builds");
+        assert!(
+            !clts_valuations_are_numeric(&clts),
+            "a non-numeric design valuation must keep the gate closed"
+        );
     }
 
     #[test]

--- a/examples/verify/r46_gap2_wide_concretize/README.md
+++ b/examples/verify/r46_gap2_wide_concretize/README.md
@@ -1,0 +1,67 @@
+# R46-6 / GAP-2 — wide field concretized + escape-to-OOB, no spurious VIOLATED
+
+> **Synthetic fixture (hand-written, NOT vendored RTL).** Like
+> `r46_synth_two_cones`, this exists to regression-test a specific
+> mechanism in isolation — here the GAP-2 composition of (a) the
+> effective-bits cap accounting and (b) the realize numericity-gate
+> soundness fix — with a design small enough to read.
+
+## What it demonstrates
+
+`source/wide7.sv` is a **24-bit** counter `cnt` with three combinational
+outputs `atK_o = (cnt == K)` for K ∈ {1, 5, 7}.
+
+Two mechanisms compose here:
+
+1. **Effective-bits cap accounting (GAP-2).** At raw width the design has
+   24 state bits — past the bit-blast cap (`MAX_STATE_BITS = 20`), so the
+   *un-abstracted* design is rejected with `StateSpaceOverflow`. The
+   sidecar (`source/wide7.mununu.json`) declares
+   `cnt : bounded_counter bound=7`, concretizing it to the value set
+   {0..7} = **3 effective bits**, which fits the cap. The cap check counts
+   `ceil(log2(|value set|))` per concretized cell, not raw width — that is
+   what lets a wide field be verified once a property only needs a small
+   slice of its range.
+
+2. **Realize numericity-gate fix (the soundness bug this fixture guards).**
+   `cnt` escapes its declared set at 7 → 8, so the bit-blaster routes that
+   transition to the absorbing **OOB sink**, which carries the marker
+   valuation `{__mununu_oob__: "true"}`. Before the fix, that single
+   non-numeric marker tripped `clts_valuations_are_numeric`, which gates
+   whether per-state numeric valuations are wired into the evaluator's
+   `abstract_states` channel. With the gate closed, formula atoms fell
+   through to the false-everywhere path and the reachability properties
+   reported a **spurious VIOLATED** — even though `cnt == 1` and `cnt == 7`
+   are genuinely reached on the path 0 → 1 → … → 7 (all in-set). The fix
+   exempts the OOB marker key from the gate; the sink stays masked by the
+   evaluator while the real states bind normally.
+
+## Expected result
+
+```
+reach_t1: SATISFIED   (cnt == 1 reached on 0 → 1)
+reach_t7: SATISFIED   (cnt == 7 reached on 0 → … → 7, just before the escape)
+```
+
+Both are SATISFIED and non-vacuous. The OOB sink itself is masked, so the
+satisfying-state count is the real-state count (the sink does not satisfy).
+
+## Run it
+
+```bash
+cargo build -p mununu-cli
+examples/verify/r46_gap2_wide_concretize/validate.sh
+```
+
+`validate.sh` requires `yosys` and `sv2v` on `PATH` (the sv-yosys
+pipeline). It checks all three contract points: the raw design is rejected
+at the cap, the concretized design lifts, and both reachable targets come
+back SATISFIED.
+
+## CI-level regression
+
+The validate.sh script needs `yosys`/`sv2v` and is a manual reproduction.
+The fix's CI-level guards are the unit tests in
+`crates/mununu-core/src/context_dsl/realize.rs`:
+`oob_sink_marker_does_not_trip_numericity_gate` (positive) and
+`non_numeric_real_valuation_still_trips_numericity_gate` (negative).

--- a/examples/verify/r46_gap2_wide_concretize/source/verify.toml
+++ b/examples/verify/r46_gap2_wide_concretize/source/verify.toml
@@ -1,0 +1,48 @@
+# R46-6 / GAP-2 — wide field concretized to a small value set, with an
+# escape-to-OOB that exercises the realize numericity-gate fix.
+#
+# `wide7.sv` has a 24-bit `cnt` (24 raw state bits > MAX_STATE_BITS = 20 →
+# rejected without abstraction). The sidecar concretizes `cnt` to
+# `bounded_counter bound=7` → value set {0..7} = 3 effective bits → fits
+# the cap (GAP-2 effective-bits accounting). `cnt` escapes at 7→8 →
+# absorbing OOB sink. The two reachability properties target values that
+# ARE in the concretized set (1 and 7), so both are genuinely reachable
+# and must come back SATISFIED. Before the realize OOB-marker fix the OOB
+# sink's `__mununu_oob__` valuation tripped the numericity gate and these
+# reported a spurious VIOLATED.
+
+[project]
+name = "R46Gap2WideConcretize"
+description = "24-bit counter concretized to bounded_counter bound=7: raw width busts the cap, concretization fits it, and the escape-to-OOB exercises the realize numericity-gate fix."
+
+[[sources]]
+id = "w"
+files = ["wide7.sv"]
+adapter = "sv-yosys"
+
+[sources.options]
+use_sv2v = true
+top = "wide7"
+sidecar = "wide7.mununu.json"
+
+[alphabet]
+strategy = "direct"
+
+[composition]
+semantics = "synchronous"
+members = ["w"]
+name = "Wide7Top"
+
+[[properties]]
+# cnt == 1 is in the concretized set {0..7} and reached on the path
+# 0 → 1, so this is genuinely reachable → SATISFIED.
+name = "reach_t1"
+formula = "mu X. (at1_o || (<> X))"
+over = "Circuit"
+
+[[properties]]
+# cnt == 7 is the top of the concretized set; reached on 0 → … → 7 just
+# before the 7 → 8 escape to OOB → SATISFIED.
+name = "reach_t7"
+formula = "mu X. (at7_o || (<> X))"
+over = "Circuit"

--- a/examples/verify/r46_gap2_wide_concretize/source/wide7.mununu.json
+++ b/examples/verify/r46_gap2_wide_concretize/source/wide7.mununu.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "mununu_sv_annotation_v1",
+  "module": "wide7",
+  "signals": [
+    { "name": "cnt", "abstraction": "bounded_counter", "bound": 7 }
+  ]
+}

--- a/examples/verify/r46_gap2_wide_concretize/source/wide7.sv
+++ b/examples/verify/r46_gap2_wide_concretize/source/wide7.sv
@@ -1,0 +1,21 @@
+// R46-6 / GAP-2 — wide field concretized to a small value set.
+//
+// A 24-bit counter: at raw width the design has 24 state bits, past the
+// bit-blast cap (MAX_STATE_BITS = 20), so it is REJECTED without an
+// abstraction. The sidecar's `bounded_counter bound=7` concretizes `cnt`
+// to the value set {0..7} = 3 effective bits, which fits the cap (the
+// GAP-2 effective-bits accounting). The counter escapes its declared set
+// at 7→8, producing the absorbing OOB sink — the exact shape that, before
+// the realize numericity-gate fix, disabled atom binding and reported a
+// spurious VIOLATED for the in-set, genuinely-reachable targets below.
+module wide7 (
+  input  logic clk_i, rst_ni, en_i,
+  output logic at1_o, at5_o, at7_o);
+  logic [23:0] cnt;
+  always_ff @(posedge clk_i or negedge rst_ni)
+    if (!rst_ni) cnt <= '0;
+    else if (en_i) cnt <= cnt + 24'd1;
+  assign at1_o = (cnt == 24'd1);
+  assign at5_o = (cnt == 24'd5);
+  assign at7_o = (cnt == 24'd7);
+endmodule

--- a/examples/verify/r46_gap2_wide_concretize/validate.sh
+++ b/examples/verify/r46_gap2_wide_concretize/validate.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# validate.sh — R46-6 / GAP-2 regression: a WIDE field concretized to a
+# small value set fits the cap (effective-bits accounting) AND its
+# escape-to-OOB no longer reports a spurious VIOLATED (realize
+# numericity-gate fix).
+#
+# Contract, in three checks:
+#   1. WITHOUT the sidecar, `wide7.sv`'s 24-bit `cnt` is REJECTED
+#      (StateSpaceOverflow: 24 > MAX_STATE_BITS = 20) — proving the raw
+#      design does not fit and the concretization is load-bearing.
+#   2. WITH the sidecar (`bounded_counter bound=7` → 3 effective bits),
+#      the design lifts: the effective-bits cap accounting (GAP-2) admits
+#      it where raw width did not.
+#   3. The two reachability properties target in-set, genuinely-reachable
+#      values (cnt == 1, cnt == 7) and come back SATISFIED + non-vacuous.
+#      Before the realize OOB-marker fix the escape-to-OOB at 7→8 produced
+#      an OOB sink whose `__mununu_oob__` valuation tripped the numericity
+#      gate, disabling atom binding and reporting a spurious VIOLATED.
+#
+# Like the R46-5 fixture, the BTOR2 is produced in mununu's own temp dir
+# (the yosys adapter), so nothing cap-busting lands under examples/ where
+# the `btor2_kmts_lift_sweep` glob would trip on it. This script writes
+# only its own report JSON, to a mktemp dir.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MUNUNU="${MUNUNU:-${THIS_DIR}/../../../target/debug/mununu}"
+SRC="${THIS_DIR}/source"
+OUT="$(mktemp -d -t mununu-r46-6-XXXXXX)"
+trap 'rm -rf "${OUT}"' EXIT
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu binary not found at ${MUNUNU}" >&2
+  echo "             build it first with: cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in yosys sv2v; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "validate.sh: required tool '${tool}' not on PATH" >&2
+    exit 2
+  fi
+done
+
+export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
+
+echo "=== R46-6 — wide field concretized + escape-to-OOB, no spurious VIOLATED ==="
+echo "fixture: ${SRC}/wide7.sv (SYNTHETIC; 24-bit counter, bounded_counter bound=7)"
+echo
+
+cd "${SRC}"
+
+# Check 1 — without the sidecar the raw 24-bit design must be REJECTED.
+echo "--- (1) raw 24-bit (no sidecar) must hit the state-bit cap ---"
+sed 's#sidecar = "wide7.mununu.json"##' verify.toml > "${OUT}/nosidecar.toml"
+if "${MUNUNU}" verify --base-dir "${SRC}" "${OUT}/nosidecar.toml" > "${OUT}/nosidecar.out" 2>&1; then
+  echo "FAIL: raw 24-bit design verified instead of hitting the cap" >&2
+  exit 1
+fi
+if ! grep -qiE "state bits|max supported|StateSpaceOverflow|2\^20" "${OUT}/nosidecar.out"; then
+  echo "FAIL: no-sidecar run did not report a state-bit cap overflow" >&2
+  tail -5 "${OUT}/nosidecar.out" >&2
+  exit 1
+fi
+echo "ok: raw 24-bit rejected (cap overflow) — concretization is load-bearing"
+echo
+
+# Check 2 + 3 — with the sidecar, the design fits and both properties are SAT.
+echo "--- (2,3) concretized (bound=7) lifts; reachable targets SATISFIED ---"
+"${MUNUNU}" verify --json verify.toml > "${OUT}/verify.json" 2>"${OUT}/verify.err" || {
+  echo "FAIL: mununu verify exited non-zero with the sidecar" >&2
+  tail -15 "${OUT}/verify.err" >&2
+  exit 1
+}
+
+python3 - "${OUT}/verify.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+verds = {v["name"]: v for v in r.get("property_verdicts", [])}
+assert verds, "FAIL: no property verdicts"
+for name in ("reach_t1", "reach_t7"):
+    v = verds.get(name)
+    assert v, f"FAIL: missing verdict {name}"
+    assert v["satisfied"], f"FAIL: {name} not SATISFIED (the spurious-VIOLATED regression)"
+    assert v["total_states"] > 0, f"FAIL: vacuous verdict for {name}"
+    assert v["satisfying_states"] > 0, f"FAIL: 0 satisfying states for {name}"
+    print(f"verdict {name}: SAT {v['satisfying_states']}/{v['total_states']} over {v['over']}")
+print("R46-6 done-criteria met: wide field concretized fits the cap, the "
+      "escape-to-OOB no longer disables atom binding, both reachable "
+      "targets SATISFIED + non-vacuous.")
+PY
+
+echo
+echo "=== R46-6 VALIDATION PASSED ==="


### PR DESCRIPTION
## Summary

Closes the R46-6 / GAP-2 blocker: a `BoundedCounter` (or `EnumValues`-subset) model whose `next` escapes its declared value set reported a **spurious VIOLATED** for genuinely-reachable targets, diverging from the otherwise-identical full bit-blast.

## Root cause

When a concretized cell escapes its value set, the bit-blaster routes that transition to the absorbing **OOB sink**, which carries the marker valuation `{__mununu_oob__: "true"}` (`bit_blast::OOB_SINK_KEY`). That one non-numeric string tripped `context_dsl::realize::clts_valuations_are_numeric`, which gates whether per-state numeric valuations are wired into the evaluator's `abstract_states` channel. With the gate closed, formula atoms fell through to the "predicate-not-found → empty bitset" (false-everywhere) path instead of the on-demand "Maybe → include" path — collapsing reachability `mu X.(atom || <>X)` to ∅.

The full bit-blast never escapes (a counter wraps mod 2^width), so it has no OOB sink, stays all-numeric, and kept the SATISFIED verdict — hence the divergence.

This was previously mis-diagnosed (in the R46-6 de-risk note) as a `BoundedCounter` value-representation / `cell == const` comparison bug. It is neither — it is abstraction-agnostic: **any** sidecar abstraction whose `next` escapes its set produces an OOB sink and hits the same gate.

> Note: the effective-bits cap accounting (`sidecar_effective_state_bits`) already landed in #93, so `main` was carrying the cap-fix *without* this soundness fix — the soundness-regressive state. This PR closes that.

## Fix

Exempt the OOB sink marker key from the numericity gate (`realize.rs`). The wiring loop already skips per-value non-numeric strings, so the marker contributes no variables to the sink's abstract state, and the sink stays masked by `evaluator::compute_oob_bits`. SV-adapter semantic encodings (variant names like `T`/`F`/`IDLE` on **real** states) still trip the gate, preserving their pre-computed-predicate path.

## Verification

Minimal repro (4-bit `timer` incrementing each cycle, `atK = (timer == K)`, sidecar `bounded_counter bound=7`, escapes 7→8):
- **Before:** `mu X.(at1 || <>X)` VIOLATED 0/9.
- **After:** SATISFIED 8/9 (8 real states reach the target; OOB sink masked) — matching the full bit-blast.

- Regression tests (`realize.rs`): `oob_sink_marker_does_not_trip_numericity_gate` (positive), `non_numeric_real_valuation_still_trips_numericity_gate` (negative).
- Full `mununu-core` lib suite green (no fixture verdict flips).
- New GAP-2 reproduction fixture `examples/verify/r46_gap2_wide_concretize/` (24-bit counter rejected raw → `bound=7` fits via cap-fix → escape-to-OOB now SATISFIED); `validate.sh` asserts all three contract points.

## Surface parity

No new user-visible capability — this is a verdict-correctness fix in the shared realize/eval path, so it manifests identically across CLI / API / UI. No surface-specific work required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)