### PR TITLE
feat(ctxdsl P1b): cube Clts → CTXDSL emit — predicates_3v round-trip

### DIFF
--- a/crates/mununu-core/src/adapter/aiger/mod.rs
+++ b/crates/mununu-core/src/adapter/aiger/mod.rs
@@ -212,6 +212,7 @@ fn to_ir(circuit: &ast::Circuit, options: &AdapterOptions) -> Result<AdapterIR, 
             name: name.clone(),
             is_initial: i == init_state_idx,
             valuations: None,
+            three_valued: None,
         })
         .collect();
 

--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -2743,6 +2743,7 @@ fn enumerate_and_blast(
                 name: split_names[i].clone(),
                 is_initial: init_split_set.contains(&i),
                 valuations: if vals.is_empty() { None } else { Some(vals) },
+                three_valued: None,
             }
         })
         .collect();
@@ -2757,6 +2758,7 @@ fn enumerate_and_blast(
             name: OOB_SINK_KEY.to_string(),
             is_initial: false,
             valuations: Some(oob_val),
+            three_valued: None,
         });
     }
 

--- a/crates/mununu-core/src/adapter/clts_to_ir.rs
+++ b/crates/mununu-core/src/adapter/clts_to_ir.rs
@@ -1,0 +1,259 @@
+//! `Clts` → [`AdapterIR`] → CTXDSL bridge.
+//!
+//! The format adapters build an [`AdapterIR`] from their source AST and the
+//! shared [`crate::adapter::emit`] emitter renders it to CTXDSL text. The
+//! *predicate-abstraction* path (the BTOR2 predicate-cube lift, the R-MM
+//! multi-module KMTS composition) instead produces a realized
+//! [`Clts`] directly — there is no source AST to translate. This module is
+//! the inverse seam: it reconstructs an [`AdapterIR`] from a realized `Clts`
+//! so the same emitter produces faithful CTXDSL for those paths too.
+//!
+//! What survives the round-trip (`clts_to_ctxdsl` → `parse` → `realize`):
+//! states (name + initial flag), transitions (flattened multi-label
+//! payloads + modality `[may]` / `[must]` + hyper-must additional targets),
+//! controllability (controllable / internal label partition), per-state
+//! display `valuations`, and — the CTXDSL Phase 1b gap fix — the per-state
+//! **3-valued (Kleene) predicate labels** (`state_3valued_predicates`),
+//! emitted as `predicates_3v { p = true|false|unknown; }` blocks. The
+//! Kleene labels are what make a predicate-cube KMTS round-trippable; before
+//! Phase 1a/1b there was no CTXDSL syntax for them, so routing a cube `Clts`
+//! through the emitter silently dropped the labelling.
+//!
+//! Not carried: mu-calculus property declarations (the cube/KMTS carries the
+//! model, not the formulae — the caller supplies those separately) and the
+//! `state_variable_bitset` 2-valued predicate set (it has no standalone
+//! per-state CTXDSL surface; it is reconstructed by the realize step from
+//! state names).
+
+use crate::adapter::AdapterError;
+use crate::adapter::SourceFormat;
+use crate::adapter::emit::emit;
+use crate::adapter::ir::{AdapterIR, AutomatonSpec, Metadata, StateSpec, TransitionSpec};
+use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, LabelId};
+use crate::context_dsl::ast::TransitionModalitySpec;
+use std::collections::HashSet;
+
+/// Render a realized `Clts` (a single automaton) as CTXDSL text via the
+/// shared [`crate::adapter::emit`] emitter.
+///
+/// `automaton_name` names the emitted `automaton <name> { … }`;
+/// `context_name` names the wrapping `context <name> { … }`.
+///
+/// Carries states + transitions + controllability + modality + per-state
+/// `valuations` **and** per-state 3-valued (Kleene) predicate labels
+/// (`predicates_3v { … }`). For a 2-valued CLTS (no 3-valued labels) the
+/// output is identical to the pre-Phase-1b emitter — the `predicates_3v`
+/// block only appears for states that carry Kleene labels.
+pub fn clts_to_ctxdsl(
+    clts: &Clts<DefaultStateIdx, DefaultLabelIdx>,
+    automaton_name: &str,
+    context_name: &str,
+) -> Result<String, AdapterError> {
+    let state_name = |s| clts.state_name(s).unwrap_or("state").to_string();
+
+    let states: Vec<StateSpec> = clts
+        .states()
+        .map(|s| {
+            // CTXDSL Phase 1b — carry the per-state 3-valued labels so the
+            // emitter writes a `predicates_3v { … }` block. Empty ⇒ `None`
+            // ⇒ no block emitted (the 2-valued path stays byte-for-byte).
+            let entries = clts.state_3valued_predicate_entries(s);
+            let three_valued = if entries.is_empty() {
+                None
+            } else {
+                Some(
+                    entries
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v))
+                        .collect(),
+                )
+            };
+            StateSpec {
+                name: state_name(s),
+                is_initial: clts.initial_states().contains(&s),
+                valuations: clts.state_valuation(s).cloned(),
+                three_valued,
+            }
+        })
+        .collect();
+
+    let mut transitions: Vec<TransitionSpec> = Vec::new();
+    for s in clts.states() {
+        let source = state_name(s);
+        for t in clts.outgoing(s) {
+            let mut labels: Vec<String> = Vec::new();
+            for &lid in t.labels() {
+                if let Some(payload) = clts.label_payload(lid) {
+                    labels.extend(payload.iter().cloned());
+                }
+            }
+            let (modality, additional_targets) = modality_to_spec(clts, t);
+            transitions.push(TransitionSpec {
+                source: source.clone(),
+                target: state_name(t.target()),
+                labels,
+                modality,
+                additional_targets,
+            });
+        }
+    }
+
+    let label_names = |set: &HashSet<LabelId<DefaultLabelIdx>>| -> Vec<String> {
+        let mut v: Vec<String> = set
+            .iter()
+            .filter_map(|&l| clts.label_payload(l))
+            .flatten()
+            .cloned()
+            .collect();
+        v.sort();
+        v.dedup();
+        v
+    };
+
+    let automaton = AutomatonSpec {
+        name: automaton_name.to_string(),
+        states,
+        transitions,
+        controllable_labels: label_names(clts.controllable_alphabet()),
+        internal_labels: label_names(clts.internal_alphabet()),
+    };
+
+    let ir = AdapterIR {
+        metadata: Metadata {
+            title: context_name.to_string(),
+            source_format: SourceFormat::SystemVerilog,
+            description: None,
+            game_semantics: None,
+            known_status: None,
+        },
+        signals: Vec::new(),
+        automata: vec![automaton],
+        compositions: Vec::new(),
+        properties: Vec::new(),
+        controller: None,
+    };
+
+    emit(&ir).map(|r| r.ctxdsl)
+}
+
+/// Map a transition's [`crate::clts::TransitionModality`] to the CTXDSL
+/// emitter's [`TransitionModalitySpec`] + the additional hyper-must target
+/// names (targets beyond the primary). `Sharp` / `MayOnly` carry no extra
+/// targets; a `MustHyperOnly` set maps to `MustOnly` with the targets after
+/// the primary surfaced as `additional_targets`.
+fn modality_to_spec(
+    clts: &Clts<DefaultStateIdx, DefaultLabelIdx>,
+    t: &crate::clts::Transition<DefaultStateIdx, DefaultLabelIdx>,
+) -> (TransitionModalitySpec, Vec<String>) {
+    use crate::clts::TransitionModality;
+    match t.modality() {
+        TransitionModality::Sharp => (TransitionModalitySpec::Sharp, Vec::new()),
+        TransitionModality::MayOnly => (TransitionModalitySpec::MayOnly, Vec::new()),
+        TransitionModality::MustHyperOnly(_) => {
+            let targets = t.modality().must_target_set(t.target());
+            let additional: Vec<String> = targets
+                .iter()
+                .skip(1)
+                .filter_map(|&st| clts.state_name(st).map(str::to_string))
+                .collect();
+            (TransitionModalitySpec::MustOnly, additional)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clts::TransitionModality;
+    use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, LabelControllability, Tristate};
+    use crate::context_dsl::parse;
+    use crate::context_dsl::realize::realize;
+
+    /// CTXDSL Phase 1b — a predicate-cube-shaped `Clts` carrying per-state
+    /// 3-valued (Kleene) labels round-trips through CTXDSL: the bridge emits
+    /// `predicates_3v { … }` blocks, the parser accepts them (Phase 1a), and
+    /// `realize` re-registers the Kleene verdicts on the rebuilt CLTS.
+    #[test]
+    fn cube_three_valued_labels_round_trip_through_ctxdsl() {
+        // Build a tiny 2-cube KMTS: one Sharp edge, one MayOnly self-loop,
+        // and a spread of Kleene labels (T / F / ⊥) on the cube states.
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        let c0 = b.state_id_or_insert("cube_0").expect("cube_0 id");
+        let c1 = b.state_id_or_insert("cube_1").expect("cube_1 id");
+        b.initial_state_id(c0);
+        let tick = b.labels().intern(["tick"]).expect("tick label");
+        b.set_label_controllability(tick, LabelControllability::Uncontrollable);
+        b.transition_ids(c0, &[tick], c1); // Sharp
+        b.transition_ids_with_modality(c1, &[tick], c1, TransitionModality::MayOnly);
+        b.with_3valued_predicate(c0, "boot_idle", Tristate::KleeneT);
+        b.with_3valued_predicate(c0, "boot_done", Tristate::KleeneF);
+        b.with_3valued_predicate(c0, "ctr_overflow", Tristate::KleeneBot);
+        b.with_3valued_predicate(c1, "boot_done", Tristate::KleeneT);
+        let clts = b.build().expect("build cube clts");
+
+        let ctxdsl = clts_to_ctxdsl(&clts, "M", "tri_roundtrip").expect("emit ctxdsl");
+
+        // Emission: the `predicates_3v` block + all three Kleene literals +
+        // the `[may]` modality suffix appear in the output.
+        assert!(
+            ctxdsl.contains("predicates_3v {"),
+            "missing block:\n{ctxdsl}"
+        );
+        assert!(ctxdsl.contains("boot_idle = true;"), "{ctxdsl}");
+        assert!(ctxdsl.contains("boot_done = false;"), "{ctxdsl}");
+        assert!(ctxdsl.contains("ctr_overflow = unknown;"), "{ctxdsl}");
+        assert!(
+            ctxdsl.contains("[may]"),
+            "MayOnly modality must round-trip:\n{ctxdsl}"
+        );
+
+        // Round-trip: parse → realize → the Kleene labels survive.
+        let doc = parse(&ctxdsl).expect("emitted ctxdsl parses");
+        let realized = realize(&doc, &[]).expect("emitted ctxdsl realizes");
+        let r = realized.context.clts("M").expect("automaton M exists");
+        assert!(
+            r.has_3valued_predicates(),
+            "3-valued labels must survive the round-trip"
+        );
+        let rs0 = r.state_id("cube_0").expect("cube_0 exists");
+        assert_eq!(
+            r.state_3valued_predicate(rs0, "boot_idle"),
+            Some(Tristate::KleeneT)
+        );
+        assert_eq!(
+            r.state_3valued_predicate(rs0, "boot_done"),
+            Some(Tristate::KleeneF)
+        );
+        assert_eq!(
+            r.state_3valued_predicate(rs0, "ctr_overflow"),
+            Some(Tristate::KleeneBot)
+        );
+        let rs1 = r.state_id("cube_1").expect("cube_1 exists");
+        assert_eq!(
+            r.state_3valued_predicate(rs1, "boot_done"),
+            Some(Tristate::KleeneT)
+        );
+    }
+
+    /// A 2-valued CLTS (no Kleene labels) emits no `predicates_3v` block —
+    /// the Phase 1b field is strictly additive for the legacy path.
+    #[test]
+    fn two_valued_clts_emits_no_predicates_3v_block() {
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        let s0 = b.state_id_or_insert("s0").expect("s0 id");
+        let s1 = b.state_id_or_insert("s1").expect("s1 id");
+        b.initial_state_id(s0);
+        let tick = b.labels().intern(["tick"]).expect("tick label");
+        b.transition_ids(s0, &[tick], s1);
+        let clts = b.build().expect("build clts");
+
+        let ctxdsl = clts_to_ctxdsl(&clts, "M", "two_valued").expect("emit ctxdsl");
+        assert!(
+            !ctxdsl.contains("predicates_3v"),
+            "no Kleene labels ⇒ no predicates_3v block:\n{ctxdsl}"
+        );
+        // Still parses + realizes (sanity).
+        let doc = parse(&ctxdsl).expect("parses");
+        realize(&doc, &[]).expect("realizes");
+    }
+}

--- a/crates/mununu-core/src/adapter/crewai/translate.rs
+++ b/crates/mununu-core/src/adapter/crewai/translate.rs
@@ -200,6 +200,7 @@ fn state_initial(name: &str) -> StateSpec {
         name: name.to_string(),
         is_initial: true,
         valuations: None,
+        three_valued: None,
     }
 }
 
