### PR TITLE
feat(ir-track P1 #4 Phase 1): observability-rich StepEval (Q2 = B)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -227,6 +227,135 @@ pub fn simulate_one_step(
     Ok(out)
 }
 
+/// P1 #4 Phase 1 (IR-unification track, Q2 = B) — the observability-rich
+/// one-step primitive behind
+/// [`crate::adapter::sts_ir::StepEval::step_observe`].
+///
+/// Same concrete `(state, inputs) ↦ next_state` semantics as
+/// [`simulate_one_step`] (absent keys default to 0, the `setundef -zero`
+/// convention), but additionally reports, from the post-`evaluate_pure` /
+/// pre-`apply_next` env (the current-cycle values):
+///
+/// - `observed`: the current value of each requested signal name. A name
+///   is resolved to the NID of the *symbol-bearing node* that carries it
+///   (a combinational `Op`'s own computed value, or a state / input
+///   value) — distinct from [`parser::collect_symbols`], which attaches
+///   alias symbols onto state cells. Names that resolve to no symbol-
+///   bearing node, or whose node has no env value (e.g. an `output` line),
+///   are omitted from the map.
+/// - `admissible`: whether every BTOR2 `constraint` line holds under this
+///   `(state, inputs)` assignment. [`simulate_one_step`] returns the
+///   next-state regardless; this variant surfaces the verdict so the
+///   Enumerate strategy can drop inadmissible input combos *without*
+///   re-opening the BTOR2 design — the Q2 = B "observability-rich
+///   contract, clamping stays policy" decision.
+///
+/// Returns a [`crate::adapter::sts_ir::StepOutcome`] (`next_state` +
+/// `observed` + `admissible`). The domain-encoding / OOB-sink /
+/// state-splitting policy stays in the caller (`enumerate_and_blast`);
+/// this primitive never mentions `FieldDomain`.
+pub fn simulate_one_step_observe(
+    file: &Btor2File,
+    register_values: &std::collections::HashMap<String, u128>,
+    input_values: &std::collections::HashMap<String, u128>,
+    observe: &[String],
+) -> Result<crate::adapter::sts_ir::StepOutcome, AdapterError> {
+    // Setup mirrors `simulate_one_step` (kept separate so the hot
+    // `simulate_one_step` path carries no admissibility/observe cost).
+    let symbols = parser::collect_symbols(file);
+    let mut symbol_to_input_nid: std::collections::HashMap<String, (Nid, u32)> =
+        std::collections::HashMap::new();
+    let mut state_meta: Vec<StateMeta> = Vec::new();
+    for line in &file.lines {
+        match &line.node {
+            Node::State { sort, .. } => {
+                let width = parser::bv_width(file, *sort).unwrap_or(0);
+                let symbol = symbols
+                    .get(&line.nid)
+                    .cloned()
+                    .unwrap_or_else(|| format!("st_n{}", line.nid));
+                state_meta.push(StateMeta {
+                    nid: line.nid,
+                    width,
+                    symbol,
+                });
+            }
+            Node::Input { sort, .. } => {
+                let width = parser::bv_width(file, *sort).unwrap_or(0);
+                let symbol = symbols
+                    .get(&line.nid)
+                    .cloned()
+                    .unwrap_or_else(|| format!("in_n{}", line.nid));
+                symbol_to_input_nid.insert(symbol, (line.nid, width));
+            }
+            _ => {}
+        }
+    }
+
+    let mut env = Env::default();
+    for sm in &state_meta {
+        let bits = register_values.get(&sm.symbol).copied().unwrap_or(0);
+        env.values.insert(sm.nid, BvValue::new(bits, sm.width));
+    }
+    for (symbol, &(nid, width)) in &symbol_to_input_nid {
+        let bits = input_values.get(symbol).copied().unwrap_or(0);
+        env.values.insert(nid, BvValue::new(bits, width));
+    }
+
+    // Evaluate the combinational cone; observability + admissibility are
+    // read here (current cycle), BEFORE `apply_next` commits the updates.
+    evaluate_pure(file, &mut env, false)?;
+    let admissible = constraints_hold(file, &env)?;
+
+    let mut observed: std::collections::HashMap<String, u128> = std::collections::HashMap::new();
+    if !observe.is_empty() {
+        // name → own NID for any symbol-bearing node (Op / State / Input /
+        // Output). First occurrence wins on collision.
+        let mut name_to_nid: std::collections::HashMap<&str, Nid> =
+            std::collections::HashMap::new();
+        for line in &file.lines {
+            let sym = match &line.node {
+                Node::Op {
+                    symbol: Some(s), ..
+                }
+                | Node::State {
+                    symbol: Some(s), ..
+                }
+                | Node::Input {
+                    symbol: Some(s), ..
+                }
+                | Node::Output {
+                    symbol: Some(s), ..
+                } => Some(s.as_str()),
+                _ => None,
+            };
+            if let Some(s) = sym {
+                name_to_nid.entry(s).or_insert(line.nid);
+            }
+        }
+        for name in observe {
+            if let Some(nid) = name_to_nid.get(name.as_str())
+                && let Some(bv) = env.values.get(nid)
+            {
+                observed.insert(name.clone(), bv.bits);
+            }
+        }
+    }
+
+    apply_next(file, &mut env, &state_meta)?;
+    let mut next_state: std::collections::HashMap<String, u128> = std::collections::HashMap::new();
+    for sm in &state_meta {
+        let bits = env.values.get(&sm.nid).map(|v| v.bits).unwrap_or(0);
+        next_state.insert(sm.symbol.clone(), bits);
+    }
+
+    Ok(crate::adapter::sts_ir::StepOutcome {
+        next_state,
+        observed,
+        admissible,
+    })
+}
+
 /// R.5b lifter integration MVP — variant of [`simulate_one_step`]
 /// that substitutes a UF zero-value for each Op NID in
 /// `uf_wrapped_nids` during the per-step evaluation. Use
