### PR TITLE
feat(sidecar C1.1): `mununu sv discover` — skeleton sidecar with real dotted state-cell names

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -877,6 +877,29 @@ enum SvCommand {
     /// is on all surfaces. The API/UI validation peer lands with the C2.2
     /// sidecar-editor panel where it has a consumer.
     Validate(SvValidateArgs),
+    /// Discover a design's state cells and emit a skeleton sidecar
+    /// (sidecar-audit C1.1 / finding E1).
+    ///
+    /// Drives sv2v → Yosys-flatten → BTOR2 and prints a `.mununu.json`
+    /// skeleton pre-populated with the design's real post-`flatten`
+    /// dotted-instance state-cell names (`u_chan0.prediv_q`) — the names
+    /// the bit-blaster and a param-concretization sidecar key on. Removes
+    /// the manual "run yosys by hand, read the netlist, transcribe the
+    /// names" step the R46-6 GAP-2 fixtures required.
+    ///
+    /// Unlike a verify/extract run, discovery does NOT bit-blast, so it
+    /// succeeds on cap-busting designs — exactly when you need the names to
+    /// write a concretization sidecar. Multi-bit cells are emitted as
+    /// `ignored` placeholders with a width note (edit to concretize:
+    /// `bounded_counter` / `enum` / keep `ignored`); 1-bit cells are
+    /// omitted (the bit-blaster handles them natively). The skeleton JSON
+    /// goes to stdout (or --output); a human summary goes to stderr.
+    ///
+    /// surface: CLI-only — a developer authoring aid for the file-based
+    /// `.mununu.json` workflow, alongside `sv preprocess` /
+    /// `sv emit-btor2-per-module`. The API/UI authoring peer lands with the
+    /// C2.2 sidecar-editor panel.
+    Discover(SvDiscoverArgs),
 }
 
 #[derive(Args, Debug)]