@@ -208,6 +209,7 @@ fn state(name: &str) -> StateSpec {
         name: name.to_string(),
         is_initial: false,
         valuations: None,
+        three_valued: None,
     }
 }
 

--- a/crates/mununu-core/src/adapter/emit.rs
+++ b/crates/mununu-core/src/adapter/emit.rs
@@ -155,6 +155,21 @@ fn sanitize_valuation_value(value: &str) -> String {
     }
 }
 
+/// CTXDSL Phase 1b — render a [`crate::clts::Tristate`] as its CTXDSL
+/// `predicates_3v` literal: `KleeneT → "true"`, `KleeneF → "false"`,
+/// `KleeneBot → "unknown"`. The parser's `parse_tristate_lit`
+/// (the `true` / `false` keywords + the `unknown` identifier) accepts
+/// exactly these three forms, so emit ∘ parse round-trips the Kleene
+/// labels of a predicate-cube KMTS.
+fn tristate_to_ctxdsl(t: crate::clts::Tristate) -> &'static str {
+    use crate::clts::Tristate;
+    match t {
+        Tristate::KleeneT => "true",
+        Tristate::KleeneF => "false",
+        Tristate::KleeneBot => "unknown",
+    }
+}
+
 /// Convert a title to snake_case for the context name.
 fn to_snake_case(s: &str) -> String {
     let mut result = String::new();
@@ -534,11 +549,21 @@ fn emit_explicit(ir: &AdapterIR) -> Result<String, AdapterError> {
             } else {
                 format!("state {}", sanitize(&state.name))
             };
-            match state.valuations.as_ref().filter(|m| !m.is_empty()) {
-                None => w.write_line(&format!("{head};")),
-                Some(vals) => {
-                    w.write_line(&format!("{head} {{"));
-                    w.indent();
+            // CTXDSL Phase 1b — a state's optional outer block carries a
+            // `valuations { … }` block (display metadata) and/or a
+            // `predicates_3v { … }` block (Kleene labels lifted from a
+            // predicate-cube KMTS's `state_3valued_predicates`). Emit the
+            // outer block when EITHER is non-empty; emit the bare
+            // `state s;` form when both are empty (preserving pre-1b output
+            // byte-for-byte for the 2-valued adapters).
+            let vals = state.valuations.as_ref().filter(|m| !m.is_empty());
+            let preds3v = state.three_valued.as_ref().filter(|m| !m.is_empty());
+            if vals.is_none() && preds3v.is_none() {
+                w.write_line(&format!("{head};"));
+            } else {
+                w.write_line(&format!("{head} {{"));
+                w.indent();
+                if let Some(vals) = vals {
                     w.write_line("valuations {");
                     w.indent();
                     for (k, v) in vals.iter() {
@@ -550,9 +575,18 @@ fn emit_explicit(ir: &AdapterIR) -> Result<String, AdapterError> {
                     }
                     w.deindent();
                     w.write_line("}");
-                    w.deindent();
-                    w.write_line("};");
                 }
+                if let Some(preds) = preds3v {
+                    w.write_line("predicates_3v {");
+                    w.indent();
+                    for (k, v) in preds.iter() {
+                        w.write_line(&format!("{} = {};", sanitize(k), tristate_to_ctxdsl(*v)));
+                    }
+                    w.deindent();
+                    w.write_line("}");
+                }
+                w.deindent();
+                w.write_line("};");
             }
         }
         w.deindent();
@@ -1149,11 +1183,13 @@ mod tests {
                         name: "idle".into(),
                         is_initial: true,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "critical".into(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                 ],
                 transitions: vec![
@@ -1309,11 +1345,13 @@ context k3_roundtrip {
                         name: "s0".into(),
                         is_initial: true,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "s1".into(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                 ],
                 transitions: vec![TransitionSpec {
@@ -1354,21 +1392,25 @@ context k3_roundtrip {
                         name: "s0".into(),
                         is_initial: true,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "t1".into(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "t2".into(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "t3".into(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                 ],
                 transitions: vec![TransitionSpec {

--- a/crates/mununu-core/src/adapter/extraction/mod.rs
+++ b/crates/mununu-core/src/adapter/extraction/mod.rs
@@ -310,6 +310,7 @@ fn build_automaton(
                 name: s.name().to_string(),
                 is_initial,
                 valuations: None,
+                three_valued: None,
             }
         })
         .collect();

--- a/crates/mununu-core/src/adapter/ir.rs
+++ b/crates/mununu-core/src/adapter/ir.rs
@@ -142,6 +142,15 @@ pub struct StateSpec {
     /// Populated by adapters that enumerate states from cross-product domains
     /// (SV Kripke, extraction). Enables structured predicate matching.
     pub valuations: Option<std::collections::BTreeMap<String, String>>,
+    /// CTXDSL Phase 1b — per-state 3-valued (Kleene) predicate labels,
+    /// keyed by predicate name. Populated by the cube `Clts` → IR bridge
+    /// ([`crate::adapter::clts_to_ir::clts_to_ctxdsl`]) so the CTXDSL
+    /// emitter can serialize them as `predicates_3v { p = true|false|unknown; }`
+    /// blocks — the round-trippable surface for a predicate-cube KMTS's
+    /// `state_3valued_predicates`. `None` (the default for every 2-valued
+    /// adapter) emits no `predicates_3v` block, preserving prior output
+    /// byte-for-byte.
+    pub three_valued: Option<std::collections::BTreeMap<String, crate::clts::Tristate>>,
 }
 
 /// A transition in an explicit automaton.

--- a/crates/mununu-core/src/adapter/langgraph/translate.rs
+++ b/crates/mununu-core/src/adapter/langgraph/translate.rs
@@ -62,6 +62,7 @@ pub fn to_ir(
             name: sanitise_ident(&n.id),
             is_initial: n.id == entry,
             valuations: None,
+            three_valued: None,
         })
         .collect();
 

--- a/crates/mununu-core/src/adapter/microcode/translate.rs
+++ b/crates/mununu-core/src/adapter/microcode/translate.rs
@@ -67,6 +67,7 @@ pub fn to_ir(
             name: state_name,
             is_initial: idx == 0,
             valuations: None,
+            three_valued: None,
         });
     }
 

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -39,6 +39,7 @@
 
 pub mod aiger;
 pub mod btor2;
+pub mod clts_to_ir;
 pub mod crewai;
 pub mod cvc5;
 pub mod domain;

--- a/crates/mununu-core/src/adapter/promela/mod.rs
+++ b/crates/mununu-core/src/adapter/promela/mod.rs
@@ -127,6 +127,7 @@ fn to_ir(program: &ast::Program, options: &AdapterOptions) -> Result<AdapterIR, 
                 name: loc.label.clone(),
                 is_initial: loc.id == proc_cfg.initial,
                 valuations: None,
+                three_valued: None,
             })
             .collect();
 
@@ -318,6 +319,7 @@ fn create_variable_automaton(
             name: state_name.clone(),
             is_initial: val == init_val,
             valuations: None,
+            three_valued: None,
         });
 
         // set_var_val transitions from any state to this value
@@ -378,6 +380,7 @@ fn create_channel_automaton(chan: &ast::ChanDecl) -> AutomatonSpec {
             name: format!("{}_idle", chan.name),
             is_initial: true,
             valuations: None,
+            three_valued: None,
         });
         let rendezvous_label = format!("rendezvous_{}", chan.name);
         transitions.push(TransitionSpec {
@@ -400,6 +403,7 @@ fn create_channel_automaton(chan: &ast::ChanDecl) -> AutomatonSpec {
                 name: state_name.clone(),
                 is_initial: k == 0,
                 valuations: None,
+                three_valued: None,
             });
         }
 

--- a/crates/mununu-core/src/adapter/xstate/mod.rs
+++ b/crates/mununu-core/src/adapter/xstate/mod.rs
@@ -168,6 +168,7 @@ fn build_automaton_from_region(
             name: s.name.clone(),
             is_initial: s.is_initial,
             valuations: None,
+            three_valued: None,
         })
         .collect();
 
@@ -293,11 +294,13 @@ fn create_bool_variable_automaton(name: &str, initial: bool) -> AutomatonSpec {
                 name: true_state.clone(),
                 is_initial: initial,
                 valuations: None,
+                three_valued: None,
             },
             StateSpec {
                 name: false_state.clone(),
                 is_initial: !initial,
                 valuations: None,
+                three_valued: None,
             },
         ],
         transitions: vec![
@@ -369,6 +372,7 @@ fn create_int_variable_automaton(name: &str, lo: i64, hi: i64, initial: i64) -> 
             name: format!("{name}_{v}"),
             is_initial: v == initial,
             valuations: None,
+            three_valued: None,
         });
     }
 

