### PR TITLE
refactor(ir-track P1 #4 Phase 2a): align step_observe resolution with the Enumerate strategy

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -236,13 +236,14 @@ pub fn simulate_one_step(
 /// convention), but additionally reports, from the post-`evaluate_pure` /
 /// pre-`apply_next` env (the current-cycle values):
 ///
-/// - `observed`: the current value of each requested signal name. A name
-///   is resolved to the NID of the *symbol-bearing node* that carries it
-///   (a combinational `Op`'s own computed value, or a state / input
-///   value) — distinct from [`parser::collect_symbols`], which attaches
-///   alias symbols onto state cells. Names that resolve to no symbol-
-///   bearing node, or whose node has no env value (e.g. an `output` line),
-///   are omitted from the map.
+/// - `observed`: the current value of each requested signal name, resolved
+///   the SAME way the Enumerate strategy resolves combinational signals so
+///   a future Pass-1 reroute is value-faithful — an `Op` node carrying the
+///   symbol → its own computed value (mirrors `combinational_signal_nids`);
+///   else an `Output` node → its referenced signal's value (mirrors
+///   `output_port_nids`); else a `State` / `Input` → its own value.
+///   Precedence Op > Output > State/Input. Names that resolve to no
+///   symbol-bearing node are omitted from the map.
 /// - `admissible`: whether every BTOR2 `constraint` line holds under this
 ///   `(state, inputs)` assignment. [`simulate_one_step`] returns the
 ///   next-state regardless; this variant surfaces the verdict so the
@@ -309,35 +310,56 @@ pub fn simulate_one_step_observe(
 
     let mut observed: std::collections::HashMap<String, u128> = std::collections::HashMap::new();
     if !observe.is_empty() {
-        // name → own NID for any symbol-bearing node (Op / State / Input /
-        // Output). First occurrence wins on collision.
-        let mut name_to_nid: std::collections::HashMap<&str, Nid> =
+        // P1 #4 Phase 2a (Q2 = B) — resolve observe names to NIDs the SAME
+        // way the Enumerate strategy does, so a future Pass-1 reroute onto
+        // this primitive is value-faithful (the `cv` mask reads the same
+        // signal values it does today):
+        //   1. an `Op` node carrying the symbol → its own computed value
+        //      (mirrors `combinational_signal_nids`);
+        //   2. else an `Output` node carrying the symbol → the value of its
+        //      referenced signal (mirrors `output_port_nids`, which keys on
+        //      `signal.nid()`); read the raw signal NID — no negation
+        //      follow — to match that helper exactly;
+        //   3. else a `State` / `Input` carrying the symbol → its own value.
+        // First occurrence wins within each tier; precedence Op > Output >
+        // State/Input (matching the enumerator's union order).
+        let mut op_nid: std::collections::HashMap<&str, Nid> = std::collections::HashMap::new();
+        let mut out_sig_nid: std::collections::HashMap<&str, Nid> =
             std::collections::HashMap::new();
+        let mut si_nid: std::collections::HashMap<&str, Nid> = std::collections::HashMap::new();
         for line in &file.lines {
-            let sym = match &line.node {
+            match &line.node {
                 Node::Op {
                     symbol: Some(s), ..
+                } => {
+                    op_nid.entry(s.as_str()).or_insert(line.nid);
                 }
-                | Node::State {
+                Node::Output {
+                    symbol: Some(s),
+                    signal,
+                } => {
+                    out_sig_nid.entry(s.as_str()).or_insert(signal.nid());
+                }
+                Node::State {
                     symbol: Some(s), ..
                 }
                 | Node::Input {
                     symbol: Some(s), ..
+                } => {
+                    si_nid.entry(s.as_str()).or_insert(line.nid);
                 }
-                | Node::Output {
-                    symbol: Some(s), ..
-                } => Some(s.as_str()),
-                _ => None,
-            };
-            if let Some(s) = sym {
-                name_to_nid.entry(s).or_insert(line.nid);
+                _ => {}
             }
         }
         for name in observe {
-            if let Some(nid) = name_to_nid.get(name.as_str())
-                && let Some(bv) = env.values.get(nid)
-            {
-                observed.insert(name.clone(), bv.bits);
+            let v = op_nid
+                .get(name.as_str())
+                .or_else(|| out_sig_nid.get(name.as_str()))
+                .or_else(|| si_nid.get(name.as_str()))
+                .and_then(|nid| env.values.get(nid))
+                .map(|bv| bv.bits);
+            if let Some(v) = v {
+                observed.insert(name.clone(), v);
             }
         }
     }
@@ -8202,6 +8224,33 @@ mod tests {
         assert!(
             !out_missing.observed.contains_key("no_such_signal"),
             "unresolvable observe names are omitted"
+        );
+    }
+
+    #[test]
+    fn p1_4_phase2a_observe_follows_output_port_signal() {
+        // P1 #4 Phase 2a — an OUTPUT-port name resolves to the value of its
+        // referenced signal (matching `output_port_nids`), not the output
+        // node itself. `myport` is an output of the combinational `q & en`
+        // (nid 4), which carries no symbol of its own.
+        let src = "1 sort bitvec 1\n2 state 1 q\n3 input 1 en\n4 and 1 2 3\n5 output 4 myport\n6 next 1 2 3\n";
+        let file = crate::adapter::btor2::parser::parse(src).expect("parse");
+        let st = |q: u128| std::collections::HashMap::from([("q".to_string(), q)]);
+        let inp = |en: u128| std::collections::HashMap::from([("en".to_string(), en)]);
+
+        let out = simulate_one_step_observe(&file, &st(1), &inp(1), &["myport".to_string()])
+            .expect("step");
+        assert_eq!(
+            out.observed.get("myport"),
+            Some(&1),
+            "output port follows its signal `q & en` = 1"
+        );
+        let out0 = simulate_one_step_observe(&file, &st(1), &inp(0), &["myport".to_string()])
+            .expect("step");
+        assert_eq!(
+            out0.observed.get("myport"),
+            Some(&0),
+            "output port follows its signal `q & en` = 0"
         );
     }
 

--- a/docs/design/sts-ir.md
+++ b/docs/design/sts-ir.md
@@ -136,8 +136,16 @@ invisible to callers.
     the new `bit_blast::simulate_one_step_observe`, which reports the requested combinational
     signals' current-cycle values + whether the BTOR2 `constraint` lines hold. The trait never
     mentions `FieldDomain` — domain-encoding / OOB-sink / state-splitting stay caller-side policy.
-    Phase 2 (reroute `enumerate_and_blast`'s Pass 1 onto `step_observe`, fixture-sweep
-    equivalence-gated) and Phase 3 (a non-RTL frontend inherits Enumerate) are the follow-ups.
+  - **P1 #4 Phase 2a (shipped):** aligned `simulate_one_step_observe`'s observe resolution with the
+    Enumerate strategy's combinational-signal resolution — `Op` → own value
+    (`combinational_signal_nids`), else `Output` → referenced-signal value (`output_port_nids`),
+    else `State`/`Input` → own value; precedence `Op > Output > State/Input`. Makes a future Pass-1
+    reroute *value-faithful* (the `cv` mask reads the same signals it does today) and is a
+    correctness fix on its own (output-port observation now follows the signal). Remaining Phase-2
+    steps: **2b** a *prepared stepper* (build symbols / `state_meta` once, step many) so the reroute
+    carries no per-step `collect_symbols` cost; **2c** the Pass-1 reroute, gated on the full
+    SV/BTOR2 fixture verdict sweep + a no-perf-regression check. Phase 3 = a non-RTL frontend
+    inherits Enumerate.
 - **P2:** unify the evaluator over `TruthDomain` (orthogonal to the IR, same track).
 - **P3:** route `mununu verify` SV/BTOR2 through the IR + chosen strategy; migrate SV
   `bounded_counter` sidecars to predicate sets; carry 3-valued verdicts.


### PR DESCRIPTION
## What

Phase 2a of the `bit_blast` (Enumerate) → `StepEval` reroute: make `simulate_one_step_observe`'s observe-name resolution match the Enumerate strategy's combinational-signal resolution **exactly**, so the eventual Pass-1 reroute is value-faithful (the `cv` state-splitting mask reads the same signal values it does today).

## Why

The reroute (Phase 2c) replaces Pass 1's inline `evaluate_pure` + `cv` extraction with `step_observe`. For the `cv` mask to be identical, `step_observe` must resolve each combinational signal name to the same value the enumerator's `comb_nids` (`combinational_signal_nids` ∪ `output_port_nids`) does. Phase 1's resolver used a "first symbol-bearing node, own nid" rule that diverged for output ports (it read the output node's own nid — usually absent from the env — instead of the referenced signal).

## How

Resolution now mirrors the enumerator:
- `Op` node carrying the symbol → its own computed value (`combinational_signal_nids`);
- else `Output` node → the value of its referenced signal (`signal.nid()`, raw — no negation follow — matching `output_port_nids`);
- else `State` / `Input` → its own value.

Precedence `Op > Output > State/Input` (the enumerator's union order).

This is also a standalone correctness fix: output-port observation now follows the signal (the value the enumerator surfaces for net-driving output ports, R-MM-4b), instead of being silently omitted.

**Safe:** nothing in the hot path consumes `step_observe` yet (the reroute is Phase 2c). Phase 1's tests use an Op-symbol signal → unchanged.

## Phase 2 is a 3-step arc (scoped during this work)

Rerouting Pass 1 naively would call `simulate_one_step_observe` per step, recomputing `collect_symbols` + `state_meta` every iteration — a per-step regression the original cached-once Pass 1 avoids. So:
- **2a (this)** — align the resolver (value-faithful groundwork).
- **2b** — a *prepared stepper* (build symbols / `state_meta` once, step many) so the reroute has no per-step setup cost.
- **2c** — the Pass-1 reroute, gated on the full SV/BTOR2 fixture verdict sweep + a no-perf-regression check.

## Tests

`p1_4_phase2a_observe_follows_output_port_signal` — an output port resolves to its `q & en` signal value, not the output node. Existing Phase 1 observe tests unchanged.

Local: clippy clean, fmt clean, `bit_blast`+`sts_ir` suites green (103 tests); pre-commit hook (full workspace + doctests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)