@@ -8030,6 +8159,49 @@ mod tests {
         assert!(
             !nids.contains(&6),
             "uf_unwrap must suppress the symbol-carrying Op (NID 6 / `small_mul`); got {nids:?}"
+        );
+    }
+
+    // P1 #4 Phase 1 (Q2 = B) — observability-rich step primitive.
+    // q' = en; g = q & en (combinational, symbol `g`); `en` is
+    // constrained to be high.
+    const STEP_OBSERVE_FIXTURE: &str =
+        "1 sort bitvec 1\n2 state 1 q\n3 input 1 en\n4 and 1 2 3 g\n5 next 1 2 3\n6 constraint 3\n";
+
+    #[test]
+    fn p1_4_simulate_one_step_observe_reports_observed_and_admissible() {
+        let file = crate::adapter::btor2::parser::parse(STEP_OBSERVE_FIXTURE).expect("parse");
+        let st = |q: u128| std::collections::HashMap::from([("q".to_string(), q)]);
+        let inp = |en: u128| std::collections::HashMap::from([("en".to_string(), en)]);
+
+        // en=1: g = q&en = 1, next q = en = 1, constraint (en) holds.
+        let out =
+            simulate_one_step_observe(&file, &st(1), &inp(1), &["g".to_string()]).expect("step");
+        assert_eq!(out.next_state.get("q"), Some(&1), "q' = en = 1");
+        assert_eq!(out.observed.get("g"), Some(&1), "g = q & en = 1");
+        assert!(out.admissible, "constraint `en` holds when en=1");
+
+        // en=0: g = 1&0 = 0, next q = 0, constraint (en) VIOLATED.
+        let out0 =
+            simulate_one_step_observe(&file, &st(1), &inp(0), &["g".to_string()]).expect("step");
+        assert_eq!(out0.next_state.get("q"), Some(&0), "q' = en = 0");
+        assert_eq!(out0.observed.get("g"), Some(&0), "g = q & en = 0");
+        assert!(!out0.admissible, "constraint `en` violated when en=0");
+
+        // next_state matches the narrow simulate_one_step (no drift).
+        let narrow = simulate_one_step(&file, &st(1), &inp(1)).expect("narrow step");
+        assert_eq!(
+            narrow, out.next_state,
+            "observe variant must match simulate_one_step's next-state"
+        );
+
+        // An unresolvable observe name is simply omitted.
+        let out_missing =
+            simulate_one_step_observe(&file, &st(1), &inp(1), &["no_such_signal".to_string()])
+                .expect("step");
+        assert!(
+            !out_missing.observed.contains_key("no_such_signal"),
+            "unresolvable observe names are omitted"
         );
     }
 

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -69,19 +69,64 @@ pub trait SymbolicTransitionSystem {
     fn resolve_register(&self, name: &str) -> Option<String>;
 }
 
