### PR TITLE
test(R46-6, R.4.6): GAP-2 per-cluster × param-concretization composition fixture

### DIFF
--- a/examples/verify/r46_gap2_per_cluster_concretize/README.md
+++ b/examples/verify/r46_gap2_per_cluster_concretize/README.md
@@ -1,0 +1,73 @@
+# R46-6 / GAP-2 — per-cluster slicing × param-concretization, composed
+
+> **Synthetic fixture (hand-written, NOT vendored RTL).** This is the
+> GAP-2 composition proof the R.4.6 de-risk called for: a design where the
+> rescue requires BOTH per-cluster slicing AND param-concretization
+> stacked together. It complements the two narrower R46 fixtures:
+>
+> | fixture | what it isolates |
+> |---|---|
+> | `r46_synth_two_cones` | per-cluster slicing only (narrow cones; "joint busts, clusters fit") |
+> | `r46_gap2_wide_concretize` | param-concretization only (single wide cell; cap-fix + escape-to-OOB soundness) |
+> | **this** | **both, composed** (wide cells *inside* each cluster's cone) |
+
+## What it demonstrates
+
+`source/three_wide.sv` is three **independent** 24-bit counters, each with
+an output `aK_o = (cnt == 7)`. Each property reads one counter, so the
+three cones are disjoint and cluster **K=3**.
+
+Two primitives must stack for the rescue:
+
+1. **Per-cluster slicing (R46-2/R46-3).** Joint width busts
+   `MAX_STATE_BITS = 20`, so the bit-blaster overflows and falls back to
+   per-cluster verification: it partitions the properties by cone overlap
+   and slices the netlist down to each cluster's own counter. But slicing
+   *alone* is not enough here — each sliced cone is still a **24-bit**
+   counter (> 20), so a sliced cluster would itself overflow.
+
+2. **Param-concretization (effective-bits cap accounting, GAP-2).** The
+   sidecar declares each counter `bounded_counter bound=127`, concretizing
+   it to the value set {0..127} = **7 effective bits**. Now each cluster's
+   sliced-and-concretized cone is 7 bits ≤ 20 and fits.
+
+The joint effective width is 3 × 7 = **21 > 20**, so per-cluster still
+fires (the concretization does not, by itself, make the joint design fit);
+each cluster is 7 bits and fits. The reachability targets (`cnt == 7`) are
+in the concretized set {0..127} and genuinely reached, and each counter
+escapes its set at 128 → an OOB sink (the soundness shape the realize
+numericity-gate fix in PR #94 makes verify correctly).
+
+## Expected result
+
+```
+reach_a7: SATISFIED  over Circuit__cl0
+reach_b7: SATISFIED  over Circuit__cl1
+reach_c7: SATISFIED  over Circuit__cl2
+```
+
+All three SATISFIED and non-vacuous, each routed to a distinct cluster
+automaton. Without the sidecar the design is rejected at 72 raw state bits
+— proving the concretization is load-bearing and slicing alone cannot
+rescue a 24-bit-per-cluster cone.
+
+## Run it
+
+```bash
+cargo build -p mununu-cli
+examples/verify/r46_gap2_per_cluster_concretize/validate.sh
+```
+
+`validate.sh` requires `yosys` and `sv2v` on `PATH`. It asserts both
+contract points: the raw design is rejected, and the
+sliced-and-concretized clusters all verify SATISFIED over distinct
+automata.
+
+## Relationship to the industrial fixture
+
+This is the synthetic stand-in for the GAP-2 shape real OpenTitan RTL
+exhibits — e.g. `pattgen` channels (per-channel `data` 64b / `prediv` 32b
+/ `clk_cnt` 32b counters) and `sysrst_ctrl` detection sub-blocks (32-bit
+debounce/detect timers): independent clusters that each carry a wide field
+needing concretization to fit. It proves the composition mechanism before
+the heavier real-RTL vendoring.

--- a/examples/verify/r46_gap2_per_cluster_concretize/source/three_wide.mununu.json
+++ b/examples/verify/r46_gap2_per_cluster_concretize/source/three_wide.mununu.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "mununu_sv_annotation_v1",
+  "module": "three_wide",
+  "signals": [
+    { "name": "cnt_a", "abstraction": "bounded_counter", "bound": 127 },
+    { "name": "cnt_b", "abstraction": "bounded_counter", "bound": 127 },
+    { "name": "cnt_c", "abstraction": "bounded_counter", "bound": 127 }
+  ]
+}

--- a/examples/verify/r46_gap2_per_cluster_concretize/source/three_wide.sv
+++ b/examples/verify/r46_gap2_per_cluster_concretize/source/three_wide.sv
@@ -1,0 +1,34 @@
+// R46-6 / GAP-2 — per-cluster slicing × param-concretization, composed.
+//
+// Three INDEPENDENT 24-bit counters (share only clk/rst). Each output
+// reads only one counter, so the three cones are disjoint and cluster K=3.
+//
+// Why this is the GAP-2 composition demo (not just R46-5's "joint busts,
+// clusters fit", and not just r46_gap2_wide_concretize's single wide cell):
+//
+//   * Joint raw width = 3 × 24 = 72 state bits — far past MAX_STATE_BITS=20.
+//   * Each cluster's cone, after SLICING, is still one 24-bit counter = 24
+//     raw bits > 20. So per-cluster SLICING ALONE cannot rescue this design.
+//   * The sidecar param-concretizes each counter to `bounded_counter
+//     bound=127` → 7 effective bits. Joint effective = 3 × 7 = 21 > 20
+//     (still busts → per-cluster fires), but each cluster = 7 ≤ 20 (fits).
+//
+// So the rescue requires BOTH primitives stacked: per-cluster slicing to
+// isolate each cone AND param-concretization to shrink the wide cell inside
+// each cone. Each counter escapes its declared set at 128 → OOB sink, the
+// shape that the realize numericity-gate fix (PR #94) makes verify soundly.
+module three_wide (
+  input  logic clk_i, rst_ni, a_en_i, b_en_i, c_en_i,
+  output logic a7_o, b7_o, c7_o);
+  logic [23:0] cnt_a, cnt_b, cnt_c;
+  always_ff @(posedge clk_i or negedge rst_ni)
+    if (!rst_ni) begin cnt_a <= '0; cnt_b <= '0; cnt_c <= '0; end
+    else begin
+      if (a_en_i) cnt_a <= cnt_a + 24'd1;
+      if (b_en_i) cnt_b <= cnt_b + 24'd1;
+      if (c_en_i) cnt_c <= cnt_c + 24'd1;
+    end
+  assign a7_o = (cnt_a == 24'd7);
+  assign b7_o = (cnt_b == 24'd7);
+  assign c7_o = (cnt_c == 24'd7);
+endmodule

--- a/examples/verify/r46_gap2_per_cluster_concretize/source/verify.toml
+++ b/examples/verify/r46_gap2_per_cluster_concretize/source/verify.toml
@@ -1,0 +1,55 @@
+# R46-6 / GAP-2 — per-cluster slicing × param-concretization, composed.
+#
+# `three_wide.sv` has three independent 24-bit counters. Each property
+# reads only one counter, so the cones are disjoint and cluster K=3.
+#
+# Joint effective width (with the sidecar) = 3 × 7 = 21 state bits, past
+# MAX_STATE_BITS = 20 → the bit-blaster overflows → automatic per-cluster
+# verification fires. It partitions the three properties by cone overlap,
+# slices the netlist to each cluster's own counter, and the sidecar's
+# `bounded_counter bound=127` concretizes that counter to 7 effective bits
+# so each cluster fits. All three reachability targets (cnt == 7) are in
+# the concretized set {0..127} and genuinely reached, so all three come
+# back SATISFIED, each over a distinct cluster automaton (`Circuit__clK`).
+#
+# Without the sidecar the design is rejected outright (72 raw state bits):
+# per-cluster slicing alone cannot rescue it because each cluster's cone is
+# still a 24-bit counter > the cap. The param-concretization is what makes
+# each cluster fit — the two primitives compose.
+
+[project]
+name = "R46Gap2PerClusterConcretize"
+description = "Three independent 24-bit counters: joint busts the cap even after concretization, per-cluster slicing isolates each cone, and param-concretization shrinks the wide counter inside each cone so the cluster fits."
+
+[[sources]]
+id = "t"
+files = ["three_wide.sv"]
+adapter = "sv-yosys"
+
+[sources.options]
+use_sv2v = true
+top = "three_wide"
+sidecar = "three_wide.mununu.json"
+
+[alphabet]
+strategy = "direct"
+
+[composition]
+semantics = "synchronous"
+members = ["t"]
+name = "ThreeWideTop"
+
+[[properties]]
+name = "reach_a7"
+formula = "mu X. (a7_o || (<> X))"
+over = "Circuit"
+
+[[properties]]
+name = "reach_b7"
+formula = "mu X. (b7_o || (<> X))"
+over = "Circuit"
+
+[[properties]]
+name = "reach_c7"
+formula = "mu X. (c7_o || (<> X))"
+over = "Circuit"

--- a/examples/verify/r46_gap2_per_cluster_concretize/validate.sh
+++ b/examples/verify/r46_gap2_per_cluster_concretize/validate.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# validate.sh — R46-6 / GAP-2: per-cluster slicing × param-concretization
+# COMPOSE. This is the synthetic proof the GAP-2 de-risk called for, and
+# the regression guard for the composed path.
+#
+# Contract, in two checks:
+#   1. WITHOUT the sidecar the design is REJECTED (72 raw state bits) —
+#      proving per-cluster slicing ALONE cannot rescue it: each cluster's
+#      cone is still a 24-bit counter past MAX_STATE_BITS = 20.
+#   2. WITH the sidecar (`bounded_counter bound=127` per counter), automatic
+#      per-cluster verification fires (joint effective = 3 × 7 = 21 > 20),
+#      slices each counter into its own cluster, and the concretization
+#      shrinks that counter to 7 effective bits so the cluster fits. All
+#      three reachability properties come back SATISFIED + non-vacuous,
+#      each routed to a distinct cluster automaton (`Circuit__clK`).
+#
+# Like the R46-5 fixture, the BTOR2 is produced in mununu's own temp dir,
+# so nothing cap-busting lands under examples/ where the
+# btor2_kmts_lift_sweep glob would trip on it.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MUNUNU="${MUNUNU:-${THIS_DIR}/../../../target/debug/mununu}"
+SRC="${THIS_DIR}/source"
+OUT="$(mktemp -d -t mununu-r46-6pc-XXXXXX)"
+trap 'rm -rf "${OUT}"' EXIT
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu binary not found at ${MUNUNU}" >&2
+  echo "             build it first with: cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in yosys sv2v; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "validate.sh: required tool '${tool}' not on PATH" >&2
+    exit 2
+  fi
+done
+
+export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
+
+echo "=== R46-6 — per-cluster slicing × param-concretization compose ==="
+echo "fixture: ${SRC}/three_wide.sv (SYNTHETIC; three independent 24-bit counters)"
+echo
+
+cd "${SRC}"
+
+# Check 1 — slicing alone (no sidecar) must not rescue the raw design.
+echo "--- (1) no sidecar: raw 72-bit design must be rejected at the cap ---"
+sed 's#sidecar = "three_wide.mununu.json"##' verify.toml > "${OUT}/nosidecar.toml"
+if "${MUNUNU}" verify --base-dir "${SRC}" "${OUT}/nosidecar.toml" > "${OUT}/nosidecar.out" 2>&1; then
+  echo "FAIL: raw design verified instead of hitting the cap" >&2
+  exit 1
+fi
+if ! grep -qiE "state bits|max supported|StateSpaceOverflow|2\^20" "${OUT}/nosidecar.out"; then
+  echo "FAIL: no-sidecar run did not report a state-bit cap overflow" >&2
+  tail -5 "${OUT}/nosidecar.out" >&2
+  exit 1
+fi
+echo "ok: raw design rejected — per-cluster slicing alone cannot rescue it"
+echo
+
+# Check 2 — slicing + concretization compose: per-cluster fires, all SAT.
+echo "--- (2) sidecar: per-cluster × concretization compose; all SATISFIED ---"
+"${MUNUNU}" verify --json verify.toml > "${OUT}/verify.json" 2>"${OUT}/verify.err" || {
+  echo "FAIL: mununu verify exited non-zero with the sidecar" >&2
+  tail -15 "${OUT}/verify.err" >&2
+  exit 1
+}
+
+python3 - "${OUT}/verify.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+
+# per-cluster fired: cluster_routing present on some source.
+routing = None
+for s in r.get("sources", []):
+    routing = (s.get("partition_summary") or {}).get("cluster_routing")
+    if routing:
+        break
+assert routing, "FAIL: no cluster_routing — per-cluster verification did not fire"
+clusters = sorted(set(routing.values()))
+assert len(clusters) >= 3, f"FAIL: expected >=3 cluster automata, got {clusters}"
+print(f"per-cluster: routed {len(routing)} properties to {len(clusters)} clusters {clusters}")
+
+verds = {v["name"]: v for v in r.get("property_verdicts", [])}
+assert verds, "FAIL: no property verdicts"
+overs = set()
+for name in ("reach_a7", "reach_b7", "reach_c7"):
+    v = verds.get(name)
+    assert v, f"FAIL: missing verdict {name}"
+    assert v["satisfied"], f"FAIL: {name} not SATISFIED (the spurious-VIOLATED regression)"
+    assert v["total_states"] > 0, f"FAIL: vacuous verdict for {name}"
+    assert v["over"].startswith("Circuit__cl"), \
+        f"FAIL: {name} not routed to a cluster automaton (over={v['over']})"
+    overs.add(v["over"])
+    print(f"verdict {name}: SAT {v['satisfying_states']}/{v['total_states']} over {v['over']}")
+assert len(overs) >= 3, f"FAIL: properties did not route to distinct clusters: {overs}"
+print("R46-6 done-criteria met: per-cluster slicing × param-concretization "
+      "compose — joint busts the cap, each wide cone is sliced out and "
+      "concretized to fit, all three targets SATISFIED over distinct clusters.")
+PY
+
+echo
+echo "=== R46-6 (per-cluster × concretization) VALIDATION PASSED ==="


### PR DESCRIPTION
## Summary

Synthetic proof (hand-written, NOT vendored RTL) that the two R.4.6 primitives **stack**: per-cluster slicing AND param-concretization together rescue a design neither can rescue alone. This is the GAP-2 composition de-risk the R.4.6 plan called for, before the heavier real-RTL pattgen/sysrst vendoring.

## What it demonstrates

`three_wide.sv` = three independent 24-bit counters (cluster K=3):
- joint raw width 72 → far past `MAX_STATE_BITS=20`;
- each cluster's *sliced* cone is still a 24-bit counter (>20), so per-cluster slicing **alone** cannot rescue it;
- the sidecar concretizes each counter to `bounded_counter bound=127` → 7 effective bits; joint effective = 3×7 = 21 > 20 (per-cluster still fires) while each cluster = 7 ≤ 20 (fits).

`validate.sh` asserts both contract points:
1. **no sidecar →** rejected at 72 raw bits (concretization is load-bearing);
2. **with sidecar →** per-cluster fires, all three reach props SATISFIED + non-vacuous, each routed to a distinct cluster automaton (`Circuit__cl0/1/2`).

Each counter escapes its set at 128 → OOB sink, the shape the realize numericity-gate fix (#94) makes verify soundly — so this fixture also guards that fix in the per-cluster path.

## Relationship to siblings

| fixture | isolates |
|---|---|
| `r46_synth_two_cones` | per-cluster slicing only |
| `r46_gap2_wide_concretize` | param-concretization only (single wide cell) |
| **this** | **both, composed** (wide cells inside each cluster cone) |

Example-only change (no Rust); CI-level guards for the underlying fixes are the `realize.rs` unit tests from #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)