### PR TITLE
test(R46-6, R.4.6): industrial GAP-2 fixture — pattgen per-cluster × param-concretization

### DIFF
--- a/examples/verify/r46_pattgen_per_cluster/README.md
+++ b/examples/verify/r46_pattgen_per_cluster/README.md
@@ -1,0 +1,85 @@
+# R46-6 / GAP-2 — pattgen per-cluster × param-concretization (real OpenTitan RTL)
+
+> **Real vendored RTL + a hand-written harness.** The channel logic is
+> OpenTitan `pattgen_chan` (vendored, pinned in `source/UPSTREAM_COMMIT.txt`,
+> Apache-2.0). The 2-channel harness and the sidecar are hand-written
+> (clearly labeled NOT vendored). This is the industrial counterpart to the
+> synthetic `r46_gap2_per_cluster_concretize` fixture: it shows the GAP-2
+> composition on RTL whose channels really do carry wide datapath/counters.
+
+## Why pattgen is a GAP-2 case
+
+A single `pattgen_chan` is **169 state bits** — `data_q`[64] + `prediv_q`[32]
++ `clk_cnt_q`[32] + `reps_q`/`rep_cnt_q`[10] + `len_q`/`bit_cnt_q`[6] + a
+handful of 1-bit FSM/config flops. One channel already busts
+`MAX_STATE_BITS = 20` on its own. There is no "narrow real-RTL channel" to
+use as a lighter rung — real channels carry wide fields. So the rescue
+needs **both** R.4.6 primitives stacked:
+
+1. **Per-cluster slicing** isolates each channel's cone (the two channels
+   are independent → cluster K=2), but a sliced channel is still 169 bits.
+2. **Param-concretization** (the sidecar) shrinks each channel's wide state
+   cells to the small value sets this property actually needs.
+
+## What the fixture verifies
+
+`source/pattgen_harness.sv` instantiates two `pattgen_chan` with a small
+constant configuration (prediv=1, a 1-bit pattern, 2 reps) and a free
+per-channel enable. With that config each wide cell holds a tiny value set,
+which `source/pattgen_harness.mununu.json` declares:
+
+| cell | raw | concretized |
+|---|---|---|
+| `prediv_q`, `clk_cnt_q` | 32b | `bounded_counter bound=1` |
+| `data_q` | 64b | `bounded_counter bound=1` |
+| `reps_q`, `rep_cnt_q` | 10b | `bounded_counter bound=1` |
+| `len_q`, `bit_cnt_q` | 6b | `ignored` (constant 0) |
+
+Each channel then fits in ~14 effective bits; the joint design is ~28 > 20,
+so per-cluster verification splits it into two 14-bit clusters. The two
+reachability properties (`mu X. (doneK_o || <>X)`) come back **SATISFIED**,
+each over a distinct cluster automaton (`Circuit__cl0` / `Circuit__cl1`),
+on **128-state** clusters — i.e. the concretized wide cells, not a
+degenerate sliced-away cone. Each channel's counters escape their
+concretized sets → an OOB sink (the 129th state), the shape the realize
+numericity-gate fix (#94) makes sound.
+
+The reachability verdict is the same shape as the R46-5 mechanism fixture
+(`r46_synth_two_cones`): this fixture exists to regression-test the
+abstraction-composition **mechanism** on real RTL, not to make a deep
+correctness claim about pattgen.
+
+## Expected result
+
+```
+(1) no sidecar             → rejected at 338 raw state bits
+(2) sidecar, one property  → rejected at 28 bits (joint busts; one cone, no split)
+(3) sidecar, two properties→ per-cluster fires:
+        reach_done0: SATISFIED 128/129 over Circuit__cl0
+        reach_done1: SATISFIED 128/129 over Circuit__cl1
+```
+
+Both `(1)` and `(2)` are the load-bearing negatives: `(1)` shows
+concretization is necessary, `(2)` shows per-cluster slicing is necessary
+*on top of* concretization. Only `(3)` — both primitives composed — fits.
+
+## Run it
+
+```bash
+cargo build -p mununu-cli
+examples/verify/r46_pattgen_per_cluster/validate.sh
+```
+
+Requires `yosys` and `sv2v` on `PATH`.
+
+## Provenance / claims integrity
+
+- `pattgen_chan` and `pattgen_ctrl_pkg` are vendored verbatim from
+  lowRISC/opentitan at the pinned commit; the channel logic is unmodified.
+- The harness narrows the module's 116-bit `ctrl_i` struct (which bundles
+  `enable` with the wide config and busts `MAX_INPUT_BITS`) to a small
+  constant config + free enables. It does not change the channel's
+  behaviour; it provides a verification interface and the concretization
+  posture the sidecar then declares.
+- The verdict is a model-level reachability check over the concretized
+  abstraction — a mechanism demonstration, not an RTL bug finding.