--- a/crates/mununu-core/src/adapter/yosys/multi_module.rs
+++ b/crates/mununu-core/src/adapter/yosys/multi_module.rs
@@ -32,7 +32,7 @@ use crate::clts::{Clts, CltsResult, DefaultLabelIdx, DefaultStateIdx, LabelId, S
 use crate::composition::{CompositionOptions, CompositionSemantics, compose};
 use crate::controllability::BoundaryDirection;
 use smallvec::SmallVec;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 /// The clock-step fallback label the bit-blaster emits for a module with no
 /// free (non-clock, non-reset) inputs. It is shared across such modules so
@@ -390,123 +390,24 @@ fn realize_module_clts(ctxdsl: &str) -> Result<Clts<DefaultStateIdx, DefaultLabe
         .ok_or_else(|| format!("automaton '{name}' missing after realise"))
 }
 
-/// R-MM-5a — Serialise a `Clts` to CTXDSL by building a single-automaton
-/// [`crate::adapter::ir::AdapterIR`] and reusing the IR→CTXDSL emitter
-/// ([`crate::adapter::emit::emit`]).
+/// R-MM-5a / CTXDSL Phase 1b — Serialise a `Clts` to CTXDSL by building a
+/// single-automaton [`crate::adapter::ir::AdapterIR`] and reusing the
+/// IR→CTXDSL emitter.
 ///
 /// This is what lets a composed multi-module KMTS re-enter the standard
 /// parse→realise→evaluate verify pipeline: the pipeline rebuilds the
 /// predicate `Environment` from the inline state valuations, so no bespoke
