### PR TITLE
feat(ctxdsl P1a): per-state predicates_3v block → state_3valued_predicates

### DIFF
--- a/crates/mununu-core/src/context_dsl/ast.rs
+++ b/crates/mununu-core/src/context_dsl/ast.rs
@@ -149,6 +149,34 @@ pub struct StateDecl {
     /// and that the trace renderer prints alongside state names in
     /// counterexamples / counterstrategies.
     pub valuations: Vec<Assignment>,
+    /// Per-state 3-valued (Kleene) predicate labels, written as
+    /// `predicates_3v { p = unknown; q = true; r = false; }` inside the optional
+    /// outer block on a state declaration. Unlike the 2-valued `predicates`
+    /// block (predicate ⇒ true at a state), these carry a full `Tristate`
+    /// (`true` / `false` / `unknown`) and realize into
+    /// [`crate::clts::Clts::with_3valued_predicate`] — the round-trippable
+    /// surface for a predicate-cube KMTS's `state_3valued_predicates`.
+    pub three_valued: Vec<ThreeValuedDecl>,
+}
+
+/// One `<predicate> = <tristate>` entry inside a state's `predicates_3v { … }`
+/// block.
+#[derive(Debug, Clone)]
+pub struct ThreeValuedDecl {
+    pub name: Ident,
+    pub value: TristateLit,
+}
+
+/// CTXDSL surface literal for a Kleene tristate, mapping to
+/// [`crate::clts::Tristate`] at the realize step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TristateLit {
+    /// `true` ⇒ `Tristate::KleeneT`.
+    True,
+    /// `false` ⇒ `Tristate::KleeneF`.
+    False,
+    /// `unknown` ⇒ `Tristate::KleeneBot`.
+    Unknown,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/mununu-core/src/context_dsl/canonicalize.rs
+++ b/crates/mununu-core/src/context_dsl/canonicalize.rs
@@ -307,6 +307,7 @@ mod tests {
                         },
                     }],
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
                 StateDecl {
                     name: ident("A"),
@@ -320,6 +321,7 @@ mod tests {
                         },
                     }],
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
             ],
             transitions: vec![
@@ -688,6 +690,7 @@ mod tests {
                     is_initial: true,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
                 StateDecl {
                     name: ident("T1"),
@@ -695,6 +698,7 @@ mod tests {
                     is_initial: false,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
                 StateDecl {
                     name: ident("T2"),
@@ -702,6 +706,7 @@ mod tests {
                     is_initial: false,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
             ],
             transitions: Vec::new(),
@@ -874,6 +879,7 @@ mod tests {
                     is_initial: true,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
                 StateDecl {
                     name: ident("T1"),
@@ -881,6 +887,7 @@ mod tests {
                     is_initial: false,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
                 StateDecl {
                     name: ident("T2"),
@@ -888,6 +895,7 @@ mod tests {
                     is_initial: false,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
             ],
             transitions: Vec::new(),
@@ -1093,6 +1101,7 @@ mod tests {
                     is_initial: true,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
                 StateDecl {
                     name: ident("T"),
@@ -1100,6 +1109,7 @@ mod tests {
                     is_initial: false,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
             ],
             transitions: Vec::new(),
@@ -1184,6 +1194,7 @@ mod tests {
                     is_initial: true,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
                 StateDecl {
                     name: ident("T1"),
@@ -1191,6 +1202,7 @@ mod tests {
                     is_initial: false,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
                 StateDecl {
                     name: ident("T2"),
@@ -1198,6 +1210,7 @@ mod tests {
                     is_initial: false,
                     overrides: Vec::new(),
                     valuations: Vec::new(),
+                    three_valued: Vec::new(),
                 },
             ],
             transitions: Vec::new(),
@@ -1409,6 +1422,7 @@ mod tests {
                 },
             ],
             valuations: Vec::new(),
+            three_valued: Vec::new(),
         });
 
         canonicalize_automaton(&mut auto);

--- a/crates/mununu-core/src/context_dsl/parser.rs
+++ b/crates/mununu-core/src/context_dsl/parser.rs
@@ -686,11 +686,13 @@ impl<'a> Parser<'a> {
         // is either `vars { ... }` (per-state initialiser overrides) or
         // `valuations { ... }` (per-state structured display metadata). They
         // may appear in any order; either may be omitted.
-        let (overrides, valuations) = if self.match_symbol(Symbol::LBrace) {
+        let (overrides, valuations, three_valued) = if self.match_symbol(Symbol::LBrace) {
             let mut overrides: Vec<Assignment> = Vec::new();
             let mut valuations: Vec<Assignment> = Vec::new();
+            let mut three_valued: Vec<ThreeValuedDecl> = Vec::new();
             let mut saw_vars = false;
             let mut saw_valuations = false;
+            let mut saw_3v = false;
             while !self.check_symbol(Symbol::RBrace) {
                 let block_span = self.peek().span;
                 if self.match_keyword(Keyword::Vars) {
@@ -719,19 +721,32 @@ impl<'a> Parser<'a> {
                         valuations.push(self.parse_valuation_pair()?);
                     }
                     self.expect_symbol(Symbol::RBrace)?;
+                } else if self.match_keyword(Keyword::Predicates3v) {
+                    if saw_3v {
+                        return Err(ParseError::DuplicateItem {
+                            name: "predicates_3v".into(),
+                            span: block_span,
+                        });
+                    }
+                    saw_3v = true;
+                    self.expect_symbol(Symbol::LBrace)?;
+                    while !self.check_symbol(Symbol::RBrace) {
+                        three_valued.push(self.parse_three_valued_pair()?);
+                    }
+                    self.expect_symbol(Symbol::RBrace)?;
                 } else {
                     let found = self.peek_kind().clone();
                     return Err(ParseError::UnexpectedToken {
                         found,
-                        expected: "`vars` or `valuations` block",
+                        expected: "`vars`, `valuations`, or `predicates_3v` block",
                         span: block_span,
                     });
                 }
             }
             self.expect_symbol(Symbol::RBrace)?;
-            (overrides, valuations)
+            (overrides, valuations, three_valued)
         } else {
-            (Vec::new(), Vec::new())
+            (Vec::new(), Vec::new(), Vec::new())
         };
 
         self.expect_symbol(Symbol::Semicolon)?;
@@ -742,7 +757,37 @@ impl<'a> Parser<'a> {
             is_initial,
             overrides,
             valuations,
+            three_valued,
         })
+    }
+
+    /// Parse one `<predicate> = <tristate>;` entry inside a `predicates_3v { … }`
+    /// block. The tristate literal is `true` / `false` (existing keywords) or the
+    /// identifier `unknown`.
+    fn parse_three_valued_pair(&mut self) -> Result<ThreeValuedDecl, ParseError> {
+        let name = self.expect_ident()?;
+        self.expect_symbol(Symbol::Assign)?;
+        let value = self.parse_tristate_lit()?;
+        self.expect_symbol(Symbol::Semicolon)?;
+        Ok(ThreeValuedDecl { name, value })
+    }
+
+    fn parse_tristate_lit(&mut self) -> Result<TristateLit, ParseError> {
+        let span = self.peek().span;
+        if self.match_keyword(Keyword::True) {
+            Ok(TristateLit::True)
+        } else if self.match_keyword(Keyword::False) {
+            Ok(TristateLit::False)
+        } else if matches!(self.peek_kind(), TokenKind::Identifier(s) if s.as_str() == "unknown") {
+            self.advance();
+            Ok(TristateLit::Unknown)
+        } else {
+            Err(ParseError::UnexpectedToken {
+                found: self.peek_kind().clone(),
+                expected: "`true`, `false`, or `unknown`",
+                span,
+            })
+        }
     }
 
     fn parse_assignment(&mut self) -> Result<Assignment, ParseError> {

--- a/crates/mununu-core/src/context_dsl/realize.rs
+++ b/crates/mununu-core/src/context_dsl/realize.rs
@@ -1075,6 +1075,7 @@ fn substitute_param(automaton: &Automaton, param_name: &str, value: i64) -> Auto
                         is_initial: state.is_initial,
                         overrides: state.overrides.clone(),
                         valuations: state.valuations.clone(),
+                        three_valued: state.three_valued.clone(),
                     });
                 } else {
                     // Different iteration variable — keep as-is for now
@@ -1090,6 +1091,7 @@ fn substitute_param(automaton: &Automaton, param_name: &str, value: i64) -> Auto
                         is_initial: state.is_initial,
                         overrides: state.overrides.clone(),
                         valuations: state.valuations.clone(),
+                        three_valued: state.three_valued.clone(),
                     });
                 } else {
                     states.push(state.clone());
@@ -2609,6 +2611,19 @@ fn build_automaton(
             if !merged.is_empty() {
                 builder.with_valuation_for_state(state_id, merged);
             }
+            // Per-state 3-valued (Kleene) predicate labels from a
+            // `predicates_3v { … }` block → `Clts::state_3valued_predicates`.
+            // This is the round-trippable surface for a predicate-cube KMTS.
+            for tv in &state.three_valued {
+                let verdict = match tv.value {
+                    crate::context_dsl::ast::TristateLit::True => crate::clts::Tristate::KleeneT,
+                    crate::context_dsl::ast::TristateLit::False => crate::clts::Tristate::KleeneF,
+                    crate::context_dsl::ast::TristateLit::Unknown => {
+                        crate::clts::Tristate::KleeneBot
+                    }
+                };
+                builder.with_3valued_predicate(state_id, tv.name.name.clone(), verdict);
+            }
         }
     }
 
@@ -3426,6 +3441,59 @@ context structured_test {
         )
         .expect("context parses");
         let _ = realize(&doc, &[]).expect("structured-pattern predicate skipped");
+    }
+
+    #[test]
+    fn predicates_3v_block_realizes_into_state_3valued_predicates() {
+        // CTXDSL-output gap fix (IR-track) — a per-state `predicates_3v { … }`
+        // block carries Kleene labels that realize into the CLTS's
+        // `state_3valued_predicates`, the round-trippable surface for a
+        // predicate-cube KMTS.
+        use crate::clts::Tristate;
+        let doc = parse(
+            r#"
+context tri_test {
+    alphabet { label tick; }
+    automata {
+        automaton M {
+            states {
+                state s0 initial {
+                    predicates_3v { p = unknown; q = true; r = false; }
+                };
+                state s1;
+            }
+            transitions {
+                transition s0 -> s1 on label tick;
+                transition s1 -> s1 on label tick;
+            }
+        }
+    }
+}
+"#,
+        )
+        .expect("context parses");
+        let realized = realize(&doc, &[]).expect("realizes");
+        let clts = realized.context.clts("M").expect("automaton M exists");
+        assert!(
+            clts.has_3valued_predicates(),
+            "3-valued labels must be registered on the CLTS"
+        );
+        let s0 = clts.state_id("s0").expect("s0 exists");
+        assert_eq!(
+            clts.state_3valued_predicate(s0, "p"),
+            Some(Tristate::KleeneBot)
+        );
+        assert_eq!(
+            clts.state_3valued_predicate(s0, "q"),
+            Some(Tristate::KleeneT)
+        );
+        assert_eq!(
+            clts.state_3valued_predicate(s0, "r"),
+            Some(Tristate::KleeneF)
+        );
+        // A state with no `predicates_3v` block carries no 3-valued labels.
+        let s1 = clts.state_id("s1").expect("s1 exists");
+        assert_eq!(clts.state_3valued_predicate(s1, "p"), None);
     }
 
     #[test]

--- a/crates/mununu-core/src/context_dsl/token.rs
+++ b/crates/mununu-core/src/context_dsl/token.rs
@@ -81,6 +81,8 @@ pub enum Keyword {
     ProofObligations,
     True,
     False,
+    // Per-state 3-valued (Kleene) predicate block: `predicates_3v { p = unknown; }`
+    Predicates3v,
     // Enum types
     Enums, // "enums" section keyword
     Enum,  // "enum" declaration keyword
@@ -129,6 +131,7 @@ impl Keyword {
             "initial" => Initial,
             "vars" => Vars,
             "valuations" => Valuations,
+            "predicates_3v" => Predicates3v,
             "transitions" => Transitions,
             "transition" => Transition,
             "on" => On,

--- a/wiki/CTXDSL-Language-Reference.md
+++ b/wiki/CTXDSL-Language-Reference.md
@@ -141,6 +141,26 @@ states {
 
 The block lives inside the optional outer state block; it can coexist with a `vars { … }` block in any order. Reserved-keyword names (e.g. `state`, `on`, `group`) are accepted as keys so the round-trip with adapter-emitted CTXDSL is safe. See [`examples/hw/traffic_light_valuations.ctxdsl`](https://github.com/vscorza/mununu/blob/main/examples/hw/traffic_light_valuations.ctxdsl) for the canonical worked example.
 
+#### Per-state 3-valued (Kleene) predicates
+
+> Source of truth: [`Clts::with_3valued_predicate`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/clts/mod.rs) + [`parse_three_valued_pair`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/context_dsl/parser.rs) — surface: CLI+API+UI (the realized CLTS evaluates under any surface).
+
+A state may carry a `predicates_3v { … }` block with `predicate = tristate;` pairs, where the tristate is `true`, `false`, or `unknown`. Unlike the 2-valued `predicates` block (which asserts a predicate *holds* at a state), these carry a full Kleene verdict and realize into the CLTS's `state_3valued_predicates` map (`KleeneT` / `KleeneF` / `KleeneBot`) — the round-trippable surface for a predicate-cube KMTS produced by the BTOR2 predicate-abstraction lift.
+
+```
+states {
+    state cube_0 initial {
+        predicates_3v {
+            boot_fsm_is_idle = true;
+            boot_fsm_is_done = false;
+            counter_overflow = unknown;
+        }
+    };
+}
+```
+
+The block lives inside the optional outer state block and coexists with `vars { … }` / `valuations { … }` in any order. `unknown` ⇒ `KleeneBot` (the abstraction is too coarse to decide the predicate at that cube — the CEGAR loop refines it).
+
 ### Controllable
 
 The `controllable` block lists labels that the controller is allowed to enable or disable. Labels not listed here are treated as **uncontrollable** (environment actions that the controller cannot prevent).


### PR DESCRIPTION
## CTXDSL-output gap fix — Phase 1a (input side)

Part of the `ctxdsl-output-on-demand` plan (the IR-track CTXDSL emission gap). CTXDSL could express transition modality (`[may]`/`[must]`, K.1–K.3) but had **no surface for per-state 3-valued (Kleene) predicate labels**, so a predicate-cube KMTS's `state_3valued_predicates` could not round-trip through CTXDSL. This adds the grammar + the **parse→realize** direction.

- **token:** new keyword `predicates_3v`.
- **ast:** `StateDecl.three_valued: Vec<ThreeValuedDecl>` + `ThreeValuedDecl` + `TristateLit { True, False, Unknown }`.
- **parser:** a per-state `predicates_3v { <pred> = true|false|unknown; }` sub-block (coexists with `vars`/`valuations` in any order; `true`/`false` reuse existing keywords, `unknown` is an identifier — no global reservation).
- **realize:** `build_automaton` applies each entry via `Clts::with_3valued_predicate` → `state_3valued_predicates` (`KleeneT`/`KleeneF`/`KleeneBot`); unrolling-path `StateDecl` clones carry the field.
- **wiki:** CTXDSL-Language-Reference gains a "Per-state 3-valued (Kleene) predicates" subsection.

### Scope
This is the **input** side — CTXDSL can now express + realize 3-valued cube labels. The **emit** side (cube `Clts` → CTXDSL `predicates_3v`, the full auto round-trip) is **Phase 1b** (emission runs from `AdapterIR`, so it needs the cube→ctxdsl bridge). 3-valued labels on the unrolling path are out of scope (cubes are explicit-state, non-unrolling).

### Test
`predicates_3v_block_realizes_into_state_3valued_predicates` — parses `predicates_3v { p = unknown; q = true; r = false; }`, asserts the realized CLTS carries `KleeneBot`/`KleeneT`/`KleeneF` (and `None` at a state without the block). clippy + fmt clean; all StateDecl construction sites updated (verified by `cargo check --tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)