### PR TITLE
docs(D.1b+D.1c): Predicate-Cube CEGAR wiki page + Caliptra walkthrough

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -27,6 +27,7 @@ Whether you are designing a handshake protocol, an arbiter, a multi-clock-domain
 | [Mu-Calculus Reference](Mu-Calculus-Reference) | Fixpoints, modalities, controllability-aware operators, common patterns |
 | [Adapter Formats](Adapter-Formats) | Import from XState, SystemVerilog, TLSF, AIGER, Promela; export controllers |
 | [RTL Verification Pipeline](RTL-Verification-Pipeline) | End-to-end SystemVerilog verification with `.mununu.json` sidecars and SMT discovery |
+| [Predicate-Cube CEGAR](Predicate-Cube-CEGAR) | Predicate-abstraction CEGAR for large RTL: 3-valued `{T, F, ⊥}` verdicts, automatic refinement, the Caliptra CWE-1245 walkthrough |
 | [Agentic Orchestration](Agentic-Orchestration) | Verify multi-agent workflows, MCP tool authorization, and handoff protocols |
 | [Agentic Adapters](Agentic-Adapters) | Native CrewAI + LangGraph JSON parsers — drop a `.crewai.json` / `.langgraph.json` directly into CLI / API / UI |
 | [Verify Project Flow](Verify-Project-Flow) | General N-source verification driven by `verify.toml` (CLI / API / UI wizard) |