-/// direct-evaluation path (and its duplicated predicate-bitset machinery)
-/// is needed. The composed design becomes a first-class, inspectable CTXDSL
-/// artifact.
+/// direct-evaluation path is needed. The composed design becomes a
+/// first-class, inspectable CTXDSL artifact.
 ///
-/// Emits the 2-valued shape (states + inline valuations + multi-label
-/// transitions + controllability + modality). 3-valued predicate labellings
-/// have no CTXDSL syntax and are absent on the 2-valued multi-module path.
-pub fn clts_to_ctxdsl(
-    clts: &Clts<DefaultStateIdx, DefaultLabelIdx>,
-    automaton_name: &str,
-    context_name: &str,
-) -> Result<String, AdapterError> {
-    use crate::adapter::SourceFormat;
-    use crate::adapter::emit::emit;
-    use crate::adapter::ir::{AdapterIR, AutomatonSpec, Metadata, StateSpec, TransitionSpec};
-
-    let state_name = |s| clts.state_name(s).unwrap_or("state").to_string();
-
-    let states: Vec<StateSpec> = clts
-        .states()
-        .map(|s| StateSpec {
-            name: state_name(s),
-            is_initial: clts.initial_states().contains(&s),
-            valuations: clts.state_valuation(s).cloned(),
-        })
-        .collect();
-
-    let mut transitions: Vec<TransitionSpec> = Vec::new();
-    for s in clts.states() {
-        let source = state_name(s);
-        for t in clts.outgoing(s) {
-            let mut labels: Vec<String> = Vec::new();
-            for &lid in t.labels() {
-                if let Some(payload) = clts.label_payload(lid) {
-                    labels.extend(payload.iter().cloned());
-                }
-            }
-            let (modality, additional_targets) = modality_to_spec(clts, t);
-            transitions.push(TransitionSpec {
-                source: source.clone(),
-                target: state_name(t.target()),
-                labels,
-                modality,
-                additional_targets,
-            });
-        }
-    }
-
-    let label_names = |set: &HashSet<LabelId<DefaultLabelIdx>>| -> Vec<String> {
-        let mut v: Vec<String> = set
-            .iter()
-            .filter_map(|&l| clts.label_payload(l))
-            .flatten()
-            .cloned()
-            .collect();
-        v.sort();
-        v.dedup();
-        v
-    };
-
-    let automaton = AutomatonSpec {
-        name: automaton_name.to_string(),
-        states,
-        transitions,
-        controllable_labels: label_names(clts.controllable_alphabet()),
-        internal_labels: label_names(clts.internal_alphabet()),
-    };
-
-    let ir = AdapterIR {
-        metadata: Metadata {
-            title: context_name.to_string(),
-            source_format: SourceFormat::SystemVerilog,
-            description: Some("R-MM composed multi-module KMTS".to_string()),
-            game_semantics: None,
-            known_status: None,
-        },
-        signals: Vec::new(),
-        automata: vec![automaton],
-        compositions: Vec::new(),
-        properties: Vec::new(),
-        controller: None,
-    };
-
-    emit(&ir).map(|r| r.ctxdsl)
-}
-
-/// Map a transition's [`crate::clts::TransitionModality`] to the CTXDSL
-/// emitter's `TransitionModalitySpec` + the additional hyper-must target
-/// names (targets beyond the primary). Sharp / MayOnly carry no extra
-/// targets; the 2-valued multi-module path is all Sharp.
-fn modality_to_spec(
-    clts: &Clts<DefaultStateIdx, DefaultLabelIdx>,
-    t: &crate::clts::Transition<DefaultStateIdx, DefaultLabelIdx>,
-) -> (crate::context_dsl::ast::TransitionModalitySpec, Vec<String>) {
-    use crate::clts::TransitionModality;
-    use crate::context_dsl::ast::TransitionModalitySpec;
-    match t.modality() {
-        TransitionModality::Sharp => (TransitionModalitySpec::Sharp, Vec::new()),
-        TransitionModality::MayOnly => (TransitionModalitySpec::MayOnly, Vec::new()),
-        TransitionModality::MustHyperOnly(_) => {
-            let targets = t.modality().must_target_set(t.target());
-            let additional: Vec<String> = targets
-                .iter()
-                .skip(1)
-                .filter_map(|&st| clts.state_name(st).map(str::to_string))
-                .collect();
-            (TransitionModalitySpec::MustOnly, additional)
-        }
-    }
-}
+/// The implementation moved to the frontend-neutral
+/// [`crate::adapter::clts_to_ir`] module (CTXDSL Phase 1b) so the
+/// predicate-cube / CEGAR path can reuse it. It now also carries each
+/// state's 3-valued (Kleene) labels as `predicates_3v { … }` blocks — the
+/// gap the prior multi-module note ("3-valued predicate labellings have no
+/// CTXDSL syntax") flagged, now closed by Phase 1a (grammar) + 1b (emit).
+/// Re-exported here for the existing R-MM multi-module callers.
+pub use crate::adapter::clts_to_ir::clts_to_ctxdsl;
 
 #[cfg(test)]
 mod tests {

--- a/crates/mununu-core/tests/adapter_xstate_viability.rs
+++ b/crates/mununu-core/tests/adapter_xstate_viability.rs
@@ -44,16 +44,19 @@ fn viability_simple_automaton_eval_synth() {
                     name: "Green".to_string(),
                     is_initial: true,
                     valuations: None,
+                    three_valued: None,
                 },
                 StateSpec {
                     name: "Yellow".to_string(),
                     is_initial: false,
                     valuations: None,
+                    three_valued: None,
                 },
                 StateSpec {
                     name: "Red".to_string(),
                     is_initial: false,
                     valuations: None,
+                    three_valued: None,
                 },
             ],
             transitions: vec![
@@ -171,11 +174,13 @@ fn viability_synchronous_composition() {
                         name: "Off".to_string(),
                         is_initial: true,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "On".to_string(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                 ],
                 transitions: vec![
@@ -207,16 +212,19 @@ fn viability_synchronous_composition() {
                         name: "Idle".to_string(),
                         is_initial: true,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "Active".to_string(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "Done".to_string(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                 ],
                 transitions: vec![
@@ -340,16 +348,19 @@ fn viability_variable_automaton_guard_sync() {
                         name: "Idle".to_string(),
                         is_initial: true,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "Working".to_string(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "Done".to_string(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                 ],
                 transitions: vec![
@@ -423,16 +434,19 @@ fn viability_variable_automaton_guard_sync() {
                         name: "counter_0".to_string(),
                         is_initial: true,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "counter_1".to_string(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                     StateSpec {
                         name: "counter_2".to_string(),
                         is_initial: false,
                         valuations: None,
+                        three_valued: None,
                     },
                 ],
                 transitions: vec![

--- a/crates/mununu-core/tests/emit_valuations_roundtrip.rs
+++ b/crates/mununu-core/tests/emit_valuations_roundtrip.rs
@@ -39,16 +39,19 @@ fn fixture_ir() -> AdapterIR {
                     name: "s0".to_string(),
                     is_initial: true,
                     valuations: Some(val(&[("empty", "1"), ("full", "0")])),
+                    three_valued: None,
                 },
                 StateSpec {
                     name: "s1".to_string(),
                     is_initial: false,
                     valuations: Some(val(&[("empty", "0"), ("full", "0")])),
+                    three_valued: None,
                 },
                 StateSpec {
                     name: "s2".to_string(),
                     is_initial: false,
                     valuations: Some(val(&[("empty", "0"), ("full", "1"), ("phase", "writing")])),
+                    three_valued: None,
                 },
             ],
             transitions: vec![


### PR DESCRIPTION
## CTXDSL output track — Phase 1b

Makes a **predicate-cube KMTS** (`state_3valued_predicates` / `Tristate`) round-trip through CTXDSL. Phase 1a (#118) added the grammar (per-state `predicates_3v { … }` block); this adds the **emit** side so `parse(emit(cube))` preserves the Kleene labels — the enabling gap fix for opt-in CTXDSL output of the abstraction/CEGAR model (Phase 2+).

### Changes
- **`ir::StateSpec`** gains `three_valued: Option<BTreeMap<String, Tristate>>` (beside `valuations`); every construction site defaults it to `None`.
- **`emit::emit_explicit`** emits a `predicates_3v { p = true|false|unknown; }` sub-block via the new `tristate_to_ctxdsl` helper. Empty/`None` emits no block, so 2-valued adapter output is **byte-for-byte unchanged**.
- **Relocated the `Clts`→IR→CTXDSL bridge** from `yosys::multi_module` to a frontend-neutral `adapter::clts_to_ir` (`clts_to_ctxdsl` + `modality_to_spec`), enhanced to carry the 3-valued labels. `yosys::multi_module` re-exports it (`pub use`), so the orchestrator + R-MM callers are unchanged and the btor2/cube path can now reach it dependency-correctly. Closes the exact gap the old multi-module doc flagged ("3-valued predicate labellings have no CTXDSL syntax").

### Tests
- `cube_three_valued_labels_round_trip_through_ctxdsl` — build a cube `Clts` (T/F/⊥ labels + Sharp + MayOnly edges) → emit → parse → realize → Kleene labels survive, `[may]` round-trips.
- `two_valued_clts_emits_no_predicates_3v_block` — strictly-additive guard.

Modality round-trips end-to-end (K.1c, `ab2fa4b`, lets labeled `[may]`/`[must]` parse).

### Verification
`fmt --check`, workspace `clippy -D warnings`, `-p mununu-core --all-features --doc` (57), and `cargo test --workspace --all-features` all green (1989 passed; the only failure is the pre-existing `write_debug_ctxdsl` — syntcomp-gated, reads from `mununu-private`, untouched here, and not in the `make ci`/CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)