### PR TITLE
feat(ir-track P3.1 + P3.2): 3-valued verify verdict surface + sidecar predicate-cube schema

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2362,6 +2362,7 @@ fn btor2_discover(args: Btor2DiscoverArgs) -> Result<(), String> {
             memories: Vec::new(),
             uf_wrap: Vec::new(),
             uf_unwrap: Vec::new(),
+            predicates: Vec::new(),
         }
     };
 

--- a/crates/mununu-core/src/adapter/sidecar/btor2_resolver.rs
+++ b/crates/mununu-core/src/adapter/sidecar/btor2_resolver.rs
@@ -118,6 +118,7 @@ mod tests {
             memories: Vec::new(),
             uf_wrap: Vec::new(),
             uf_unwrap: Vec::new(),
+            predicates: Vec::new(),
         }
     }
 

--- a/crates/mununu-core/src/adapter/systemverilog/annotation.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/annotation.rs
@@ -221,6 +221,43 @@ pub struct SvAnnotation {
     /// (queued); until then, schema-only.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub uf_unwrap: Vec<String>,
+
+    /// IR-track P3.2 (2026-06-22) — predicate-cube declaration for the
+    /// SV **verify** path. Each entry is a `{name, register, value}`
+    /// register-value equality predicate (`register == value`) that
+    /// bounds the abstraction — the same shape the cegar
+    /// `predicate_cube_lift` / API `PredicateSpecRequest` consume.
+    ///
+    /// When non-empty, the verify path (IR-track **P3.3**, NOT yet
+    /// wired) routes this module through `predicate_cube_lift` + the
+    /// 3-valued (`KleeneDom`) evaluator instead of the bit-blast
+    /// `FieldDomain` path — i.e. this is how an SV verify run opts into
+    /// the predicate-cube abstraction. Until P3.3's verify-dispatch
+    /// integration ships, declarations here are accepted + validated by
+    /// the schema but have NO effect on the abstract model (the verify
+    /// path stays bit-blast).
+    ///
+    /// Default empty — preserves the bit-blast behaviour for every
+    /// existing fixture.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub predicates: Vec<PredicateDeclaration>,
+}
+
+/// IR-track P3.2 (2026-06-22) — one register-value equality predicate
+/// for the predicate-cube verify path. Mirrors the cegar
+/// [`crate::adapter::btor2::kmts_lift::PredicateSpec`] and the API
+/// `PredicateSpecRequest` shape so the sidecar declaration threads
+/// directly into the cube lift once P3.3 wires it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PredicateDeclaration {
+    /// Human-readable predicate name (e.g. `"boot_idle"`).
+    pub name: String,
+    /// BTOR2/register symbol the predicate tests (the same name space
+    /// the `signals[]` entries' `name` field targets).
+    pub register: String,
+    /// Value the predicate checks: the predicate holds iff
+    /// `register == value`.
+    pub value: u64,
 }
 
 /// §Phase 10 §10.2 stage 2 — Memory-cell annotation.