+/// P1 #4 Phase 1 (IR-unification track, Q2 = B) — the structured result of
+/// an observability-rich step. Everything the *explicit / Enumerate*
+/// edge-strategy (`enumerate_and_blast`) needs from one concrete step,
+/// WITHOUT the trait knowing anything about the abstraction model
+/// (`FieldDomain` / OOB sink stay caller-side policy).
+#[derive(Debug, Clone, Default)]
+pub struct StepOutcome {
+    /// Next state assignment, keyed by [`StsVar::name`].
+    pub next_state: HashMap<String, u128>,
+    /// Current-cycle value of each requested observable signal name
+    /// (combinational signals, ports, registers). Names that resolve to
+    /// no signal are omitted — callers treat absence as "not observable
+    /// in this design".
+    pub observed: HashMap<String, u128>,
+    /// Whether every constraint of the system holds under this
+    /// `(state, inputs)` assignment. Lets the Enumerate strategy drop
+    /// inadmissible input combinations without re-opening the frontend.
+    pub admissible: bool,
+}
+
 /// Concrete one-step semantics: given a full assignment of state vars +
 /// inputs, compute the next state assignment. This is everything the
 /// *explicit / Enumerate* edge-strategy (today's `bit_blast`) needs to
 /// build a Sharp CLTS.
 pub trait StepEval: SymbolicTransitionSystem {
-    /// Step the design one clock: `(state, inputs) ↦ next_state`. Both
-    /// maps are keyed by [`StsVar::name`]; absent keys default to 0
-    /// (the `setundef -zero` convention).
+    /// P1 #4 Phase 1 (Q2 = B) — the **observability-rich** one-step
+    /// primitive. Steps the design one clock and additionally reports the
+    /// current-cycle value of each requested `observe` signal plus whether
+    /// the step's constraints held. Both `state` / `inputs` maps are keyed
+    /// by [`StsVar::name`]; absent keys default to 0 (`setundef -zero`).
+    ///
+    /// This is the contract the Enumerate strategy consumes: it supplies
+    /// the concrete next-state (for the caller's domain-encoding / OOB
+    /// policy), the property/combinational signal values (for state
+    /// splitting), and the admissibility verdict (for constraint
+    /// filtering) — all without the trait referencing the abstraction
+    /// model. A non-RTL frontend that can answer these inherits the
+    /// Enumerate strategy with mununu's abstraction policy layered on top.
+    fn step_observe(
+        &self,
+        state: &HashMap<String, u128>,
+        inputs: &HashMap<String, u128>,
+        observe: &[String],
+    ) -> Result<StepOutcome, AdapterError>;
+
+    /// The narrow `(state, inputs) ↦ next_state` step. Both maps are keyed
+    /// by [`StsVar::name`]; absent keys default to 0 (the `setundef -zero`
+    /// convention). Provided in terms of [`StepEval::step_observe`] with no
+    /// observed signals; the admissibility verdict is discarded (the
+    /// next-state is returned regardless, matching the pre-Phase-1 contract
+    /// the predicate-cube sampling path relies on).
     fn step(
         &self,
         state: &HashMap<String, u128>,
         inputs: &HashMap<String, u128>,
-    ) -> Result<HashMap<String, u128>, AdapterError>;
+    ) -> Result<HashMap<String, u128>, AdapterError> {
+        Ok(self.step_observe(state, inputs, &[])?.next_state)
+    }
 }
 
 /// SMT predicate-image: the *predicate-cube / SmtImage* edge-strategy
