### PR TITLE
feat(ctxdsl P2): opt-in emit-ctxdsl of the CEGAR cube model + formula

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -323,6 +323,16 @@ struct Btor2CegarArgs {
     /// Example: `--sidecar examples/v6_controllability_kmts/source/amba_arbiter.mununu.json`.
     #[arg(long = "sidecar", value_name = "PATH")]
     sidecar: Option<PathBuf>,
+    /// CTXDSL Phase 2 (2026-06-22) — opt-in: write the final refined
+    /// predicate-cube model + the checked formula to this path as a
+    /// self-contained CTXDSL document. Default off (the cube is dropped at
+    /// loop exit). The emitted CTXDSL carries the cube states' 3-valued
+    /// (`predicates_3v`) labels + transition modality + a `mu_formulas`
+    /// block with the formula. Pass `/dev/stdout` to print to the terminal.
+    ///
+    /// Example: `--emit-ctxdsl /tmp/cegar_model.ctxdsl`.
+    #[arg(long = "emit-ctxdsl", value_name = "PATH")]
+    emit_ctxdsl: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -1895,6 +1905,9 @@ fn btor2_cegar(args: Btor2CegarArgs) -> Result<(), String> {
         lift_strategy: LiftStrategy::Eager,
         must_edge_inference,
         may_edge_inference,
+        // CTXDSL Phase 2 — capture the final cube model only when the
+        // `--emit-ctxdsl` flag asks for it.
+        emit_ctxdsl: args.emit_ctxdsl.is_some(),
     };
 
     // R-S8 session 2 (2026-06-08) — parse the `--config-values`
@@ -1952,6 +1965,39 @@ fn btor2_cegar(args: Btor2CegarArgs) -> Result<(), String> {
         &cegar_opts,
     )
     .map_err(|e| format!("cegar refine loop: {}", e.message))?;
+
+    // CTXDSL Phase 2 (2026-06-22) — opt-in model + formula CTXDSL dump.
+    // When `--emit-ctxdsl <PATH>` is set, the loop captured the final
+    // refined cube `Clts` into `trace.final_clts`; serialize it together
+    // with the checked formula (the original `--formula` string) and write
+    // the document to PATH. Uses stderr for the confirmation so the
+    // `--json` verdict on stdout stays clean.
+    if let Some(emit_path) = &args.emit_ctxdsl {
+        match &trace.final_clts {
+            Some(clts) => {
+                let model_ctxdsl = mununu_core::adapter::clts_to_ir::clts_to_ctxdsl_with_formula(
+                    clts,
+                    "lifted_kmts",
+                    "cegar_model",
+                    "checked_property",
+                    &args.formula,
+                )
+                .map_err(|e| format!("emit ctxdsl: {}", e.message))?;
+                std::fs::write(emit_path, &model_ctxdsl)
+                    .map_err(|e| format!("write ctxdsl to '{}': {e}", emit_path.display()))?;
+                eprintln!(
+                    "Wrote model + formula CTXDSL to {} ({} bytes)",
+                    emit_path.display(),
+                    model_ctxdsl.len()
+                );
+            }
+            None => {
+                eprintln!(
+                    "warning: --emit-ctxdsl set but the CEGAR loop produced no final cube model"
+                );
+            }
+        }
+    }
 
     // #2 (M.4) — surface the final 3-valued verdict the loop reached.
     // Previously the CLI printed only `terminated_with` + the predicate

--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -245,6 +245,14 @@ pub struct CegarOptions {
     /// with a non-`Off` `must_edge_inference` is not yet wired — see
     /// [`crate::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs`].
     pub may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference,
+    /// CTXDSL Phase 2 (2026-06-22) — when `true`, the loop captures the
+    /// final refined predicate-cube `Clts` into [`CegarTrace::final_clts`]
+    /// so a caller can serialize the abstract model to CTXDSL via
+    /// [`crate::adapter::clts_to_ir::clts_to_ctxdsl_with_formula`]. Default
+    /// `false`, in which case the cube is dropped at loop exit (no clone
+    /// cost). This is the opt-in behind the `--emit-ctxdsl` CLI flag and
+    /// the API's `emit_ctxdsl` request field.
+    pub emit_ctxdsl: bool,
 }
 
 /// R.5 lazy KMTS sub-item 2.4 (2026-06-04) — selector for the
@@ -297,6 +305,10 @@ impl std::fmt::Debug for CegarOptions {
             // overridden.
             ds.field("must_edge_inference", &self.must_edge_inference);
         }
+        if self.emit_ctxdsl {
+            // emit_ctxdsl default is false; only print when opted in.
+            ds.field("emit_ctxdsl", &true);
+        }
         ds.finish()
     }
 }