@@ -1297,6 +1334,7 @@ const SV_TOP_KEYS: &[&str] = &[
     "memories",
     "uf_wrap",
     "uf_unwrap",
+    "predicates",
 ];
 const SV_SIGNAL_KEYS: &[&str] = &[
     "name",
@@ -1608,6 +1646,46 @@ mod tests {
     }
 
     #[test]
+    fn sidecar_with_predicate_declarations_round_trips_and_lints_clean() {
+        // IR-track P3.2 — a `predicates` block deserializes into
+        // PredicateDeclaration entries, is NOT flagged as an unknown
+        // root field by the lint (it's in SV_TOP_KEYS), and round-trips
+        // on serialize. Schema-only — no verify wiring yet (P3.3).
+        let json = r#"{
+            "$schema": "mununu_sv_annotation_v1",
+            "module": "boot",
+            "signals": [{ "name": "boot_fsm_ns", "abstraction": "discover" }],
+            "predicates": [
+                { "name": "boot_idle", "register": "boot_fsm_ns", "value": 0 },
+                { "name": "boot_done", "register": "boot_fsm_ns", "value": 7 }
+            ]
+        }"#;
+        let ann: SvAnnotation = serde_json::from_str(json).expect("parses");
+        assert_eq!(ann.predicates.len(), 2);
+        assert_eq!(ann.predicates[0].name, "boot_idle");
+        assert_eq!(ann.predicates[0].register, "boot_fsm_ns");
+        assert_eq!(ann.predicates[1].value, 7);
+        // `predicates` is an allowlisted root key → no unknown-field warning.
+        let warnings = lint_annotation_json(json, "boot.mununu.json").expect("lints");
+        assert!(
+            !warnings.iter().any(|w| w.contains("predicates")),
+            "predicates must not warn as unknown; got: {warnings:?}"
+        );
+        // Round-trips on serialize.
+        let out = serde_json::to_string(&ann).expect("serializes");
+        assert!(out.contains("\"predicates\""), "serialized: {out}");
+    }
+
+    #[test]
+    fn sidecar_without_predicates_defaults_empty() {
+        // Back-compat: legacy sidecars (no `predicates` key) load with
+        // an empty predicate set — the bit-blast verify path is unchanged.
+        let json = r#"{ "module": "m", "signals": [] }"#;
+        let ann: SvAnnotation = serde_json::from_str(json).expect("parses");
+        assert!(ann.predicates.is_empty());
+    }
+
+    #[test]
     fn parse_discover_with_discovered_values() {
         let json = r#"{
             "module": "alu",
@@ -1702,6 +1780,7 @@ mod tests {
             memories: Vec::new(),
             uf_wrap: Vec::new(),
             uf_unwrap: Vec::new(),
+            predicates: Vec::new(),
         }
     }
 
