### PR TITLE
feat(ir-track DR1): expose sound may-edge mode via `btor2 cegar --may-edge-inference`

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -153,6 +153,25 @@ enum PredicateSourceArg {
     Craig,
 }
 
+/// DR1 (IR-unification track, 2026-06-19) — may-edge inference
+/// selector for `mununu btor2 cegar`. Mirrors
+/// [`mununu_core::adapter::btor2::kmts_lift::MayEdgeInference`].
+#[derive(Clone, Debug, Copy, clap::ValueEnum, Default)]
+enum MayEdgeInferenceArg {
+    /// Sampling-based may-edges (default). Fast, but an
+    /// under-approximation of the may relation — sampling can MISS a
+    /// real may-edge, which is unsound for safety. Preserves the
+    /// pre-DR1 CEGAR behaviour.
+    #[default]
+    Off,
+    /// Sound all-pairs SMT may-edges: for every (src, tgt) cube pair Z3
+    /// decides whether a concrete witness exists; an edge is excluded
+    /// only when proven impossible (a sound over-approximation). O(cubes²)
+    /// SMT calls — tractable at small cube counts. Combining with a
+    /// non-`off` `--must-edge-inference` is not yet wired.
+    SmtAllPairs,
+}
+
 /// R.2.5b session-1 follow-up (2026-06-06) — must-edge inference
 /// selector for `mununu btor2 cegar`. Mirrors the values of
 /// [`mununu_core::adapter::btor2::kmts_lift::MustEdgeInference`].
@@ -230,6 +249,14 @@ struct Btor2CegarArgs {
     /// post-pass fires.
     #[arg(long, value_enum, default_value_t = MustEdgeInferenceArg::Off)]
     must_edge_inference: MustEdgeInferenceArg,
+    /// DR1 (IR-unification track, 2026-06-19) — may-edge inference
+    /// policy for the per-iteration `predicate_cube_lift`. Defaults to
+    /// `off` (sampling may-edges; fast but an under-approximation of the
+    /// may relation, unsound for safety). Set to `smt-all-pairs` for the
+    /// sound all-pairs SMT may relation (an edge is excluded only when
+    /// Z3 proves it impossible).
+    #[arg(long, value_enum, default_value_t = MayEdgeInferenceArg::Off)]
+    may_edge_inference: MayEdgeInferenceArg,
     /// R-S8 session 2 (2026-06-08) — under-constrained constant's
     /// admissible value set. Format: `REGISTER=v1,v2,v3`. May be
     /// repeated. Bridges to the R-Y7 symbolic-init path by
@@ -1875,6 +1902,14 @@ fn btor2_cegar(args: Btor2CegarArgs) -> Result<(), String> {
         }
     };
 
+    // DR1 (2026-06-19) — map CLI MayEdgeInferenceArg to the core enum.
+    let may_edge_inference = match args.may_edge_inference {
+        MayEdgeInferenceArg::Off => mununu_core::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+        MayEdgeInferenceArg::SmtAllPairs => {
+            mununu_core::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs
+        }
+    };
+
     let cegar_opts = CegarOptions {
         max_iterations: args.max_iterations,
         predicate_source,
@@ -1884,6 +1919,7 @@ fn btor2_cegar(args: Btor2CegarArgs) -> Result<(), String> {
         smart_uf_cap: true,
         lift_strategy: LiftStrategy::Eager,
         must_edge_inference,
+        may_edge_inference,
     };
 
     // R-S8 session 2 (2026-06-08) — parse the `--config-values`

--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -233,6 +233,18 @@ pub struct CegarOptions {
     /// R.2.5b session 2 (SMT-backed must-edge query via Z3 array
     /// theory) replaces the sampling pass with a sound proof.
     pub must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference,
+    /// DR1 (IR-unification track, 2026-06-19) — may-edge inference
+    /// policy forwarded to each iteration's `predicate_cube_lift`.
+    /// `Off` (default) keeps the sampling may-edges (fast, but an
+    /// under-approximation of the may relation — unsound for safety);
+    /// `SmtAllPairs` uses the sound all-pairs SMT may relation
+    /// (over-approximation; an edge is excluded only when Z3 proves it
+    /// impossible). Surfacing this through `CegarOptions` is the DR1
+    /// enablement that lets the CEGAR path run with a sound may
+    /// relation (the P1/P3 prerequisite). Note: combining `SmtAllPairs`
+    /// with a non-`Off` `must_edge_inference` is not yet wired — see
+    /// [`crate::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs`].
+    pub may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference,
 }
 
 /// R.5 lazy KMTS sub-item 2.4 (2026-06-04) — selector for the
@@ -300,6 +312,7 @@ impl Default for CegarOptions {
             smart_uf_cap: true,
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         }
     }
 }
