### PR TITLE
feat(ir-track DR0): STS-IR abstraction seam + design note

### DIFF
--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -51,6 +51,7 @@ pub mod partition;
 pub mod promela;
 pub mod sidecar;
 pub mod state_enum;
+pub mod sts_ir;
 pub mod systemverilog;
 pub mod templates;
 pub mod tlsf;

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -1,0 +1,265 @@
+//! Symbolic Transition System IR — the frontend-agnostic abstraction seam.
+//!
+//! > Status: planning / DR0 stub (IR-unification track). Design:
+//! > `docs/design/sts-ir.md`. This module defines the *interface* the two
+//! > abstraction engines need from a symbolic transition system, plus one
+//! > implementation ([`BtorSts`]) that wraps a parsed BTOR2 file by
+//! > delegating to existing, already-shipped functions. **No existing
+//! > call site is rewired by DR0** — `bit_blast` and `predicate_cube_lift`
+//! > still talk to BTOR2 directly; this seam exists to prove the
+//! > abstraction is expressible without leaking BTOR2/Z3 types, and to be
+//! > the consumption point that P1 reroutes the engines onto.
+//!
+//! The seam is two traits over a shared metadata trait:
+//!
+//! - [`StepEval`] — concrete one-step semantics. The *explicit /
+//!   Enumerate* edge-strategy (today's `bit_blast`) needs only this.
+//! - [`SmtEncode`] — SMT predicate-image. The *predicate-cube / SmtImage*
+//!   edge-strategy (today's `predicate_cube_lift`) needs this.
+//!
+//! Neither trait surface names a BTOR2 or Z3 type: state/input structure
+//! is [`StsVar`] (name + width); the concrete step is name-keyed
+//! `HashMap<String, u128>`; the SMT predicate-image is expressed over
+//! [`PredicateSpec`] (a frontend-agnostic `{name, register, value}`) and
+//! returns plain cube-index pairs. A future non-RTL frontend that can
+//! emit these two semantics inherits both abstraction policies + the
+//! KMTS evaluator + CEGAR with no new abstraction code (the P4/P5 goal).
+
+use std::collections::HashMap;
+
+use crate::adapter::AdapterError;
+use crate::adapter::btor2::ast::{Btor2File, Node};
+use crate::adapter::btor2::kmts_lift::PredicateSpec;
+use crate::adapter::btor2::{bit_blast, parser};
+
+/// A typed state or input variable of a symbolic transition system.
+/// Frontend-agnostic: just a name and a bit width.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StsVar {
+    /// The variable's symbol (e.g. a register name `u_chan0.prediv_q`).
+    pub name: String,
+    /// Bit width.
+    pub width: u32,
+}
+
+/// Structure of a symbolic transition system — the metadata both
+/// abstraction engines need before they can lift.
+pub trait SymbolicTransitionSystem {
+    /// State variables (registers / latches), sorted by name.
+    fn state_vars(&self) -> Vec<StsVar>;
+    /// Free input variables, sorted by name.
+    fn input_vars(&self) -> Vec<StsVar>;
+}
+
+/// Concrete one-step semantics: given a full assignment of state vars +
+/// inputs, compute the next state assignment. This is everything the
+/// *explicit / Enumerate* edge-strategy (today's `bit_blast`) needs to
+/// build a Sharp CLTS.
+pub trait StepEval: SymbolicTransitionSystem {
+    /// Step the design one clock: `(state, inputs) ↦ next_state`. Both
+    /// maps are keyed by [`StsVar::name`]; absent keys default to 0
+    /// (the `setundef -zero` convention).
+    fn step(
+        &self,
+        state: &HashMap<String, u128>,
+        inputs: &HashMap<String, u128>,
+    ) -> Result<HashMap<String, u128>, AdapterError>;
+}
+
+/// SMT predicate-image: the *predicate-cube / SmtImage* edge-strategy
+/// (today's `predicate_cube_lift`). Batched per the Z3-scope-reuse
+/// consideration in `docs/design/sts-ir.md` §"Z3 scope".
+pub trait SmtEncode: SymbolicTransitionSystem {
+    /// Sound over-approximating may-relation over predicate cubes.
+    ///
+    /// Cubes are indexed `0..2^|predicates|`; bit `i` of a cube index is
+    /// the polarity of `predicates[i]` (identical encoding to
+    /// `predicate_cube_lift`). Returns every `(src, tgt)` pair for which
+    /// a concrete witness `∃ s ⊨ src, s' ⊨ tgt. (s, s') ∈ R` exists — a
+    /// pair is **excluded only when the SMT backend proves it
+    /// impossible**, so the relation is a sound over-approximation
+    /// (timeouts / unresolved predicates conservatively keep the edge).
+    ///
+    /// The must-relation (`∀∀` / `∀∃` / hyper-must) follows the same
+    /// shape over the same encoding (`smt_must_edge::smt_per_target_must_*`);
+    /// DR0 ships only the may-relation to prove the seam.
+    fn may_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)>;
+}
+
+/// The BTOR2 implementation of the STS-IR seam — a thin borrow over a
+/// parsed [`Btor2File`]. Every method delegates to an already-shipped
+/// function, so DR0 changes no behaviour and rewires no call site.
+pub struct BtorSts<'a> {
+    file: &'a Btor2File,
+}
+
+impl<'a> BtorSts<'a> {
+    /// Wrap a parsed BTOR2 file as a symbolic transition system.
+    pub fn new(file: &'a Btor2File) -> Self {
+        Self { file }
+    }
+
+    fn vars_of(&self, want_state: bool) -> Vec<StsVar> {
+        let symbols = parser::collect_symbols(self.file);
+        let mut out: Vec<StsVar> = self
+            .file
+            .lines
+            .iter()
+            .filter_map(|line| {
+                let (sort, is_state) = match &line.node {
+                    Node::State { sort, .. } => (*sort, true),
+                    Node::Input { sort, .. } => (*sort, false),
+                    _ => return None,
+                };
+                if is_state != want_state {
+                    return None;
+                }
+                let name = symbols.get(&line.nid)?.clone();
+                let width = parser::bv_width(self.file, sort)?;
+                Some(StsVar { name, width })
+            })
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        out.dedup();
+        out
+    }
+}
+
+impl SymbolicTransitionSystem for BtorSts<'_> {
+    fn state_vars(&self) -> Vec<StsVar> {
+        self.vars_of(true)
+    }
+
+    fn input_vars(&self) -> Vec<StsVar> {
+        self.vars_of(false)
+    }
+}
+
+impl StepEval for BtorSts<'_> {
+    fn step(
+        &self,
+        state: &HashMap<String, u128>,
+        inputs: &HashMap<String, u128>,
+    ) -> Result<HashMap<String, u128>, AdapterError> {
+        // Delegate to the shipped concrete-step evaluator unchanged.
+        bit_blast::simulate_one_step(self.file, state, inputs)
+    }
+}
+
+impl SmtEncode for BtorSts<'_> {
+    fn may_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)> {
+        use crate::adapter::btor2::smt_must_edge::{
+            SmtMayVerdict, build_register_nid_map, smt_per_target_may_check,
+        };
+        use crate::adapter::sidecar::predicate_image::btor2_encode::encode_design;
+
+        if predicates.is_empty() {
+            return Vec::new();
+        }
+        // DR0 uses the BvOnly `encode_design`; P1 swaps in the
+        // memory-aware `encode_design_for_lift` (array theory) — see
+        // `docs/design/sts-ir.md` §"Z3 scope".
+        let n_cubes = 1usize << predicates.len();
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = match encode_design(self.file) {
+                Ok(v) => v,
+                // Encoder can't build the view (e.g. an unsupported op):
+                // no may-edges rather than an unsound guess. Mirrors the
+                // predicate_cube_lift fallback.
+                Err(_) => return Vec::new(),
+            };
+            let nid_map = build_register_nid_map(&view);
+            let mut edges = Vec::new();
+            for i in 0..n_cubes {
+                for j in 0..n_cubes {
+                    if matches!(
+                        smt_per_target_may_check(
+                            &view, i as u64, j as u64, predicates, &nid_map, timeout_ms,
+                        ),
+                        SmtMayVerdict::May
+                    ) {
+                        edges.push((i, j));
+                    }
+                }
+            }
+            edges
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A 1-bit register `q` with `q' = en`, plus an input `en`. Exercises
+    // both the state/input metadata and the concrete-step delegation.
+    const STEP_BTOR2: &str =
+        "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 input 1 en\n6 next 1 3 5\n";
+
+    #[test]
+    fn btor_sts_reports_state_and_input_vars() {
+        let file = parser::parse(STEP_BTOR2).expect("parse");
+        let sts = BtorSts::new(&file);
+        assert_eq!(
+            sts.state_vars(),
+            vec![StsVar {
+                name: "q".into(),
+                width: 1
+            }]
+        );
+        assert_eq!(
+            sts.input_vars(),
+            vec![StsVar {
+                name: "en".into(),
+                width: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn btor_sts_step_delegates_to_simulate_one_step() {
+        let file = parser::parse(STEP_BTOR2).expect("parse");
+        let sts = BtorSts::new(&file);
+        // q' = en: with en=1, q goes 0 → 1.
+        let next = sts
+            .step(
+                &HashMap::from([("q".to_string(), 0u128)]),
+                &HashMap::from([("en".to_string(), 1u128)]),
+            )
+            .expect("step");
+        assert_eq!(next.get("q"), Some(&1u128));
+        // en=0 keeps q at 0.
+        let next0 = sts
+            .step(
+                &HashMap::from([("q".to_string(), 1u128)]),
+                &HashMap::from([("en".to_string(), 0u128)]),
+            )
+            .expect("step");
+        assert_eq!(next0.get("q"), Some(&0u128));
+    }
+
+    #[test]
+    fn btor_sts_may_edges_match_predicate_image() {
+        // Toggle: `q' = !q`. Predicate `q == 1` → cube_0 = {q=0},
+        // cube_1 = {q=1}. The transition relation forces 0→1 and 1→0, so
+        // the sound may-relation is exactly {(0,1),(1,0)} — never the
+        // self-loops (0,0)/(1,1).
+        let toggle =
+            "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 not 1 3\n6 next 1 3 5\n";
+        let file = parser::parse(toggle).expect("parse");
+        let sts = BtorSts::new(&file);
+        let preds = vec![PredicateSpec {
+            name: "q_is_1".into(),
+            register: "q".into(),
+            value: 1,
+        }];
+        let edges = sts.may_edges(&preds, 5_000);
+        assert!(edges.contains(&(0, 1)), "0→1 must be a may-edge: {edges:?}");
+        assert!(edges.contains(&(1, 0)), "1→0 must be a may-edge: {edges:?}");
+        assert!(
+            !edges.contains(&(0, 0)) && !edges.contains(&(1, 1)),
+            "self-loops are provably impossible: {edges:?}"
+        );
+    }
+}

--- a/docs/design/sts-ir.md
+++ b/docs/design/sts-ir.md
@@ -1,0 +1,132 @@
+# STS-IR — the frontend-agnostic abstraction seam
+
+> Status: planning (DR0, IR-unification track). Concept + interface design; the stub lives at
+> [`crates/mununu-core/src/adapter/sts_ir.rs`](../../crates/mununu-core/src/adapter/sts_ir.rs).
+> Roadmap context: `.claude/plans/ir-unification-track-plan.md` (P0→P5) and
+> `.claude/plans/state-abstraction-merge-assessment.md`.
+
+## 1. Why
+
+Today mununu has two abstraction/lift engines that both consume BTOR2 but share no interface:
+
+- **`bit_blast`** — explicit register-cross-product enumeration → Sharp `Clts`
+  (`crates/mununu-core/src/adapter/btor2/bit_blast.rs`).
+- **`predicate_cube_lift`** — predicate-cube → 3-valued may/must KMTS
+  (`crates/mununu-core/src/adapter/btor2/kmts_lift.rs:1427`), reachable today only via
+  `btor2 cegar` / `/btor2/cegar`.
+
+`predicate_cube_lift` `parser::parse`s BTOR2 *internally*, so nothing but BTOR2 can feed it. The
+STS-IR is the **narrow waist** that decouples the abstraction engines from the BTOR2 frontend:
+
+```
+frontend ──lower──▶ STS-IR ──┬─ Enumerate strategy ─▶ Sharp CLTS ─┐
+ (BTOR2 ~1:1;                 └─ SmtImage strategy ──▶ KMTS        ─┴▶ one Clts ─▶ eval_node<D: TruthDomain>
+  C/Promela lower under P5)
+```
+
+A frontend that can present the two semantics below inherits *both* abstraction policies + the
+KMTS evaluator + CEGAR with no new abstraction code. BTOR2 maps to the IR ~1:1 (it already *is* a
+symbolic transition system); value-rich non-RTL frontends (Promela, a C subset) *lower to* it
+(P4/P5). Discrete frontends keep their direct-CLTS path and never touch this seam.
+
+## 2. The interface (two semantics over shared metadata)
+
+Defined in [`adapter/sts_ir.rs`](../../crates/mununu-core/src/adapter/sts_ir.rs):
+
+```rust
+pub struct StsVar { pub name: String, pub width: u32 }
+
+pub trait SymbolicTransitionSystem {
+    fn state_vars(&self) -> Vec<StsVar>;
+    fn input_vars(&self) -> Vec<StsVar>;
+}
+
+// Concrete one-step semantics — the Enumerate (explicit) strategy needs only this.
+pub trait StepEval: SymbolicTransitionSystem {
+    fn step(&self, state: &HashMap<String,u128>, inputs: &HashMap<String,u128>)
+        -> Result<HashMap<String,u128>, AdapterError>;
+}
+
+// SMT predicate-image — the SmtImage (predicate-cube) strategy needs this.
+pub trait SmtEncode: SymbolicTransitionSystem {
+    fn may_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize,usize)>;
+    // must-relation (∀∀ / ∀∃ / hyper) follows the same shape — see §5.
+}
+```
+
+### No BTOR2 / Z3 leakage — the load-bearing property
+
+The whole seam is expressible without naming a BTOR2 or Z3 type:
+
+- structure is `StsVar` (name + width);
+- the concrete step is name-keyed `HashMap<String,u128>` in and out;
+- the SMT predicate-image is expressed over `PredicateSpec` (`{name, register, value}`, where
+  `register` is a *symbol name*, not a NID) and returns plain `(usize, usize)` cube-index pairs.
+
+`Btor2File`, `Btor2SmtView`, `Nid`, and the `z3::*` types stay entirely behind `BtorSts`. This is
+the DR0 gate: if the seam could not be stated without leaking BTOR2, the IR would be a fiction.
+
+## 3. The BTOR2 implementation (`BtorSts`) — pure delegation
+
+`BtorSts<'a>(&'a Btor2File)` implements all three traits by delegating to already-shipped, public
+functions — **DR0 changes no behaviour and rewires no call site**:
+
+| Trait method | Delegates to |
+|---|---|
+| `state_vars` / `input_vars` | `parser::collect_symbols` + `parser::bv_width` over `Node::State`/`Node::Input` |
+| `StepEval::step` | `bit_blast::simulate_one_step` (name-keyed, unchanged) |
+| `SmtEncode::may_edges` | `with_z3_config` → `btor2_encode::encode_design` → `smt_must_edge::build_register_nid_map` → `smt_per_target_may_check` (the exact batched pattern at `kmts_lift.rs:1634`) |
+
+## 4. How each engine consumes the seam (the consumption sketch)
+
+- **`bit_blast` → `StepEval` (Enumerate strategy).** Explicit enumeration is "for each reachable
+  state assignment, for each input combination, `step()` to the next assignment, add a Sharp
+  edge." That is exactly `StepEval::step` in a loop bounded by `state_vars()` widths. `bit_blast`
+  becomes the *Enumerate edge-strategy* over any `StepEval`, not a BTOR2-specific engine.
+- **`predicate_cube_lift` → `SmtEncode` (SmtImage strategy).** The `MayEdgeInference::SmtAllPairs`
+  block at `kmts_lift.rs:1634` *is* `SmtEncode::may_edges`. Behind the trait it becomes
+  `for (i,j) in sts.may_edges(&predicates, t) { builder.transition(..MayOnly..) }` — the lift no
+  longer parses BTOR2 or touches Z3; it consumes an `&dyn SmtEncode`.
+
+Both consumption paths produce the *same* `Clts` (a Sharp CLTS is a degenerate KMTS), fed to the
+one evaluator family (`BoolDomain` cheap path / `KleeneDomain` sound-abstraction path).
+
+## 5. Z3 scope & batching (why `may_edges` is batched, not per-pair)
+
+Z3 calls must run inside a `z3::with_z3_config` scope, and the efficient pattern builds the
+`encode_design` view **once** and reuses it across all cube-pair queries (the `kmts_lift.rs:1634`
+loop). So the trait exposes a **batched** `may_edges(predicates) -> Vec<(src,tgt)>` rather than a
+per-pair `may_edge(src,tgt)` — the impl owns the scope and the view lifetime, and the caller never
+sees Z3. The must-relation methods (P1) take the same batched shape over
+`smt_must_edge::smt_per_target_must_check{,_standard}` / `smt_hyper_must_check`.
+
+DR0's `may_edges` uses the BvOnly `encode_design`; **P1 swaps in the memory-aware
+`encode_design_for_lift`** (array theory for `$mem` cells) — a one-line change behind the trait,
+invisible to callers.
+
+## 6. What DR0 ships vs what the P-phases do
+
+- **DR0 (this):** the traits + `BtorSts` (delegating) + tests proving `step` and `may_edges` work
+  through the seam, with no leakage and no call-site changes. Plus this note.
+- **P0:** promote the stub to the real seam (move the SMT/step helpers behind the trait as the
+  canonical interface); BTOR2 stays the only impl; behaviour-preserving.
+- **P1:** reroute `bit_blast` (Enumerate) and `predicate_cube_lift` (SmtImage) to consume
+  `&dyn StepEval` / `&dyn SmtEncode` instead of `Btor2File` directly; add the batched must methods.
+- **P2:** unify the evaluator over `TruthDomain` (orthogonal to the IR, same track).
+- **P3:** route `mununu verify` SV/BTOR2 through the IR + chosen strategy; migrate SV
+  `bounded_counter` sidecars to predicate sets; carry 3-valued verdicts.
+- **P4/P5:** a non-RTL frontend (Promela, then C-extraction) *lowers to* the IR and inherits the
+  abstraction stack — the flexibility proof and (P5, measurement-gated) the retirement of
+  `AbstractionType` / `FieldDomain` / `state_enum`.
+
+## 7. Open design questions for the Go/No-Go review
+
+1. **Must-relation surface.** DR0 ships `may_edges` only; confirm the three must variants
+   (`SmtPerTarget` ∀∀, `SmtPerTargetStandard` ∀∃, `SmtHyperMust`) all fit the same batched shape
+   without a richer return than `Vec<(usize,usize)>` (hyper-must needs target *sets*).
+2. **Enumerate strategy via `StepEval` only.** Confirm `bit_blast`'s sidecar-driven field
+   clamping (Ignored / width bounds / OOB sink) is expressible as a policy *over* `StepEval`
+   rather than needing more of BTOR2 — or whether the IR must also carry an init/constraint
+   accessor. (DR0 omits `init`/constraints; P1 decides if they're needed at the seam.)
+3. **Lowering cost.** P4 will measure the real cost of lowering Promela to `StepEval` +
+   `SmtEncode`; that number gates whether P5 (global `AbstractionType` retirement) is worth it.


### PR DESCRIPTION
## DR0 — de-risk gate for the IR-unification track

First de-risk step for the IR-unification track (assessment + plan in `.claude/plans/`, design note in this PR). **Goal:** prove the predicate-cube/KMTS abstraction is expressible behind a *frontend-agnostic* seam that does **not** leak BTOR2/Z3 types, and that both lift engines can consume it — before any P-phase refactor.

### What's here

**`crates/mununu-core/src/adapter/sts_ir.rs`** — the seam:
- `SymbolicTransitionSystem` — `state_vars()` / `input_vars()` as `StsVar { name, width }`.
- `StepEval::step` — name-keyed concrete one-step (`HashMap<String,u128>` in/out); the *Enumerate* edge-strategy `bit_blast` needs only this.
- `SmtEncode::may_edges` — sound over-approximating may-relation over predicate cubes; the *SmtImage* edge-strategy `predicate_cube_lift` needs this.

**`BtorSts<'a>(&Btor2File)`** implements all three by **delegating to already-shipped public functions** (`collect_symbols`/`bv_width`, `simulate_one_step`, and the batched `with_z3_config → encode_design → build_register_nid_map → smt_per_target_may_check` pattern from `kmts_lift.rs:1634`). **No existing call site is rewired; no behaviour changes** — this is the consumption point P1 will reroute the engines onto.

### The DR0 gate (met)

- **No BTOR2/Z3 leakage:** the trait surface names only `StsVar`, `HashMap<String,u128>`, `PredicateSpec`, and `(usize,usize)`. `Btor2File` / `Btor2SmtView` / `Nid` / `z3::*` stay behind `BtorSts`.
- **Both engines' consumption shown:** `StepEval` (bit_blast/Enumerate) + `SmtEncode` (predicate_cube_lift/SmtImage).
- **3 tests green:** state/input metadata; `step` delegation; a toggle design (`q' = !q`) whose may-relation is exactly `{(0,1),(1,0)}` with self-loops proven impossible — exercising the full Z3 delegation path.

**`docs/design/sts-ir.md`** — the seam, the no-leakage argument, the Z3-scope batching rationale, the per-engine consumption sketch, and the DR0→P0→P5 phasing. Status: planning.

### Not in scope (by design)

DR0 ships `may_edges` only (the must-relation follows the same batched shape — §5/§7 of the note) and uses the BvOnly `encode_design` (P1 swaps in the memory-aware `encode_design_for_lift`). No engine is rerouted (that's P1). Open design questions for the Go/No-Go review are listed in the note §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)