@@ -313,6 +325,7 @@ impl Default for CegarOptions {
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         }
     }
 }
@@ -462,6 +475,16 @@ pub struct CegarTrace {
     /// - No classifying transition's source predicate maps to
     ///   a register in the BTOR2 source.
     pub init_refinement_candidates: Vec<String>,
+    /// CTXDSL Phase 2 (2026-06-22) — the final refined predicate-cube
+    /// `Clts` (the abstract model the loop converged/capped on), captured
+    /// only when [`CegarOptions::emit_ctxdsl`] is `true`. A caller pairs
+    /// it with the checked formula and
+    /// [`crate::adapter::clts_to_ir::clts_to_ctxdsl_with_formula`] to
+    /// return the model + formula as inspectable CTXDSL (the opt-in
+    /// `--emit-ctxdsl` / `emit_ctxdsl` surfaces). `None` when the opt-in
+    /// was off — the cube is dropped at loop exit, avoiding the clone.
+    pub final_clts:
+        Option<crate::clts::Clts<crate::clts::DefaultStateIdx, crate::clts::DefaultLabelIdx>>,
 }
 
 /// R.5 MVP — Run the CEGAR refinement loop on a BTOR2 fixture +
@@ -514,6 +537,15 @@ pub fn cegar_refine_loop(
     // deterministic ordering in the trace output.
     let mut init_refinement_candidates: std::collections::BTreeSet<String> =
         std::collections::BTreeSet::new();
+    // CTXDSL Phase 2 (2026-06-22) — when `emit_ctxdsl` is set, hold the
+    // most-recent iteration's lifted cube `Clts` so the final `CegarTrace`
+    // carries the abstract model for CTXDSL serialization. Each iteration
+    // overwrites it, so at any return point it holds the final (latest)
+    // model. Cloned per iteration only under the opt-in; stays `None`
+    // (no clone) otherwise.
+    let mut captured_clts: Option<
+        crate::clts::Clts<crate::clts::DefaultStateIdx, crate::clts::DefaultLabelIdx>,
+    > = None;
     // R.5 B.4.a (2026-06-01) — effective iteration cap. Starts as
     // `cegar_opts.max_iterations`; iteration 0's UF-wrap detection
     // may lower it to `SMART_UF_MAX_ITERATIONS` when the smart
@@ -624,6 +656,13 @@ pub fn cegar_refine_loop(
                 )?
             }
         };
+
+        // CTXDSL Phase 2 (2026-06-22) — capture this iteration's cube model
+        // for the opt-in CTXDSL dump. Each iteration overwrites, so at any
+        // return point `captured_clts` holds the final (latest) model.
+        if cegar_opts.emit_ctxdsl {
+            captured_clts = Some(lift_result.clts.clone());
+        }
 
         // R.5 B.3.b (2026-06-01) — soundness warning. After the
         // FIRST lift, check whether the input formula has
@@ -879,6 +918,8 @@ pub fn cegar_refine_loop(
                 approximant_reuse_enabled: cegar_opts.enable_approximant_reuse,
                 warnings: warnings.clone(),
                 init_refinement_candidates: init_refinement_candidates.iter().cloned().collect(),
+                // CTXDSL Phase 2 — final cube model (Some only under emit_ctxdsl).
+                final_clts: captured_clts.take(),
             });
         }
 
