### PR TITLE
feat(cube-soundness): PO-2 — warn on out-of-fragment modalities over a cube

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -695,6 +695,33 @@ pub fn cegar_refine_loop(
             });
         }
 
+        // PO-2 (cube-modal soundness audit, 2026-06-23) — surface a
+        // soundness warning for any modality form OUTSIDE the audited-sound
+        // cube fragment (controllability `ctrl=…` ⇒ unaudited per-player
+        // game semantics PO-3/R.6.8; bounded `steps=k` ⇒ may/must filter
+        // not applied PO-4/R.6.3.b; label-specific on a non-cube label ⇒
+        // vacuous). Computed once (iteration 0) from the formula + the
+        // cube's actual label symbols. Makes the out-of-fragment boundary
+        // explicit on the `btor2 cegar` / `sv cegar` / `/cegar` surfaces
+        // rather than silently returning an unsound/unaudited/vacuous
+        // verdict. A WARNING, not a reject — V.6's controllability-aware
+        // cube path keeps working (flagged, until R.6.8 closes).
+        if iteration == 0 {
+            let cube_labels: std::collections::HashSet<&str> = lift_result
+                .clts
+                .label_entries()
+                .flatten()
+                .map(|s| s.as_str())
+                .collect();
+            for msg in crate::mu_calculus::cube_modality_soundness_warnings(formula, &cube_labels) {
+                warnings.push(crate::adapter::AdapterWarning {
+                    kind: crate::adapter::WarningKind::ApproximateTranslation,
+                    location: None,
+                    message: format!("adapter/btor2/cegar (PO-2 cube-modal soundness): {msg}"),
+                });
+            }
+        }
+
         // R.5 B.4.a (2026-06-01) — smart `max_iterations` cap.
         // When the predicate source is WP AND the first lift
         // emits a UF-wrap warning AND `smart_uf_cap` is on

--- a/crates/mununu-core/src/mu_calculus/mod.rs
+++ b/crates/mununu-core/src/mu_calculus/mod.rs
@@ -263,6 +263,71 @@ impl Formula {
     }
 }
 