@@ -888,6 +911,28 @@ struct SvValidateArgs {
     /// exit non-zero if any are found. Default: warnings print but exit 0.
     #[arg(long)]
     strict: bool,
+}
+
+#[derive(Args, Debug)]
+struct SvDiscoverArgs {
+    /// SystemVerilog source file(s). The FIRST is the primary/top source;
+    /// the rest are additional sources / `\`include` targets (e.g. a
+    /// package or a `prim_assert.sv` stub), staged so includes resolve —
+    /// the same convention as a `verify.toml` `files` list.
+    #[arg(value_name = "FILE", num_args = 1..)]
+    files: Vec<PathBuf>,
+    /// Top module name. Recommended for multi-module designs so Yosys
+    /// flattens from the right root.
+    #[arg(long)]
+    top: Option<String>,
+    /// Run sv2v before Yosys. Required for modern SV (module-header
+    /// `import pkg::*;`, structs, interfaces) — i.e. essentially all real
+    /// OpenTitan / Caliptra / ibex RTL.
+    #[arg(long)]
+    preprocess_sv2v: bool,
+    /// Write the skeleton sidecar here instead of stdout.
+    #[arg(long, value_name = "FILE")]
+    output: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -3051,7 +3096,107 @@ fn handle_sv(command: SvCommand) -> Result<(), String> {
         SvCommand::Preprocess(args) => sv_preprocess(args),
         SvCommand::EmitBtor2PerModule(args) => sv_emit_btor2_per_module(args),
         SvCommand::Validate(args) => sv_validate(args),
+        SvCommand::Discover(args) => sv_discover(args),
     }
+}
+
+/// Build the skeleton `SvAnnotation` from discovered state cells (the pure,
+/// testable core of `sv discover`). Multi-bit cells become `ignored`
+/// placeholders carrying a width note (the author edits them to
+/// `bounded_counter` / `enum`); 1-bit cells are omitted — the bit-blaster
+/// handles them natively, so listing them is noise.
+fn build_discover_skeleton(
+    module: &str,
+    cells: &[mununu_core::adapter::yosys::SvStateCell],
+) -> mununu_core::adapter::systemverilog::annotation::SvAnnotation {
+    use mununu_core::adapter::systemverilog::annotation::{
+        SV_ANNOTATION_SCHEMA, SignalAbstraction, SignalAnnotation, SvAnnotation,
+    };
+    let signals = cells
+        .iter()
+        .filter(|c| c.width > 1)
+        .map(|c| SignalAnnotation {
+            name: c.name.clone(),
+            abstraction: SignalAbstraction::Ignored,
+            note: Some(format!(
+                "width={} — TODO concretize: bounded_counter (bound=K) | enum | keep ignored",
+                c.width
+            )),
+            ..Default::default()
+        })
+        .collect();
+    SvAnnotation {
+        schema: Some(SV_ANNOTATION_SCHEMA.to_string()),
+        module: module.to_string(),
+        signals,
+        ..Default::default()
+    }
+}
+
+/// `mununu sv discover <FILE..>` — sidecar-audit C1.1 / finding E1.
+fn sv_discover(args: SvDiscoverArgs) -> Result<(), String> {
+    use std::fs;
+
+    let (primary, rest) = args
+        .files
+        .split_first()
+        .ok_or("sv discover: at least one .sv file is required")?;
+    let content = fs::read_to_string(primary)
+        .map_err(|e| format!("failed to read '{}': {e}", primary.display()))?;
+    let mut additional_sources: Vec<(String, String)> = Vec::new();
+    for src in rest {
+        let name = src
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| format!("invalid additional source path: {}", src.display()))?;
+        let body = fs::read_to_string(src)
+            .map_err(|e| format!("failed to read '{}': {e}", src.display()))?;
+        additional_sources.push((name.to_string(), body));
+    }
+
+    let yopts = mununu_core::adapter::yosys::YosysOptions {
+        top: args.top.clone(),
+        additional_sources,
+        primary_source_path: Some(primary.display().to_string()),
+        use_sv2v: args.preprocess_sv2v,
+        ..Default::default()
+    };
+
+    let cells = mununu_core::adapter::yosys::sv_discover_state_cells(&content, &yopts)
+        .map_err(|e| format!("sv discover: {e}"))?;
+
+    let module = args.top.clone().unwrap_or_else(|| "TOP_MODULE".to_string());
+    let skeleton = build_discover_skeleton(&module, &cells);
+    let json = serde_json::to_string_pretty(&skeleton)
+        .map_err(|e| format!("sv discover: failed to serialize skeleton: {e}"))?;
+
+    // Human summary → stderr; clean skeleton JSON → stdout (or --output).
+    let total_bits: u32 = cells.iter().map(|c| c.width).sum();
+    let multi_bit = cells.iter().filter(|c| c.width > 1).count();
+    eprintln!(
+        "sv discover: {} state cell(s), {} state bit(s); {} multi-bit cell(s) in the skeleton, \
+         {} 1-bit cell(s) omitted (handled natively).",
+        cells.len(),
+        total_bits,
+        multi_bit,
+        cells.len() - multi_bit,
+    );
+    if total_bits > 20 {
+        eprintln!(
+            "sv discover: raw state width {total_bits} exceeds MAX_STATE_BITS=20 — \
+             concretize the multi-bit cells above (e.g. bounded_counter) to fit the bit-blaster."
+        );
+    }
+
+    match &args.output {
+        Some(path) => {
+            fs::write(path, format!("{json}\n"))
+                .map_err(|e| format!("failed to write '{}': {e}", path.display()))?;
+            eprintln!("sv discover: wrote skeleton sidecar to {}", path.display());
+        }
+        None => println!("{json}"),
+    }
+    Ok(())
 }
 
 /// `mununu sv validate <SIDECAR>` — sidecar-audit C0.2.
@@ -5032,5 +5177,59 @@ mod sv_validate_tests {
         });
         let _ = std::fs::remove_file(&p);
         assert!(r.is_err(), "a removed `$schema` must hard-fail");