@@ -561,10 +574,11 @@ pub fn cegar_refine_loop(
         // edges + a [R.2.5b-sampling-must] AdapterWarning that
         // propagates through the CegarTrace to the verdict surface.
         must_edge_inference: cegar_opts.must_edge_inference,
-        // MIG-3.2 (2026-06-13) — may-edge policy. CEGAR keeps the
-        // sampling default; the sound all-pairs SMT may-edge path is
-        // opt-in at the lift layer (not yet surfaced to CegarOptions).
-        may_edge_inference: Default::default(),
+        // MIG-3.2 (2026-06-13) — may-edge policy. DR1 (2026-06-19)
+        // surfaces this through `CegarOptions::may_edge_inference`:
+        // `Off` (default) keeps the sampling may-edges; `SmtAllPairs`
+        // selects the sound all-pairs SMT may relation.
+        may_edge_inference: cegar_opts.may_edge_inference,
         // R-Y7 (2026-06-07) + R-S8 session 2 (2026-06-08) —
         // symbolic-init via predicate cubes. Read the
         // `signals[].config_values` map from the sidecar JSON
@@ -1380,6 +1394,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -1399,6 +1414,60 @@ mod tests {
         }
         assert!(trace.lazy_lift_pending);
         assert!(!trace.approximant_reuse_enabled);
+    }
+
+    #[test]
+    fn cegar_honors_smt_all_pairs_may_edge_inference() {
+        // DR1 (IR-unification track) — CegarOptions::may_edge_inference =
+        // SmtAllPairs threads through to predicate_cube_lift's sound
+        // all-pairs may relation. On a toggle (q' = !q) with predicate
+        // {q == 0}, EF(q==0) = `mu X. (p0 | <step> X)`: the q==0 cube is
+        // KleeneT (already idle); the q≠0 cube is KleeneBot — the
+        // diamond `<step>` needs a must-witness to be KleeneT, and
+        // must-edge inference is Off, so the SOUND verdict is "indefinite,
+        // refine", NOT a (spurious) definite false. This pins the sound
+        // outcome through the CEGAR surface, distinct from any sampling
+        // under-approximation that could drop the q≠0 → q==0 may-edge.
+        const TOGGLE: &str =
+            "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 not 1 3\n6 next 1 3 5\n";
+        let formula = parser::parse("mu X. (p0 | <step> X)").expect("formula parses");
+        let initial = vec![PredicateSpec {
+            name: "p0".into(),
+            register: "q".into(),
+            value: 0,
+        }];
+        let env = Environment::new(2);
+        let cegar_opts = CegarOptions {
+            max_iterations: 3,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs,
+            ..Default::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            TOGGLE,
+            initial,
+            &env,
+            &AdapterOptions::default(),
+            &cegar_opts,
+        )
+        .expect("cegar succeeds under SmtAllPairs");
+        // Count the verdict cells: exactly one KleeneT (q==0) and one
+        // KleeneBot (q≠0); no spurious definite-false.
+        let mut t = 0;
+        let mut f = 0;
+        let mut bot = 0;
+        for s in 0..trace.final_verdict.len() {
+            match trace.final_verdict.verdict_at(s) {
+                Trit::True => t += 1,
+                Trit::False => f += 1,
+                Trit::Unknown => bot += 1,
+            }
+        }
+        assert_eq!(
+            (t, f, bot),
+            (1, 0, 1),
+            "SmtAllPairs EF(q==0) should be sound (T + ⊥, no spurious F); got T={t} F={f} ⊥={bot}"
+        );
     }
 
     #[test]