--- a/examples/verify/r46_pattgen_per_cluster/source/UPSTREAM_COMMIT.txt
+++ b/examples/verify/r46_pattgen_per_cluster/source/UPSTREAM_COMMIT.txt
@@ -1,0 +1,11 @@
+558921ccc8aeefab652b45c1402c10bceb63accc
+
+Vendored from lowRISC/opentitan at the pinned commit above (Apache-2.0):
+  pattgen_ctrl_pkg.sv   hw/ip/pattgen/rtl/pattgen_ctrl_pkg.sv
+  pattgen_chan.sv       hw/ip/pattgen/rtl/pattgen_chan.sv
+
+Hand-written (NOT vendored), clearly labeled in-file:
+  pattgen_harness.sv          2-channel harness narrowing the 116-bit
+                              ctrl_i struct to a small constant config +
+                              free per-channel enables.
+  pattgen_harness.mununu.json param-concretization sidecar.

--- a/examples/verify/r46_pattgen_per_cluster/source/pattgen_chan.sv
+++ b/examples/verify/r46_pattgen_per_cluster/source/pattgen_chan.sv
@@ -1,0 +1,191 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module pattgen_chan
+  import pattgen_ctrl_pkg::*;
+(
+  input                       clk_i,
+  input                       rst_ni,
+  input  pattgen_chan_ctrl_t  ctrl_i,
+  output logic                pda_o,
+  output logic                pcl_o,
+  output logic                event_done_o
+);
+
+  logic        enable;
+  logic        polarity_q;
+  logic        inactive_level_pcl_q;
+  logic        inactive_level_pda_q;
+  logic [31:0] prediv_q;
+  logic [63:0] data_q;
+  logic [5:0]  len_q;
+  logic [9:0]  reps_q;
+
+  logic        clk_en;
+  logic        pcl_int_d;
+  logic        pcl_int_q;
+  logic [31:0] clk_cnt_d;
+  logic [31:0] clk_cnt_q;
+  logic        prediv_clk_rollover;
+
+  logic        bit_cnt_en;
+  logic [5:0]  bit_cnt_d;
+  logic [5:0]  bit_cnt_q;
+
+  logic        rep_cnt_en;
+  logic [9:0]  rep_cnt_d;
+  logic [9:0]  rep_cnt_q;
+
+  logic        complete_en;
+  logic        complete_d;
+  logic        complete_q;
+  logic        complete_q2;
+
+  logic        active, active_d, active_q;
+
+  // only accept new control signals when
+  // enable is deasserted
+  assign enable = ctrl_i.enable;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      polarity_q           <=  1'h0;
+      inactive_level_pcl_q <=  1'h0;
+      inactive_level_pda_q <=  1'h0;
+      prediv_q             <= 32'h0;
+      data_q               <= 64'h0;
+      len_q                <=  6'h0;
+      reps_q               <= 10'h0;
+    end else begin
+      polarity_q           <= enable ? polarity_q           : ctrl_i.polarity;
+      inactive_level_pcl_q <= enable ? inactive_level_pcl_q : ctrl_i.inactive_level_pcl;
+      inactive_level_pda_q <= enable ? inactive_level_pda_q : ctrl_i.inactive_level_pda;
+      prediv_q             <= enable ? prediv_q             : ctrl_i.prediv;
+      data_q               <= enable ? data_q               : ctrl_i.data;
+      len_q                <= enable ? len_q                : ctrl_i.len;
+      reps_q               <= enable ? reps_q               : ctrl_i.reps;
+    end
+  end
+
+  // Drive pcl_o and pda_o directly from FF, so that they don't glitch.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      pcl_o <= 1'b0;
+      pda_o <= 1'b0;
+    end else begin
+      pcl_o <= active ? (polarity_q ? ~pcl_int_q : pcl_int_q)
+                      : inactive_level_pcl_q;
+      pda_o <= active ? data_q[bit_cnt_q]
+                      : inactive_level_pda_q;
+    end
+  end
+
+  // Hold the prediv counter and internal clock (PCL) once the previous pattern is complete
+  assign clk_en = ~complete_q;
+
+  // Predivision Counter -> Create an internal pulse (prediv_clk_rollover) which advances the
+  // pattern generation state at the input clk frequency scaled down by the predivider.
+  assign prediv_clk_rollover = (clk_cnt_q == prediv_q);
+  assign clk_cnt_d = (!enable) ? 32'h0:
+                     prediv_clk_rollover ? 32'h0 : // Rollover
+                     (clk_cnt_q + 32'h1);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      clk_cnt_q <= 32'h0;
+    end else begin
+      clk_cnt_q <= clk_en ? clk_cnt_d : clk_cnt_q;
+    end
+  end
+
+  // Generate an internal pattern clock (PCL)
+  // - PCL toggles each time the predivider counter (clk_cnt_q) wraps.
+  // - The internal PCL is zero at the start of the pattern and for the first period, only toggling
+  //   at the end of the first period.
+  // - The internal PCL is inverted at the output flop if configured to do so by the polarity.
+  assign pcl_int_d = (!enable) ? 1'h0 :
+                     prediv_clk_rollover ? ~pcl_int_q : // Rollover
+                     pcl_int_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      pcl_int_q <= 1'h0;
+    end else begin
+      pcl_int_q <= clk_en ? pcl_int_d : pcl_int_q;
+    end
+  end
+
+  // Increment through bits of the pattern register, wrapping when the configured length is
+  // reached. The index then muxes the current bit to the output with 'data_q[bit_cnt_q]'.
+  // - Only update just before the falling edge of pcl_int
+  // - Reset to zero immediately and do not increment when enable is inactive.
+  assign bit_cnt_en = (pcl_int_q & prediv_clk_rollover) | (~enable);
+  assign bit_cnt_d  = (!enable) ? 6'h0 :
+                      (bit_cnt_q == len_q) ? 6'h0 : // Rollover
+                      bit_cnt_q + 6'h1;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      bit_cnt_q <= 6'h0;
+    end else begin
+      bit_cnt_q <= bit_cnt_en ? bit_cnt_d : bit_cnt_q;
+    end
+  end
+
+  // Increment a counter for the number of times the pattern data is repeated within a single
+  // activation. When the configured reps count is reached, the END state for this activation is
+  // reached by signaling completion, and the counter resets.
+  // - Increment as bit_cnt_q rolls over to zero.
+  // - Reset to zero immediately and do not increment when enable is inactive.
+  assign rep_cnt_en = (bit_cnt_en & (bit_cnt_q == len_q)) | (~enable);
+  assign rep_cnt_d  = (!enable) ? 10'h0 :
+                      (rep_cnt_q == reps_q) ? 10'h0 : // Rollover
+                      rep_cnt_q + 10'h1;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rep_cnt_q <= 10'h0;
+    end else begin
+      rep_cnt_q <= rep_cnt_en ? rep_cnt_d : rep_cnt_q;
+    end
+  end
+
+  // Set the completion signal (complete_q) when rep_cnt reaches the configured limit and rolls
+  // over to zero.
+  // Clear / reset to zero when enable goes inactive.
+  assign complete_en = (rep_cnt_en & (rep_cnt_q == reps_q)) | (~enable);
+  assign complete_d  = (!enable) ? 1'h0 : 1'h1;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      complete_q  <= 1'h0;
+      complete_q2 <= 1'h0;
+    end else begin
+      complete_q  <= complete_en ? complete_d : complete_q;
+      complete_q2 <= complete_q;
+    end
+  end
+
+  // Trigger the event-type interrupt upon completion of the pattern.
+  assign event_done_o = complete_q & ~complete_q2;
+
+  // Track the state of the pattern generation with the 'active' signal (IDLE/END=0:ACTIVE=1)
+  // _Transitions_
+  // IDLE   -> (enable -> 1)     -> ACTIVE
+  // ACTIVE -> (complete_q -> 1) -> END
+  // ACTIVE -> (enable -> 0)     -> IDLE
+  // END    -> (enable -> 0)     -> IDLE
+  assign active_d = complete_q ? 1'b0 : // clearing on completion takes precedence
+                    enable     ? 1'b1 : // set to active when enabled (and not complete)
+                    active_q;           // otherwise hold
+  assign active = enable ? active_d : active_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      active_q <= 1'b0;
+    end else begin
+      active_q <= active_d;
+    end
+  end
+
+endmodule : pattgen_chan

--- a/examples/verify/r46_pattgen_per_cluster/source/pattgen_ctrl_pkg.sv
+++ b/examples/verify/r46_pattgen_per_cluster/source/pattgen_ctrl_pkg.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package pattgen_ctrl_pkg;
+
+  typedef struct packed {
+    logic        enable;
+    logic        polarity;
+    logic        inactive_level_pcl;
+    logic        inactive_level_pda;
+    logic [31:0] prediv;
+    logic [63:0] data;
+    logic [5:0]  len;
+    logic [9:0]  reps;
+  } pattgen_chan_ctrl_t;
+
+endpackage : pattgen_ctrl_pkg

--- a/examples/verify/r46_pattgen_per_cluster/source/pattgen_harness.mununu.json
+++ b/examples/verify/r46_pattgen_per_cluster/source/pattgen_harness.mununu.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "mununu_sv_annotation_v1",
+  "module": "pattgen_harness",
+  "signals": [
+    { "name": "u_chan0.prediv_q",  "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan0.clk_cnt_q", "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan0.data_q",    "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan0.len_q",     "abstraction": "ignored" },
+    { "name": "u_chan0.bit_cnt_q", "abstraction": "ignored" },
+    { "name": "u_chan0.reps_q",    "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan0.rep_cnt_q", "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan1.prediv_q",  "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan1.clk_cnt_q", "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan1.data_q",    "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan1.len_q",     "abstraction": "ignored" },
+    { "name": "u_chan1.bit_cnt_q", "abstraction": "ignored" },
+    { "name": "u_chan1.reps_q",    "abstraction": "bounded_counter", "bound": 1 },
+    { "name": "u_chan1.rep_cnt_q", "abstraction": "bounded_counter", "bound": 1 }
+  ]
+}

