### PR TITLE
feat(ir-track P1 #3): SmtEncode::must_edges + SmtAllPairs may+must composition

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -470,9 +470,16 @@ pub enum MayEdgeInference {
     /// per-source enumeration (O(edges), reusing `all_smt`) is the
     /// queued perf follow-up; this MVP ships the sound all-pairs form.
     ///
-    /// **Note.** Combining with a non-`Off` `must_edge_inference` is not
-    /// yet wired (the must post-passes consume the sampling pass's
-    /// `sampled_targets_per_source`, which `SmtAllPairs` bypasses).
+    /// **Composing with must (P1 #3, IR-unification track).** Combining
+    /// with a non-`Off` `must_edge_inference` now composes: the eager
+    /// `predicate_cube_lift` computes the canonical ∀∃ KMTS must-relation
+    /// via [`crate::adapter::sts_ir::SmtEncode::must_edges`] and promotes
+    /// each must-edge `MayOnly` → `Sharp` (every must-edge ⊆ the
+    /// SmtAllPairs may-edges by construction). This yields a KMTS with
+    /// both may and must edges — the prerequisite for sound DEFINITE
+    /// 3-valued verdicts (DR1 F5). The SmtAllPairs path uses the standard
+    /// ∀∃ must for any non-Off inference; the per-variant ∀∀ / hyper-must
+    /// distinctions remain on the sampling (`!SmtAllPairs`) path.
     SmtAllPairs,
 }
 
@@ -1715,6 +1722,50 @@ pub fn predicate_cube_lift(
                 state_ids[j],
                 crate::clts::TransitionModality::MayOnly,
             );
+        }
+
+        // P1 #3 (IR-unification track) — may+must composition. Closes
+        // the DR1 F5 gap: a sound DEFINITE verdict needs must-witnesses
+        // (diamonds need a must-successor), but SmtAllPairs may + a
+        // non-Off must inference previously did not compose (the must
+        // post-pass consumed the sampling pass's candidate set, which
+        // SmtAllPairs bypasses). When a non-Off must inference is
+        // requested alongside SmtAllPairs may, compute the canonical ∀∃
+        // KMTS must-relation via the same STS-IR seam and promote each
+        // must-edge MayOnly → Sharp. `R_must ⊆ R_may` by construction
+        // (∀∃ ⟹ ∃), so every promoted edge already exists as a may-edge
+        // above; the builder's edge-modality merge (Sharp dominates
+        // MayOnly to the same target) upgrades it in place.
+        //
+        // The SmtAllPairs composition uses the standard ∀∃ must for ANY
+        // non-Off inference — it is the canonical, sound KMTS must
+        // (Bruns–Godefroid CONCUR 2000) and supersedes the
+        // sampling-derived SamplingConfluence heuristic, which has no
+        // meaning without a sampling pass. The per-variant ∀∀ /
+        // hyper-must distinctions remain selectable on the sampling
+        // (`!SmtAllPairs`) path below.
+        if !matches!(lift_opts.must_edge_inference, MustEdgeInference::Off) {
+            use crate::adapter::sts_ir::{BtorSts, SmtEncode};
+            let must_edges = BtorSts::new(&file).must_edges(&predicates, 5_000);
+            let promoted = must_edges.len();
+            for (i, j) in must_edges {
+                builder.transition_ids_with_modality(
+                    state_ids[i],
+                    &[step_label],
+                    state_ids[j],
+                    crate::clts::TransitionModality::Sharp,
+                );
+            }
+            sharp_edges_promoted += promoted;
+            if promoted > 0 {
+                warnings.push(crate::adapter::AdapterWarning {
+                    kind: crate::adapter::WarningKind::ApproximateTranslation,
+                    message: format!(
+                        "[P1 #3 may+must] predicate_cube_lift: SmtAllPairs may + SMT must composition promoted {promoted} edge(s) MayOnly → Sharp via the canonical ∀∃ must-relation (Z3-proved; sound under-approximation). The resulting KMTS carries both may (over-approx) and must (under-approx) edges, enabling sound DEFINITE 3-valued verdicts."
+                    ),
+                    location: None,
+                });
+            }
         }
         predicate_image_pending = false;
     }
