### PR TITLE
feat(M.6 parity): expose config_values + may_edge_inference on the cegar API

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1777,39 +1777,14 @@ fn build_adapter_options_with_config_values(
     config_values_args: &[String],
 ) -> Result<mununu_core::adapter::AdapterOptions, String> {
     use mununu_core::adapter::AdapterOptions;
-    if config_values_args.is_empty() {
-        return Ok(AdapterOptions::default());
-    }
-    let mut signals = Vec::with_capacity(config_values_args.len());
-    for entry in config_values_args {
-        let (reg, values_str) = entry.split_once('=').ok_or_else(|| {
-            format!("invalid --config-values entry {entry:?}: expected REG=v1,v2,v3 format")
-        })?;
-        let values: Vec<u64> = values_str
-            .split(',')
-            .map(|s| {
-                s.trim()
-                    .parse::<u64>()
-                    .map_err(|e| format!("invalid value {s:?} in --config-values: {e}"))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        if values.is_empty() {
-            return Err(format!(
-                "--config-values {entry:?}: at least one value required"
-            ));
-        }
-        signals.push(serde_json::json!({
-            "name": reg,
-            "config_values": values,
-        }));
-    }
-    let synthetic = serde_json::json!({
-        "module": "cli-cegar",
-        "source": "cli-cegar.btor2",
-        "signals": signals,
-    });
+    // M.6 parity (2026-06-20) — the `REG=v1,v2,...` parse moved to the shared
+    // core helper `adapter::btor2::cegar::config_values_to_sidecar_json` so the
+    // CLI `--config-values` and the API `config_values` field parse identically
+    // (single source of truth; the format can't drift between surfaces).
+    let sidecar_json =
+        mununu_core::adapter::btor2::cegar::config_values_to_sidecar_json(config_values_args)?;
     Ok(AdapterOptions {
-        sidecar_json: Some(synthetic.to_string()),
+        sidecar_json,
         ..AdapterOptions::default()
     })
 }

--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -1356,10 +1356,77 @@ fn walk_state_cells_proposing(
     out
 }
 
+/// Parse `--config-values`-style `REG=v1,v2,...` entries into the synthetic
+/// sidecar JSON the predicate-cube lift reads via `sidecar_config_values`
+/// (R-S8). Shared by the CLI (`mununu btor2 cegar --config-values`) and the
+/// HTTP API (`POST /api/v1/btor2/cegar` `config_values`) so the entry format
+/// has a single source of truth (no CLI↔API drift). Returns `None` for an
+/// empty input (no synthetic sidecar), `Some(json)` otherwise. Each entry is
+/// `REG=v1,v2,...` with at least one `u64` value.
+pub fn config_values_to_sidecar_json(entries: &[String]) -> Result<Option<String>, String> {
+    if entries.is_empty() {
+        return Ok(None);
+    }
+    let mut signals = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let (reg, values_str) = entry.split_once('=').ok_or_else(|| {
+            format!("invalid config-values entry {entry:?}: expected REG=v1,v2,v3 format")
+        })?;
+        let values: Vec<u64> = values_str
+            .split(',')
+            .map(|s| {
+                s.trim()
+                    .parse::<u64>()
+                    .map_err(|e| format!("invalid value {s:?} in config-values: {e}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if values.is_empty() {
+            return Err(format!(
+                "config-values {entry:?}: at least one value required"
+            ));
+        }
+        signals.push(serde_json::json!({ "name": reg, "config_values": values }));
+    }
+    let synthetic = serde_json::json!({
+        "module": "cegar",
+        "source": "cegar.btor2",
+        "signals": signals,
+    });
+    Ok(Some(synthetic.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::mu_calculus::parser;
+
+    // M.6 parity — the shared `REG=v1,v2,...` parse used by both the CLI
+    // `--config-values` flag and the API `config_values` field.
+    #[test]
+    fn config_values_to_sidecar_json_empty_is_none() {
+        assert_eq!(config_values_to_sidecar_json(&[]).unwrap(), None);
+    }
+
+    #[test]
+    fn config_values_to_sidecar_json_parses_entries() {
+        let json = config_values_to_sidecar_json(&["boot_fsm_ns=0,1,2,3,4,5,6,7".to_string()])
+            .unwrap()
+            .expect("non-empty input yields a synthetic sidecar");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let sig = &parsed["signals"][0];
+        assert_eq!(sig["name"], "boot_fsm_ns");
+        assert_eq!(
+            sig["config_values"],
+            serde_json::json!([0, 1, 2, 3, 4, 5, 6, 7])
+        );
+    }
+
+    #[test]
+    fn config_values_to_sidecar_json_rejects_malformed() {
+        assert!(config_values_to_sidecar_json(&["no_equals_sign".to_string()]).is_err());
+        assert!(config_values_to_sidecar_json(&["reg=".to_string()]).is_err());
+        assert!(config_values_to_sidecar_json(&["reg=1,notanumber".to_string()]).is_err());
+    }
 
     const SMALL_BTOR2: &str = "\
 1 sort bitvec 1

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -602,8 +602,9 @@ pub async fn btor2_cegar_handler(
     use crate::adapter::AdapterOptions;
     use crate::adapter::btor2::cegar::{
         CegarOptions, CegarTermination, LiftStrategy, PredicateSource, cegar_refine_loop,
+        config_values_to_sidecar_json,
     };
-    use crate::adapter::btor2::kmts_lift::{MustEdgeInference, PredicateSpec};
+    use crate::adapter::btor2::kmts_lift::{MayEdgeInference, MustEdgeInference, PredicateSpec};
     use crate::mu_calculus::trit::{Trit, TritSet};
     use crate::mu_calculus::{Environment, parser as mu_parser};
 
@@ -644,6 +645,13 @@ pub async fn btor2_cegar_handler(
         Some("smt-hyper-must") => MustEdgeInference::SmtHyperMust,
         _ => MustEdgeInference::Off,
     };
+    // M.6 parity (2026-06-20) — the may-edge inference policy is now an API
+    // field (was CLI-only). `smt-all-pairs` selects the sound all-pairs
+    // may-relation, matching `--may-edge-inference`; default is Off.
+    let may_edge_inference = match request.may_edge_inference.as_deref() {
+        Some("smt-all-pairs") => MayEdgeInference::SmtAllPairs,
+        _ => MayEdgeInference::Off,
+    };
 
     let cegar_opts = CegarOptions {
         max_iterations: request.max_iterations.unwrap_or(16),
@@ -654,13 +662,24 @@ pub async fn btor2_cegar_handler(
         smart_uf_cap: true,
         lift_strategy: LiftStrategy::Eager,
         must_edge_inference,
-        // DR1 (2026-06-19) — API keeps the sampling may-edges (default);
-        // the sound `SmtAllPairs` path is opt-in via the CLI for now.
-        may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+        may_edge_inference,
     };
 
+    // M.6 parity (2026-06-20) — config-values symbolic init is now an API
+    // field (was CLI-only). The shared `config_values_to_sidecar_json` helper
+    // gives the CLI and the API one parse for the `REG=v1,v2,...` format; the
+    // synthetic sidecar threads through to the predicate-cube lift's
+    // `config_values` (R-S8 init expansion — e.g. the M.4 boot_fsm_ns hazard).
+    let sidecar_json =
+        config_values_to_sidecar_json(&request.config_values).map_err(|message| {
+            ApiError::BadRequest {
+                message,
+                details: None,
+            }
+        })?;
     let adapter_options = AdapterOptions {
         controllable_inputs: request.controllable_inputs.clone(),
+        sidecar_json,
         ..Default::default()
     };
 
@@ -2829,6 +2848,8 @@ members = ["x"]
             predicate_source: None,
             max_iterations: Some(4),
             must_edge_inference: None,
+            may_edge_inference: None,
+            config_values: vec![],
         };
 
         let Json(out) = btor2_cegar_handler(Json(request))
@@ -2858,6 +2879,69 @@ members = ["x"]
         );
         // The final predicate set includes at least the bootstrap predicate.
         assert!(!out.final_predicates.is_empty());
+    }
+
+    /// M.6 parity (2026-06-20) — the CEGAR endpoint now accepts `config_values`
+    /// (R-S8 symbolic init) and `may_edge_inference`, both previously CLI-only.
+    /// A well-formed request with both set runs end-to-end.
+    #[tokio::test]
+    async fn btor2_cegar_handler_accepts_config_values_and_may_edge() {
+        use crate::api::models::PredicateSpecRequest;
+        let btor2 = "\
+1 sort bitvec 2
+2 state 2 burst
+3 zero 2
+4 init 2 2 3
+5 const 2 01
+6 sub 2 2 5
+7 next 2 2 6
+";
+        let request = Btor2CegarRequest {
+            content: btor2.to_string(),
+            formula: "nu X. < true > X".to_string(),
+            predicates: vec![PredicateSpecRequest {
+                name: "burst_zero".to_string(),
+                register: "burst".to_string(),
+                value: 0,
+            }],
+            controllable_inputs: vec![],
+            predicate_source: None,
+            max_iterations: Some(4),
+            must_edge_inference: None,
+            may_edge_inference: Some("smt-all-pairs".to_string()),
+            config_values: vec!["burst=0,1,2,3".to_string()],
+        };
+        let Json(out) = btor2_cegar_handler(Json(request))
+            .await
+            .expect("CEGAR endpoint should accept config_values + may_edge_inference");
+        assert!(out.success);
+        assert!(!out.iterations.is_empty());
+    }
+
+    /// M.6 parity — a malformed `config_values` entry is a 400, not a panic.
+    #[tokio::test]
+    async fn btor2_cegar_handler_rejects_malformed_config_values() {
+        use crate::api::models::PredicateSpecRequest;
+        let btor2 = "1 sort bitvec 1\n2 state 1 r\n3 zero 1\n4 init 1 2 3\n5 next 1 2 3\n";
+        let request = Btor2CegarRequest {
+            content: btor2.to_string(),
+            formula: "nu X. < true > X".to_string(),
+            predicates: vec![PredicateSpecRequest {
+                name: "r_zero".to_string(),
+                register: "r".to_string(),
+                value: 0,
+            }],
+            controllable_inputs: vec![],
+            predicate_source: None,
+            max_iterations: Some(2),
+            must_edge_inference: None,
+            may_edge_inference: None,
+            config_values: vec!["this is not valid".to_string()],
+        };
+        let err = btor2_cegar_handler(Json(request))
+            .await
+            .expect_err("malformed config_values must be rejected");
+        assert!(matches!(err, ApiError::BadRequest { .. }));
     }
 
     /// R.6.7 / V.6 — when only `predicates` is set (no

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -854,6 +854,17 @@ pub struct Btor2CegarRequest {
     /// `"smt-per-target-standard"` | `"smt-hyper-must"`.
     #[serde(default)]
     pub must_edge_inference: Option<String>,
+    /// May-edge inference policy (kebab-case; default `"off"`):
+    /// `"smt-all-pairs"` for the sound all-pairs may-relation. Mirrors the
+    /// CLI `--may-edge-inference`.
+    #[serde(default)]
+    pub may_edge_inference: Option<String>,
+    /// R-S8 symbolic-init config-values, one entry per register as
+    /// `"REG=v1,v2,..."` (mirrors the CLI `--config-values`). Each register's
+    /// admissible power-up set seeds the predicate-cube initial states. Empty =
+    /// no synthetic init sidecar.
+    #[serde(default)]
+    pub config_values: Vec<String>,
 }
 
 /// U.0 — CEGAR refinement trace, JSON-shaped for the refinement-trace


### PR DESCRIPTION
## M.6 parity — close the cegar CLI↔API gap

M.6's parity audit found `POST /api/v1/btor2/cegar` (and the UI `RefinementTracePanel`) was a strict subset of the CLI `mununu btor2 cegar`: `--config-values` (R-S8 symbolic init) and `--may-edge-inference` had no API/UI peer. This closes the **CLI↔API** half (the UI half is a companion mununu-ui PR).

- `Btor2CegarRequest` gains `config_values: Vec<String>` (`REG=v1,v2,...` each) + `may_edge_inference: Option<String>`, both `#[serde(default)]` (strict-additive).
- `btor2_cegar_handler` parses `may_edge_inference` (was hardcoded `Off`) and threads `config_values` into `AdapterOptions::sidecar_json` → the predicate-cube lift's R-S8 init expansion. Malformed config-values → 400, not a panic.
- New shared core helper `adapter::btor2::cegar::config_values_to_sidecar_json` is the **single source of truth** for the `REG=v1,v2,...` parse; the CLI's `build_adapter_options_with_config_values` now delegates to it (was an inline copy) — the format can't drift between surfaces.

### Tests
- cegar.rs: 3 helper unit tests (empty→None, parse, malformed→Err).
- handlers.rs: `accepts_config_values_and_may_edge` (end-to-end, smt-all-pairs) + `rejects_malformed_config_values` (→ BadRequest) + the existing handler test updated for the new fields. All 6 pass under `--all-features`; clippy clean. CI runs the api tests via `cargo test --lib api --features api`.

Note: `config_values` is the field the UI needs to reproduce the **M.4** init-hazard demo directly (without relying on the BTOR2 already carrying `setundef -anyconst`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)