@@ -186,13 +231,17 @@ impl SymbolicTransitionSystem for BtorSts<'_> {
 }
 
 impl StepEval for BtorSts<'_> {
-    fn step(
+    fn step_observe(
         &self,
         state: &HashMap<String, u128>,
         inputs: &HashMap<String, u128>,
-    ) -> Result<HashMap<String, u128>, AdapterError> {
-        // Delegate to the shipped concrete-step evaluator unchanged.
-        bit_blast::simulate_one_step(self.file, state, inputs)
+        observe: &[String],
+    ) -> Result<StepOutcome, AdapterError> {
+        // Delegate to the shipped observability-rich evaluator (it returns
+        // `StepOutcome` directly). `step` (the narrow next-state-only form)
+        // is the provided default over this, so it keeps delegating to the
+        // same concrete-step logic.
+        bit_blast::simulate_one_step_observe(self.file, state, inputs, observe)
     }
 }
 
@@ -303,6 +352,52 @@ mod tests {
         assert_eq!(sts.resolve_register("cnt_d").as_deref(), Some("cnt_d"));
         // A name matching no state cell does not resolve.
         assert_eq!(sts.resolve_register("nonexistent"), None);
+    }
+
+    // P1 #4 Phase 1 (Q2 = B) — `q' = en`, combinational `g = q & en`,
+    // and `en` constrained high. Exercises the seam's observability-rich
+    // step + the provided narrow `step` default.
+    const OBSERVE_BTOR2: &str =
+        "1 sort bitvec 1\n2 state 1 q\n3 input 1 en\n4 and 1 2 3 g\n5 next 1 2 3\n6 constraint 3\n";
+
+    #[test]
+    fn btor_sts_step_observe_reports_observed_and_admissible() {
+        let file = parser::parse(OBSERVE_BTOR2).expect("parse");
+        let sts = BtorSts::new(&file);
+        let st = HashMap::from([("q".to_string(), 1u128)]);
+
+        // en=1 → g=1, q'=1, admissible.
+        let out = sts
+            .step_observe(
+                &st,
+                &HashMap::from([("en".to_string(), 1u128)]),
+                &["g".to_string()],
+            )
+            .expect("step_observe");
+        assert_eq!(out.next_state.get("q"), Some(&1));
+        assert_eq!(out.observed.get("g"), Some(&1));
+        assert!(out.admissible);
+
+        // en=0 → g=0, q'=0, NOT admissible (constraint violated).
+        let out0 = sts
+            .step_observe(
+                &st,
+                &HashMap::from([("en".to_string(), 0u128)]),
+                &["g".to_string()],
+            )
+            .expect("step_observe");
+        assert_eq!(out0.observed.get("g"), Some(&0));
+        assert!(!out0.admissible);
+
+        // The provided narrow `step` default returns just the next-state,
+        // identical to step_observe's, discarding observability/admissibility.
+        let next = sts
+            .step(&st, &HashMap::from([("en".to_string(), 1u128)]))
+            .expect("step");
+        assert_eq!(
+            next, out.next_state,
+            "provided `step` matches step_observe's next-state"
+        );
     }
 
     #[test]