@@ -2340,6 +2419,7 @@ mod tests {
             memories: Vec::new(),
             uf_wrap: Vec::new(),
             uf_unwrap: Vec::new(),
+            predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2407,6 +2487,7 @@ mod tests {
             memories: Vec::new(),
             uf_wrap: Vec::new(),
             uf_unwrap: Vec::new(),
+            predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2549,6 +2630,7 @@ mod tests {
             memories: Vec::new(),
             uf_wrap: Vec::new(),
             uf_unwrap: Vec::new(),
+            predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2700,6 +2782,7 @@ mod tests {
             memories: Vec::new(),
             uf_wrap: Vec::new(),
             uf_unwrap: Vec::new(),
+            predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2798,6 +2881,7 @@ mod tests {
             memories: Vec::new(),
             uf_wrap: Vec::new(),
             uf_unwrap: Vec::new(),
+            predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -1281,6 +1281,19 @@ fn evaluate_one_property(
         .collect();
     let satisfied = !initial_states.is_empty() && initial_satisfying.len() == initial_states.len();
 
+    // IR-track P3.1 — 3-valued { T, F, ⊥ } summary over the initial
+    // states, derived from the 2-valued `result`. This is the verify
+    // path's bit-blast model (exact for the explicit state space), so
+    // every initial state is definite: T = satisfying, F = not. No
+    // KleeneBot arises here (`unknown_cells = 0`); the predicate-cube
+    // path (P3.3) is what introduces ⊥. Derived, not a second eval —
+    // additive surface with zero verdict change + zero perf cost.
+    let initial_verdict_summary = crate::verify::report::ThreeValuedSummary {
+        true_cells: initial_satisfying.len(),
+        false_cells: initial_states.len() - initial_satisfying.len(),
+        unknown_cells: 0,
+    };
+
     let counterexample = if !satisfied {
         build_counterexample_witness(clts, &result, TRACE_WITNESS_STEP_CAP)
     } else {
@@ -1297,6 +1310,7 @@ fn evaluate_one_property(
         satisfying_states,
         initial_states,
         initial_satisfying,
+        initial_verdict_summary,
         counterexample,
     })
 }
@@ -1850,7 +1864,16 @@ over = "S"
         // The XState adapter consumed only the primary file — the
         // automaton in the composition came from `primary.xstate.json`.
         assert_eq!(report.sources[0].id, "x");
-        assert!(report.property_verdicts[0].satisfied);
+        let v = &report.property_verdicts[0];
+        assert!(v.satisfied);
+        // IR-track P3.1 — the 3-valued summary mirrors the 2-valued
+        // result on the bit-blast path: every initial state is a
+        // definite KleeneT (satisfying `true`), no KleeneBot.
+        let s = &v.initial_verdict_summary;
+        assert_eq!(s.true_cells, v.initial_satisfying.len());
+        assert_eq!(s.true_cells + s.false_cells, v.initial_states.len());
+        assert_eq!(s.unknown_cells, 0, "bit-blast verify path has no ⊥");
+        assert_eq!(s.false_cells, 0, "satisfied ⇒ no violating initial state");
     }
 
     #[test]

--- a/crates/mununu-core/src/verify/report.rs
+++ b/crates/mununu-core/src/verify/report.rs
@@ -53,6 +53,22 @@ pub struct CompositionInfo {
     pub members: Vec<String>,
 }
 
+/// IR-track P3.1 (2026-06-22) — a 3-valued { KleeneT, KleeneF,
+/// KleeneBot } cell-count summary. Same shape as the cegar
+/// `CegarVerdictSummary` so the UI can reuse the `Trit` renderer.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ThreeValuedSummary {
+    /// States with a definite KleeneT (satisfying) verdict.
+    pub true_cells: usize,
+    /// States with a definite KleeneF (violating) verdict.
+    pub false_cells: usize,
+    /// States with an indefinite KleeneBot (⊥) verdict — "needs
+    /// refinement". Always 0 on the 2-valued bit-blast verify path
+    /// (the explicit-state model is exact); populated by the
+    /// predicate-cube path (IR-track P3.3).
+    pub unknown_cells: usize,
+}
+
 /// Verdict for one property.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PropertyVerdict {
@@ -76,6 +92,14 @@ pub struct PropertyVerdict {
     pub initial_states: Vec<String>,
     /// Subset of `initial_states` that satisfy the formula.
     pub initial_satisfying: Vec<String>,
+    /// IR-track P3.1 (2026-06-22) — 3-valued { T, F, ⊥ } summary over
+    /// the **initial** states. On the 2-valued bit-blast verify path
+    /// the model is exact, so `unknown_cells` is 0 and this mirrors
+    /// `satisfied` (T = satisfying, F = not). The predicate-cube path
+    /// (P3.3) populates `unknown_cells` with genuine KleeneBot cells.
+    /// `#[serde(default)]` so pre-P3 reports still deserialize.
+    #[serde(default)]
+    pub initial_verdict_summary: ThreeValuedSummary,
     /// Witness path from a violating initial state, when the
     /// verdict is unsatisfied and a witness can be constructed. The
     /// orchestrator emits this opportunistically — `None` is also


### PR DESCRIPTION
## What

The two **low-risk, additive** opening steps of IR-track **P3** (route the verify path through the predicate-cube + 3-valued evaluator). Both are surface-building only — **no verdict changes, no verify-dispatch changes**. The high-risk core (P3.3 cube routing + P3.4 fixture migration) is a separate Go/No-Go. Breakdown: `.claude/plans/ir-track-p3-breakdown.md`.

Two commits:

### P3.1 — 3-valued `{ T, F, ⊥ }` verdict summary on the verify path (`400aca0`)
- `report.rs`: `ThreeValuedSummary { true_cells, false_cells, unknown_cells }` (same shape as the cegar `CegarVerdictSummary`) + `PropertyVerdict.initial_verdict_summary` (`#[serde(default)]`).
- `orchestrator.rs`: `evaluate_one_property` derives the summary over the initial states **from the existing 2-valued `result`** — not a second eval, so the 2-valued path is byte-for-byte unchanged and `unknown_cells` is always 0 here. P3.3 populates `⊥` from the predicate-cube + `KleeneDom` evaluator.
- The API verify handler returns `report::VerifyReport` directly → the field flows to the API for free. UI peer: mununu-ui PR #23.

### P3.2 — sidecar predicate-cube declaration (`ae59b4d`)
- `annotation.rs`: `PredicateDeclaration { name, register, value }` (mirrors `PredicateSpec`/`PredicateSpecRequest`) + `SvAnnotation.predicates`; added `"predicates"` to the `SV_TOP_KEYS` lint allowlist; 8 full-literal construction sites get `predicates: Vec::new()`.
- Schema-only: accepted + validated, **no verify wiring** (P3.3). Default empty preserves bit-blast behaviour for every fixture.

## Tests

- P3.1: verify orchestrator test asserts the summary mirrors the 2-valued result (`true == initial_satisfying`, `T+F == initials`, `⊥ == 0`).
- P3.2: round-trip + no-unknown-field-warning + back-compat (empty default).
- Pre-push green: `clippy --all-features --all-targets -D warnings`, `cargo test --workspace`, `--all-features` doctests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)