--- a/examples/verify/r46_pattgen_per_cluster/source/pattgen_harness.sv
+++ b/examples/verify/r46_pattgen_per_cluster/source/pattgen_harness.sv
@@ -1,0 +1,60 @@
+// HAND-WRITTEN harness — NOT vendored OpenTitan RTL.
+//
+// `pattgen_chan` takes its entire configuration as one 116-bit packed
+// `pattgen_chan_ctrl_t ctrl_i` struct (enable + polarity + 2 inactive
+// levels + prediv[32] + data[64] + len[6] + reps[10]). That single bus
+// busts MAX_INPUT_BITS, and bundles `enable` together with the wide
+// config, so the vendored module cannot be driven through a narrow
+// verification interface on its own.
+//
+// This harness gives each channel a sane narrow interface: a free 1-bit
+// `enXX_i` enable and a SMALL constant configuration (prediv=1, a 1-bit
+// pattern, 2 reps). With that config each channel runs a short, bounded
+// pattern and asserts `event_doneXX_o` on completion — the property the
+// fixture verifies. The vendored `pattgen_chan` logic is unchanged; the
+// harness only narrows + concretizes the configuration interface.
+//
+// Two INDEPENDENT channels (share only clk/rst) → disjoint cones →
+// cluster K=2. Each channel's cone still carries the channel's wide state
+// (prediv_q[32], data_q[64], clk_cnt_q[32], reps_q/rep_cnt_q[10], …), so
+// per-cluster slicing alone cannot fit a cluster — the sidecar's
+// param-concretization of those wide cells is what makes each cluster fit.
+module pattgen_harness
+  import pattgen_ctrl_pkg::*;
+(
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  logic en0_i,
+  input  logic en1_i,
+  output logic done0_o,
+  output logic done1_o
+);
+  // Small constant configuration: a 1-bit pattern (len=0 → one data bit),
+  // prediv=1 (the predivider counts 0,1), repeated twice (reps=1).
+  function automatic pattgen_chan_ctrl_t mk_ctrl(logic en);
+    pattgen_chan_ctrl_t c;
+    c.enable             = en;
+    c.polarity           = 1'b0;
+    c.inactive_level_pcl = 1'b0;
+    c.inactive_level_pda = 1'b0;
+    c.prediv             = 32'd1;
+    c.data               = 64'd1;
+    c.len                = 6'd0;
+    c.reps               = 10'd1;
+    return c;
+  endfunction
+
+  logic pda0, pcl0, pda1, pcl1;
+
+  pattgen_chan u_chan0 (
+    .clk_i(clk_i), .rst_ni(rst_ni),
+    .ctrl_i(mk_ctrl(en0_i)),
+    .pda_o(pda0), .pcl_o(pcl0), .event_done_o(done0_o)
+  );
+
+  pattgen_chan u_chan1 (
+    .clk_i(clk_i), .rst_ni(rst_ni),
+    .ctrl_i(mk_ctrl(en1_i)),
+    .pda_o(pda1), .pcl_o(pcl1), .event_done_o(done1_o)
+  );
+endmodule : pattgen_harness