+    }
+}
+
+#[cfg(test)]
+mod sv_discover_tests {
+    //! C1.1 `mununu sv discover` skeleton-building core (the SV→BTOR2 +
+    //! state-cell extraction is integration-tested in
+    //! `adapter::yosys::tests`; this covers the pure skeleton shape).
+    use super::build_discover_skeleton;
+    use mununu_core::adapter::systemverilog::annotation::SignalAbstraction;
+    use mununu_core::adapter::yosys::SvStateCell;
+
+    #[test]
+    fn skeleton_keeps_multi_bit_cells_and_omits_one_bit() {
+        let cells = vec![
+            SvStateCell {
+                name: "u0.cnt".into(),
+                width: 32,
+            },
+            SvStateCell {
+                name: "u0.flag".into(),
+                width: 1,
+            },
+            SvStateCell {
+                name: "u0.state".into(),
+                width: 2,
+            },
+        ];
+        let sk = build_discover_skeleton("top", &cells);
+        assert_eq!(sk.module, "top");
+        assert_eq!(sk.schema.as_deref(), Some("mununu_sv_annotation_v1"));
+        // Only the two multi-bit cells; the 1-bit `flag` is omitted.
+        assert_eq!(sk.signals.len(), 2, "got {:?}", sk.signals);
+        assert!(!sk.signals.iter().any(|s| s.name == "u0.flag"));
+        let cnt = sk
+            .signals
+            .iter()
+            .find(|s| s.name == "u0.cnt")
+            .expect("cnt in skeleton");
+        assert!(matches!(cnt.abstraction, SignalAbstraction::Ignored));
+        assert!(cnt.note.as_deref().unwrap_or_default().contains("width=32"));
+    }
+
+    #[test]
+    fn skeleton_for_all_one_bit_design_has_no_signals() {
+        let cells = vec![SvStateCell {
+            name: "st".into(),
+            width: 1,
+        }];
+        let sk = build_discover_skeleton("fsm", &cells);
+        assert!(
+            sk.signals.is_empty(),
+            "a pure 1-bit design needs no abstraction entries"
+        );
     }
 }

--- a/crates/mununu-core/src/adapter/systemverilog/annotation.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/annotation.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 /// Top-level annotation loaded from `<module>.mununu.json`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SvAnnotation {
     /// Schema version identifier.
     #[serde(rename = "$schema", default, skip_serializing_if = "Option::is_none")]
@@ -490,7 +490,7 @@ pub struct ResetSequence {
 }
 
 /// Annotation for a register or internal signal.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SignalAnnotation {
     /// Signal name (must match an SV declaration).
     pub name: String,