@@ -905,6 +946,8 @@ pub fn cegar_refine_loop(
                 approximant_reuse_enabled: cegar_opts.enable_approximant_reuse,
                 warnings: warnings.clone(),
                 init_refinement_candidates: init_refinement_candidates.iter().cloned().collect(),
+                // CTXDSL Phase 2 — final cube model (Some only under emit_ctxdsl).
+                final_clts: captured_clts.take(),
             });
         }
 
@@ -978,6 +1021,8 @@ pub fn cegar_refine_loop(
                 approximant_reuse_enabled: cegar_opts.enable_approximant_reuse,
                 warnings: warnings.clone(),
                 init_refinement_candidates: init_refinement_candidates.iter().cloned().collect(),
+                // CTXDSL Phase 2 — final cube model (Some only under emit_ctxdsl).
+                final_clts: captured_clts.take(),
             });
         }
 
@@ -1462,6 +1507,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -1481,6 +1527,55 @@ mod tests {
         }
         assert!(trace.lazy_lift_pending);
         assert!(!trace.approximant_reuse_enabled);
+        // CTXDSL Phase 2 — emit_ctxdsl defaulted false ⇒ no captured cube.
+        assert!(trace.final_clts.is_none());
+    }
+
+    /// CTXDSL Phase 2 (2026-06-22) — `emit_ctxdsl: true` captures the final
+    /// refined cube `Clts` into the trace; it serializes to a model +
+    /// formula CTXDSL document via `clts_to_ctxdsl_with_formula`.
+    #[test]
+    fn cegar_emit_ctxdsl_captures_final_cube_model() {
+        let formula = parser::parse("true").expect("formula parses");
+        let initial = vec![PredicateSpec {
+            name: "p".into(),
+            register: "reg_a".into(),
+            value: 0,
+        }];
+        let env = Environment::new(2);
+        let cegar_opts = CegarOptions {
+            emit_ctxdsl: true,
+            ..Default::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            SMALL_BTOR2,
+            initial,
+            &env,
+            &AdapterOptions::default(),
+            &cegar_opts,
+        )
+        .expect("cegar succeeds");
+        let clts = trace
+            .final_clts
+            .as_ref()
+            .expect("emit_ctxdsl=true ⇒ final cube model captured");
+        let ctxdsl = crate::adapter::clts_to_ir::clts_to_ctxdsl_with_formula(
+            clts,
+            "lifted_kmts",
+            "cegar_model",
+            "checked_property",
+            "true",
+        )
+        .expect("serialize model + formula");
+        assert!(
+            ctxdsl.contains("automaton lifted_kmts {"),
+            "model automaton missing:\n{ctxdsl}"
+        );
+        assert!(
+            ctxdsl.contains("body = true;"),
+            "formula body missing:\n{ctxdsl}"
+        );
     }
 
     #[test]