@@ -3013,6 +3064,69 @@ mod tests {
             err.message.contains("no_such_signal"),
             "error should name the unknown register; got: {}",
             err.message
+        );
+    }
+
+    #[test]
+    fn p1_3_smt_all_pairs_composes_with_must_promotes_sharp() {
+        // P1 #3 (IR-unification track) — SmtAllPairs may + a non-Off must
+        // inference now compose (DR1 F5). On the deterministic toggle
+        // q'=!q the canonical ∀∃ must-relation equals the may-relation, so
+        // both 0→1 and 1→0 promote MayOnly → Sharp. Baseline (must=Off)
+        // composes nothing; the composed run promotes two edges.
+        let toggle =
+            "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 not 1 3\n6 next 1 3 5\n";
+        let preds = || {
+            vec![PredicateSpec {
+                name: "q_is_1".into(),
+                register: "q".into(),
+                value: 1,
+            }]
+        };
+        let opts = |must| PredicateCubeLiftOptions {
+            max_cube_count: 1024,
+            max_input_bits: 8,
+            must_edge_inference: must,
+            may_edge_inference: MayEdgeInference::SmtAllPairs,
+            config_values: std::collections::HashMap::new(),
+        };
+
+        // Baseline: SmtAllPairs may, no must → MayOnly only, zero promotions.
+        let no_must = predicate_cube_lift(
+            preds(),
+            toggle,
+            &AdapterOptions::default(),
+            &opts(MustEdgeInference::Off),
+        )
+        .expect("lift (may only)");
+        assert_eq!(
+            no_must.sharp_edges_promoted, 0,
+            "must=Off composes no must-edges"
+        );
+
+        // Composed: SmtAllPairs may + ∀∃ must → 2 Sharp promotions.
+        let composed = predicate_cube_lift(
+            preds(),
+            toggle,
+            &AdapterOptions::default(),
+            &opts(MustEdgeInference::SmtPerTargetStandard),
+        )
+        .expect("lift (may + must)");
+        assert_eq!(
+            composed.sharp_edges_promoted, 2,
+            "both toggle edges (0→1, 1→0) must promote MayOnly → Sharp"
+        );
+        let mut sharp = 0usize;
+        for s in composed.clts.states() {
+            for t in composed.clts.outgoing(s) {
+                if matches!(t.modality(), crate::clts::TransitionModality::Sharp) {
+                    sharp += 1;
+                }
+            }
+        }
+        assert!(
+            sharp >= 2,
+            "composed CLTS must carry the promoted Sharp must-edges; got {sharp}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -102,6 +102,29 @@ pub trait SmtEncode: SymbolicTransitionSystem {
     /// shape over the same encoding (`smt_must_edge::smt_per_target_must_*`);
     /// DR0 ships only the may-relation to prove the seam.
     fn may_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)>;
+
+    /// P1 #3 (IR-unification track) — sound under-approximating
+    /// **must-relation** over predicate cubes, the canonical ∀∃ KMTS
+    /// must per Bruns–Godefroid CONCUR 2000:
+    ///
+    /// ```text
+    /// (src, tgt) ∈ R_must  ⟺  ∀ s ⊨ src. ∃ inputs, s'. (s, s') ∈ R ∧ s' ⊨ tgt
+    /// ```
+    ///
+    /// Same cube encoding as [`SmtEncode::may_edges`] (indices
+    /// `0..2^|predicates|`). A pair is **included only when the SMT
+    /// backend proves the ∀∃ obligation** (UNSAT of its negation), so the
+    /// relation is a sound under-approximation: timeouts / unresolved
+    /// predicates / encoder failure conservatively *drop* the edge (never
+    /// fabricate a must-witness). By construction `R_must ⊆ R_may` (∀∃ ⟹
+    /// ∃), so callers can promote each returned pair from `MayOnly` to
+    /// `Sharp`.
+    ///
+    /// The ∀∃ *standard* form is the default companion to `may_edges`;
+    /// the stricter ∀∀ form and the generalised hyper-must form remain
+    /// available directly via `smt_must_edge::smt_per_target_must_check`
+    /// / `smt_hyper_must_check` on the sampling-candidate path.
+    fn must_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)>;
 }
 
 /// The BTOR2 implementation of the STS-IR seam — a thin borrow over a