--- a/docs/design/sts-ir.md
+++ b/docs/design/sts-ir.md
@@ -128,6 +128,16 @@ invisible to callers.
     `MayOnly` → `Sharp`, yielding a KMTS with both relations — the prerequisite for sound DEFINITE
     3-valued verdicts (closes DR1 F5; previously the must post-pass only consumed the sampling
     pass's candidate set, which `SmtAllPairs` bypassed).
+  - **P1 #4 Phase 1 (shipped):** widened `StepEval` for the `bit_blast` (Enumerate) reroute, per
+    the **Q2 = B** decision (observability-rich contract, clamping stays policy). Added
+    `StepOutcome { next_state, observed, admissible }` + `StepEval::step_observe(state, inputs,
+    observe)`; `step` is now a provided default over it (next-state only, discards
+    observability/admissibility — the pre-Phase-1 contract). `BtorSts::step_observe` delegates to
+    the new `bit_blast::simulate_one_step_observe`, which reports the requested combinational
+    signals' current-cycle values + whether the BTOR2 `constraint` lines hold. The trait never
+    mentions `FieldDomain` — domain-encoding / OOB-sink / state-splitting stay caller-side policy.
+    Phase 2 (reroute `enumerate_and_blast`'s Pass 1 onto `step_observe`, fixture-sweep
+    equivalence-gated) and Phase 3 (a non-RTL frontend inherits Enumerate) are the follow-ups.
 - **P2:** unify the evaluator over `TruthDomain` (orthogonal to the IR, same track).
 - **P3:** route `mununu verify` SV/BTOR2 through the IR + chosen strategy; migrate SV
   `bounded_counter` sidecars to predicate sets; carry 3-valued verdicts.


### PR DESCRIPTION
## What

Phase 1 of the `bit_blast` (Enumerate) → `StepEval` reroute, unblocked by the **Q2 = B** decision (observability-rich contract, clamping stays caller-side policy). Lands the widened seam contract + primitive; Phase 2 (rerouting `enumerate_and_blast` onto it, fixture-sweep-gated) is the follow-up.

## Why (Q2 recap)

`enumerate_and_blast` needs more from one step than the narrow `(s,i) ↦ next_registers` `step` returns: the property/combinational signal values (for state-splitting) and the constraint-admissibility verdict (to drop inadmissible input combos). Option A (narrow `step`) would force the enumerator back onto `Btor2File` for those — re-coupling. Option C (abstraction-aware trait) would couple the frontend-agnostic seam to `FieldDomain`. **Option B** threads the extra *observability* through the trait while keeping the *clamping / OOB / domain-encoding* policy in the caller.

## How

- `StepOutcome { next_state, observed, admissible }` + new primitive `StepEval::step_observe(state, inputs, observe)`. `step` is now a **provided default** over it (next-state only; discards observability/admissibility — the pre-Phase-1 contract the predicate-cube sampling path relies on, unchanged).
- `bit_blast::simulate_one_step_observe`: same concrete `(s,i) ↦ s'` as `simulate_one_step` (kept separate so the hot path carries no extra cost), but also reports each requested signal's current-cycle value (resolved to the symbol-bearing node's **own** nid — a combinational `Op`'s computed value, distinct from `collect_symbols`' state-attachment) and whether the BTOR2 `constraint` lines hold. Returns `StepOutcome` directly (no tuple — avoids clippy `type_complexity`). The trait never mentions `FieldDomain`.
- `BtorSts::step_observe` delegates; `BtorSts::step` uses the provided default.

**Behaviour-preserving:** nothing consumes `step_observe` yet, and `step`'s next-state is identical to `simulate_one_step`'s. The existing `btor_sts_step_delegates_to_simulate_one_step` test stays green via the default.

## Tests

- `p1_4_simulate_one_step_observe_reports_observed_and_admissible` — observed combinational `g`; admissibility flips on a violated `constraint`; next-state matches the narrow `simulate_one_step`; unresolvable observe name omitted.
- `btor_sts_step_observe_reports_observed_and_admissible` — seam level + provided `step` matches `step_observe`'s next-state.

Local: clippy clean (`type_complexity` resolved), fmt clean, `sts_ir`+`bit_blast` suites green (102 tests); pre-commit hook (full workspace + doctests) passed.

## Track status

DR0 #102 · DR1 #103 · P0 #104 · P1 #1 #105 · #2 #106 · #3 #107 · **#4 Phase 1 (this)**. Q2 answered = B. Follow-ups: P1 #4 Phase 2 (reroute `enumerate_and_blast` Pass 1 onto `step_observe`, equivalence-gated) and the measurement-gated O(edges) may perf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)