@@ -1577,6 +1672,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -1636,6 +1732,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2037,6 +2134,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace_off = cegar_refine_loop(
             &formula,
@@ -2068,6 +2166,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace_on = cegar_refine_loop(
             &formula,
@@ -2163,6 +2262,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace_off = cegar_refine_loop(
             &formula,
@@ -2185,6 +2285,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace_on = cegar_refine_loop(
             &formula,
@@ -2388,6 +2489,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let env_iter0 = Environment::new(2);
         let result_off = cegar_refine_loop(
@@ -2413,6 +2515,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let result_on = cegar_refine_loop(
             &formula,
@@ -2487,6 +2590,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2537,6 +2641,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2674,6 +2779,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2718,6 +2824,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2802,6 +2909,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2888,6 +2996,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -2952,6 +3061,7 @@ mod tests {
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -3017,6 +3127,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let debug_str = format!("{opts:?}");
         assert!(
@@ -3070,6 +3181,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace_result = cegar_refine_loop(
             &formula,
@@ -3125,6 +3237,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -3176,6 +3289,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace = cegar_refine_loop(
             &formula,
@@ -3239,6 +3353,7 @@ mod tests {
 
             must_edge_inference: crate::adapter::btor2::kmts_lift::MustEdgeInference::Off,
             may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            emit_ctxdsl: false,
         };
         let trace_eager = cegar_refine_loop(
             &formula,

--- a/crates/mununu-core/src/adapter/clts_to_ir.rs
+++ b/crates/mununu-core/src/adapter/clts_to_ir.rs
@@ -28,7 +28,10 @@
 use crate::adapter::AdapterError;
 use crate::adapter::SourceFormat;
 use crate::adapter::emit::emit;
-use crate::adapter::ir::{AdapterIR, AutomatonSpec, Metadata, StateSpec, TransitionSpec};
+use crate::adapter::ir::{
+    AdapterIR, AutomatonSpec, Metadata, PropertyFormula, PropertyKind, PropertyRole, PropertySpec,
+    StateSpec, TransitionSpec,
+};
 use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, LabelId};
 use crate::context_dsl::ast::TransitionModalitySpec;
 use std::collections::HashSet;
@@ -49,6 +52,55 @@ pub fn clts_to_ctxdsl(
     automaton_name: &str,
     context_name: &str,
 ) -> Result<String, AdapterError> {
+    let ir = build_ir(clts, automaton_name, context_name, Vec::new());
+    emit(&ir).map(|r| r.ctxdsl)
+}
+
+/// CTXDSL Phase 2 — like [`clts_to_ctxdsl`] but also emits the checked
+/// property as a `mu_formulas { formula <name> { over <automaton>; body =
+/// <formula_body>; } }` block, producing a self-contained "model +
+/// formula" CTXDSL document (the artifact the opt-in `--emit-ctxdsl` /
+/// `emit_ctxdsl` surfaces return for the predicate-cube / CEGAR path).
+///
+/// `formula_body` is the **original** mu-calculus source text (the emitter
+/// writes it verbatim as the `body`), so it must be a string the CTXDSL
+/// parser accepts — pass the user-supplied formula string, not a
+/// re-rendered AST (`mu_calculus::Formula` has no CTXDSL `Display`).
+///
+/// Fidelity note: the emitted document is an inspectable record of the
+/// abstract model + the formula that was checked. Re-verifying it is
+/// subject to the same 2-valued-evaluator-vs-Kleene-label gap the rest of
+/// the predicate-cube path has (the evaluator reads atomic propositions,
+/// not the `predicates_3v` Kleene labels); the artifact is faithful to the
+/// model + formula, not a guaranteed re-runnable proof.
+pub fn clts_to_ctxdsl_with_formula(
+    clts: &Clts<DefaultStateIdx, DefaultLabelIdx>,
+    automaton_name: &str,
+    context_name: &str,
+    formula_name: &str,
+    formula_body: &str,
+) -> Result<String, AdapterError> {
+    let property = PropertySpec {
+        name: formula_name.to_string(),
+        kind: PropertyKind::Safety,
+        formula: PropertyFormula::MuCalculus(formula_body.to_string()),
+        role: PropertyRole::Standalone,
+        over: Some(automaton_name.to_string()),
+        description: None,
+    };
+    let ir = build_ir(clts, automaton_name, context_name, vec![property]);
+    emit(&ir).map(|r| r.ctxdsl)
+}
+
+/// Reconstruct an [`AdapterIR`] from a realized `Clts` plus an optional set
+/// of properties. Shared by [`clts_to_ctxdsl`] (no properties) and
+/// [`clts_to_ctxdsl_with_formula`] (one mu-calculus property).
+fn build_ir(
+    clts: &Clts<DefaultStateIdx, DefaultLabelIdx>,
+    automaton_name: &str,
+    context_name: &str,
+    properties: Vec<PropertySpec>,
+) -> AdapterIR {
     let state_name = |s| clts.state_name(s).unwrap_or("state").to_string();
 
     let states: Vec<StateSpec> = clts
@@ -118,7 +170,7 @@ pub fn clts_to_ctxdsl(
         internal_labels: label_names(clts.internal_alphabet()),
     };
 
-    let ir = AdapterIR {
+    AdapterIR {
         metadata: Metadata {
             title: context_name.to_string(),
             source_format: SourceFormat::SystemVerilog,
@@ -129,11 +181,9 @@ pub fn clts_to_ctxdsl(
         signals: Vec::new(),
         automata: vec![automaton],
         compositions: Vec::new(),
-        properties: Vec::new(),
+        properties,
         controller: None,
-    };
-
-    emit(&ir).map(|r| r.ctxdsl)
+    }
 }
 
 /// Map a transition's [`crate::clts::TransitionModality`] to the CTXDSL
@@ -255,5 +305,47 @@ mod tests {
         // Still parses + realizes (sanity).
         let doc = parse(&ctxdsl).expect("parses");
         realize(&doc, &[]).expect("realizes");
+    }
+
+    /// CTXDSL Phase 2 — `clts_to_ctxdsl_with_formula` emits the model AND a
+    /// `mu_formulas` block carrying the checked property, and the whole
+    /// document parses (model + formula round-trip).
+    #[test]
+    fn model_plus_formula_emits_mu_formulas_block_and_parses() {
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        let c0 = b.state_id_or_insert("cube_0").expect("cube_0 id");
+        let c1 = b.state_id_or_insert("cube_1").expect("cube_1 id");
+        b.initial_state_id(c0);
+        let tick = b.labels().intern(["tick"]).expect("tick label");
+        b.transition_ids(c0, &[tick], c1);
+        b.transition_ids(c1, &[tick], c1);
+        b.with_3valued_predicate(c0, "boot_idle", Tristate::KleeneT);
+        let clts = b.build().expect("build clts");
+
+        let formula = "nu X. ([] X)";
+        let ctxdsl = clts_to_ctxdsl_with_formula(
+            &clts,
+            "lifted_kmts",
+            "cegar_model",
+            "checked_property",
+            formula,
+        )
+        .expect("emit ctxdsl + formula");
+
+        assert!(ctxdsl.contains("mu_formulas {"), "{ctxdsl}");
+        assert!(
+            ctxdsl.contains("formula checked_property {"),
+            "named formula block missing:\n{ctxdsl}"
+        );
+        assert!(ctxdsl.contains("over lifted_kmts;"), "{ctxdsl}");
+        assert!(
+            ctxdsl.contains(&format!("body = {formula};")),
+            "verbatim formula body missing:\n{ctxdsl}"
+        );
+        // The model still carries its 3-valued labels alongside the formula.
+        assert!(ctxdsl.contains("predicates_3v {"), "{ctxdsl}");
+        // The whole "model + formula" document parses + realizes.
+        let doc = parse(&ctxdsl).expect("model+formula ctxdsl parses");
+        realize(&doc, &[]).expect("model+formula ctxdsl realizes");
     }
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -663,6 +663,9 @@ pub async fn btor2_cegar_handler(
         lift_strategy: LiftStrategy::Eager,
         must_edge_inference,
         may_edge_inference,
+        // CTXDSL Phase 2 — capture the final cube model only when the
+        // request opts in via `emit_ctxdsl`.
+        emit_ctxdsl: request.emit_ctxdsl,
     };
 
     // M.6 parity (2026-06-20) — config-values symbolic init is now an API
@@ -717,6 +720,32 @@ pub async fn btor2_cegar_handler(
         value: p.value,
     };
 
+    // CTXDSL Phase 2 (2026-06-22) — opt-in model + formula CTXDSL. When the
+    // request set `emit_ctxdsl`, the loop captured the final refined cube
+    // `Clts` into `trace.final_clts`; serialize it together with the checked
+    // formula (the original request string). Absent ⇒ `None` ⇒ the `ctxdsl`
+    // response field is omitted.
+    let ctxdsl = if request.emit_ctxdsl {
+        match &trace.final_clts {
+            Some(clts) => Some(
+                crate::adapter::clts_to_ir::clts_to_ctxdsl_with_formula(
+                    clts,
+                    "lifted_kmts",
+                    "cegar_model",
+                    "checked_property",
+                    &request.formula,
+                )
+                .map_err(|e| ApiError::BadRequest {
+                    message: format!("emit ctxdsl: {}", e.message),
+                    details: None,
+                })?,
+            ),
+            None => None,
+        }
+    } else {
+        None
+    };
+
     let iterations = trace
         .iterations
         .iter()
@@ -744,6 +773,7 @@ pub async fn btor2_cegar_handler(
         lazy_lift_pending: trace.lazy_lift_pending,
         approximant_reuse_enabled: trace.approximant_reuse_enabled,
         warnings: trace.warnings.iter().map(|w| w.message.clone()).collect(),
+        ctxdsl,
     }))
 }
 
@@ -2850,6 +2880,7 @@ members = ["x"]
             must_edge_inference: None,
             may_edge_inference: None,
             config_values: vec![],
+            emit_ctxdsl: false,
         };
 
         let Json(out) = btor2_cegar_handler(Json(request))
@@ -2879,6 +2910,64 @@ members = ["x"]
         );
         // The final predicate set includes at least the bootstrap predicate.
         assert!(!out.final_predicates.is_empty());
+        // CTXDSL Phase 2 — emit_ctxdsl defaulted false ⇒ no ctxdsl field.
+        assert!(
+            out.ctxdsl.is_none(),
+            "ctxdsl must be omitted when emit_ctxdsl=false"
+        );
+    }
+
+    /// CTXDSL Phase 2 (2026-06-22) — `emit_ctxdsl: true` returns the final
+    /// refined cube model + the checked formula as a self-contained CTXDSL
+    /// document in the response's `ctxdsl` field.
+    #[tokio::test]
+    async fn btor2_cegar_handler_emit_ctxdsl_returns_model_and_formula() {
+        use crate::api::models::PredicateSpecRequest;
+        let btor2 = "\
+1 sort bitvec 2
+2 state 2 burst
+3 zero 2
+4 init 2 2 3
+5 const 2 01
+6 sub 2 2 5
+7 next 2 2 6
+";
+        let request = Btor2CegarRequest {
+            content: btor2.to_string(),
+            formula: "nu X. ([] X)".to_string(),
+            predicates: vec![PredicateSpecRequest {
+                name: "burst_zero".to_string(),
+                register: "burst".to_string(),
+                value: 0,
+            }],
+            controllable_inputs: vec![],
+            predicate_source: None,
+            max_iterations: Some(2),
+            must_edge_inference: None,
+            may_edge_inference: None,
+            config_values: vec![],
+            emit_ctxdsl: true,
+        };
+        let Json(out) = btor2_cegar_handler(Json(request))
+            .await
+            .expect("CEGAR endpoint runs with emit_ctxdsl");
+        let ctxdsl = out
+            .ctxdsl
+            .expect("emit_ctxdsl=true ⇒ response carries the model CTXDSL");
+        assert!(ctxdsl.contains("context "), "ctxdsl:\n{ctxdsl}");
+        assert!(
+            ctxdsl.contains("automaton lifted_kmts {"),
+            "ctxdsl:\n{ctxdsl}"
+        );
+        assert!(ctxdsl.contains("mu_formulas {"), "ctxdsl:\n{ctxdsl}");
+        assert!(
+            ctxdsl.contains("formula checked_property {"),
+            "ctxdsl:\n{ctxdsl}"
+        );
+        assert!(
+            ctxdsl.contains("body = nu X. ([] X);"),
+            "formula body must round-trip verbatim; ctxdsl:\n{ctxdsl}"
+        );
     }
 
     /// M.6 parity (2026-06-20) — the CEGAR endpoint now accepts `config_values`
@@ -2910,6 +2999,7 @@ members = ["x"]
             must_edge_inference: None,
             may_edge_inference: Some("smt-all-pairs".to_string()),
             config_values: vec!["burst=0,1,2,3".to_string()],
+            emit_ctxdsl: false,
         };
         let Json(out) = btor2_cegar_handler(Json(request))
             .await
@@ -2937,6 +3027,7 @@ members = ["x"]
             must_edge_inference: None,
             may_edge_inference: None,
             config_values: vec!["this is not valid".to_string()],
+            emit_ctxdsl: false,
         };
         let err = btor2_cegar_handler(Json(request))
             .await

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -865,6 +865,13 @@ pub struct Btor2CegarRequest {
     /// no synthetic init sidecar.
     #[serde(default)]
     pub config_values: Vec<String>,
+    /// CTXDSL Phase 2 (2026-06-22) — opt-in (default `false`): when set, the
+    /// response gains a `ctxdsl` field carrying the final refined cube model
+    /// and the checked formula as a self-contained CTXDSL document (the
+    /// `predicates_3v` Kleene labels, transition modality, and a
+    /// `mu_formulas` block). Mirrors the CLI `--emit-ctxdsl`.
+    #[serde(default)]
+    pub emit_ctxdsl: bool,
 }
 
 /// U.0 — CEGAR refinement trace, JSON-shaped for the refinement-trace
@@ -887,6 +894,11 @@ pub struct Btor2CegarResponse {
     pub approximant_reuse_enabled: bool,
     /// Soundness / advisory warnings produced during the run.
     pub warnings: Vec<String>,
+    /// CTXDSL Phase 2 (2026-06-22) — the final refined cube model + the
+    /// checked formula as CTXDSL, present only when the request set
+    /// `emit_ctxdsl: true`. Omitted from the JSON otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ctxdsl: Option<String>,
 }
 
 /// One CEGAR iteration, viewer-shaped.


### PR DESCRIPTION
## CTXDSL output track — Phase 2 (CLI + API; UI peer in mununu-ui#19)

Closes the Q2 gap on the predicate-cube / CEGAR path: return the **abstract model + the checked formula** as CTXDSL, **opt-in (default off)**, across CLI + API (+ UI). Builds directly on the Phase 1b `Clts`→CTXDSL bridge (#119).

**Scope:** the CEGAR path only — the import (bit-blast) path already returns CTXDSL by default and `context eval` consumes CTXDSL as input, so CEGAR was the only surface with *no* CTXDSL output.

### Changes
- **`clts_to_ir::clts_to_ctxdsl_with_formula`** — emits the model (the Phase 1b bridge) plus a `mu_formulas { formula <name> { over <aut>; body = <f>; } }` block. The formula text is the user's original mu-calculus string written verbatim (`mu_calculus::Formula` has no CTXDSL `Display`).
- **`CegarOptions::emit_ctxdsl`** (default `false`) → `cegar_refine_loop` captures the final refined cube `Clts` into the new **`CegarTrace::final_clts`** (cloned only under the opt-in; `None` otherwise — zero cost on the default path).
- **CLI**: `mununu btor2 cegar --emit-ctxdsl <PATH>` writes the model+formula CTXDSL to PATH (stderr confirmation; stdout/`--json` stays clean; `/dev/stdout` to print).
- **API**: `Btor2CegarRequest.emit_ctxdsl` (`#[serde(default)]`) → `Btor2CegarResponse.ctxdsl: Option<String>` (`skip_serializing_if`).

### Tests
- `clts_to_ir::model_plus_formula_emits_mu_formulas_block_and_parses`
- `cegar::cegar_emit_ctxdsl_captures_final_cube_model` (+ `is_none` default assertion)
- `handlers::btor2_cegar_handler_emit_ctxdsl_returns_model_and_formula` (+ `is_none` default)

### Verification
`make ci` (default features) green — **2228 passed, 0 failed**; `cargo test -p mununu-core --all-features --doc` 57; `cargo clippy --workspace --all-features --all-targets -D warnings` clean; `cargo fmt --check` clean.

UI peer: **vscorza/mununu-ui#19**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)