### PR TITLE
feat(sidecar C1.3): warn on unmatched sidecar signal names + surface on verify

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -442,6 +442,13 @@ pub fn to_ir(
 > {
     let mut warnings = Vec::new();
 
+    // C1.3 (sidecar Phase 1) — warn for sidecar `signals[]` entries whose
+    // name (or `drives` override) matches no state cell. Runs HERE, against
+    // the original full `file` BEFORE the cone-slice rebinding below, so a
+    // name that resolves in the whole circuit but is later sliced out of a
+    // per-cluster cone does NOT warn — only genuine non-matches do.
+    warn_unmatched_sidecar_signals(file, options, &mut warnings);
+
     // R46-1/R46-2 (R.4.6) — cone restriction by SLICING. When the caller
     // (or the per-cluster fallback) requests a cone restriction, replace
     // the design with the exact sub-circuit its property atoms depend on:
@@ -1301,6 +1308,62 @@ fn enrich_symbols_with_sidecar_drives(
         }
     }
     out
+}
+
+/// C1.3 (sidecar Phase 1) — warn for each sidecar `signals[]` entry
+/// whose resolved target (the `drives` override, falling back to
+/// `name`) matches no state cell in the BTOR2.
+///
+/// Such an entry is a silent no-op today:
+/// [`enrich_symbols_with_sidecar_drives`],
+/// [`sidecar_state_value_counts`], and the `sidecar_effective_state_bits`
+/// accounting all skip names that [`parser::resolve_state_by_symbol`]
+/// cannot resolve. So a mistyped dotted name — the common error when
+/// hand-editing a `mununu sv discover` skeleton — declares an
+/// abstraction that never takes effect, and the lift proceeds as if the
+/// entry were absent. The warning names the offending entry and points
+/// the user back at `mununu sv discover` for the real post-flatten cell
+/// names.
+///
+/// Absent / unparseable sidecar JSON is skipped silently here — the
+/// load-time lint ([`crate::adapter::systemverilog::annotation::lint_annotation_json`])
+/// owns malformed-sidecar diagnostics; this pass only catches
+/// well-formed entries that point at nothing.
+fn warn_unmatched_sidecar_signals(
+    file: &Btor2File,
+    options: &AdapterOptions,
+    warnings: &mut Vec<AdapterWarning>,
+) {
+    let Some(json) = &options.sidecar_json else {
+        return;
+    };
+    let Ok(ann) =
+        serde_json::from_str::<crate::adapter::systemverilog::annotation::SvAnnotation>(json)
+    else {
+        return;
+    };
+    for sig in &ann.signals {
+        let target = sig.drives.as_deref().unwrap_or(sig.name.as_str());
+        if parser::resolve_state_by_symbol(file, target).is_some() {
+            continue;
+        }
+        let drives_note = if sig.drives.is_some() {
+            format!(" (drives = \"{target}\")")
+        } else {
+            String::new()
+        };
+        warnings.push(AdapterWarning {
+            kind: WarningKind::UnsupportedConstruct,
+            message: format!(
+                "sidecar signal \"{}\"{} matched no state cell in the BTOR2 — its declared \
+                 abstraction has no effect. Check the name against the design; \
+                 `mununu sv discover` prints the real post-flatten cell names (dotted per \
+                 instance, e.g. `u_inst.reg_q`).",
+                sig.name, drives_note
+            ),
+            location: None,
+        });
+    }
 }
 
 /// §Phase 10 §10.2 stage 1 — metadata for one memory state cell