--- a/examples/verify/r46_pattgen_per_cluster/source/verify.toml
+++ b/examples/verify/r46_pattgen_per_cluster/source/verify.toml
@@ -1,0 +1,24 @@
+[project]
+name = "R46PattgenPerCluster"
+[[sources]]
+id = "pg"
+files = ["pattgen_ctrl_pkg.sv", "pattgen_chan.sv", "pattgen_harness.sv"]
+adapter = "sv-yosys"
+[sources.options]
+use_sv2v = true
+top = "pattgen_harness"
+sidecar = "pattgen_harness.mununu.json"
+[alphabet]
+strategy = "direct"
+[composition]
+semantics = "synchronous"
+members = ["pg"]
+name = "PattgenTop"
+[[properties]]
+name = "reach_done0"
+formula = "mu X. (done0_o || (<> X))"
+over = "Circuit"
+[[properties]]
+name = "reach_done1"
+formula = "mu X. (done1_o || (<> X))"
+over = "Circuit"

--- a/examples/verify/r46_pattgen_per_cluster/validate.sh
+++ b/examples/verify/r46_pattgen_per_cluster/validate.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# validate.sh — R46-6 / GAP-2 on REAL OpenTitan RTL: per-cluster slicing ×
+# param-concretization compose to verify a design neither primitive can fit
+# alone.
+#
+# Fixture: two independent `pattgen_chan` instances (vendored OpenTitan,
+# pinned in source/UPSTREAM_COMMIT.txt) wrapped by a hand-written harness
+# that narrows the 116-bit ctrl_i struct to a small constant config + a free
+# per-channel enable. Each channel carries the channel's wide state
+# (prediv_q[32], data_q[64], clk_cnt_q[32], reps_q/rep_cnt_q[10], …).
+#
+# Contract, in three checks:
+#   1. NO sidecar → REJECTED at 338 raw state bits (2 × 169). The raw real
+#      RTL is hopeless without abstraction.
+#   2. Sidecar but a SINGLE property → REJECTED at 28 state bits: the joint
+#      design, even with every wide cell concretized, is still 2 × 14 > 20,
+#      and a single cone gives one cluster so per-cluster cannot split it.
+#      → per-cluster slicing is load-bearing, not just concretization.
+#   3. Sidecar + TWO disjoint properties → automatic per-cluster fires,
+#      slices each channel into its own cluster (14 effective bits each),
+#      and both reachability properties come back SATISFIED + non-vacuous
+#      (128-state clusters — i.e. the concretized wide cells, NOT a
+#      degenerate sliced-away cone), each over a distinct cluster automaton.
+#
+# The reachability verdict is the same shape as the R46-5 mechanism fixture
+# (`mu X. (done || <>X)`); this fixture's purpose is the abstraction-
+# composition mechanism on real RTL, not a deep property finding. Each
+# channel's counter escapes its concretized set → an OOB sink (the 129th
+# state), the shape the realize numericity-gate fix (PR #94) makes sound.
+#
+# Like the other R46 fixtures, the BTOR2 is produced in mununu's own temp
+# dir, so nothing cap-busting lands under examples/.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MUNUNU="${MUNUNU:-${THIS_DIR}/../../../target/debug/mununu}"
+SRC="${THIS_DIR}/source"
+OUT="$(mktemp -d -t mununu-r46-pattgen-XXXXXX)"
+trap 'rm -rf "${OUT}"' EXIT
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu binary not found at ${MUNUNU}" >&2
+  echo "             build it first with: cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in yosys sv2v; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "validate.sh: required tool '${tool}' not on PATH" >&2
+    exit 2
+  fi
+done
+
+export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
+
+echo "=== R46-6 — pattgen per-cluster × param-concretization (real OpenTitan RTL) ==="
+echo "fixture: ${SRC}/pattgen_chan.sv (vendored, pinned) + hand-written 2-channel harness"
+echo
+
+cd "${SRC}"
+
+# Check 1 — raw real RTL must be rejected (concretization load-bearing).
+echo "--- (1) no sidecar: raw 338-bit design must be rejected at the cap ---"
+sed 's#sidecar = "pattgen_harness.mununu.json"##' verify.toml > "${OUT}/nosidecar.toml"
+if "${MUNUNU}" verify --base-dir "${SRC}" "${OUT}/nosidecar.toml" > "${OUT}/nosidecar.out" 2>&1; then
+  echo "FAIL: raw design verified instead of hitting the cap" >&2
+  exit 1
+fi
+grep -qiE "state bits|max supported|StateSpaceOverflow|2\^20" "${OUT}/nosidecar.out" || {
+  echo "FAIL: no-sidecar run did not report a state-bit cap overflow" >&2
+  tail -5 "${OUT}/nosidecar.out" >&2; exit 1; }
+echo "ok: raw RTL rejected — param-concretization is load-bearing"
+echo
+
+# Check 2 — concretized joint, single property, must still be rejected
+# (per-cluster slicing load-bearing on top of concretization).
+echo "--- (2) sidecar + single property: concretized joint still busts (per-cluster needed) ---"
+sed -n '1,/\[\[properties\]\]/p' verify.toml > "${OUT}/single.toml"
+cat >> "${OUT}/single.toml" <<'EOF'
+name = "reach_done0"
+formula = "mu X. (done0_o || (<> X))"
+over = "Circuit"
+EOF
+if "${MUNUNU}" verify --base-dir "${SRC}" "${OUT}/single.toml" > "${OUT}/single.out" 2>&1; then
+  echo "FAIL: single-property concretized design verified instead of busting" >&2
+  exit 1
+fi
+grep -qiE "state bits|max supported|StateSpaceOverflow|2\^20" "${OUT}/single.out" || {
+  echo "FAIL: single-property run did not report a cap overflow" >&2
+  tail -5 "${OUT}/single.out" >&2; exit 1; }
+echo "ok: concretized joint still busts with one cone — per-cluster slicing is load-bearing too"
+echo
+
+# Check 3 — both primitives compose: per-cluster + concretization → all SAT.
+echo "--- (3) sidecar + two disjoint properties: per-cluster × concretization compose ---"
+"${MUNUNU}" verify --json verify.toml > "${OUT}/verify.json" 2>"${OUT}/verify.err" || {
+  echo "FAIL: mununu verify exited non-zero" >&2
+  tail -15 "${OUT}/verify.err" >&2; exit 1; }
+
+python3 - "${OUT}/verify.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+
+routing = None
+for s in r.get("sources", []):
+    routing = (s.get("partition_summary") or {}).get("cluster_routing")
+    if routing:
+        break
+assert routing, "FAIL: no cluster_routing — per-cluster verification did not fire"
+clusters = sorted(set(routing.values()))
+assert len(clusters) >= 2, f"FAIL: expected >=2 cluster automata, got {clusters}"
+print(f"per-cluster: routed {len(routing)} properties to {len(clusters)} clusters {clusters}")
+
+verds = {v["name"]: v for v in r.get("property_verdicts", [])}
+assert verds, "FAIL: no property verdicts"
+overs = set()
+for name in ("reach_done0", "reach_done1"):
+    v = verds.get(name)
+    assert v, f"FAIL: missing verdict {name}"
+    assert v["satisfied"], f"FAIL: {name} not SATISFIED"
+    # Non-vacuous: the cluster must carry the concretized wide cells, i.e.
+    # many states (2^7 = 128 real + OOB), not a degenerate sliced-away cone.
+    assert v["total_states"] >= 64, \
+        f"FAIL: {name} cluster has only {v['total_states']} states — wide cells were sliced away, not concretized"
+    assert v["over"].startswith("Circuit__cl"), \
+        f"FAIL: {name} not routed to a cluster automaton (over={v['over']})"
+    overs.add(v["over"])
+    print(f"verdict {name}: SAT {v['satisfying_states']}/{v['total_states']} over {v['over']}")
+assert len(overs) >= 2, f"FAIL: properties did not route to distinct clusters: {overs}"
+print("R46-6 done-criteria met: real OpenTitan pattgen channels — raw RTL "
+      "rejected, concretized joint still busts, per-cluster × "
+      "param-concretization compose to fit each channel, both SATISFIED "
+      "over distinct clusters on non-degenerate (concretized) cones.")
+PY
+
+echo
+echo "=== R46-6 (pattgen per-cluster × concretization) VALIDATION PASSED ==="