+/// PO-2 (cube-modal soundness audit, 2026-06-23) — scan a formula for
+/// modality forms that fall OUTSIDE the one audited-sound predicate-cube
+/// fragment (`Control::All`, bare/label-agnostic, unbounded — the only
+/// slice the §4.5 preservation theorem covers over a cube; see
+/// `.claude/reviews/cube-modal-soundness/`). Returns one human-readable
+/// soundness warning per offending modality (deduplicated).
+///
+/// `cube_labels` is the set of label symbols the cube actually carries: a
+/// label-specific modality on one of those is sound (it equals the bare
+/// modality), while one on any other label is *vacuous* because the cube
+/// collapses every concrete action onto its own label(s). The `control`
+/// and `bounded` checks are cube-label-independent (out-of-fragment over
+/// any cube).
+///
+/// Used by the CEGAR loop ([`crate::adapter::btor2::cegar`]) to surface a
+/// warning on the `btor2 cegar` / `sv cegar` / `/cegar` cube surfaces,
+/// making the out-of-fragment boundary explicit rather than silently
+/// returning an unsound/unaudited/vacuous verdict.
+pub fn cube_modality_soundness_warnings(
+    formula: &Formula,
+    cube_labels: &std::collections::HashSet<&str>,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for node in formula.nodes() {
+        let Node::Modal { kind, guard, .. } = node else {
+            continue;
+        };
+        let op = match kind {
+            ModalKind::Box => "[]",
+            ModalKind::Diamond => "<>",
+        };
+        if guard.control != Control::All {
+            out.push(format!(
+                "{op} modality with ctrl={:?} over a predicate cube: the per-player \
+                 (controller × environment) game semantics is UNAUDITED (PO-3 / R.6.8; \
+                 de Alfaro–Godefroid–Jagadeesan LICS 2004) — this is NOT a sound definite \
+                 controllability verdict. Use a bare {op} for verification, or treat the \
+                 result as a design-pattern demonstration until R.6.8 closes.",
+                guard.control
+            ));
+        }
+        if let Some(k) = guard.max_steps {
+            out.push(format!(
+                "{op} bounded modality (steps={k}) over a predicate cube: the may/must \
+                 (3-valued) filter is NOT applied to bounded modal steps (PO-4 / R.6.3.b), \
+                 so the 3-valued soundness of the bounded verdict is not established. Use an \
+                 unbounded {op} for a sound cube verdict."
+            ));
+        }
+        for lbl in &guard.labels {
+            if !cube_labels.contains(lbl.as_str()) {
+                out.push(format!(
+                    "{op}{{{lbl}}} label-specific modality over a predicate cube: the cube \
+                     collapses every concrete action onto its own label(s) {cube_labels:?}, so \
+                     a modality on '{lbl}' matches no transition and is VACUOUS. Only bare \
+                     (label-agnostic) {op} modalities are sound over a cube."
+                ));
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
 /// Arena entry describing a single fixpoint variable (name only for now).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FormulaVar {
@@ -485,6 +550,50 @@ mod tests {
         let parsed = parser::parse("true").expect("formula parses");
         let root = parsed.root();
         assert!(matches!(parsed.node(root), super::Node::True));
+    }
+
+    /// PO-2 — the cube-modal soundness linter flags out-of-fragment
+    /// modality forms (controllability / bounded / non-cube-label) and
+    /// stays silent on the audited-sound fragment (bare `Control::All`).
+    #[test]
+    fn po2_cube_modality_soundness_warnings() {
+        use super::cube_modality_soundness_warnings;
+        let cube_labels: std::collections::HashSet<&str> = ["step"].into_iter().collect();
+        let warn = |s: &str| {
+            cube_modality_soundness_warnings(&parser::parse(s).expect("parse"), &cube_labels)
+        };
+
+        // Sound fragment: no warnings.
+        assert!(warn("<>p").is_empty(), "bare diamond is in-fragment");
+        assert!(warn("[]p").is_empty(), "bare box is in-fragment");
+        assert!(
+            warn("<step>p").is_empty(),
+            "<step> == bare over a single-`step` cube ⇒ sound"
+        );
+        assert!(
+            warn("nu X. (p && [] X)").is_empty(),
+            "alternation-free bare safety is in-fragment"
+        );
+
+        // Controllability ⇒ unaudited (PO-3).
+        let w = warn("[ (ctrl = controllable) ] p");
+        assert_eq!(w.len(), 1, "one ctrl warning: {w:?}");
+        assert!(w[0].contains("UNAUDITED") && w[0].contains("R.6.8"));
+
+        // Bounded ⇒ 3-valued-blind (PO-4).
+        let w = warn("< (steps = 5) > p");
+        assert_eq!(w.len(), 1, "one bounded warning: {w:?}");
+        assert!(w[0].contains("steps=5") && w[0].contains("R.6.3.b"));
+
+        // Label-specific on a non-cube label ⇒ vacuous.
+        let w = warn("<foo>p");
+        assert_eq!(w.len(), 1, "one label warning: {w:?}");
+        assert!(w[0].contains("VACUOUS") && w[0].contains("foo"));
+
+        // Combined on one node ⇒ both control + bounded fire; dedup keeps
+        // distinct messages.
+        let w = warn("< (steps = 2, ctrl = controllable) > p");
+        assert_eq!(w.len(), 2, "control + bounded both flagged: {w:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes **PO-2** from the 2026-06-23 cube-modal soundness audit.

## Why
The predicate-cube path is sound only for the **`Control::All`, bare (label-agnostic), unbounded** modality fragment — the slice `kmts-theory.md` §4.5 preservation covers, now mechanised by PO-1 (#127, the lift is a sound may/must KMTS) + PO-5 (#126, the evaluator computes §4.3). The *other* modality forms silently returned unsound / unaudited / vacuous verdicts over a cube. PO-2 makes that boundary explicit.

## What — a soundness *warning*, not a reject
New pure `mu_calculus::cube_modality_soundness_warnings(formula, cube_labels)` emits one warning per offending modal node:
- **`ctrl=Controllable|Environment`** → the per-player (controller × environment) game semantics is **UNAUDITED** (PO-3 / R.6.8; de Alfaro–Godefroid–Jagadeesan LICS 2004) — not a sound definite controllability verdict.
- **bounded `steps=k`** → the may/must (3-valued) filter is **not applied** to bounded modal steps (PO-4 / R.6.3.b).
- **label-specific on a non-cube label** → **vacuous** (the cube collapses every concrete action onto its own label(s)). `<step>` over a single-`step` cube `==` bare ⇒ **no** warning (false-positive-free).

A warning rather than a reject so **V.6's controllability-aware cube path keeps working** (flagged, until R.6.8 closes).

Wired into `cegar_refine_loop` once (iteration 0) using the cube's actual label symbols (`Clts::label_entries`). It rides the existing `AdapterWarning` channel ⇒ **parity is automatic**: CLI prints, API returns (`Btor2CegarResponse.warnings`), UI renders (`CegarTraceView`). No new user control.

## Verification
- `cargo test -p mununu-core --lib`: 1844 passed (incl. `po2_cube_modality_soundness_warnings`). clippy clean; fmt clean.
- **e2e through the CLI**: `btor2 cegar … --formula '<(ctrl=controllable)> p1'` surfaces the PO-2 warning; bare `<> p1` is silent.

## Ledger
PO-1, PO-2, PO-5 closed. Remaining open are gated: PO-3 (= R.6.8, gates V.6 definite verdicts), PO-4 (bounded filter), PO-6 (⊥-state-predicate, unreachable). Follow-up: the verify-cube path (P3.3) is a separate cube consumer not yet wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)