@@ -6161,6 +6224,90 @@ mod tests {
         assert!(
             !ctxdsl.contains("drop_1"),
             "drop should be pinned to 0; ctxdsl was:\n{ctxdsl}"
+        );
+    }
+
+    #[test]
+    fn c1_3_unmatched_sidecar_signal_name_warns() {
+        // C1.3 — a sidecar `signals[]` entry whose name matches no
+        // state cell is a silent no-op today. The warning catches the
+        // mistyped-dotted-name case (the common error when editing a
+        // `mununu sv discover` skeleton).
+        let src = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n";
+        let file = parser::parse(src).expect("parse");
+        let sidecar = serde_json::json!({
+            "$schema": "mununu_sv_annotation_v1",
+            "module": "demo",
+            "signals": [
+                { "name": "nonexistent_reg", "abstraction": "ignored" },
+            ],
+        })
+        .to_string();
+        let opts = AdapterOptions {
+            sidecar_json: Some(sidecar),
+            ..Default::default()
+        };
+        let (_ir, warnings, _summary) = to_ir(&file, &opts).expect("translate");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.message.contains("nonexistent_reg")
+                    && w.message.contains("matched no state cell")),
+            "expected an unmatched-sidecar-signal warning; got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn c1_3_matched_sidecar_signal_name_does_not_warn() {
+        // The mirror: a name that DOES resolve to a state cell must not
+        // trip the unmatched-name warning.
+        let src = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n";
+        let file = parser::parse(src).expect("parse");
+        let sidecar = serde_json::json!({
+            "$schema": "mununu_sv_annotation_v1",
+            "module": "demo",
+            "signals": [
+                { "name": "q", "abstraction": "boolean" },
+            ],
+        })
+        .to_string();
+        let opts = AdapterOptions {
+            sidecar_json: Some(sidecar),
+            ..Default::default()
+        };
+        let (_ir, warnings, _summary) = to_ir(&file, &opts).expect("translate");
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| w.message.contains("matched no state cell")),
+            "matched signal must not warn; got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn c1_3_unmatched_sidecar_signal_via_drives_warns() {
+        // When `drives` is the resolution target, the warning names both
+        // the sidecar entry and the unresolved `drives` value.
+        let src = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n";
+        let file = parser::parse(src).expect("parse");
+        let sidecar = serde_json::json!({
+            "$schema": "mununu_sv_annotation_v1",
+            "module": "demo",
+            "signals": [
+                { "name": "alias", "drives": "ghost", "abstraction": "ignored" },
+            ],
+        })
+        .to_string();
+        let opts = AdapterOptions {
+            sidecar_json: Some(sidecar),
+            ..Default::default()
+        };
+        let (_ir, warnings, _summary) = to_ir(&file, &opts).expect("translate");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.message.contains("alias") && w.message.contains("drives = \"ghost\"")),
+            "expected drives-note in warning; got {warnings:?}"
         );
     }
 

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -959,7 +959,20 @@ fn dispatch_sv_yosys(
         ..Default::default()
     };
     crate::adapter::yosys::translate_sv(content, &opts, &yopts)
-        .map(|out| (out.ctxdsl, out.partition_summary))
+        .map(|out| {
+            // C1.3 — surface the bit-blaster's AdapterWarnings on the
+            // verify path, at the same `tracing::warn!` visibility as the
+            // C0.1 sidecar lint above (the CLI defaults to the "info"
+            // EnvFilter, so WARN is shown without RUST_LOG). Without this
+            // the warnings (an unmatched sidecar signal name — the C1.3
+            // typo guard — plus large-state-space / havoc / per-cluster
+            // notes) are dropped here, never reaching a `mununu verify`
+            // user editing a `sv discover` skeleton.
+            for w in &out.warnings {
+                tracing::warn!(source_id, "{}", w.message);
+            }
+            (out.ctxdsl, out.partition_summary)
+        })
         .map_err(|err| VerifyError::AdapterTranslationFailed {
             source_id: source_id.to_string(),
             adapter: "sv-yosys".to_string(),


### PR DESCRIPTION
## C1.3 — unmatched-dotted-name warning (sidecar Phase 1)

Closes the last small refinement of sidecar Phase 1 (after C1.1 `mununu sv discover` #100). A sidecar `signals[]` entry whose name (or `drives` override) resolves to **no** BTOR2 state cell is silently dropped today — `enrich_symbols_with_sidecar_drives`, `sidecar_state_value_counts`, and `sidecar_effective_state_bits` all skip names that `resolve_state_by_symbol` can't match. So a **mistyped dotted name** — the common error when hand-editing a `sv discover` skeleton — declares an abstraction that never takes effect, and the lift proceeds as if the entry were absent.

### What this does

**Commit 1 — the warning (`bit_blast.rs`).** New `warn_unmatched_sidecar_signals`, called from `to_ir` against the **full** design *before* the cone-slice rebinding — so a name that resolves in the whole circuit but is later sliced out of a per-cluster cone does **not** warn; only genuine non-matches do. Rides the existing `AdapterWarning` channel (informational, no verdict impact) and points the user back at `mununu sv discover` for the real post-flatten cell names.

**Commit 2 — surface it on the verify path (`orchestrator.rs`).** The single-module `sv-yosys` dispatch was mapping `translate_sv`'s output to `(ctxdsl, partition_summary)`, dropping `out.warnings` — so neither C1.3 nor the pre-existing large-state-space / havoc / per-cluster notes reached a `mununu verify` user. Forwarded via `tracing::warn!(source_id, …)`, the same visibility as the C0.1 sidecar lint a few lines up (the CLI defaults to the `info` EnvFilter, so WARN shows without `RUST_LOG`).

Together this completes C1.3 end-to-end: discover emits the names → the bit-blaster flags typos → verify reports them.

### Design notes

- **Placement.** `to_ir` (top-level, runs once on the full design) rather than `enumerate_and_blast` (which also runs per-cluster on *sliced* sub-designs, where a legitimately out-of-cone signal would falsely warn).
- **`WarningKind::UnsupportedConstruct`** reused (a declared abstraction that could not be applied) — no new enum variant, no API/UI blast radius.
- **Multi-module** composition surfacing is a noted follow-up (its return shape carries no warning channel today); single-module is the path the discover skeleton targets.

### Tests

3 new unit tests in `bit_blast.rs`: unmatched name warns; matched name does not; an unmatched `drives` target names the drives value. Full `mununu-core` lib suite green (1840 tests); both commit hooks ran the full workspace test + doctest + clippy + fmt gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)