### PR DESCRIPTION
## Summary

The **real-RTL** industrial counterpart to the synthetic `r46_gap2_per_cluster_concretize` fixture (#95): two independent OpenTitan `pattgen_chan` instances (vendored + pinned at `558921c`, Apache-2.0) wrapped by a hand-written 2-channel harness, verified via per-cluster slicing × param-concretization composed.

## Why pattgen is a GAP-2 case

A single `pattgen_chan` is **169 state bits** (`data_q`[64] + `prediv_q`[32] + `clk_cnt_q`[32] + `reps`/`rep_cnt`[10] + `len`/`bit_cnt`[6] + FSM flops) — one channel alone busts `MAX_STATE_BITS=20`. The feasibility review found there is no "narrow real-RTL channel": real channels carry wide datapath/counters. So the rescue needs **both** R.4.6 primitives stacked.

## What `validate.sh` asserts (two load-bearing negatives + the composed case)

1. **no sidecar → rejected at 338 raw state bits** — param-concretization is necessary.
2. **sidecar + one property → rejected at 28 bits** — the concretized joint is still 2×14 > 20, and one cone gives one cluster, so per-cluster cannot split it: per-cluster slicing is necessary *on top of* concretization.
3. **sidecar + two disjoint properties → per-cluster fires** — slices each channel to its own 14-bit cluster; both reach props **SATISFIED 128/129** over distinct cluster automata (`Circuit__cl0`/`cl1`) on non-degenerate (concretized, 128-state) cones.

Each channel's counters escape their concretized sets → an OOB sink (the 129th state), the shape the realize numericity-gate fix (#94) makes sound — so this fixture also guards #94 in the per-cluster × concretization path on real RTL.

## Provenance / claims integrity

- `pattgen_chan` + `pattgen_ctrl_pkg` vendored verbatim, pinned; channel logic unmodified.
- The harness narrows the module's 116-bit `ctrl_i` struct (which bundles `enable` with the wide config and busts `MAX_INPUT_BITS`) to a small constant config + free enables — a verification interface, not a behaviour change.
- The verdict is a model-level reachability check over the concretized abstraction — a mechanism demonstration (same shape as the R46-5 fixture), **not** an RTL bug finding. The README states this explicitly.

Example-only change (no Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)