--- a/wiki/Predicate-Cube-CEGAR.md
+++ b/wiki/Predicate-Cube-CEGAR.md
@@ -1,0 +1,157 @@
+# Predicate-Cube CEGAR
+
+> **Source of truth:** [`adapter::btor2::cegar::cegar_refine_loop`](../crates/mununu-core/src/adapter/btor2/cegar.rs), [`adapter::btor2::kmts_lift::predicate_cube_lift`](../crates/mununu-core/src/adapter/btor2/kmts_lift.rs), [`mu_calculus::evaluate_tri`](../crates/mununu-core/src/mu_calculus/evaluator.rs) — surface: CLI+API+UI (`mununu btor2 cegar` / `mununu sv cegar`, `POST /api/v1/btor2/cegar` / `POST /api/v1/sv/cegar`, the `/cegar` panel).
+
+Predicate-cube CEGAR is mununu's **second RTL verification engine**. Where the
+[RTL Verification Pipeline](RTL-Verification-Pipeline) bit-blasts the design into
+an explicit state space (exact, but capped at ~2^18 states, single module), this
+engine abstracts the design into a **predicate cube** — abstract states are
+truth-assignments to a small set of Boolean predicates over the design's
+registers — and decides properties with a **3-valued (Kleene) mu-calculus** over a
+**Kripke Modal Transition System (KMTS)**, refining the predicate set with **CEGAR**
+when the abstraction is too coarse. It is the path for designs whose register
+width blows the bit-blast cap.
+
+## When to use which engine
+
+| | [Bit-blast pipeline](RTL-Verification-Pipeline) | Predicate-cube CEGAR (this page) |
+|---|---|---|
+| Abstract state space | `2^(register bits)` (≤ 2^18 cap) | `2^(predicate count)` — independent of register width |
+| Verdict | 2-valued (`true` / `false`) | 3-valued (`KleeneT` / `KleeneF` / `KleeneBot`) |
+| Refinement | manual (edit the sidecar) | automatic (CEGAR adds predicates) |
+| Best for | small FSM-heavy control logic | wide-datapath / large-register designs, security hazards |
+
+## Pipeline
+
+```
+SystemVerilog ──sv2v──► Verilog ──Yosys (no flatten)──► BTOR2
+   │                                                      │
+   └────────── (mununu sv cegar wraps this) ──────────────┘
+                                                          ▼
+                          predicate_cube_lift  (BTOR2 → KMTS over 2^|P| cubes)
+                                                          ▼
+                       3-valued mu-calculus  (evaluate_tri: KleeneT/KleeneF/KleeneBot)
+                                                          ▼
+                       CEGAR  (on KleeneBot: add a predicate, re-lift, re-evaluate)
+                                                          ▼
+                          verdict cells:  T=… F=… ⊥=…
+```
+
+`mununu btor2 cegar` consumes a BTOR2 file directly; `mununu sv cegar` is the
+one-call variant that runs sv2v + Yosys for you.
+
+## CLI
+
+> **Source of truth:** the `btor2 cegar` / `sv cegar` subcommands in [`crates/mununu-cli/src/main.rs`](../crates/mununu-cli/src/main.rs) — surface: CLI.
+
+```bash
+mununu btor2 cegar <design.btor2> \
+  --formula '<> (p5 || p6 || p7)' \        # the mu-calculus property
+  --predicate p5:boot_fsm_ns=5 \           # NAME:REGISTER=VALUE (repeatable)
+  --predicate p6:boot_fsm_ns=6 \
+  --predicate p7:boot_fsm_ns=7 \
+  --config-values 'boot_fsm_ns=0,1,2,3,4,5,6,7' \  # admit these power-up values
+  --must-edge-inference smt-per-target              # prove must-edges with Z3
+```
+
+Key flags:
+
+| Flag | Purpose |
+|---|---|
+| `--formula` | the mu-calculus property (see [Mu-Calculus Reference](Mu-Calculus-Reference)) |
+| `--predicate NAME:REG=VALUE` | one cube predicate (`REG == VALUE`); repeatable |
+| `--config-values 'REG=v1,v2,…'` | admit an under-constrained register's power-up values (R-Y7 symbolic init) |
+| `--must-edge-inference` | `off` (sampling) \| `smt-per-target` (∀∀, Z3-proved) \| `smt-per-target-standard` (∀∃) \| … |
+| `--may-edge-inference` | `off` (sampling) \| `smt-all-pairs` (sound ∃ over-approximation) |
+| `--max-iterations` | CEGAR refinement cap (default 16) |
+| `--controllable-input` | mark an input as controller-chosen (synthesis / controllability-aware lift) |
+| `--emit-ctxdsl <PATH>` | dump the refined cube model as CTXDSL |
+
+`mununu sv cegar <design.sv> --formula … --predicate …` accepts the same property
+flags and runs sv2v + Yosys internally.
+
+## 3-valued verdicts
+
+Each cube gets one of three verdicts, and the CLI prints the tally as
+`verdict cells: T=… F=… ⊥=…`:
+
+- **`KleeneT`** — the property is *definitely true* on this cube. By the KMTS
+  preservation theorem (Bruns–Godefroid CONCUR 2000) a definite verdict
+  **transfers to the concrete RTL**.
+- **`KleeneF`** — *definitely false* on this cube; also transfers.
+- **`KleeneBot` (⊥)** — the abstraction is **too coarse to decide**. This is not a
+  failure: it is the explicit "refine me" signal. CEGAR adds a predicate and
+  retries; if it cannot, `⊥` is the sound, honest answer (the design may be safe
+  or not — this cube can't tell).
+
+## Soundness — the audited-sound fragment
+
+> **Source of truth:** [`mu_calculus::cube_modality_soundness_warnings`](../crates/mununu-core/src/mu_calculus/mod.rs) — surface: CLI+API+UI (the cegar `warnings` channel). Full write-up: [`docs/design/predicate-abstraction-recipe.md`](../docs/design/predicate-abstraction-recipe.md) §4.9.
+
+A definite verdict transfers soundly for the fragment the cube path actually
+evaluates: **bare (label-agnostic), single-agent (`Control::All`), unbounded**
+modalities — i.e. plain `<>` and `[]`. For a synchronous design this is the
+*complete* modal vocabulary (one clock = one step, with the input quantified
+inside the modality), so M.4-style properties like `<> (p5 || p6 || p7)` are
+exactly in fragment. The soundness chain — the lift is a sound may/must KMTS, and
+the evaluator computes the standard 3-valued modal semantics — is mechanised in CI.
+
+Modal forms **outside** that fragment are not silently answered — the tool emits a
+soundness warning in the `warnings` channel:
+
+| Out-of-fragment form | Warning |
+|---|---|
+| controllability `<(ctrl=controllable)>` / `[(ctrl=environment)]` | per-player game semantics is **unaudited** (awaits the R.6.8 per-player audit) — not a sound *definite* controllability verdict |
+| bounded `<(steps=k)>` | the may/must filter is not applied to bounded steps — 3-valued soundness not established |
+| label-specific `<a>` on a non-cube label | **vacuous** — the cube collapses every concrete action onto its own label |
+
+For example, running a `<(ctrl=controllable)>` property over a cube prints:
+
+```
+warnings:
+  - adapter/btor2/cegar (PO-2 cube-modal soundness): <> modality with
+    ctrl=Controllable over a predicate cube: the per-player (controller ×
+    environment) game semantics is UNAUDITED (PO-3 / R.6.8; …) — this is NOT a
+    sound definite controllability verdict. …
+```
+
+## Worked example — Caliptra boot-FSM (CWE-1245)
+
+> **Runnable:** [`examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh`](../examples/verify/sv_yosys_caliptra_rtl_150/) (requires `yosys` + `sv2v` + `z3` on `PATH`). This is mununu's M.4 milestone — full automated CEGAR on real industrial RTL.
+
+The Caliptra `soc_ifc_boot_fsm` holds its state in a 3-bit `boot_fsm_state_e`
+register with five legal encodings (0–4). The bug-bearing `pre_fix` variant has a
+`unique casez` with **no `default` arm**, so the type-admissible-but-unhandled
+encodings {5, 6, 7} latch (MITRE **CWE-1245**). The `post_fix` variant adds a
+`default` that routes every other encoding back to a defined state.
+
+Property: `<> (p5 || p6 || p7)` over the cube `{boot_fsm_ns ∈ {5,6,7}}` —
+"the next-state register can transition into an undefined encoding." Under
+`setundef -anyconst` (the power-up value is unconstrained):
+
+```
+pre_fix  (no default arm):    verdict cells T=7 F=1 ⊥=0   → hazard DEFINITELY present
+post_fix (default + reset):   verdict cells T=4 F=1 ⊥=3   → hazard NO LONGER DEFINITE
+```
+
+**Reading the result honestly.** `pre_fix` is a sound CWE-1245 detection: every
+cube is decided (`⊥=0`) and the undefined encoding is reachable (`T=7`). `post_fix`
+is **`KleeneBot`, not "verified safe"**: the fix's `default: boot_fsm_ns =
+boot_fsm_ps` *holds* the undefined encoding and the FSM only escapes via the reset
+window, so the coarse `{p5,p6,p7}` cube **cannot prove the fixed FSM safe** — `⊥` is
+the correct verdict. The milestone is the sound **pre/post distinction** (definite
+hazard → indefinite), *not* a safety proof. Proving safety would need a finer
+abstraction / CEGAR to convergence.
+
+## API + UI
+
+- **API:** `POST /api/v1/btor2/cegar` and `POST /api/v1/sv/cegar` ([`crates/mununu-core/src/api/handlers.rs`](../crates/mununu-core/src/api/handlers.rs)) return the per-iteration trace + the `{T, F, ⊥}` verdict + the `warnings` list.
+- **UI:** the `/cegar` panel renders the verdict with `KleeneBot` iconography, the per-iteration refinement trace, the final predicate set, and the soundness warnings; it round-trips a predicate edit and re-runs.
+
+## See Also
+
+- [RTL Verification Pipeline](RTL-Verification-Pipeline) — the complementary bit-blast engine
+- [Mu-Calculus Reference](Mu-Calculus-Reference) — `<>` / `[]`, controllability operators, fixpoints
+- [Adapter Formats](Adapter-Formats) — BTOR2 + SystemVerilog import
+- [`docs/design/predicate-abstraction-recipe.md`](../docs/design/predicate-abstraction-recipe.md) — the full operational recipe (predicate seeding, may/must image, CEGAR, §4.9 soundness)
+- [`docs/design/kmts-theory.md`](../docs/design/kmts-theory.md) — KMTS + 3-valued mu-calculus theory

--- a/wiki/RTL-Verification-Pipeline.md
+++ b/wiki/RTL-Verification-Pipeline.md
@@ -271,7 +271,7 @@ Based on MITRE CWE-1245, with real CVEs (CVE-2024-21853, CVE-2024-24968). One-ho
 
 ## Limitations
 
-- **Explicit-state only:** state space capped at 2^18 (262K states). No BDD/SAT backend.
+- **Explicit-state only:** state space capped at 2^18 (262K states). No BDD/SAT backend. For wide-register designs that blow this cap, use the [Predicate-Cube CEGAR](Predicate-Cube-CEGAR) engine, which abstracts to `2^(predicate count)` instead of `2^(register bits)`.
 - **Single module:** no submodule hierarchy or multi-clock domains.
 - **Abstraction is manual:** users must annotate which registers to preserve and how.
 - **SMT discovery is combinational-only:** doesn't trace through sequential (clock-edge) dependencies.
@@ -279,6 +279,7 @@ Based on MITRE CWE-1245, with real CVEs (CVE-2024-21853, CVE-2024-24968). One-ho
 
 ## See Also
 
+- [Predicate-Cube CEGAR](Predicate-Cube-CEGAR) — the complementary predicate-abstraction engine for designs too large to bit-blast (3-valued `{T, F, ⊥}` verdicts + automatic refinement)
 - [Adapter Formats — SystemVerilog](Adapter-Formats#systemverilog) — supported SV subset and inline annotations
 - [Hardware Verification Patterns](Hardware-Verification-Patterns) — CTXDSL patterns for common hardware
 - [CLI Reference](CLI-Reference) — `sv preprocess`, `sv emit-btor2-per-module`, `btor2 discover`, `context eval`, `context synth`


### PR DESCRIPTION
**Slot 8 (D-track) wiki track.** The predicate-cube CEGAR path — `btor2 cegar` / `sv cegar`, 3-valued `{T, F, ⊥}` verdicts, the M.4 Caliptra result, the headline R.5/R.6 capability — had **zero wiki coverage**; `RTL-Verification-Pipeline.md` documents only the bit-blast engine (capped at 2^18). This adds the dedicated page (D.1b) with the Caliptra walkthrough as its worked example (D.1c).

## What
- **`wiki/Predicate-Cube-CEGAR.md` (new):**
  - when-to-use vs the bit-blast engine (`2^predicates` vs `2^register-bits`);
  - the sv2v → Yosys → BTOR2 → cube-lift → 3-valued eval → CEGAR pipeline;
  - the CLI (`btor2 cegar` / `sv cegar`, **verified flag names**);
  - `{KleeneT / KleeneF / KleeneBot}` verdict semantics (⊥ = refine, not failure);
  - the **audited-sound fragment** + the **PO-2 out-of-fragment warning** (verbatim, verified);
  - the **Caliptra boot-FSM CWE-1245 worked example** with the honest verdict (`pre T=7 ⊥=0` / `post T=4 ⊥=3` — detect + definite-hazard-removed, *not* proven-safe).
  - `> Source of truth:` anchored.
- **`wiki/Home.md`:** TOC row.
- **`wiki/RTL-Verification-Pipeline.md`:** the 2^18-cap limitation + See-Also now point at the cube-CEGAR engine as the complement.

## Verification (CLAUDE.md wiki rule — examples tested against the binary)
- M.4 verdict via `validate_m4_cegar.sh` (exit 0; `pre T=7 ⊥=0` / `post T=4 ⊥=3`).
- PO-2 warning text + all CLI flag names via the built `mununu` CLI (`--help`).
- All `../crates`/`../docs`/`../examples` anchors + internal wiki links verified to resolve.
- Markdown-only; `make ci` unaffected.

Note: `wiki/` is committed to the main repo here; **publishing to the GitHub wiki repo is a separate manual step.**

## Slot 8 status
This + #129/#130/#131 cover D.0 (recipe §4.9 + abstraction.md + literature) and the D.1b/D.1c wiki. Optional remaining touch-ups: minor cube-CEGAR mentions in `Verify-Project-Flow` / `Composition` if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)