### PR TITLE
feat(R46-6, R.4.6): sysrst_ctrl K=5 industrial GAP-2 fixture + sv2v include-path fix

### DIFF
--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -207,25 +207,32 @@ pub fn translate_sv(
     if yopts.use_sv2v {
         let sv2v = locate_sv2v()?;
         let preprocessed = tmp.path().join("preprocessed.sv");
-        // Include-search path: the parent dir of the primary source on
-        // disk, if known. `caliptra_sva.svh` and similar header files
-        // live next to the `.sv` the user invoked us on; sv2v can't
-        // see them otherwise because mununu staged a per-call tempdir.
+        // Include-search path. Two sources, in priority order:
         //
-        // Canonicalize to an absolute path so relative invocations
-        // (e.g. `mununu context eval foo.sv` from the source dir)
-        // resolve to a usable `-I` rather than the empty-parent path.
-        let include_dirs: Vec<PathBuf> = yopts
-            .primary_source_path
-            .as_ref()
-            .and_then(|p| {
-                let abs = Path::new(p)
-                    .canonicalize()
-                    .unwrap_or_else(|_| PathBuf::from(p));
-                abs.parent().map(Path::to_path_buf)
-            })
-            .into_iter()
-            .collect();
+        // 1. The staging tempdir itself. Every `additional_sources` entry
+        //    is written here (see above), so an `\`include "X.sv"` whose
+        //    target is one of the staged sources — e.g. real OpenTitan RTL
+        //    doing `\`include "prim_assert.sv"` where the stub prim_assert
+        //    is passed as an additional source (the verify-path /
+        //    multi-file case, which never sets `primary_source_path`) —
+        //    resolves against the staged copy. sv2v does not search the
+        //    including file's own directory by default, so without this the
+        //    include fails even though the file is right next to it.
+        //
+        // 2. The parent dir of the primary source on disk, if known.
+        //    `caliptra_sva.svh` and similar header files live next to the
+        //    `.sv` the user invoked us on (the `context eval` single-file
+        //    case); sv2v can't see them otherwise because mununu staged a
+        //    per-call tempdir. Canonicalized to an absolute path so
+        //    relative invocations (e.g. `mununu context eval foo.sv` from
+        //    the source dir) resolve to a usable `-I`.
+        let mut include_dirs: Vec<PathBuf> = vec![tmp.path().to_path_buf()];
+        include_dirs.extend(yopts.primary_source_path.as_ref().and_then(|p| {
+            let abs = Path::new(p)
+                .canonicalize()
+                .unwrap_or_else(|_| PathBuf::from(p));
+            abs.parent().map(Path::to_path_buf)
+        }));
         run_sv2v(&sv2v, &sources, &include_dirs, &preprocessed)?;
         // Replace the original .sv inputs with the single combined
         // Verilog-2005 file. sv2v resolves cross-file packages,
@@ -2375,6 +2382,49 @@ endpackage
         let out = translate_sv(primary, &opts, &yopts).expect("sv2v multi-file translate");
         // Reachability: at least 1 state. The actual count depends on
         // Yosys's flatten + chformal; we assert non-empty.
+        assert!(
+            out.source_info.state_count >= 1,
+            "got state_count = {}",
+            out.source_info.state_count
+        );
+    }
+
+    #[test]
+    fn sv2v_include_resolves_staged_additional_source_header() {
+        if !yosys_available() || !sv2v_available() {
+            eprintln!("skipping: yosys or sv2v not on PATH");
+            return;
+        }
+        // An `\`include`d header supplied as an `additional_sources` entry
+        // (staged into the per-call tempdir) must resolve — even on the
+        // verify / multi-file path, which never sets
+        // `primary_source_path`. Real OpenTitan RTL does
+        // `\`include "prim_assert.sv"`; before the staging tempdir was
+        // added to sv2v's `-I` search path the include failed with
+        // "Could not find file", because sv2v does not search the
+        // including file's own directory by default. Regression for the
+        // R46-6 sysrst_ctrl K=5 fixture.
+        let primary = r#"
+`include "defs.svh"
+module top (input wire clk, input wire rst_ni, output logic flag);
+    logic q;
+    always_ff @(posedge clk or negedge rst_ni)
+        if (!rst_ni) q <= 1'b0; else q <= `MK_NEXT(q);
+    assign flag = q;
+endmodule
+"#;
+        let header = "`define MK_NEXT(x) (~(x))\n";
+        let opts = AdapterOptions::default();
+        let yopts = YosysOptions {
+            top: Some("top".into()),
+            // No `primary_source_path` (the verify-path shape). The header
+            // resolves only because the staging tempdir is on sv2v's `-I`.
+            additional_sources: vec![("defs.svh".into(), header.into())],
+            use_sv2v: true,
+            ..Default::default()
+        };
+        let out = translate_sv(primary, &opts, &yopts)
+            .expect("`include of a staged additional-source header resolves");
         assert!(
             out.source_info.state_count >= 1,
             "got state_count = {}",

--- a/examples/verify/r46_sysrst_detect_k5/README.md
+++ b/examples/verify/r46_sysrst_detect_k5/README.md
@@ -1,0 +1,93 @@
+# R46-6 / GAP-2 at K=5 — sysrst_ctrl detect per-cluster × param-concretization
+
+> **Real vendored RTL + a hand-written harness.** The detector logic is
+> OpenTitan `sysrst_ctrl_detect` (vendored, pinned in
+> `source/UPSTREAM_COMMIT.txt`, Apache-2.0). The K=5 harness and the
+> sidecar are hand-written (clearly labeled NOT vendored). This is the
+> K=5 industrial scale-up of the pattgen (K=2) fixture: the headline
+> sysrst_ctrl clustering case the R.4.6 plan named.
+
+## Why sysrst_ctrl is the K=5 driver
+
+OpenTitan `sysrst_ctrl` runs **K=5 independent debounce/detect sub-blocks**
+(autoblock / ulp / keyintr / combo / pin), each an instance of the
+parameterized `sysrst_ctrl_detect` timer block, with disjoint CSR groups
+that share only a small synced input bundle. The joint cone busts
+`MAX_STATE_BITS = 20` through the **five 32-bit detect/debounce timers**,
+while each detector cluster fits once its timer is param-concretized — the
+exact GAP-2 shape, at K=5.
+
+This fixture reproduces that shape directly: `source/sysrst_harness.sv`
+instantiates five `sysrst_ctrl_detect` blocks (five distinct EventTypes —
+level, edge, sticky — mirroring the real top's mix) with a free per-detector
+trigger + enable and small constant timer thresholds. It bypasses the
+TileLink-UL register file (irrelevant to the per-cluster mechanism).
+
+## What the fixture verifies
+
+Each `sysrst_ctrl_detect` carries a 32-bit timer counter `cnt_q` plus a
+2-bit FSM (`state_q`) and, for edge detectors, a 1-bit edge flop. The
+sidecar concretizes each timer:
+
+| cell | raw | concretized |
+|---|---|---|
+| `u_detK.cnt_q` (×5) | 32b | `bounded_counter bound=7` |
+
+State-bit budget:
+
+```
+no sidecar:        5 × (32-bit timer + FSM + flops)  = 172 bits → rejected
+sidecar, 1 prop:   concretized joint                 =  27 bits → rejected (one cone, no split)
+sidecar, 5 props:  per-cluster → each detector        ≈ 5–6 bits → fits
+```
+
+The five reachability properties (`mu X. (detK_o || <>X)`) come back
+**SATISFIED**, each over a distinct cluster automaton
+(`Circuit__cl0 … cl4`), on **32–64 state** clusters (the concretized timer
++ FSM, not a degenerate sliced-away cone). Each timer escapes its
+concretized set at the threshold → an OOB sink, the shape the realize
+numericity-gate fix (#94) makes sound.
+
+The reachability verdict is the same shape as the R46-5 mechanism fixture:
+this fixture exists to regression-test the abstraction-composition
+**mechanism** on real RTL at K=5, not to make a correctness claim about
+sysrst_ctrl.
+
+## Expected result
+
+```
+(1) no sidecar              → rejected at 172 raw state bits
+(2) sidecar, one property   → rejected at 27 bits (joint busts; one cone, no split)
+(3) sidecar, five properties→ per-cluster fires:
+        reach_det0: SATISFIED over Circuit__cl0   (level)
+        reach_det1: SATISFIED over Circuit__cl1   (level)
+        reach_det2: SATISFIED over Circuit__cl2   (edge)
+        reach_det3: SATISFIED over Circuit__cl3   (edge)
+        reach_det4: SATISFIED over Circuit__cl4   (level, sticky)
+```
+
+`(1)` and `(2)` are the load-bearing negatives: `(1)` shows concretization
+is necessary, `(2)` shows per-cluster slicing is necessary *on top of* it.
+
+## Run it
+
+```bash
+cargo build -p mununu-cli
+examples/verify/r46_sysrst_detect_k5/validate.sh
+```
+
+Requires `yosys` and `sv2v` on `PATH`. `sysrst_ctrl_detect` does
+`` `include "prim_assert.sv" ``; the stub resolves on the verify path
+because the sv2v staging tempdir is on the include search path (added in
+the same PR as this fixture).
+
+## Provenance / claims integrity
+
+- `sysrst_ctrl_detect` + `sysrst_ctrl_pkg` are vendored verbatim, pinned;
+  the detector logic is unmodified.
+- `prim_assert.sv` is a synthesis-equivalent empty-SVA-macro stub (the same
+  one the M.2 fixture uses).
+- The harness gives each detector a narrow free trigger/enable + small
+  constant timer thresholds; it does not change the detector's behaviour.
+- The verdict is a model-level reachability check over the concretized
+  abstraction — a K=5 mechanism demonstration, not an RTL bug finding.

--- a/examples/verify/r46_sysrst_detect_k5/source/UPSTREAM_COMMIT.txt
+++ b/examples/verify/r46_sysrst_detect_k5/source/UPSTREAM_COMMIT.txt
@@ -1,0 +1,14 @@
+558921ccc8aeefab652b45c1402c10bceb63accc
+
+Vendored from lowRISC/opentitan at the pinned commit above (Apache-2.0):
+  sysrst_ctrl_detect.sv  hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
+  sysrst_ctrl_pkg.sv     hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_pkg.sv
+
+Stub (synthesis-equivalent empty SVA macros), copied from the M.2 fixture:
+  prim_assert.sv         (sysrst_ctrl_detect does `include "prim_assert.sv")
+
+Hand-written (NOT vendored), clearly labeled in-file:
+  sysrst_harness.sv          K=5 harness instantiating 5 sysrst_ctrl_detect
+                             with narrow free trigger/enable + small constant
+                             timer thresholds.
+  sysrst_harness.mununu.json param-concretization sidecar (the 5 32-bit timers).

--- a/examples/verify/r46_sysrst_detect_k5/source/prim_assert.sv
+++ b/examples/verify/r46_sysrst_detect_k5/source/prim_assert.sv
@@ -1,0 +1,43 @@
+// Stub `prim_assert.sv` for sv2v + Yosys ingestion of OpenTitan RTL.
+//
+// All SVA macros expand to empty — synthesis-equivalent to
+// OpenTitan's `prim_assert_dummy_macros.svh` (Apache 2.0).
+//
+// Also defines `PRIM_FLOP_SPARSE_FSM` as a plain `always_ff` register
+// (the upstream definition wraps a `prim_sparse_fsm_flop` submodule
+// for FPV / runtime-encoding hardening, neither of which matters for
+// the synthesised KMTS lift). The plain `always_ff` form preserves
+// the FSM's functional semantics — `state_q` updates to `state_d`
+// each clock unless reset is asserted, then `state_q` becomes the
+// reset value.
+//
+// SOUNDNESS: dropping the sparse-FSM hardening removes only the
+// runtime "alert if state_q is not one of the legal encodings"
+// behaviour; the property the M.2 milestone verifies (idle is
+// reachable from every reachable state) doesn't depend on the
+// hardening — the FSM transitions remain identical.
+
+`define ASSERT_I(__name, __prop)
+`define ASSERT_INIT(__name, __prop)
+`define ASSERT_INIT_NET(__name, __prop)
+`define ASSERT_FINAL(__name, __prop)
+`define ASSERT_AT_RESET(__name, __prop, __rst = 0)
+`define ASSERT_AT_RESET_AND_FINAL(__name, __prop, __rst = 0)
+`define ASSERT(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_NEVER(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_KNOWN(__name, __sig, __clk = 0, __rst = 0)
+`define COVER(__name, __prop, __clk = 0, __rst = 0)
+`define ASSUME(__name, __prop, __clk = 0, __rst = 0)
+`define ASSUME_I(__name, __prop)
+`define ASSERT_PULSE(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_IF(__name, __prop, __enable, __clk = 0, __rst = 0)
+`define ASSERT_KNOWN_IF(__name, __sig, __enable, __clk = 0, __rst = 0)
+
+`define PRIM_FLOP_SPARSE_FSM(__name, __d, __q, __type, __resval = '0, __clk = clk_i, __rst_n = rst_ni, __alert_trigger_sva_en = 1) \
+  always_ff @(posedge __clk or negedge __rst_n) begin                                                                              \
+    if (!__rst_n) begin                                                                                                            \
+      __q <= __resval;                                                                                                             \
+    end else begin                                                                                                                 \
+      __q <= __d;                                                                                                                  \
+    end                                                                                                                            \
+  end

--- a/examples/verify/r46_sysrst_detect_k5/source/sysrst_ctrl_detect.sv
+++ b/examples/verify/r46_sysrst_detect_k5/source/sysrst_ctrl_detect.sv
@@ -1,0 +1,318 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Debounce and detector module.
+//
+// The module is able to detect either low/high levels, or transitions to low/high levels (edges).
+// The event type to trigger on can be configured via the EventType parameter.
+//
+// Whenever a trigger event is seen at the input (for instance a transition to low) the module first
+// backs off for the amount of debounce cycles configured through cfg_debounce_timer_i. Then the
+// module samples the input value again and if it still matches the active level (low in this
+// example), the module goes into detection mode. In detection mode, the module checks whether the
+// trigger signal remains stable for the number of cycles configured via cfg_detect_timer_i. If it
+// does, event_detected_pulse_o will be pulsed high for one cycle and event_detected_o will be held
+// high until the input trigger value changes.
+//
+// Note that if the module is configured as "Sticky", the module needs to be explicitly disabled
+// and enabled again in order to reset the internal FSM into its idle state.
+//
+
+`include "prim_assert.sv"
+
+module sysrst_ctrl_detect
+  import sysrst_ctrl_pkg::*;
+#(
+  // The module only contains one counter to implement both timers.
+  // The width of that counter is set to the maximum of the two values below.
+  parameter int unsigned DebounceTimerWidth = 16,
+  parameter int unsigned DetectTimerWidth = 32,
+  // Determines the event type that the detector should be sensitive to.
+  parameter event_t      EventType = LowLevel,
+  // If this parameter is set to 1, the l2h_detected_o and h2l_detected_o conditions can only be
+  // reset by disabling the corresponding detector (cfg_l2h_en_i or cfg_h2l_en_i).
+  parameter bit          Sticky = 0
+) (
+  input                                 clk_i,
+  input                                 rst_ni,
+  // Trigger input signal.
+  input                                 trigger_i,
+  // Debounce and detection timer thresholds.
+  input        [DebounceTimerWidth-1:0] cfg_debounce_timer_i,
+  input        [DetectTimerWidth-1:0]   cfg_detect_timer_i,
+  // Enables the detector module.
+  // Note that the internal state machine can be reset to its idle state by disabling the module.
+  input                                 cfg_enable_i,
+  // Held high after detection of the event as long as the trigger level is correct.
+  output logic                          event_detected_o,
+  // Pulsed high for one cycle when the event is detected.
+  output logic                          event_detected_pulse_o
+);
+
+  //////////////////
+  // Detect Event //
+  //////////////////
+
+  // This just decodes the active level needed for detection.
+  logic trigger_active;
+  if ((EventType == LowLevel) || (EventType == EdgeToLow)) begin : gen_trigger_active_low
+    assign trigger_active = (trigger_i == 1'b0);
+  end else begin : gen_trigger_active_high
+    assign trigger_active = (trigger_i == 1'b1);
+  end
+
+  // In case of edge events, we also need to detect the transition.
+  logic trigger_event;
+  if ((EventType == EdgeToLow) || (EventType == EdgeToHigh)) begin : gen_trigger_event_edge
+    // This flop is always active, no matter the enable state.
+    logic trigger_active_q;
+    always_ff @(posedge clk_i or negedge rst_ni) begin : p_trigger_reg
+      if (!rst_ni) begin
+        trigger_active_q <= 1'b0;
+      end else begin
+        trigger_active_q <= trigger_active;
+      end
+    end
+
+    assign trigger_event = trigger_active & ~trigger_active_q;
+  // In case of level events, the event is equal to the level being active.
+  end else begin : gen_trigger_event_level
+    assign trigger_event = trigger_active;
+  end
+
+  /////////////////
+  // Timer Logic //
+  /////////////////
+
+  // Take the maximum width of both timer values.
+  localparam int unsigned TimerWidth =
+      (DetectTimerWidth > DebounceTimerWidth) ? DetectTimerWidth : DebounceTimerWidth;
+
+  logic cnt_en, cnt_clr;
+  logic [TimerWidth-1:0] cnt_d, cnt_q;
+  assign cnt_d = (cnt_clr) ? '0           :
+                 (cnt_en)  ? cnt_q + 1'b1 :
+                             cnt_q;
+
+
+  logic cnt_done, thresh_sel;
+  logic [TimerWidth-1:0] thresh;
+  assign thresh = (thresh_sel) ? TimerWidth'(cfg_detect_timer_i) :
+                                 TimerWidth'(cfg_debounce_timer_i);
+  assign cnt_done = (cnt_q >= thresh);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_cnt_reg
+    if (!rst_ni) begin
+      cnt_q <= '0;
+    end else begin
+      cnt_q <= cnt_d;
+    end
+  end
+
+  /////////
+  // FSM //
+  /////////
+
+  typedef enum logic [1:0] {
+    IdleSt,
+    DebounceSt,
+    DetectSt,
+    StableSt
+  } state_t;
+
+  state_t state_d, state_q;
+
+  always_comb begin : p_fsm
+    state_d = state_q;
+
+    // Counter controls (clear has priority).
+    cnt_clr = 1'b0;
+    cnt_en = 1'b0;
+
+    // Detected outputs
+    event_detected_o = 1'b0;
+    event_detected_pulse_o = 1'b0;
+
+    // Threshold select
+    // 0: debounce
+    // 1: detect
+    thresh_sel = 1'b0;
+
+    unique case (state_q)
+      ////////////////////////////////////////////
+      // We are waiting for the event to occur.
+      // This can be either a specific level or edge,
+      // depending on the configuration.
+      IdleSt: begin
+        // Stay here if the detector is disabled.
+        if (trigger_event && cfg_enable_i) begin
+          state_d = DebounceSt;
+          cnt_en = 1'b1;
+        end
+      end
+      ////////////////////////////////////////////
+      // If an event has occurred, we back off for
+      // the amount of debounce cycles configured.
+      // Once the timer has expired, we sample the
+      // signal again and check whether it has the
+      // correct level. If so, we move on to the
+      // detection stage, otherwise we fall back.
+      DebounceSt: begin
+        cnt_en = 1'b1;
+        // Unconditionally go back to idle if the detector is disabled.
+        if (!cfg_enable_i) begin
+          state_d = IdleSt;
+          cnt_clr = 1'b1;
+        end else if (cnt_done) begin
+          cnt_clr = 1'b1;
+          if (trigger_active) begin
+            state_d = DetectSt;
+          end else begin
+            state_d = IdleSt;
+          end
+        end
+      end
+      ////////////////////////////////////////////
+      // Once the debounce period has passed, we
+      // check whether the signal remains stable
+      // throughout the entire detection period.
+      // If it is not stable at any cycle, we fall
+      // back to idle.
+      DetectSt: begin
+        thresh_sel = 1'b1;
+        cnt_en = 1'b1;
+        // Go back to idle if either the trigger level is not active anymore, or if the
+        // detector is disabled.
+        if (!cfg_enable_i || !trigger_active) begin
+          state_d = IdleSt;
+          cnt_clr = 1'b1;
+        // If the trigger is active, count up.
+        end else begin
+          if (cnt_done) begin
+            state_d = StableSt;
+            cnt_clr = 1'b1;
+            event_detected_o = 1'b1;
+            event_detected_pulse_o = 1'b1;
+          end
+        end
+      end
+      ////////////////////////////////////////////
+      // At this point we have detected the event
+      // and monitor whether the signal remains stable.
+      StableSt: begin
+        // Go back to idle if either the trigger level is not active anymore, or if the detector is
+        // disabled. Note that if the detector is sticky, it has to be explicitly disabled in order
+        // to go back to the idle state.
+        if (!cfg_enable_i || (!trigger_active && !Sticky)) begin
+          state_d = IdleSt;
+        // Otherwise keep the event detected output signal high.
+        end else begin
+          event_detected_o = 1'b1;
+        end
+      end
+      ////////////////////////////////////////////
+      // This is a full case statement
+      default: ;
+    endcase // state_q
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_fsm_reg
+    if (!rst_ni) begin
+      state_q <= IdleSt;
+    end else begin
+      state_q <= state_d;
+    end
+  end
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  `ASSERT(DisabledIdleSt_A, !cfg_enable_i |=> state_q == IdleSt)
+  `ASSERT(DisabledNoDetection_A, !cfg_enable_i |-> !event_detected_o && !event_detected_pulse_o)
+
+  if ((EventType == LowLevel) || (EventType == EdgeToLow)) begin : gen_low_level_sva
+    `ASSERT(LowLevelEvent_A, !trigger_i === trigger_active)
+  end else begin: gen_high_level_sva
+    `ASSERT(HighLevelEvent_A, trigger_i === trigger_active)
+  end
+
+  if (EventType == LowLevel) begin : gen_low_event_sva
+    `ASSERT(LowLevelEvent_A, !trigger_i === trigger_event)
+  end else if (EventType == HighLevel) begin : gen_high_event_sva
+    `ASSERT(HighLevelEvent_A, trigger_i === trigger_event)
+  end else if (EventType == EdgeToLow) begin : gen_edge_to_low_event_sva
+    `ASSERT(EdgeToLowEvent_A, !trigger_i && $past(trigger_i) |-> trigger_event)
+  end else if (EventType == EdgeToLow) begin : gen_edge_to_high_event_sva
+    `ASSERT(EdgeToHighEvent_A, trigger_i && !$past(trigger_i) |-> trigger_event)
+  end
+
+  `ASSERT(EnterDebounceSt_A,
+      state_q == IdleSt && cfg_enable_i && trigger_event
+      |=>
+      state_q == DebounceSt)
+
+  `ASSERT(EnterDetectSt_A,
+      state_q == DebounceSt && cnt_q >= cfg_debounce_timer_i && trigger_active && cfg_enable_i
+      |=>
+      state_q == DetectSt)
+
+  `ASSERT(DetectStDropOut_A,
+      state_q == DetectSt && !trigger_active && cfg_enable_i
+      |=>
+      state_q == IdleSt)
+
+  `ASSERT(EnterStableSt_A,
+      state_q == DetectSt && cnt_q >= cfg_detect_timer_i && trigger_active && cfg_enable_i
+      |=>
+      state_q == StableSt)
+
+  `ASSERT(StayInStableSt,
+      state_q == StableSt && trigger_active && cfg_enable_i
+      |=>
+      state_q == StableSt)
+
+  if (Sticky) begin : gen_sticky_sva
+    `ASSERT(StableStDropOut_A,
+        state_q == StableSt && cfg_enable_i && !trigger_active
+        |=>
+        state_q == StableSt)
+  end else begin : gen_not_sticky_sva
+    `ASSERT(StableStDropOut_A,
+        state_q == StableSt && cfg_enable_i && !trigger_active
+        |=>
+        state_q == IdleSt)
+  end
+
+  `ASSERT(DetectedOut_A,
+      state_q == StableSt && trigger_active && cfg_enable_i ||
+      state_q == DetectSt && cnt_q >= cfg_detect_timer_i && trigger_active && cfg_enable_i
+      |->
+      event_detected_o)
+
+  `ASSERT(DetectedPulseOut_A,
+      state_q == DetectSt && cnt_q >= cfg_detect_timer_i && trigger_active && cfg_enable_i
+      |->
+      event_detected_pulse_o)
+
+  `ASSERT(PulseIsPulse_A,
+      event_detected_pulse_o |=> !event_detected_pulse_o)
+
+  // Counter does not wrap around unless it is explicitly cleared
+  `ASSERT(CntNoWrap_A,
+      !cnt_clr
+      |=>
+      cnt_q >= $past(cnt_q))
+
+  `ASSERT(CntClr_A,
+      cnt_clr
+      |=>
+      cnt_q == '0)
+
+  `ASSERT(CntIncr_A,
+      cnt_en && !cnt_clr
+      |=>
+      cnt_q == $past(cnt_q) + 1)
+
+endmodule : sysrst_ctrl_detect

--- a/examples/verify/r46_sysrst_detect_k5/source/sysrst_ctrl_pkg.sv
+++ b/examples/verify/r46_sysrst_detect_k5/source/sysrst_ctrl_pkg.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sysrst_ctrl_pkg;
+
+  typedef enum logic [1:0] {
+    LowLevel,
+    HighLevel,
+    EdgeToLow,
+    EdgeToHigh
+  } event_t;
+
+endpackage : sysrst_ctrl_pkg

--- a/examples/verify/r46_sysrst_detect_k5/source/sysrst_harness.mununu.json
+++ b/examples/verify/r46_sysrst_detect_k5/source/sysrst_harness.mununu.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "mununu_sv_annotation_v1",
+  "module": "sysrst_harness",
+  "signals": [
+    { "name": "u_det0.cnt_q", "abstraction": "bounded_counter", "bound": 7 },
+    { "name": "u_det1.cnt_q", "abstraction": "bounded_counter", "bound": 7 },
+    { "name": "u_det2.cnt_q", "abstraction": "bounded_counter", "bound": 7 },
+    { "name": "u_det3.cnt_q", "abstraction": "bounded_counter", "bound": 7 },
+    { "name": "u_det4.cnt_q", "abstraction": "bounded_counter", "bound": 7 }
+  ]
+}

--- a/examples/verify/r46_sysrst_detect_k5/source/sysrst_harness.sv
+++ b/examples/verify/r46_sysrst_detect_k5/source/sysrst_harness.sv
@@ -1,0 +1,60 @@
+// HAND-WRITTEN harness — NOT vendored OpenTitan RTL.
+//
+// OpenTitan `sysrst_ctrl` runs K independent debounce/detect sub-blocks
+// (autoblock / ulp / keyintr / combo / pin), each an instance of the
+// vendored `sysrst_ctrl_detect` parameterized timer block, wired together
+// through a TileLink-UL register file. The full top therefore pulls in the
+// reg_top + tlul infrastructure, which is irrelevant to the per-cluster
+// verification mechanism this fixture exercises.
+//
+// This harness reproduces sysrst_ctrl's load-bearing shape — K=5
+// INDEPENDENT detectors that share only clk/rst, each carrying the
+// vendored block's 32-bit detect/debounce timer counter (`cnt_q`) — with
+// a narrow interface: a free per-detector `trigKK_i` trigger + `enKK_i`
+// enable, and SMALL constant timer thresholds. The wide `cfg_*_timer_i`
+// inputs (16b + 32b) and the 32-bit `cnt_q` are exactly the fields the
+// de-risk note flagged: the joint cone busts MAX_STATE_BITS via the five
+// 32-bit timers, while each detector cluster fits once its timer is
+// param-concretized. Five distinct EventTypes mirror the real top's mix of
+// level/edge detectors.
+module sysrst_harness
+  import sysrst_ctrl_pkg::*;
+(
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  logic trig0_i, trig1_i, trig2_i, trig3_i, trig4_i,
+  input  logic en0_i,   en1_i,   en2_i,   en3_i,   en4_i,
+  output logic det0_o,  det1_o,  det2_o,  det3_o,  det4_o
+);
+  // Small constant timer thresholds: debounce after 1 cycle, detect after 7.
+  // The vendored counter (`cnt_q`, 32 bits) only ever reaches the larger
+  // threshold (7), so the sidecar concretizes it to {0..7}.
+  localparam logic [15:0] DEB = 16'd1;
+  localparam logic [31:0] DET = 32'd7;
+
+  sysrst_ctrl_detect #(.EventType(LowLevel)) u_det0 (
+    .clk_i, .rst_ni, .trigger_i(trig0_i),
+    .cfg_debounce_timer_i(DEB), .cfg_detect_timer_i(DET), .cfg_enable_i(en0_i),
+    .event_detected_o(det0_o), .event_detected_pulse_o()
+  );
+  sysrst_ctrl_detect #(.EventType(HighLevel)) u_det1 (
+    .clk_i, .rst_ni, .trigger_i(trig1_i),
+    .cfg_debounce_timer_i(DEB), .cfg_detect_timer_i(DET), .cfg_enable_i(en1_i),
+    .event_detected_o(det1_o), .event_detected_pulse_o()
+  );
+  sysrst_ctrl_detect #(.EventType(EdgeToLow)) u_det2 (
+    .clk_i, .rst_ni, .trigger_i(trig2_i),
+    .cfg_debounce_timer_i(DEB), .cfg_detect_timer_i(DET), .cfg_enable_i(en2_i),
+    .event_detected_o(det2_o), .event_detected_pulse_o()
+  );
+  sysrst_ctrl_detect #(.EventType(EdgeToHigh)) u_det3 (
+    .clk_i, .rst_ni, .trigger_i(trig3_i),
+    .cfg_debounce_timer_i(DEB), .cfg_detect_timer_i(DET), .cfg_enable_i(en3_i),
+    .event_detected_o(det3_o), .event_detected_pulse_o()
+  );
+  sysrst_ctrl_detect #(.EventType(LowLevel), .Sticky(1)) u_det4 (
+    .clk_i, .rst_ni, .trigger_i(trig4_i),
+    .cfg_debounce_timer_i(DEB), .cfg_detect_timer_i(DET), .cfg_enable_i(en4_i),
+    .event_detected_o(det4_o), .event_detected_pulse_o()
+  );
+endmodule : sysrst_harness

--- a/examples/verify/r46_sysrst_detect_k5/source/verify.toml
+++ b/examples/verify/r46_sysrst_detect_k5/source/verify.toml
@@ -1,0 +1,36 @@
+[project]
+name = "R46SysrstDetectK5"
+[[sources]]
+id = "sr"
+files = ["sysrst_ctrl_pkg.sv", "sysrst_ctrl_detect.sv", "prim_assert.sv", "sysrst_harness.sv"]
+adapter = "sv-yosys"
+[sources.options]
+use_sv2v = true
+top = "sysrst_harness"
+sidecar = "sysrst_harness.mununu.json"
+[alphabet]
+strategy = "direct"
+[composition]
+semantics = "synchronous"
+members = ["sr"]
+name = "SysrstTop"
+[[properties]]
+name = "reach_det0"
+formula = "mu X. (det0_o || (<> X))"
+over = "Circuit"
+[[properties]]
+name = "reach_det1"
+formula = "mu X. (det1_o || (<> X))"
+over = "Circuit"
+[[properties]]
+name = "reach_det2"
+formula = "mu X. (det2_o || (<> X))"
+over = "Circuit"
+[[properties]]
+name = "reach_det3"
+formula = "mu X. (det3_o || (<> X))"
+over = "Circuit"
+[[properties]]
+name = "reach_det4"
+formula = "mu X. (det4_o || (<> X))"
+over = "Circuit"

--- a/examples/verify/r46_sysrst_detect_k5/validate.sh
+++ b/examples/verify/r46_sysrst_detect_k5/validate.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# validate.sh — R46-6 / GAP-2 at K=5 on REAL OpenTitan RTL: per-cluster
+# slicing × param-concretization across five independent detectors.
+#
+# Fixture: five `sysrst_ctrl_detect` instances (vendored OpenTitan, pinned
+# in source/UPSTREAM_COMMIT.txt) wrapped by a hand-written harness. Each
+# detector is one of sysrst_ctrl's debounce/detect sub-blocks and carries
+# the vendored block's 32-bit detect/debounce timer counter (`cnt_q`) —
+# the exact wide field the R.4.6 plan named as the sysrst cap-buster.
+#
+# Contract, in three checks (two load-bearing negatives + composed):
+#   1. NO sidecar → REJECTED at 172 raw state bits (5 × 32-bit timers +
+#      FSM flops). The raw RTL is hopeless without abstraction.
+#   2. Sidecar but a SINGLE property → REJECTED at 27 state bits: the joint
+#      design, even with all five timers concretized, is still > 20, and a
+#      single cone gives one cluster so per-cluster cannot split it.
+#      → per-cluster slicing is load-bearing on top of concretization.
+#   3. Sidecar + FIVE disjoint properties → automatic per-cluster fires,
+#      slices each detector into its own cluster (Circuit__cl0..cl4), and
+#      all five reachability properties come back SATISFIED + non-vacuous
+#      (32–64 state clusters — the concretized timer + FSM, NOT a
+#      degenerate sliced-away cone), each over a distinct cluster automaton.
+#
+# Verdict shape = the R46-5 mechanism fixture (`mu X. (det || <>X)`); this
+# fixture's purpose is the abstraction-composition mechanism on real RTL at
+# K=5, not a deep property finding. Each timer escapes its concretized set
+# at the threshold → an OOB sink, the shape the realize numericity-gate fix
+# (PR #94) makes sound.
+#
+# The included `prim_assert.sv` resolves on the verify path because the
+# sv2v staging tempdir is on the include search path (the same PR that adds
+# this fixture).
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MUNUNU="${MUNUNU:-${THIS_DIR}/../../../target/debug/mununu}"
+SRC="${THIS_DIR}/source"
+OUT="$(mktemp -d -t mununu-r46-sysrst-XXXXXX)"
+trap 'rm -rf "${OUT}"' EXIT
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu binary not found at ${MUNUNU}" >&2
+  echo "             build it first with: cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in yosys sv2v; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "validate.sh: required tool '${tool}' not on PATH" >&2
+    exit 2
+  fi
+done
+
+export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
+
+echo "=== R46-6 — sysrst_ctrl detect K=5 per-cluster × concretization (real OpenTitan RTL) ==="
+echo "fixture: ${SRC}/sysrst_ctrl_detect.sv (vendored, pinned) × 5 via a hand-written harness"
+echo
+
+cd "${SRC}"
+
+echo "--- (1) no sidecar: raw 172-bit design must be rejected at the cap ---"
+sed 's#sidecar = "sysrst_harness.mununu.json"##' verify.toml > "${OUT}/nosidecar.toml"
+if "${MUNUNU}" verify --base-dir "${SRC}" "${OUT}/nosidecar.toml" > "${OUT}/nosidecar.out" 2>&1; then
+  echo "FAIL: raw design verified instead of hitting the cap" >&2; exit 1
+fi
+grep -qiE "state bits|max supported|StateSpaceOverflow|2\^20" "${OUT}/nosidecar.out" || {
+  echo "FAIL: no-sidecar run did not report a cap overflow" >&2
+  tail -5 "${OUT}/nosidecar.out" >&2; exit 1; }
+echo "ok: raw RTL rejected — param-concretization is load-bearing"
+echo
+
+echo "--- (2) sidecar + single property: concretized joint still busts (per-cluster needed) ---"
+sed -n '1,/\[\[properties\]\]/p' verify.toml > "${OUT}/single.toml"
+cat >> "${OUT}/single.toml" <<'EOF'
+name = "reach_det0"
+formula = "mu X. (det0_o || (<> X))"
+over = "Circuit"
+EOF
+if "${MUNUNU}" verify --base-dir "${SRC}" "${OUT}/single.toml" > "${OUT}/single.out" 2>&1; then
+  echo "FAIL: single-property concretized design verified instead of busting" >&2; exit 1
+fi
+grep -qiE "state bits|max supported|StateSpaceOverflow|2\^20" "${OUT}/single.out" || {
+  echo "FAIL: single-property run did not report a cap overflow" >&2
+  tail -5 "${OUT}/single.out" >&2; exit 1; }
+echo "ok: concretized joint still busts with one cone — per-cluster slicing is load-bearing too"
+echo
+
+echo "--- (3) sidecar + five disjoint properties: per-cluster × concretization compose ---"
+"${MUNUNU}" verify --json verify.toml > "${OUT}/verify.json" 2>"${OUT}/verify.err" || {
+  echo "FAIL: mununu verify exited non-zero" >&2
+  tail -15 "${OUT}/verify.err" >&2; exit 1; }
+
+python3 - "${OUT}/verify.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+
+routing = None
+for s in r.get("sources", []):
+    routing = (s.get("partition_summary") or {}).get("cluster_routing")
+    if routing:
+        break
+assert routing, "FAIL: no cluster_routing — per-cluster verification did not fire"
+clusters = sorted(set(routing.values()))
+assert len(clusters) >= 5, f"FAIL: expected >=5 cluster automata, got {clusters}"
+print(f"per-cluster: routed {len(routing)} properties to {len(clusters)} clusters {clusters}")
+
+verds = {v["name"]: v for v in r.get("property_verdicts", [])}
+assert verds, "FAIL: no property verdicts"
+overs = set()
+for name in ("reach_det0", "reach_det1", "reach_det2", "reach_det3", "reach_det4"):
+    v = verds.get(name)
+    assert v, f"FAIL: missing verdict {name}"
+    assert v["satisfied"], f"FAIL: {name} not SATISFIED"
+    assert v["total_states"] >= 16, \
+        f"FAIL: {name} cluster has only {v['total_states']} states — timer was sliced away, not concretized"
+    assert v["over"].startswith("Circuit__cl"), \
+        f"FAIL: {name} not routed to a cluster automaton (over={v['over']})"
+    overs.add(v["over"])
+    print(f"verdict {name}: SAT {v['satisfying_states']}/{v['total_states']} over {v['over']}")
+assert len(overs) >= 5, f"FAIL: properties did not route to 5 distinct clusters: {overs}"
+print("R46-6 K=5 done-criteria met: real OpenTitan sysrst_ctrl detect blocks — "
+      "raw RTL rejected, concretized joint still busts, per-cluster × "
+      "param-concretization compose to fit all five detectors, all SATISFIED "
+      "over distinct clusters on non-degenerate (concretized) cones.")
+PY
+
+echo
+echo "=== R46-6 (sysrst_ctrl detect K=5) VALIDATION PASSED ==="


### PR DESCRIPTION
## Summary

The **K=5 industrial scale-up** of the pattgen (K=2) fixture (#96) — the headline `sysrst_ctrl` clustering case the R.4.6 plan named — plus the verify-path `include`-resolution fix it depends on. Completes the R46-6 GAP-2 arc (per-cluster slicing × param-concretization, now proven synthetic + real-RTL at K=2 and K=5).

## Fixture: `examples/verify/r46_sysrst_detect_k5/`

Five OpenTitan `sysrst_ctrl_detect` instances (vendored + pinned at `558921c`, Apache-2.0 — the parameterized debounce/detect block with a **32-bit timer** `cnt_q` + 2-bit FSM) wrapped by a hand-written K=5 harness with narrow free trigger/enable + small constant timer thresholds (five distinct EventTypes: level/edge/sticky, mirroring the real top's detector mix). Bypasses the TileLink-UL register file (irrelevant to the per-cluster mechanism).

`validate.sh` — two load-bearing negatives + the composed case:
1. **no sidecar → rejected at 172 raw state bits** (5 × 32-bit timers + flops) — concretization needed.
2. **sidecar + one property → rejected at 27 bits** — concretized joint still > 20, one cone gives one cluster, so per-cluster can't split it: per-cluster slicing needed *on top of* concretization.
3. **sidecar + five disjoint properties → per-cluster fires** — slices each detector to its own cluster; all five reach props **SATISFIED** (32/33 level, 64/65 edge — non-degenerate concretized cones) over distinct automata `Circuit__cl0..cl4`.

Each timer escapes its concretized set at the threshold → an OOB sink, so the fixture also guards #94 at K=5 on real RTL. Verdict shape = the R46-5 mechanism fixture; this is a K=5 mechanism demonstration, not an RTL bug finding (README is explicit).

## Code fix: sv2v staging-tempdir on the include search path

`sysrst_ctrl_detect` does `` `include "prim_assert.sv" ``. On the verify / multi-file path, additional sources are staged into a per-call tempdir but `primary_source_path` is never set, so `translate_sv`'s sv2v `-I` list was empty and the include failed (`Could not find file`) — sv2v doesn't search the including file's own directory by default. **Fix:** prepend the staging tempdir to the sv2v include path so any `include` of a staged additional source resolves. The `context eval` single-file path (primary_source_path → parent) is preserved as a second search dir.

Regression test `sv2v_include_resolves_staged_additional_source_header` (guarded on yosys+sv2v availability, like the sibling multi-file test). Full `mununu-core` suite green via the commit hook.

## Provenance / claims integrity

- `sysrst_ctrl_detect` + `sysrst_ctrl_pkg` vendored verbatim, pinned; detector logic unmodified. `prim_assert.sv` is the M.2 empty-SVA-macro stub.
- The harness gives each detector a narrow free trigger/enable + small constant timers — a verification interface, not a behaviour change.
- Verdict is model-level reachability over the concretized abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)