@@ -1440,6 +1509,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -1498,6 +1568,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -1898,6 +1969,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace_off = cegar_refine_loop(
             &formula,
@@ -1928,6 +2000,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace_on = cegar_refine_loop(
             &formula,
@@ -2022,6 +2095,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace_off = cegar_refine_loop(
             &formula,
@@ -2043,6 +2117,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace_on = cegar_refine_loop(
             &formula,
@@ -2245,6 +2320,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let env_iter0 = Environment::new(2);
         let result_off = cegar_refine_loop(
@@ -2269,6 +2345,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let result_on = cegar_refine_loop(
             &formula,
@@ -2342,6 +2419,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2391,6 +2469,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2527,6 +2606,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2570,6 +2650,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2653,6 +2734,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2738,6 +2820,7 @@ mod tests {
             smart_uf_cap: false,
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2801,6 +2884,7 @@ mod tests {
             smart_uf_cap: false,
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2865,6 +2949,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let debug_str = format!("{opts:?}");
         assert!(
@@ -2917,6 +3002,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace_result = cegar_refine_loop(
             &formula,
@@ -2971,6 +3057,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -3021,6 +3108,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -3083,6 +3171,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
         };
         let trace_eager = cegar_refine_loop(
             &formula,

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -654,6 +654,9 @@ pub async fn btor2_cegar_handler(
         smart_uf_cap: true,
         lift_strategy: LiftStrategy::Eager,
         must_edge_inference,
+        // DR1 (2026-06-19) — API keeps the sampling may-edges (default);
+        // the sound `SmtAllPairs` path is opt-in via the CLI for now.
+        may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
     };
 
     let adapter_options = AdapterOptions {


### PR DESCRIPTION
## DR1 — de-risk gate #2 for the IR-unification track

DR1 ran the predicate-cube/KMTS path against the M.1 OpenTitan `uart_tx` counter (`bit_cnt_q` = `bounded_counter{11}`) to test whether state abstraction can replace `bounded_counter` *soundly*. **Verdict: GO**, with a concrete P1 punch-list. Full findings: `.claude/plans/measurements/DR1-uart-poc-2026-06-19.md`.

### What DR1 found

- **F0 — the footgun is real.** The M.1 `bounded_counter` verdict is *already* under-approximating (`45824 transitions dropped … unsound for safety`).
- **F1 ✅ — the premise holds.** The explicit/`bit_blast` path **cannot lift uart_tx** (`21 state bits > 20` cap); the predicate-cube path ran on the same BTOR2 with no cap.
- **F2 ✅ — sound where predicates bind.** On a clean toggle, `EF(q==0)` returns `T + KleeneBot` (diamond needs a must-witness; must=Off → "indefinite, refine") — the sound answer, never a spurious definite-false.
- **F3 ⛔ (P1 #1, the blocker)** — `btor2 cegar --predicate` lacks the sidecar's `drives`/`resolve_state_by_symbol` BFS, so it can't bind to symbol-stripped registers (uart_tx `bit_cnt_q` survives only on a `uext` alias). The DR0 STS-IR `state_vars()` seam is where that resolution belongs.
- **F4 → fixed here.** The sound MIG-3.2 all-pairs SMT may relation (`SmtAllPairs`) was **unreachable from the CEGAR CLI** (default `Off` = sampling/under-approx; no flag; `cegar.rs` hard-coded `Default::default()`).
- **F5 ⛔ (P1 #3)** — a sound *definite* verdict needs may+must composition (`SmtAllPairs` may + non-`Off` must is "not yet wired").

### What this PR lands (F4)

- `CegarOptions::may_edge_inference` (default `Off` — **zero behaviour change**), threaded into each iteration's `predicate_cube_lift`.
- `mununu btor2 cegar --may-edge-inference {off,smt-all-pairs}` — exposes the sound all-pairs SMT may relation through the CEGAR surface.
- API handler keeps the sampling default.
- Regression test `cegar_honors_smt_all_pairs_may_edge_inference` — pins the sound toggle verdict (`T=1, ⊥=1`, no spurious F).

This is **P1 prerequisite #2**. The remaining P1 work (#1 predicate `drives` resolution — the blocker; #3 may+must composition; #4 O(edges) may perf) is documented in the measurement doc and the track plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)