@@ -213,6 +236,45 @@ impl SmtEncode for BtorSts<'_> {
             edges
         })
     }
+
+    fn must_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)> {
+        use crate::adapter::btor2::kmts_lift::encode_design_for_lift;
+        use crate::adapter::btor2::smt_must_edge::{
+            SmtMustVerdict, build_register_nid_map, smt_per_target_must_check_standard,
+        };
+
+        if predicates.is_empty() {
+            return Vec::new();
+        }
+        // Mirrors `may_edges` exactly — same faithful memory-aware encode,
+        // same cube encoding, same all-pairs sweep — but runs the ∀∃
+        // standard must-check and keeps a pair only on a definite `Must`
+        // (UNSAT) verdict. NotMust / Unknown / encoder failure drop the
+        // edge (sound under-approximation: never fabricate a must-witness).
+        let n_cubes = 1usize << predicates.len();
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = match encode_design_for_lift(self.file) {
+                Ok(v) => v,
+                Err(_) => return Vec::new(),
+            };
+            let nid_map = build_register_nid_map(&view);
+            let mut edges = Vec::new();
+            for i in 0..n_cubes {
+                for j in 0..n_cubes {
+                    if matches!(
+                        smt_per_target_must_check_standard(
+                            &view, i as u64, j as u64, predicates, &nid_map, timeout_ms,
+                        ),
+                        SmtMustVerdict::Must
+                    ) {
+                        edges.push((i, j));
+                    }
+                }
+            }
+            edges
+        })
+    }
 }
 
 #[cfg(test)]
@@ -307,5 +369,35 @@ mod tests {
             !edges.contains(&(0, 0)) && !edges.contains(&(1, 1)),
             "self-loops are provably impossible: {edges:?}"
         );
+    }
+
+    #[test]
+    fn btor_sts_must_edges_match_predicate_image() {
+        // P1 #3 — same deterministic toggle `q' = !q`. The transition is
+        // a function (no inputs), so the ∀∃ must-relation coincides with
+        // the may-relation: 0→1 and 1→0 are forced, the self-loops are
+        // provably never must. Confirms the seam's must companion is sound
+        // and the cube encoding matches `may_edges`.
+        let toggle =
+            "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 not 1 3\n6 next 1 3 5\n";
+        let file = parser::parse(toggle).expect("parse");
+        let sts = BtorSts::new(&file);
+        let preds = vec![PredicateSpec {
+            name: "q_is_1".into(),
+            register: "q".into(),
+            value: 1,
+        }];
+        let must = sts.must_edges(&preds, 5_000);
+        assert!(must.contains(&(0, 1)), "0→1 must be a must-edge: {must:?}");
+        assert!(must.contains(&(1, 0)), "1→0 must be a must-edge: {must:?}");
+        assert!(
+            !must.contains(&(0, 0)) && !must.contains(&(1, 1)),
+            "self-loops are never must (the toggle never stays): {must:?}"
+        );
+        // R_must ⊆ R_may by construction.
+        let may: std::collections::HashSet<_> = sts.may_edges(&preds, 5_000).into_iter().collect();
+        for e in &must {
+            assert!(may.contains(e), "must-edge {e:?} must also be a may-edge");
+        }
     }
 }

--- a/docs/design/sts-ir.md
+++ b/docs/design/sts-ir.md
@@ -119,6 +119,15 @@ invisible to callers.
     binds to the real register across the `simulate_one_step` map, the `next_registers` readback,
     `pred_register_widths`, and the SMT `build_register_nid_map`. Direct hits are kept; aliases
     are rewritten; unresolvable names still error. This is the first call site to consume the seam.