--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -174,11 +174,26 @@ impl FormatAdapter for YosysAdapter {
 
 /// Translate SystemVerilog source to AdapterOutput by invoking Yosys and
 /// reading back the BTOR2.
-pub fn translate_sv(
+/// The flattened-design artifacts produced by [`run_sv_flatten_btor2`]:
+/// the BTOR2 text, the pre-flatten hierarchy JSON (empty when Yosys did
+/// not emit it), and the staged primary-source path (for rewriting
+/// tempdir paths back to the user's invocation path).
+struct SvFlattenArtifacts {
+    btor2: String,
+    hier_json: String,
+    staged_primary: String,
+}
+
+/// Run sv2v (optional) + the flattened Yosys script and return the
+/// design's BTOR2 text plus the hierarchy snapshot. Shared by
+/// [`translate_sv`] (which bit-blasts the BTOR2) and
+/// [`sv_discover_state_cells`] (which only reads the BTOR2's named state
+/// cells), so the sv2v include-path + Yosys-invocation logic lives in one
+/// place.
+fn run_sv_flatten_btor2(
     content: &str,
-    options: &AdapterOptions,
     yopts: &YosysOptions,
-) -> Result<AdapterOutput, AdapterError> {
+) -> Result<SvFlattenArtifacts, AdapterError> {
     let yosys = locate_yosys()?;
     if !yopts.skip_verific_check {
         verify_no_verific(&yosys)?;
@@ -277,7 +292,7 @@ pub fn translate_sv(
         });
     }
 
-    let btor = std::fs::read_to_string(&btor_path).map_err(|e| AdapterError {
+    let btor2 = std::fs::read_to_string(&btor_path).map_err(|e| AdapterError {
         kind: AdapterErrorKind::ParseError,
         message: format!(
             "adapter/yosys: yosys ran but did not produce {} ({e})",
@@ -285,6 +300,77 @@ pub fn translate_sv(
         ),
         location: None,
     })?;
+
+    // Best-effort hierarchy snapshot (port directions + blackbox scan);
+    // empty when Yosys did not emit it.
+    let hier_json = std::fs::read_to_string(&hier_json_path).unwrap_or_default();
+
+    Ok(SvFlattenArtifacts {
+        btor2,
+        hier_json,
+        staged_primary: primary.to_string_lossy().into_owned(),
+    })
+}
+
+/// A named state cell discovered in a flattened SV design — the
+/// post-`flatten` dotted-instance name (`u_chan0.prediv_q`) the
+/// bit-blaster sees, plus its register width. Surfaced by
+/// [`sv_discover_state_cells`] so authors can populate a sidecar's
+/// `signals[]` without a manual Yosys netlist dump (sidecar-audit C1.1 /
+/// finding E1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SvStateCell {
+    /// The cell's Yosys symbol (e.g. `u_chan0.prediv_q`).
+    pub name: String,
+    /// The register's bit width.
+    pub width: u32,
+}
+
+/// Drive sv2v → Yosys-flatten → BTOR2 and return the design's named state
+/// cells (sidecar-audit C1.1 / finding E1). Unlike [`translate_sv`], this
+/// does NOT bit-blast, so it succeeds on cap-busting designs — exactly the
+/// case where the author needs the dotted state-cell names to write a
+/// param-concretization sidecar. Cells without a Yosys symbol (synthetic
+/// `chformal`-lowered flops) are skipped. Sorted by name; deduped.
+pub fn sv_discover_state_cells(
+    content: &str,
+    yopts: &YosysOptions,
+) -> Result<Vec<SvStateCell>, AdapterError> {
+    use super::btor2::ast::Node;
+    let artifacts = run_sv_flatten_btor2(content, yopts)?;
+    let file = super::btor2::parser::parse(&artifacts.btor2).map_err(|e| AdapterError {
+        kind: AdapterErrorKind::ParseError,
+        message: format!("adapter/yosys: discover could not parse the BTOR2: {e}"),
+        location: None,
+    })?;
+    let symbols = super::btor2::parser::collect_symbols(&file);
+    let mut cells: Vec<SvStateCell> = file
+        .lines
+        .iter()
+        .filter_map(|line| match &line.node {
+            Node::State { sort, .. } => {
+                let name = symbols.get(&line.nid)?.clone();
+                let width = super::btor2::parser::bv_width(&file, *sort)?;
+                Some(SvStateCell { name, width })
+            }
+            _ => None,
+        })
+        .collect();
+    cells.sort_by(|a, b| a.name.cmp(&b.name));
+    cells.dedup();
+    Ok(cells)
+}
+
+pub fn translate_sv(
+    content: &str,
+    options: &AdapterOptions,
+    yopts: &YosysOptions,
+) -> Result<AdapterOutput, AdapterError> {
+    let SvFlattenArtifacts {
+        btor2: btor,
+        hier_json,
+        staged_primary,
+    } = run_sv_flatten_btor2(content, yopts)?;
 
     // Document B task B1: capture the top module's port directions
     // from the pre-flatten hierarchy snapshot, feed them through the
@@ -294,10 +380,11 @@ pub fn translate_sv(
     let top_directions: std::collections::HashMap<
         String,
         crate::controllability::BoundaryDirection,
-    > = std::fs::read_to_string(&hier_json_path)
-        .ok()
-        .map(|body| parse_top_module_port_directions(&body, yopts.top.as_deref()))
-        .unwrap_or_default();
+    > = if hier_json.is_empty() {
+        Default::default()
+    } else {
+        parse_top_module_port_directions(&hier_json, yopts.top.as_deref())
+    };
 
     let btor_options = if top_directions.is_empty() {
         options.clone()
@@ -327,17 +414,16 @@ pub fn translate_sv(
     // each. The hierarchy file is best-effort — if yosys did not
     // produce it, we proceed without sidecars rather than failing the
     // whole translation.
-    if let Ok(hier_body) = std::fs::read_to_string(&hier_json_path) {
-        let mut blackboxes = parse_blackbox_modules(&hier_body);
+    if !hier_json.is_empty() {
+        let mut blackboxes = parse_blackbox_modules(&hier_json);
         // Rewrite the tempdir path back to the user's primary source
         // path when known. Yosys saw the SV as `<tempdir>/work.sv`;
         // the user expects to see the path they actually invoked
         // mununu on.
         if let Some(real_path) = yopts.primary_source_path.as_ref() {
-            let tempdir_prefix = primary.to_string_lossy().into_owned();
             for bb in blackboxes.iter_mut() {
                 if let Some(ref src) = bb.source_file
-                    && src == &tempdir_prefix
+                    && src == &staged_primary
                 {
                     bb.source_file = Some(real_path.clone());
                 }
@@ -2429,6 +2515,43 @@ endmodule
             out.source_info.state_count >= 1,
             "got state_count = {}",
             out.source_info.state_count
+        );
+    }
+
+    #[test]
+    fn sv_discover_state_cells_reports_named_registers_and_widths() {
+        // C1.1 (finding E1): discovery returns the design's named state
+        // cells + widths WITHOUT bit-blasting, so it works even when the
+        // raw design would bust MAX_STATE_BITS. Plain Verilog → no sv2v
+        // needed (only Yosys).
+        if !yosys_available() {
+            eprintln!("skipping: yosys not on PATH");
+            return;
+        }
+        let dut = r#"
+module dut(input wire clk, input wire rst_ni, input wire en, output wire [7:0] o);
+  reg [7:0] wide;
+  reg flag;
+  always @(posedge clk or negedge rst_ni)
+    if (!rst_ni) begin wide <= 8'd0; flag <= 1'b0; end
+    else begin if (en) wide <= wide + 8'd1; flag <= en; end
+  assign o = wide;
+endmodule
+"#;
+        let yopts = YosysOptions {
+            top: Some("dut".into()),
+            use_sv2v: false,
+            ..Default::default()
+        };
+        let cells = sv_discover_state_cells(dut, &yopts).expect("discover state cells");
+        let wide = cells
+            .iter()
+            .find(|c| c.name == "wide")
+            .expect("the 8-bit `wide` register is discovered by name");
+        assert_eq!(wide.width, 8, "wide register width");
+        assert!(
+            cells.iter().any(|c| c.name == "flag" && c.width == 1),
+            "the 1-bit `flag` register is discovered too; got {cells:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Sidecar-audit **Phase 1**, the top ergonomics win (finding **E1**). Authoring a param-concretization sidecar previously meant running yosys by hand, reading the flattened netlist, and transcribing each post-`flatten` dotted-instance name (`u_chan0.prediv_q`) — the exact pain the R46-6 GAP-2 fixtures imposed (5 hand-written `u_detN.cnt_q`, 14 hand-written `u_chanN.*_q`). This does it in one command.

```
mununu sv discover --preprocess-sv2v --top sysrst_harness \
  sysrst_ctrl_pkg.sv sysrst_ctrl_detect.sv prim_assert.sv sysrst_harness.sv
```
→ a `.mununu.json` skeleton pre-populated with the design's real named state cells (`u_det0.cnt_q` width=32, `u_det0.state_q` width=2, …) + a stderr summary + a cap-overrun hint.

Crucially it does **NOT** bit-blast, so it succeeds on cap-busting designs — exactly when the names are needed to write a concretization sidecar. Multi-bit cells become `ignored` placeholders with a `width=N` note (edit to `bounded_counter` / `enum` / keep `ignored`); 1-bit cells are omitted (handled natively). Skeleton JSON → stdout (or `--output`). The emitted skeleton round-trips clean through `sv validate`.

## Implementation

- `adapter::yosys::sv_discover_state_cells(content, yopts) -> Vec<SvStateCell>` (new pub) — runs the flatten pipeline and reads named state cells via `parser::collect_symbols` + per-line width. New pub `SvStateCell { name, width }`.
- Factored the sv2v + Yosys-run + BTOR2-read prelude out of `translate_sv` into a shared `run_sv_flatten_btor2` helper (avoids the **D3** duplication the audit flags). `translate_sv` behaviour is unchanged — **full mununu-core suite (incl. the SV integration tests) green**.
- `#[derive(Default)]` on `SvAnnotation` + `SignalAnnotation` so skeletons construct via `..Default::default()` (also eases the **D1** construction-site fragility).
- CLI `SvCommand::Discover` (CLI-only, declared inline) + the pure, unit-tested `build_discover_skeleton`.

## Tests

Guarded integration test for `sv_discover_state_cells` (named registers + widths, no bit-blast) + 2 skeleton unit tests (multi-bit kept / 1-bit omitted; all-1-bit → empty). Workspace check + doctests green (touched `SvAnnotation`, so the full pre-push gate was run).

## Surface

**CLI-only** — a file-workflow authoring aid alongside `sv preprocess` / `sv emit-btor2-per-module`; the API/UI peer lands with the C2.2 sidecar-editor panel.

Remaining Phase 1: C1.2 (advisory `bounded_counter` bound from reachable values) + C1.3 (unmatched-dotted-name warning in the resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)