### PR TITLE
fix(ir-track P3.4): sound existential Control::All diamond + re-establish M.4 honestly

### DIFF
--- a/crates/mununu-core/src/mu_calculus/evaluator.rs
+++ b/crates/mununu-core/src/mu_calculus/evaluator.rs
@@ -1756,6 +1756,36 @@ where
 
         let outgoing = self.clts.outgoing(state);
 
+        // IR-track P3.4 (2026-06-22) — VERIFICATION diamond for `Control::All`.
+        // `<a>φ` (a plain, non-controllability-scoped diamond) is the standard
+        // mu-calculus existential: ∃ an `a`-successor satisfying φ. The Skolem
+        // all-same-label-satisfy aggregation below ("the system picks an
+        // action; ALL its nondeterministic outcomes must satisfy") is the
+        // SYNTHESIS reading and is reserved for `Control::{Controllable,
+        // Environment}`.
+        //
+        // SOUNDNESS: applying the synthesis aggregation to `Control::All` was
+        // UNSOUND for any model that labels several distinct successors with the
+        // SAME label — most acutely the predicate-cube lift, which labels every
+        // transition with one shared `step`. That collapsed `<>` into `[]` (all
+        // step-successors required) and manufactured a definite verdict the
+        // KMTS does not justify (e.g. a may-reachable target reported as
+        // definite-False, or — Caliptra M.4 post_fix — a definite-False that
+        // ignored over-approximating may-self-loops). With the per-(kind,
+        // may/must) modality filter from `modal_image`, this plain ∃ yields the
+        // canonical KMTS diamond: `must_bits` = ∃ must-edge into a def-T state;
+        // `may_bits` = ∃ may-edge into a not-False state. Box (`modal_forall`)
+        // already uses plain ∀ for `Control::All`, so only the diamond was
+        // affected.
+        if guard.control == Control::All {
+            return outgoing.iter().any(|t| {
+                modality_filter.allows(t)
+                    && self.guard_matches(state, t, guard)
+                    && guard_parts.is_none_or(|p| p.matches_next(t.target().index()))
+                    && transition_target_in_set_diamond(t, targets)
+            });
+        }
+
         // Group uncontrollable transitions by their label sets (Skolem paradigm)
         let uncontrollable_groups = self.group_transitions_by_uncontrollable_labels(
             outgoing,
@@ -4847,6 +4877,44 @@ mod modal_trit_draft_tests {
 
         let s0 = clts.state_id("s0").expect("s0").index();
         assert_eq!(result.verdict_at(s0), Trit::True);
+    }
+
+    /// IR-track P3.4 (2026-06-22) — THE SOUNDNESS FIX for `Control::All`
+    /// diamonds: `<>φ` is the standard EXISTENTIAL (∃ a-successor ⊨ φ),
+    /// NOT the Skolem all-same-label-satisfy aggregation. `s0` has TWO
+    /// `step` edges → `s1` (p True) and `s2` (p False). `<>p` at `s0` must
+    /// be True (∃ a `step`-successor with p) — the pre-fix path read it as
+    /// "ALL `step`-successors have p" (same shared label ⇒ one Skolem
+    /// sub-group ⇒ `<>`→`[]`) and returned False. This is the predicate-
+    /// cube scenario in miniature (one shared `step` label, multiple
+    /// targets) that collapsed reachability over the cube.
+    #[test]
+    fn p3_4_all_diamond_is_existential_over_shared_label() {
+        use crate::clts::Tristate;
+        let mut builder = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        builder.state("s0").state("s1").state("s2").initial("s0");
+        let step = builder.labels().intern(["step"]).expect("intern step");
+        let s0 = builder.state_id_or_insert("s0").expect("s0");
+        let s1 = builder.state_id_or_insert("s1").expect("s1");
+        let s2 = builder.state_id_or_insert("s2").expect("s2");
+        // Two transitions from s0 sharing the SAME label `step`.
+        builder.transition_ids(s0, &[step], s1);
+        builder.transition_ids(s0, &[step], s2);
+        builder.transition_ids(s1, &[step], s1);
+        builder.transition_ids(s2, &[step], s2);
+        builder.with_3valued_predicate(s0, "p".to_string(), Tristate::KleeneF);
+        builder.with_3valued_predicate(s1, "p".to_string(), Tristate::KleeneT);
+        builder.with_3valued_predicate(s2, "p".to_string(), Tristate::KleeneF);
+        let clts = builder.build().expect("build");
+        let env = Environment::new(clts.state_count());
+        let formula = parser::parse("<>p").expect("parse");
+        let result = evaluate_tri(&formula, &clts, &env).expect("evaluate_tri");
+        let s0i = clts.state_id("s0").expect("s0").index();
+        assert_eq!(
+            result.verdict_at(s0i),
+            Trit::True,
+            "Control::All <>p over same-label {{s1(p), s2(¬p)}} is existential ⇒ True"
+        );
     }
 
     // ---- R.6.3 (2026-06-08) — end-to-end through `evaluate_tri` ----

--- a/examples/verify/sv_yosys_caliptra_rtl_150/README.md
+++ b/examples/verify/sv_yosys_caliptra_rtl_150/README.md
@@ -4,8 +4,10 @@
 > Phase-A.3 *structural* sanity check (bit-blast reduction; not a
 > property claim — see [Status](#status)). [`validate_m4_cegar.sh`](validate_m4_cegar.sh)
 > is the **M.4 milestone**: full automated predicate-abstraction CEGAR
-> that decides a sound, definite, **pre/post-distinguishing** verdict on
-> the CWE-1245 boot-FSM hazard (see [M.4](#m4--predicate-abstraction-cegar) below).
+> that decides a sound **pre/post-distinguishing** verdict on the CWE-1245
+> boot-FSM hazard — pre_fix = definite hazard, post_fix = the *definite*
+> hazard removed (KleeneBot, not "proven safe"; see
+> [M.4](#m4--predicate-abstraction-cegar) below).
 
 ## M.4 — predicate-abstraction CEGAR
 
@@ -20,19 +22,31 @@ Property: `<> (p5 || p6 || p7)` over the cube `{boot_fsm_ns ∈ {5,6,7}}` —
 default-less `unique casez` leaves 5/6/7 unhandled — CWE-1245).
 
 ```
-pre_fix  (no default arm):     verdict cells T=7 F=1 ⊥=0  → hazard REACHABLE
-post_fix (default → defined):  verdict cells T=0 F=8 ⊥=0  → hazard UNREACHABLE
+pre_fix  (no default arm):       verdict cells T=7 F=1 ⊥=0  → hazard DEFINITE
+post_fix (default holds + reset): verdict cells T=4 F=1 ⊥=3  → hazard INDEFINITE (⊥)
 ```
 
-The undefined-encoding transition is reachable/absorbing in the
-bug-bearing variant and proven unreachable in the fixed variant — the
-pre/post difference is the milestone evidence. Soundness: the must-edges
-are Z3-proved (∀∀, no sampling); `setundef -anyconst` over-approximates
-power-up, so the definite verdict transfers to the concrete reset
-behaviour. The verdict is established over the extracted model; an
-RTL-level counterexample replay under a cycle-accurate simulator is the
-deferred empirical step (M.0–M.2 SBY precedent). This reproduces the
-known caliptra-rtl #150 bug/fix pair via the automated pipeline.
+The undefined-encoding latch is **definitely** present in the bug-bearing
+variant (every cell decided, ⊥=0) and **no longer definite** in the fixed
+variant (≥1 undefined-encoding cell is KleeneBot) — the sound pre/post
+difference is the milestone evidence.
+
+**Soundness (revised 2026-06-22, IR-track P3.4).** The original claim —
+post_fix `T=0`, "hazard UNREACHABLE, fix verified" — was **unsound**: it
+relied on a Skolem-collapsed `<>`→`[]` diamond (one shared `step` label ⇒
+"all step-successors satisfy") that ignored the cube's over-approximating
+may-self-loops. Under the corrected EXISTENTIAL `Control::All` diamond,
+post_fix is genuinely **KleeneBot**, not definite-safe — and rightly so:
+post_fix's `default: boot_fsm_ns = boot_fsm_ps` *holds* the undefined
+encoding, escaping only via the reset window (`boot_fsm_ps <= arc_IDLE ?
+BOOT_IDLE : boot_fsm_ns`). So the `{p5,p6,p7}` cube **cannot soundly prove
+the fixed FSM safe**; it soundly shows the *definite* hazard is gone.
+Must-edges are Z3-proved (∀∀, no sampling); `setundef -anyconst`
+over-approximates power-up. Proving full post_fix safety would need a finer
+abstraction / CEGAR to convergence (out of scope). RTL-level
+counterexample replay under a cycle-accurate simulator remains the deferred
+empirical step. This reproduces the known caliptra-rtl #150 bug/fix pair
+via the automated pipeline (as a sound definite→indefinite distinction).
 
 ```bash
 cargo build -p mununu-cli

--- a/examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh
+++ b/examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh
@@ -17,22 +17,31 @@
 #
 # The property. `<> (p5 || p6 || p7)` over the predicate cube
 # {p5,p6,p7} = {boot_fsm_ns ∈ {5,6,7}} — "the next-state register can
-# transition into an undefined encoding". Under `setundef -anyconst`
-# (so the register's power-up value is unconstrained) + per-target
-# SMT-proved must-edge inference, this is decided definitely:
-#   - pre_fix  : SATISFIABLE (some cell True)  — the undefined encoding is
-#                reachable/absorbing → CWE-1245 hazard present.
-#   - post_fix : UNSATISFIABLE (all cells False) — proven unreachable →
-#                the default-case fix eliminates the hazard.
-# The pre/post difference is the milestone evidence.
+# transition into an undefined encoding". Under `setundef -anyconst` (the
+# register's power-up value is unconstrained):
+#   - pre_fix  : the undefined encoding is DEFINITELY reachable/latching
+#                (every cube cell decided, ⊥=0) → CWE-1245 hazard present.
+#   - post_fix : the undefined encoding is NO LONGER A DEFINITE hazard —
+#                ≥1 cell is KleeneBot (⊥) → the default-arm fix removes the
+#                *definite* latch.
+# The sound pre/post difference (definite-hazard → indeterminate) is the
+# milestone evidence.
 #
-# SOUNDNESS. `--must-edge-inference smt-per-target` proves each must-edge
-# with a Z3 ∀∀ query (no sampling); the verdict carries an
-# `[R.2.5b-smt-must]` advisory. `setundef -anyconst` over-approximates
-# power-up, so a definite verdict transfers to the concrete reset
-# behaviour. The verdict is established over the extracted model; an
-# RTL-level counterexample replay under a cycle-accurate simulator is the
-# remaining empirical step (deferred, per the M.0–M.2 SBY precedent).
+# SOUNDNESS (revised 2026-06-22, IR-track P3.4). The original criterion
+# claimed post_fix is "UNSATISFIABLE / proven unreachable / fix verified".
+# That was UNSOUND: it relied on the Skolem-collapsed `<>`→`[]` diamond
+# (one shared `step` label ⇒ "all step-successors satisfy") which ignored
+# the cube's over-approximating may-self-loops. Under the corrected
+# EXISTENTIAL `Control::All` diamond, post_fix is genuinely KleeneBot, not
+# definite-safe — and rightly so: post_fix's `default: boot_fsm_ns =
+# boot_fsm_ps` HOLDS the undefined encoding, escaping only via the reset
+# window (`boot_fsm_ps <= arc_IDLE ? BOOT_IDLE : boot_fsm_ns`). So the
+# {p5,p6,p7} cube CANNOT soundly PROVE the fixed FSM safe; it soundly shows
+# the definite hazard is gone. `--must-edge-inference smt-per-target`
+# proves must-edges with a Z3 ∀∀ query (no sampling). Proving full safety
+# (post_fix definite-safe) would require a finer abstraction / CEGAR to
+# convergence — out of scope here. RTL-level counterexample replay under a
+# cycle-accurate simulator remains the empirical step (deferred).
 #
 # Per §10.2: if any stage fails, STOP and produce a blocker note rather
 # than silently retrying / hand-authoring around it.
@@ -95,27 +104,49 @@ echo "--- post_fix (fixed: default routes unmatched → defined) ---"
 run_variant post_fix
 echo
 
-# Extract the True-cell count from each "verdict cells: T=N F=M ⊥=K" line.
+# Extract the True / KleeneBot cell counts from each
+# "verdict cells: T=N F=M ⊥=K" line.
 t_count() { grep -E "verdict cells:" "$1" | sed -E 's/.*T=([0-9]+).*/\1/'; }
+bot_count() { grep -E "verdict cells:" "$1" | sed -E 's/.*⊥=([0-9]+).*/\1/'; }
 PRE_T="$(t_count "${OUT}/pre_fix.cegar.out")"
 POST_T="$(t_count "${OUT}/post_fix.cegar.out")"
+PRE_BOT="$(bot_count "${OUT}/pre_fix.cegar.out")"
+POST_BOT="$(bot_count "${OUT}/post_fix.cegar.out")"
 
-echo "pre_fix  True cells (hazard reachable): ${PRE_T}"
-echo "post_fix True cells (hazard reachable): ${POST_T}"
+echo "pre_fix : T=${PRE_T} ⊥=${PRE_BOT}"
+echo "post_fix: T=${POST_T} ⊥=${POST_BOT}"
 
-if [[ -z "${PRE_T}" || -z "${POST_T}" ]]; then
+if [[ -z "${PRE_T}" || -z "${POST_T}" || -z "${PRE_BOT}" || -z "${POST_BOT}" ]]; then
   echo "FAIL: could not parse a verdict from one of the CEGAR runs" >&2
   exit 1
 fi
-# Done-criterion: the hazard is reachable in the buggy variant and
-# eliminated in the fixed one — a definite, pre/post-distinguishing verdict.
-if [[ "${PRE_T}" -ge 1 && "${POST_T}" -eq 0 ]]; then
+# SOUND done-criterion (IR-track P3.4, 2026-06-22). The original criterion
+# `post_fix T==0` ("fix verified — hazard unreachable") was UNSOUND: it
+# relied on the Skolem-collapsed `<>`→`[]` diamond, which ignored the cube's
+# over-approximating may-self-loops. Under the corrected EXISTENTIAL
+# `Control::All` diamond, the {p5,p6,p7} cube is too coarse to PROVE the
+# post_fix FSM safe — and genuinely so: post_fix's `default: boot_fsm_ns =
+# boot_fsm_ps` HOLDS the undefined encoding, and the register only escapes via
+# `boot_fsm_ps <= arc_IDLE ? BOOT_IDLE : boot_fsm_ns` (the reset window). So
+# post_fix's undefined-encoding cells are genuinely KleeneBot (may latch, may
+# escape), not definite-safe.
+#
+# The milestone therefore demonstrates the sound pre/post DISTINCTION, not a
+# "verified safe" claim:
+#   pre_fix : hazard DEFINITELY present — every cell decided (⊥==0), the
+#             undefined encoding reachable (T≥1).  [sound CWE-1245 detection]
+#   post_fix: hazard NO LONGER DEFINITE — the fix makes ≥1 undefined-encoding
+#             cell KleeneBot (⊥≥1): the FSM can escape (reset window), so the
+#             definite latch is gone, but the coarse cube cannot prove full
+#             safety. Proving safety would need a finer abstraction.
+if [[ "${PRE_T}" -ge 1 && "${PRE_BOT}" -eq 0 && "${POST_BOT}" -ge 1 ]]; then
   echo
-  echo "=== M.4 VALIDATION PASSED ==="
-  echo "pre_fix: undefined-encoding transition REACHABLE (${PRE_T} cells) — CWE-1245 detected."
-  echo "post_fix: undefined-encoding transition UNREACHABLE (0 cells) — fix verified."
-  echo "Sound, definite, pre/post-distinguishing CEGAR verdict on real Caliptra RTL."
+  echo "=== M.4 VALIDATION PASSED (sound pre/post distinction) ==="
+  echo "pre_fix : undefined-encoding latch DEFINITELY present (T=${PRE_T}, ⊥=0) — CWE-1245 detected (sound)."
+  echo "post_fix: undefined-encoding latch NO LONGER DEFINITE (⊥=${POST_BOT}) — the fix removes the definite hazard."
+  echo "NOTE: post_fix is KleeneBot, not definite-safe — the {p5,p6,p7} cube cannot soundly PROVE the fixed"
+  echo "      FSM safe (it escapes only via the reset window). 'Fix verified' would require a finer abstraction."
 else
-  echo "FAIL: expected pre_fix True>=1 and post_fix True==0; got pre=${PRE_T} post=${POST_T}" >&2
+  echo "FAIL: expected pre(T>=1, ⊥==0) and post(⊥>=1); got pre(T=${PRE_T},⊥=${PRE_BOT}) post(T=${POST_T},⊥=${POST_BOT})" >&2
   exit 1
 fi


### PR DESCRIPTION
## What

Fixes an **unsoundness** in the predicate-cube path's reachability/liveness verdicts, surfaced while attempting P3.4 fixture migration.

**Root cause:** the cube lift labels every transition with one shared `step` label, and mununu's `<>` is synthesis-flavored — `modal_exists` requires **all** same-(full-)label successors to satisfy (the controller picks an action, the environment picks the outcome). One shared label collapses `<>φ` into `[step]φ`, so existential reachability over the cube was wrong (a may-reachable target reported as definite-False).

**Fix:** a plain-∃ early path in `modal_exists` for `Control::All` (a bare `<>`): `<a>φ` = ∃ an `a`-successor ⊨ φ — the standard mu-calculus existential. The Skolem all-same-label-satisfy aggregation stays for `Control::{Controllable, Environment}` (synthesis), so the synthesis tests are untouched. With the per-(kind, may/must) modality filter this is the canonical KMTS diamond. **Full workspace test: 0 regressions.**

## Two unsound cube verdicts corrected

- A coarse-cube reachability that returned **definite-VIOLATED** now correctly returns **⊥** ("needs refinement").
- **M.4 (Caliptra) post_fix `T=0` ("fix verified") was unsound** — the Skolem `<>`→`[]` artifact. Under the sound diamond post_fix is genuinely **⊥**, and rightly so: post_fix's `default: boot_fsm_ns = boot_fsm_ps` *holds* the undefined encoding; the FSM escapes only via the reset window (`boot_fsm_ps <= arc_IDLE ? BOOT_IDLE : boot_fsm_ns`), so the `{p5,p6,p7}` cube **cannot soundly prove the fixed FSM safe**.

## M.4 re-established soundly (claims-integrity)

Re-stated as a sound **pre/post distinction**, not "fix verified":
- pre_fix : `T=7 ⊥=0` — undefined-encoding latch **definitely** present (CWE-1245 soundly detected; conclusion unchanged, now sound).
- post_fix: `T=4 ⊥=3` — latch **no longer definite** (⊥): the fix removes the *definite* hazard; proving full safety needs a finer abstraction.

`validate_m4_cegar.sh` done-criterion + `README.md` (+ the `M-4-result.md` local note) updated honestly per CLAUDE.md §Claims Integrity. `validate_m4_cegar.sh` **PASSES** under the sound criterion.

## Tests

- `p3_4_all_diamond_is_existential_over_shared_label`: a `Control::All` `<>p` over two same-`step` edges to `{p-true, p-false}` is **True** (∃), not False (the pre-fix Skolem reading).
- Pre-push green: `clippy --all-features --all-targets -D warnings`, `cargo test --workspace`, `--all-features` doctests; M.4 validate passes.

## Note on P3.4/P3.5

This makes cube reachability **sound** (⊥ instead of wrong verdicts). Getting *definite* cube verdicts for fixture migration (P3.4) still needs CEGAR-in-verify or finer predicate sets — a separate decision; P3.4/P3.5 remain blocked on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)