+  - **P1 #2 (shipped):** `predicate_cube_lift`'s `SmtAllPairs` may-block consumes
+    `SmtEncode::may_edges` instead of re-inlining the encode → nid-map → all-pairs Z3 loop —
+    de-dups the two copies onto the single seam implementation.
+  - **P1 #3 (shipped):** added `SmtEncode::must_edges` (the canonical ∀∃ KMTS must-relation,
+    all-pairs, sound under-approximation, `R_must ⊆ R_may`). The eager `predicate_cube_lift`
+    composes it: `SmtAllPairs` may + a non-Off must inference now promote each must-edge
+    `MayOnly` → `Sharp`, yielding a KMTS with both relations — the prerequisite for sound DEFINITE
+    3-valued verdicts (closes DR1 F5; previously the must post-pass only consumed the sampling
+    pass's candidate set, which `SmtAllPairs` bypassed).
 - **P2:** unify the evaluator over `TruthDomain` (orthogonal to the IR, same track).
 - **P3:** route `mununu verify` SV/BTOR2 through the IR + chosen strategy; migrate SV
   `bounded_counter` sidecars to predicate sets; carry 3-valued verdicts.


### PR DESCRIPTION
## What

P1 #3 of the IR-unification track: adds the canonical must-relation to the STS-IR seam and composes it with the `SmtAllPairs` may pass in the eager predicate-cube lift.

This closes the **DR1 F5 gap**: a sound DEFINITE 3-valued verdict needs must-witnesses (diamonds need a must-successor), but `SmtAllPairs` may + a non-Off must inference previously did **not** compose — the must post-passes consumed the sampling pass's candidate set, which `SmtAllPairs` bypasses.

## How

- **New `SmtEncode::must_edges(predicates, timeout)`** (`sts_ir.rs`): the canonical ∀∃ KMTS must-relation (Bruns–Godefroid CONCUR 2000), all-pairs over the same cube encoding as `may_edges`. `BtorSts` impl mirrors `may_edges` exactly (faithful memory-aware encode, same sweep), running `smt_per_target_must_check_standard` and keeping a pair only on a definite `Must` (UNSAT) verdict. NotMust / Unknown / encoder failure drop the edge — sound under-approximation, never a fabricated must-witness. `R_must ⊆ R_may` by construction (∀∃ ⟹ ∃).
- **Composition in `predicate_cube_lift`**: when `must_edge_inference` is non-Off, the `SmtAllPairs` block computes `must_edges` via the seam and promotes each `MayOnly` → `Sharp` (each must-edge already exists as a may-edge; Sharp dominates in the downstream parity-game edge merge). Emits an `AdapterWarning` naming the promotion count. The `SmtAllPairs` path uses the standard ∀∃ must for any non-Off inference (the canonical sound KMTS must); the per-variant ∀∀ / hyper-must distinctions remain on the sampling path.
- Updates the `SmtAllPairs` doc note (no longer "not yet wired").

## Tests

- `btor_sts_must_edges_match_predicate_image` — toggle: must == may = {(0,1),(1,0)}, self-loops never must, `R_must ⊆ R_may`.
- `p1_3_smt_all_pairs_composes_with_must_promotes_sharp` — baseline (must=Off) → 0 promotions; composed (∀∃) → 2 Sharp promotions, Sharp edges present in the CLTS.

Local: clippy clean, fmt clean, `sts_ir`+`kmts_lift` suites green (64 tests); pre-commit hook (full workspace + doctests) passed; rebased onto main (#106) cleanly.

## Track status

DR0 #102 · DR1 #103 · P0 #104 · P1 #1 #105 · P1 #2 #106 · **P1 #3 (this)**. After this, both lift engines' SMT paths consume the seam (`resolve_register`, `may_edges`, `must_edges`). P1 #4 (O(edges) may perf; bit_blast→StepEval) remains — both are follow-up-shaped (one measurement-gated per §6.7, one blocked on the §6.7 Q2 StepEval-contract design question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)