### PR TITLE
docs(wiki): fix broken repo-file links + refresh API reference

### DIFF
--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -2,7 +2,9 @@
 
 # API Reference
 
-Mununu exposes a REST API for programmatic access to context summarization, controller synthesis, graph generation, and formula verification. The server is built on [Axum](https://github.com/tokio-rs/axum) and listens on a configurable address (default `127.0.0.1:3000`).
+Mununu exposes a REST API for programmatic access to context summarization, controller synthesis, graph generation, formula verification, predicate-abstraction CEGAR, AST extraction, assume/guarantee contracts, and HW/SW codesign. The server is built on [Axum](https://github.com/tokio-rs/axum) and listens on a configurable address (default `127.0.0.1:3000`).
+
+> Source of truth: [`api::server::create_router`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/server.rs) — surface: API. (Route table — the canonical list of live endpoints.)
 
 Start the server with:
 
@@ -10,28 +12,64 @@ Start the server with:
 mununu serve --bind 127.0.0.1:3000
 ```
 
-All request and response bodies use `application/json`. CORS is open by default (`Access-Control-Allow-Origin: *`).
+All request and response bodies use `application/json`. CORS is open by default (`Access-Control-Allow-Origin: *`). The request body limit is 1 MiB and the request timeout is 30 s.
 
 ---
 
 ## Table of Contents
 
+**Health**
 - [GET /api/v1/health](#get-apiv1health)
+
+**Context (CTXDSL) endpoints**
 - [POST /api/v1/context/summarize](#post-apiv1contextsummarize)
 - [POST /api/v1/context/synthesize](#post-apiv1contextsynthesize)
 - [POST /api/v1/context/graphs](#post-apiv1contextgraphs)
 - [POST /api/v1/context/verify](#post-apiv1contextverify)
 - [POST /api/v1/context/import](#post-apiv1contextimport)
-- [POST /api/v1/verify](#post-apiv1verify) — general N-source verify framework
+- [POST /api/v1/context/predicates](#post-apiv1contextpredicates)
+
+**Verification framework (N-source)**
+- [POST /api/v1/verify](#post-apiv1verify)
+- [POST /api/v1/verify/memory-check](#post-apiv1verifymemory-check)
+
+**CEGAR (predicate-abstraction refinement)**
+- [POST /api/v1/btor2/cegar](#post-apiv1btor2cegar)
+- [POST /api/v1/sv/cegar](#post-apiv1svcegar)
+
+**AST extraction**
+- [GET /api/v1/extraction/domains](#get-apiv1extractiondomains)
+- [GET /api/v1/extraction/composition-modes](#get-apiv1extractioncomposition-modes)
+- [POST /api/v1/extraction/propose-composition](#post-apiv1extractionpropose-composition)
+- [POST /api/v1/extraction/extract](#post-apiv1extractionextract)
+- [POST /api/v1/extraction/validate](#post-apiv1extractionvalidate)
+
+**Contracts (assume/guarantee, black-box interfaces)**
+- [POST /api/v1/contract/validate](#post-apiv1contractvalidate)
+- [POST /api/v1/contract/discover](#post-apiv1contractdiscover)
+- [POST /api/v1/contract/query](#post-apiv1contractquery)
+- [POST /api/v1/contract/review](#post-apiv1contractreview)
+
+**HW/SW codesign**
+- [POST /api/v1/codesign/verify](#post-apiv1codesignverify)
+- [POST /api/v1/codesign/reconcile-labels](#post-apiv1codesignreconcile-labels)
+- [POST /api/v1/codesign/emit-chaotic-stub](#post-apiv1codesignemit-chaotic-stub)
+
+**Templates**
 - [GET /api/v1/templates](#get-apiv1templates)
+
+**Reference**
 - [Common Types](#common-types)
 - [Error Responses](#error-responses)
+- [Logging](#logging)
 
 ---
 
 ## GET /api/v1/health
 
 Returns the server health status. Use this for readiness probes and connectivity checks.
+
+> Source of truth: [`api::handlers::health_check`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 ### Response
 
@@ -53,6 +91,8 @@ curl http://localhost:3000/api/v1/health
 ## POST /api/v1/context/summarize
 
 Parse a CTXDSL context (with optional sidecar files) and return a summary of all automata, formulas, and declared controllers. Controllers are synthesized on the fly so the response includes realizability and size metrics.
+
+> Source of truth: [`api::handlers::context_summarize_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 > **Adapter formats:** this endpoint accepts CTXDSL only. To summarize an external format (`.xstate.json`, `.sv`, `.tlsf`, `.aag`/`.aig`, `.pml`, `.espec.json`), first translate via [`POST /api/v1/context/import`](#post-apiv1contextimport) and pass the resulting `ctxdsl` field to this endpoint. The CLI command `mununu context summarize <file> --adapter <format>` does this two-step internally; clients of the HTTP API must do it explicitly. The same convention applies to `/context/verify` and `/context/synthesize`.
 
@@ -123,11 +163,7 @@ curl -X POST http://localhost:3000/api/v1/context/summarize \
   "summary": {
     "context_name": "traffic",
     "automata": [
-      {
-        "name": "light",
-        "states_count": 2,
-        "transitions_count": 2
-      }
+      { "name": "light", "states_count": 2, "transitions_count": 2 }
     ],
     "formulas_count": 0,
     "controllers_count": 0,
@@ -140,7 +176,9 @@ curl -X POST http://localhost:3000/api/v1/context/summarize \
 
 ## POST /api/v1/context/synthesize
 
-Synthesize a controller for a given automaton and mu-calculus formula. The controller restricts the system's controllable transitions so that the formula is satisfied. When the specification is realizable, the response includes the controller serialized as CTXDSL source.
+Synthesize a controller for a given automaton and mu-calculus formula. The controller restricts the system's controllable transitions so that the formula is satisfied. When the specification is realizable, the response includes the controller serialized as CTXDSL source (and, optionally, in a native target format).
+
+> Source of truth: [`api::handlers::context_synthesize_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 ### Request Body
 
@@ -149,7 +187,8 @@ Synthesize a controller for a given automaton and mu-calculus formula. The contr
 | `context` | `FileContent` | Yes | Main CTXDSL file. |
 | `sidecars` | `SidecarFile[]` | No | Sidecar files. Defaults to `[]`. |
 | `automaton` | `string` | Yes | Target automaton name. |
-| `formula` | `string` | Yes | Formula name defined in the context. |
+| `formula` | `string \| null` | One of `formula` / `template_ref` | Formula name defined in the context. Mutually exclusive with `template_ref`. |
+| `template_ref` | `TemplateRef \| null` | One of `formula` / `template_ref` | Instantiate a [property template](Property-Templates) instead of selecting an existing formula. `{"template": "no_deadlock"}` or `{"template": "reachable", "args": {"TARGET": "Idle"}}`. Mutually exclusive with `formula`. |
 | `options` | `SynthesisOptions` | No | Synthesis configuration. |
 
 **SynthesisOptions**
@@ -159,7 +198,7 @@ Synthesize a controller for a given automaton and mu-calculus formula. The contr
 | `minimize` | `boolean` | `false` | Apply bisimulation minimization to the controller. |
 | `diagnostics` | `DiagnosticsOptions` | `{}` | Control diagnostic output. |
 | `extract_strategy` | `boolean` | `false` | **Legacy** — equivalent to `controller_mode: "functional"`. When `controller_mode` is set, that takes precedence. |
-| `controller_mode` | `string \| null` | `null` (= `"projection"` or `"functional"` if `extract_strategy=true`) | Controller extraction mode. One of `"projection"`, `"functional"`, `"permissive"`, `"signature-memory"`, `"product-game"`, `"parity-game"`. Case-insensitive; dashes/underscores interchangeable. Unknown values return `400 Bad Request`. See [Controller Modes](Controller-Modes.md) for the full reference. |
+| `controller_mode` | `string \| null` | `null` (= `"projection"`, or `"functional"` if `extract_strategy=true`) | Controller extraction mode. One of `"projection"`, `"functional"`, `"permissive"`, `"signature-memory"`, `"product-game"`, `"parity-game"`. Case-insensitive; dashes/underscores interchangeable. Unknown values return `400 Bad Request`. See [Controller Modes](Controller-Modes.md) for the full reference. |
 | `output_format` | `string \| null` | `null` | Native controller export format: `"xstate"` or `"systemverilog"`/`"sv"`. When set, the response includes a `controller_native` field. |
 
 **DiagnosticsOptions**
@@ -178,8 +217,9 @@ Synthesize a controller for a given automaton and mu-calculus formula. The contr
 | `success` | `boolean` | `true` on success. |
 | `realizable` | `boolean` | Whether a winning controller exists. |
 | `controller` | `FileContent \| null` | Synthesized controller as CTXDSL. `null` when unrealizable. |
+| `controller_native` | `FileContent \| null` | Controller in the requested native format (`output_format`). Omitted unless requested. |
 | `diagnostics` | `SynthesisDiagnostics` | Diagnostic information. |
-| `counterstrategy` | `CounterstrategyResult \| null` | Environment counterstrategy graph for unrealizable cases. Automatically computed when synthesis fails. See [CounterstrategyResult](#counterstrategyresult) below. |
+| `counterstrategy` | `CounterstrategyResult \| null` | Environment counterstrategy graph for unrealizable cases. Automatically computed when synthesis fails. See the `CounterstrategyResult` table under [POST /api/v1/context/verify](#post-apiv1contextverify). |
 
 **SynthesisDiagnostics**
 
@@ -224,19 +264,12 @@ Synthesize a controller for a given automaton and mu-calculus formula. The contr
 curl -X POST http://localhost:3000/api/v1/context/synthesize \
   -H "Content-Type: application/json" \
   -d '{
-    "context": {
-      "name": "arbiter.ctxdsl",
-      "content": "... CTXDSL source ..."
-    },
+    "context": { "name": "arbiter.ctxdsl", "content": "... CTXDSL source ..." },
     "automaton": "arbiter",
     "formula": "mutual_exclusion",
     "options": {
       "minimize": true,
-      "diagnostics": {
-        "counterexample": true,
-        "deadlock_traces": true,
-        "max_counter_traces": 5
-      }
+      "diagnostics": { "counterexample": true, "deadlock_traces": true, "max_counter_traces": 5 }
     }
   }'
 ```
@@ -257,11 +290,7 @@ curl -X POST http://localhost:3000/api/v1/context/synthesize \
     "counterexample_trace": null,
     "counterstrategy_traces": [],
     "deadlock_traces": [],
-    "minimization": {
-      "removed_states": 3,
-      "removed_transitions": 7,
-      "merged_states": ["s1_s3", "s2_s4"]
-    },
+    "minimization": { "removed_states": 3, "removed_transitions": 7, "merged_states": ["s1_s3", "s2_s4"] },
     "proof_obligations": []
   }
 }
@@ -301,6 +330,8 @@ curl -X POST http://localhost:3000/api/v1/context/synthesize \
 ## POST /api/v1/context/graphs
 
 Generate Cytoscape-compatible graph elements for automata, compositions, and (optionally) synthesized controllers. Returns nodes and edges that can be rendered directly in a Cytoscape.js visualization layer.
+
+> Source of truth: [`api::handlers::context_graphs_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 ### Request Body
 
@@ -348,6 +379,7 @@ Generate Cytoscape-compatible graph elements for automata, compositions, and (op
 | `parent` | `string \| null` | Parent node ID for compound graphs. |
 | `vars` | `string[]` | State variable annotations. |
 | `actions` | `string[]` | Enabled actions. |
+| `valuations` | `{ [name: string]: string } \| null` | Structured per-state variable valuations (e.g. `{is_red: "0", phase: "green"}`). Sourced from adapter side-channels (SV Kripke, BTOR2, extraction). Omitted when empty. |
 
 **GraphElementData (Edge)**
 
@@ -362,6 +394,7 @@ Generate Cytoscape-compatible graph elements for automata, compositions, and (op
 | `action_type` | `string \| null` | `"controllable"` or `"uncontrollable"`. |
 | `guard` | `string \| null` | Guard expression. |
 | `effect` | `string \| null` | Effect expression. |
+| `modality` | `string \| null` | KMTS transition modality: `"sharp"`, `"may_only"`, or `"must_hyper_only"`. Omitted (≡ `"sharp"`) on edges that don't come from a CLTS transition or for the default case. |
 
 **GraphMetadata**
 
@@ -377,10 +410,7 @@ Generate Cytoscape-compatible graph elements for automata, compositions, and (op
 curl -X POST http://localhost:3000/api/v1/context/graphs \
   -H "Content-Type: application/json" \
   -d '{
-    "context": {
-      "name": "traffic.ctxdsl",
-      "content": "... CTXDSL source ..."
-    },
+    "context": { "name": "traffic.ctxdsl", "content": "... CTXDSL source ..." },
     "graph_types": ["dsl", "unrolled"],
     "include_controllers": true,
     "minimize_controllers": true
@@ -404,27 +434,11 @@ curl -X POST http://localhost:3000/api/v1/context/graphs \
       "automaton": "light",
       "graph_type": "dsl",
       "elements": [
-        {
-          "data": { "type": "node", "id": "light_red", "label": "red", "vars": [], "actions": ["go"] },
-          "position": null,
-          "classes": "state initial"
-        },
-        {
-          "data": { "type": "node", "id": "light_green", "label": "green", "vars": [], "actions": ["stop"] },
-          "position": null,
-          "classes": "state"
-        },
-        {
-          "data": { "type": "edge", "id": "light_e0", "source": "light_red", "target": "light_green", "label": "go", "action": "go", "action_type": "controllable" },
-          "position": null,
-          "classes": null
-        }
+        { "data": { "type": "node", "id": "light_red", "label": "red", "vars": [], "actions": ["go"] }, "position": null, "classes": "state initial" },
+        { "data": { "type": "node", "id": "light_green", "label": "green", "vars": [], "actions": ["stop"] }, "position": null, "classes": "state" },
+        { "data": { "type": "edge", "id": "light_e0", "source": "light_red", "target": "light_green", "label": "go", "action": "go", "action_type": "controllable" }, "position": null, "classes": null }
       ],
-      "metadata": {
-        "states_count": 2,
-        "transitions_count": 2,
-        "initial_states": ["red"]
-      }
+      "metadata": { "states_count": 2, "transitions_count": 2, "initial_states": ["red"] }
     }
   ]
 }
@@ -435,6 +449,8 @@ curl -X POST http://localhost:3000/api/v1/context/graphs \
 ## POST /api/v1/context/verify
 
 Evaluate mu-calculus formulas over automata and report which initial states satisfy or violate each formula. When a formula is not satisfied and `counterstrategy` is requested, the response includes the environment's winning region and a Cytoscape graph of the counterstrategy automaton.
+
+> Source of truth: [`api::handlers::context_verify_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 ### Request Body
 
@@ -447,6 +463,9 @@ Evaluate mu-calculus formulas over automata and report which initial states sati
 | `automaton` | `string \| null` | No | Target automaton. `null` uses each formula's declared targets. |
 | `counterstrategy` | `boolean` | No | Compute counterstrategy for failed formulas. Defaults to `false`. |
 | `minimize_counterstrategy` | `boolean` | No | Apply bisimulation minimization to counterstrategy. Defaults to `false`. |
+| `hide` | `string[]` | No | Labels to hide (reclassify as internal) before evaluation. Defaults to `[]`. |
+| `minimize` | `boolean` | No | Apply bisimulation minimization before evaluation. Defaults to `false`. |
+| `stubs` | `SidecarFile[]` | No | Stub `.espec.json` content to compose as sidecars (interface automata). Defaults to `[]`. |
 
 ### Response Body
 
@@ -486,10 +505,7 @@ Evaluate mu-calculus formulas over automata and report which initial states sati
 curl -X POST http://localhost:3000/api/v1/context/verify \
   -H "Content-Type: application/json" \
   -d '{
-    "context": {
-      "name": "arbiter.ctxdsl",
-      "content": "... CTXDSL source ..."
-    },
+    "context": { "name": "arbiter.ctxdsl", "content": "... CTXDSL source ..." },
     "formula": "mutual_exclusion",
     "automaton": "arbiter",
     "counterstrategy": true,
@@ -519,65 +535,50 @@ curl -X POST http://localhost:3000/api/v1/context/verify \
 }
 ```
 
-### Example Response (Not Satisfied, with Counterstrategy)
-
-```json
-{
-  "success": true,
-  "all_satisfied": false,
-  "results": [
-    {
-      "formula_name": "liveness",
-      "automaton": "arbiter",
-      "satisfied": false,
-      "total_states": 6,
-      "satisfying_states": 4,
-      "initial_states": ["idle"],
-      "initial_satisfying": [],
-      "initial_violating": ["idle"],
-      "satisfying_state_names": ["grant1", "grant2", "wait1", "wait2"],
-      "counterstrategy": {
-        "environment_winning_states": ["idle", "reset"],
-        "graph_elements": [
-          { "data": { "type": "node", "id": "cs_idle", "label": "idle", "vars": [], "actions": [] }, "classes": "winning" },
-          { "data": { "type": "edge", "id": "cs_e0", "source": "cs_idle", "target": "cs_reset", "label": "timeout" } }
-        ],
-        "inverted_formula": "mu X . (<tau> true & [grant] false) | (<tau> X)",
-        "minimized": false
-      }
-    }
-  ]
-}
-```
-
 ---
 
 ## POST /api/v1/context/import
 
-Import an external format (XState, SystemVerilog, TLSF, AIGER, Promela, CrewAI, LangGraph) and translate it to CTXDSL.
+Import an external format (XState, SystemVerilog, TLSF, AIGER, BTOR2, Promela, CrewAI, LangGraph, extraction) and translate it to CTXDSL.
 
-> Source of truth: [`api::handlers::context_import_handler`](../crates/mununu-core/src/api/handlers.rs) — surface: API.
+> Source of truth: [`api::handlers::context_import_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 ### Request Body
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `content` | string | Yes | Raw file content in the source format |
-| `format` | string | No | Format hint: `"auto"` (default), `"tlsf"`, `"aiger"`, `"btor2"` (or `"btor"`), `"promela"`, `"xstate"`, `"systemverilog"` (hand-written parser), `"sv-yosys"` (or `"yosys"`, Yosys-driven elaboration), `"extraction"`, `"crewai"`, `"langgraph"` |
-| `filename` | string | No | Original filename (used for extension-based detection if format is `"auto"`) |
-| `additional_sources` | array | No | Extra SV source files to compile alongside the primary input (Yosys path only). Each entry: `{name, content}`. |
+| `content` | `string` | Yes | Raw file content in the source format. |
+| `format` | `string` | No | Format hint: `"auto"` (default), `"tlsf"`, `"aiger"`, `"btor2"` (or `"btor"`), `"promela"`, `"xstate"`, `"systemverilog"` (hand-written parser), `"sv-yosys"` (or `"yosys"`, Yosys-driven elaboration), `"extraction"`, `"crewai"`, `"langgraph"`. |
+| `filename` | `string \| null` | No | Original filename (used for extension-based detection if format is `"auto"`). |
+| `sidecar` | `string \| null` | No | Optional sidecar content (`.mununu.json` for SV, `.espec.json` for extraction). Drives abstraction/property configuration. |
+| `additional_sources` | `FileContent[]` | No | Extra SV source files to compile alongside the primary input (Yosys path). Each entry: `{name, content}`. |
+| `use_sv2v` | `boolean` | No | When `format == "sv-yosys"`, run the `sv2v` preprocessor before Yosys. Required for modern SV dialects. Mirrors the CLI `--preprocessor sv2v`. Defaults to `false`. |
+| `predicates` | `PredicateSpecRequest[]` | No | Predicate set for the controllability-aware predicate-cube lift. Each entry: `{name, register, value}`. When non-empty (with `controllable_inputs`) and `format` produces BTOR2, the predicate-cube lift runs and a KMTS is returned. Mirrors `--predicate NAME:REG=VALUE`. |
+| `controllable_inputs` | `string[]` | No | Names of BTOR2 input symbols the controller drives. Mirrors `--controllable-input`. Enables the controllability-aware lift when combined with `predicates`. |
+| `sv_source_path` | `string \| null` | No | Filesystem path to the original SV source. With a `simulate_reset` sidecar block and a discoverable Verilator, runs a short reset simulation. Mirrors `--sv-source`. |
+| `sidecar_path` | `string \| null` | No | Filesystem path to the sidecar JSON, used to resolve relative `vcd_traces` entries. Mirrors `--sidecar`. |
+
+**PredicateSpecRequest**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Human-readable predicate name (e.g. `"burst_zero"`). |
+| `register` | `string` | BTOR2 register symbol the predicate is anchored on. |
+| `value` | `number` | Integer value the predicate witnesses (`register == value`). |
 
 ### Response Body
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `success` | boolean | Whether the import succeeded |
-| `ctxdsl` | string | Translated CTXDSL content |
-| `source_format` | string | Detected source format name |
-| `warnings` | string[] | Translation warnings (unsupported constructs, neutral controllability, etc.) |
-| `signal_count` | number | Number of signals/events in the source |
-| `state_count` | number | Number of states (for signal-state encoding) |
-| `property_count` | number | Number of properties translated |
+| `success` | `boolean` | Whether the import succeeded. |
+| `ctxdsl` | `string` | Translated CTXDSL content. |
+| `source_format` | `string` | Detected source format name. |
+| `warnings` | `string[]` | Translation warnings (unsupported constructs, neutral controllability, etc.). |
+| `signal_count` | `number` | Number of signals/events in the source. |
+| `state_count` | `number` | Number of states (for signal-state encoding). |
+| `property_count` | `number` | Number of properties translated. |
+| `state_valuations` | `object \| null` | State valuations for structured predicate matching, when available. |
+| `transition_observations` | `object \| null` | Per-transition Mealy observations, keyed by automaton name, when the adapter emits them. |
 
 ### Example
 
@@ -594,11 +595,42 @@ See [Adapter Formats](Adapter-Formats.md) for details on each supported format.
 
 ---
 
+## POST /api/v1/context/predicates
+
+List the predicate names declared per automaton in a parsed and realized context. Mirrors `mununu context predicates`. Useful for populating predicate pickers in clients before issuing a verify/synthesize request.
+
+> Source of truth: [`api::handlers::context_predicates_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `context` | `FileContent` | Yes | Main CTXDSL file. |
+| `sidecars` | `SidecarFile[]` | No | Sidecar files. Defaults to `[]`. |
+| `automaton` | `string \| null` | No | Filter to a single automaton. `null` returns every automaton. |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | `true` on success. |
+| `predicates` | `{ [automaton: string]: string[] }` | Map from automaton name to its declared predicate names. |
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/context/predicates \
+  -H "Content-Type: application/json" \
+  -d '{ "context": { "name": "m.ctxdsl", "content": "... CTXDSL source ..." } }'
+```
+
+---
+
 ## POST /api/v1/verify
 
 Run the general N-source verification framework against a `verify.toml` manifest. Mirrors `mununu verify` (CLI). See [Verify Project Flow](Verify-Project-Flow.md) for the conceptual model.
 
-> Source of truth: [`api::handlers::verify_project_handler`](../crates/mununu-core/src/api/handlers.rs) — surface: API.
+> Source of truth: [`api::handlers::verify_project_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 ### Request Body
 
@@ -606,17 +638,18 @@ Supply exactly one of `config` (pre-parsed) or `config_toml` (raw verify.toml te
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `config` | object | No | Pre-parsed `VerifyConfig` JSON. Mutually exclusive with `config_toml`. |
-| `config_toml` | string | No | Raw verify.toml text. Parsed server-side via `VerifyConfig::from_toml`. Mutually exclusive with `config`. Convenient for thin clients (UI wizard) that don't bundle a TOML parser. |
-| `base_dir` | string | Yes | Directory the source paths in the config resolve against. Must exist on the server's filesystem. |
+| `config` | `object \| null` | No | Pre-parsed `VerifyConfig` JSON. Mutually exclusive with `config_toml`. |
+| `config_toml` | `string \| null` | No | Raw verify.toml text. Parsed server-side via `VerifyConfig::from_toml`. Mutually exclusive with `config`. Convenient for thin clients (UI wizard) that don't bundle a TOML parser. |
+| `base_dir` | `string` | Yes | Directory the source paths in the config resolve against. Must exist on the server's filesystem. |
+| `cluster_similarity_floor` | `number \| null` | No | R.4 clustered-COI Jaccard similarity floor for the BTOR2 (`sv-yosys`) route. Overrides any value in `config` / `config_toml`. `null` (default) → the recommended `0.5`. |
 
 ### Response Body
 
-`VerifyReport`:
+`VerifyReport` — see [`verify::report::VerifyReport`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/report.rs) for the full shape.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `project` | string | Project name from `[project]`. |
+| `project` | `string` | Project name from `[project]`. |
 | `sources` | `SourceSummary[]` | Per-source diagnostics (`id`, `adapter`, resolved automaton name). |
 | `composition` | `CompositionInfo` | `semantics`, resolved composition `name`, resolved member names. |
 | `property_verdicts` | `PropertyVerdict[]` | One verdict per `[[properties]]` entry. |
@@ -636,15 +669,500 @@ curl -X POST http://localhost:3000/api/v1/verify \
 
 ---
 
+## POST /api/v1/verify/memory-check
+
+Analyze a `verify.toml` config's memory posture and return advisory warnings (over-approximation risks, unbounded counters, large enumeration domains). Mirrors `mununu verify memory-check`. The analysis is **pure** (it inspects only the parsed config), so no `base_dir` is required. The handler is **advisory** — warnings appear in the body but never surface as a 4xx; callers decide whether to gate on them.
+
+> Source of truth: [`api::handlers::memory_check_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+Supply exactly one of `config` or `config_toml`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `config` | `object \| null` | No | Pre-parsed `VerifyConfig` JSON. Mutually exclusive with `config_toml`. |
+| `config_toml` | `string \| null` | No | Raw verify.toml text. Mutually exclusive with `config`. |
+
+### Response Body
+
+`MemoryCheckReport` — see [`verify::memory_check::MemoryCheckReport`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/memory_check.rs) for the full shape (per-source posture entries plus aggregate advisory warnings).
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/verify/memory-check \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg toml "$(cat verify.toml)" '{config_toml: $toml}')"
+```
+
+---
+
+## POST /api/v1/btor2/cegar
+
+Run the CEGAR predicate-abstraction-refinement loop over a BTOR2 design and return the per-iteration refinement trace. Mirrors `mununu btor2 cegar`. See [Predicate-Cube CEGAR](Predicate-Cube-CEGAR.md) for the algorithm and the 3-valued (Kleene) verdict semantics.
+
+> Source of truth: [`api::handlers::btor2_cegar_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | `string` | Yes | BTOR2 source content. |
+| `formula` | `string` | Yes | μ-calculus formula evaluated over the lifted KMTS. |
+| `predicates` | `PredicateSpecRequest[]` | Yes | Initial predicate set (bootstraps the `2^|P|` cube space). At least one entry required. Each: `{name, register, value}`. |
+| `controllable_inputs` | `string[]` | No | R.6.6 controllability split — controller-driven input symbols. Mirrors `--controllable-input`. Defaults to `[]`. |
+| `predicate_source` | `string \| null` | No | Predicate-discovery source: `"wp"` (default) or `"craig"`. |
+| `max_iterations` | `number \| null` | No | Max CEGAR iterations. Defaults to `16`. |
+| `must_edge_inference` | `string \| null` | No | Must-edge inference policy (default `"off"`): `"sampling-confluence"`, `"smt-per-target"`, `"smt-per-target-standard"`, `"smt-hyper-must"`. |
+| `may_edge_inference` | `string \| null` | No | May-edge inference policy (default `"off"`): `"smt-all-pairs"`. |
+| `config_values` | `string[]` | No | R-S8 symbolic-init values, one entry per register as `"REG=v1,v2,..."`. Seeds the predicate-cube initial states. Defaults to `[]`. |
+| `emit_ctxdsl` | `boolean` | No | When `true`, the response `ctxdsl` field carries the final refined cube model + checked formula as a self-contained CTXDSL document. Mirrors `--emit-ctxdsl`. Defaults to `false`. |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | `true` on success. |
+| `iterations` | `CegarIterationView[]` | Per-iteration refinement records (iteration 0 = initial evaluation). |
+| `final_predicates` | `PredicateView[]` | Predicate set at termination (initial + every added predicate). |
+| `terminated_with` | `string` | Why the loop stopped: `"converged"`, `"bounded-iterations-reached"`, or `"predicate-source-exhausted"`. |
+| `verdict` | `CegarVerdictSummary` | Cell-count summary of the final 3-valued verdict. |
+| `lazy_lift_pending` | `boolean` | `true` when the eager `predicate_cube_lift` was used. |
+| `approximant_reuse_enabled` | `boolean` | Whether prior-iteration approximants were threaded forward. |
+| `warnings` | `string[]` | Soundness / advisory warnings produced during the run. |
+| `ctxdsl` | `string \| null` | Final refined cube model + formula as CTXDSL, present only when `emit_ctxdsl: true`. |
+
+**CegarIterationView**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `iteration` | `number` | Iteration index. |
+| `predicate_count` | `number` | Predicate-set size at the start of this iteration. |
+| `had_failure_subgame` | `boolean` | `true` iff this iteration's verdict carried `KleeneBot` cells (drove a refinement). |
+| `predicates_added` | `PredicateView[]` | Predicates the source added in response to this iteration. |
+| `game_position_evaluations` | `number` | Proxy counter for game-position evaluations (approximant-reuse diagnostics). |
+| `verdict` | `CegarVerdictSummary` | Cell-count summary of this iteration's 3-valued verdict. |
+
+**CegarVerdictSummary**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `true_cells` | `number` | `KleeneT` (definitely-true) cells. |
+| `false_cells` | `number` | `KleeneF` (definitely-false) cells. |
+| `unknown_cells` | `number` | `KleeneBot` (unknown — needs refinement) cells. |
+
+**PredicateView** — `{ name: string, register: string, value: number }`.
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/btor2/cegar \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "... BTOR2 source ...",
+    "formula": "nu X. ([] X && mu Y. (done || <> Y))",
+    "predicates": [ { "name": "burst_zero", "register": "burst_cnt", "value": 0 } ],
+    "controllable_inputs": ["start"],
+    "max_iterations": 8
+  }'
+```
+
+---
+
+## POST /api/v1/sv/cegar
+
+SV-direct CEGAR (cegar-extraction Stage 2): lift a SystemVerilog design to a single flattened BTOR2 (sv2v + Yosys) in one call, then run the same predicate-abstraction refinement loop as [`/api/v1/btor2/cegar`](#post-apiv1btor2cegar) and return the same response. Mirrors `mununu sv cegar`. Lets an SV workflow run CEGAR without a manual emit-BTOR2-per-module step.
+
+> Source of truth: [`api::handlers::sv_cegar_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+The CEGAR fields (`formula`, `predicates`, `controllable_inputs`, `predicate_source`, `max_iterations`, `must_edge_inference`, `may_edge_inference`, `config_values`, `emit_ctxdsl`) are identical to [`/api/v1/btor2/cegar`](#post-apiv1btor2cegar). Only the source half differs:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source` | `string` | Yes | SystemVerilog primary source content. |
+| `additional_sources` | `FileContent[]` | No | Additional SV source files (multi-file designs / packages / include targets). Defaults to `[]`. |
+| `top` | `string \| null` | No | Top module name. Recommended for multi-module designs; `null` lets Yosys auto-detect. |
+| `use_sv2v` | `boolean` | No | Run sv2v before Yosys (required for modern SV). Mirrors `--preprocess-sv2v`. Defaults to `false`. |
+| `setundef_anyseq` | `boolean` | No | Yosys `setundef -anyseq` (per-cycle havoc on undefined nets). Defaults to `false`. |
+| `setundef_anyconst` | `boolean` | No | Yosys `setundef -anyconst` (one nondeterministic constant per undefined bit — the Caliptra CWE-1245 power-up policy). Defaults to `false`. |
+| `formula` | `string` | Yes | μ-calculus formula (see `/btor2/cegar`). |
+| `predicates` | `PredicateSpecRequest[]` | Yes | Initial predicate set (see `/btor2/cegar`). |
+| _CEGAR fields…_ | | No | `controllable_inputs`, `predicate_source`, `max_iterations`, `must_edge_inference`, `may_edge_inference`, `config_values`, `emit_ctxdsl` — identical to `/btor2/cegar`. |
+
+### Response Body
+
+Identical to [`/api/v1/btor2/cegar`](#post-apiv1btor2cegar) (`Btor2CegarResponse`).
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/sv/cegar \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "module counter(...); ... endmodule",
+    "top": "counter",
+    "use_sv2v": true,
+    "formula": "nu X. ([] X && mu Y. (done || <> Y))",
+    "predicates": [ { "name": "burst_zero", "register": "burst_cnt", "value": 0 } ]
+  }'
+```
+
+---
+
+## GET /api/v1/extraction/domains
+
+List the available domain profiles (language + description) for AST extraction. Mirrors `mununu extraction domains`.
+
+> Source of truth: [`api::handlers::extraction_domains_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `profiles` | `DomainProfileInfo[]` | Available domain profiles. |
+
+**DomainProfileInfo** — `{ name: string, language: string, description: string }`.
+
+### Example
+
+```bash
+curl http://localhost:3000/api/v1/extraction/domains
+```
+
+---
+
+## GET /api/v1/extraction/composition-modes
+
+List the supported composition modes (synchronous / asynchronous) that the extraction config's `composition.type` accepts.
+
+> Source of truth: [`api::handlers::extraction_composition_modes_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `modes` | `CompositionModeInfo[]` | Supported composition modes. |
+
+**CompositionModeInfo** — `{ name: string, description: string }`.
+
+### Example
+
+```bash
+curl http://localhost:3000/api/v1/extraction/composition-modes
+```
+
+---
+
+## POST /api/v1/extraction/propose-composition
+
+Scan source code for concurrency idioms and propose `composition.instances[]` / `shared[]` blocks for an extraction config. Output is **suggestion-grade** — the user reviews each finding before promoting it into the config. Mirrors `mununu extraction propose-composition`. An empty `findings` list is the common case, not an error.
+
+> Source of truth: [`api::handlers::extraction_propose_composition_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API. (Requires the `ast-extract` feature.)
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source` | `string` | Yes | Source content to scan. |
+| `language` | `string \| null` | No | Source language: `"typescript"`, `"python"`, or `"rust"`. There is no filename to infer from here, so callers should specify it. |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `findings` | `DetectedConcurrency[]` | Detected concurrency findings in source order. See [`concurrency_detect::DetectedConcurrency`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/extraction/ast_extract/concurrency_detect.rs) for the full shape (`kind`, source span, `suggested_instance_names`, `suggested_class_hint`). |
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/extraction/propose-composition \
+  -H "Content-Type: application/json" \
+  -d '{ "source": "... TypeScript source ...", "language": "typescript" }'
+```
+
+---
+
+## POST /api/v1/extraction/extract
+
+Run AST-based extraction from source code (TypeScript / Python / Rust) and produce an `.espec.json` extraction spec. Mirrors `mununu extraction extract`.
+
+> Source of truth: [`api::handlers::extraction_extract_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API. (Requires the `ast-extract` feature.)
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `config` | `string` | Yes | Extraction config content (`.extract.json`). |
+| `source` | `string` | Yes | Source code content. |
+| `language` | `string \| null` | No | Source language (`typescript`, `python`, `rust`). Auto-detected if omitted. |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | `true` on success. |
+| `espec` | `string` | Generated `.espec.json` content. |
+| `warnings` | `string[]` | Extraction warnings. |
+| `automata` | `ExtractionAutomatonInfo[]` | Extracted automata. |
+
+**ExtractionAutomatonInfo** — `{ id: string, state_count: number, transition_count: number }`.
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/extraction/extract \
+  -H "Content-Type: application/json" \
+  -d '{ "config": "... .extract.json ...", "source": "... source ...", "language": "typescript" }'
+```
+
+See [Compositional Extraction Tutorial](Compositional-Extraction-Tutorial.md) for an end-to-end walkthrough.
+
+---
+
+## POST /api/v1/extraction/validate
+
+Validate an extraction spec against its source code: detect drifted/mismatched anchors and uncovered accesses. Mirrors `mununu extraction validate`.
+
+> Source of truth: [`api::handlers::extraction_validate_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `spec` | `string` | Yes | Extraction spec (`.espec.json`) content. |
+| `source` | `string` | Yes | Source code content to validate against. |
+| `drift_window` | `number` | No | Line window for fuzzy anchor matching. Defaults to `5`. |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | `true` on success. |
+| `summary` | `ValidationSummaryApi` | Aggregate counts: `total`, `exact`, `drifted`, `mismatch`, `error`, `uncovered_accesses`. |
+| `anchors` | `AnchorResultApi[]` | Per-anchor results: `id`, `section`, `status`, `line`, `found_line`, `message`. |
+| `uncovered` | `UncoveredAccessApi[]` | Accesses with no covering anchor: `line`, `field`, `content`. |
+| `commit_match` | `boolean \| null` | Whether the spec's recorded commit matches the source, when determinable. |
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/extraction/validate \
+  -H "Content-Type: application/json" \
+  -d '{ "spec": "... .espec.json ...", "source": "... source ...", "drift_window": 5 }'
+```
+
+---
+
+## POST /api/v1/contract/validate
+
+Validate an assume/guarantee contract set's discharge graph (SCC analysis). Mirrors `mununu contract validate`. The request body **is** a `ContractSet` (no wrapper); the response **is** a `DischargeVerdict`.
+
+> Source of truth: [`api::handlers::contract_validate_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+A [`contract::ContractSet`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/contract/mod.rs) JSON value — clauses (assume/guarantee) plus the discharge edges between them.
+
+### Response Body
+
+A [`contract::discharge::DischargeVerdict`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/contract/discharge.rs) — whether the discharge graph is sound, with any offending cycles / undischarged obligations.
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/contract/validate \
+  -H "Content-Type: application/json" \
+  -d '{ "clauses": [ ... ], "edges": [ ... ] }'
+```
+
+---
+
+## POST /api/v1/contract/discover
+
+Run phase-1 contract discovery on a black-box interface description: classify labels (controllable / uncontrollable), detect fairness gaps, and resolve `@mununu_interface contract://` corpus references. Mirrors `mununu contract discover`. The server still emits structured `tracing::warn!` diagnostics; the response carries the full `Phase1Output` for the UI.
+
+> Source of truth: [`api::handlers::contract_discover_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `interface` | `BlackBoxInterface` | Yes | Black-box interface description. See [`contract::discover::BlackBoxInterface`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/contract/discover.rs). |
+| `force_controllable` | `string[]` | No | Labels to force-classify as controllable. Defaults to `[]`. |
+| `force_uncontrollable` | `string[]` | No | Labels to force-classify as uncontrollable. Defaults to `[]`. |
+| `emit_fairness_gap` | `boolean` | No | Emit fairness-gap markers. Defaults to `false`. |
+| `corpus` | `string \| null` | No | Filesystem path to a contract corpus root used to resolve `contract://` URIs. Mirrors `--corpus`. |
+
+### Response Body
+
+A [`contract::discover::Phase1Output`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/contract/discover.rs) — classified labels, fairness-gap markers, and corpus resolutions.
+
+---
+
+## POST /api/v1/contract/query
+
+Query the contract corpus (Document D task D2) by `<domain>/<name>` plus parameters, and return the ranked candidate list. Mirrors `mununu contract query`.
+
+> Source of truth: [`api::handlers::contract_query_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | `<domain>/<name>` identifier, e.g. `"rtl_protocol/axi4_slave"`. A malformed id returns `400`. |
+| `corpus` | `string` | Yes | Filesystem path of the corpus root the server loads. A non-existent path is treated as an empty corpus. |
+| `parameters` | `{ [key: string]: any }` | No | Parameters to match against (numbers, strings, bools). Defaults to `{}`. |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `candidates` | `ContractEntry[]` | Ranked matching corpus entries. See [`corpus::ContractEntry`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/corpus/mod.rs). |
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/contract/query \
+  -H "Content-Type: application/json" \
+  -d '{ "id": "rtl_protocol/axi4_slave", "corpus": "/srv/corpus", "parameters": { "data_width": 32 } }'
+```
+
+---
+
+## POST /api/v1/contract/review
+
+HITL stage-4 review surface (Document A §A7 / Document D §D.8). Wraps phase-1/phase-2 discovery and adds a flat list of proposed clauses extracted from `@mununu_assume` / `@mununu_guarantee` annotations and resolved corpus references. Mirrors `mununu contract review`. The approve/edit/reject UX lives in the CLI / UI surfaces.
+
+> Source of truth: [`api::handlers::contract_review_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+Same shape as [`/api/v1/contract/discover`](#post-apiv1contractdiscover): `interface`, `force_controllable`, `force_uncontrollable`, `emit_fairness_gap`, `corpus`.
+
+### Response Body
+
+A [`contract::review::ReviewPackage`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/contract/review.rs) — the phase-1 output plus the proposed-clause list for the review UI.
+
+---
+
+## POST /api/v1/codesign/verify
+
+HW/SW codesign verification (Document C task C4). Compose firmware CTXDSL with a register-map sidecar, splice the coupling fragment, realize the composed context, and evaluate a named formula. Returns the verdict plus the composed CTXDSL so the UI can render both. Mirrors `mununu codesign verify`.
+
+> Source of truth: [`api::handlers::codesign_verify_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `register_map` | `RegisterMap` | Yes | Register-map sidecar as a parsed JSON value. Same shape the CLI loads from `register_map.json`. See [`codesign::register_map::RegisterMap`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/codesign/register_map.rs). |
+| `firmware_ctxdsl` | `string` | Yes | Firmware CTXDSL document text. |
+| `formula` | `string` | Yes | Formula name to evaluate in the composed context. |
+| `automaton` | `string \| null` | No | Composition / automaton to evaluate over. Defaults to the codesign composition `<PERIPHERAL>System`. |
+| `peripheral_automaton` | `string \| null` | No | Override for the peripheral automaton name. |
+| `composition_name` | `string \| null` | No | Override for the composition name. |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `satisfied` | `boolean` | Whether every initial state satisfies the formula. |
+| `total_states` | `number` | States in the composed automaton/composition. |
+| `satisfying_states` | `number` | States satisfying the formula. |
+| `initial_states` | `string[]` | Initial state names. |
+| `initial_satisfying` | `string[]` | Subset of `initial_states` satisfying the formula. |
+| `composition` | `CodesignCompositionInfo` | `{ peripheral_automaton, composition_name, firmware_members, automaton }`. |
+| `composed_ctxdsl` | `string` | The composed CTXDSL the verifier ran against. |
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/codesign/verify \
+  -H "Content-Type: application/json" \
+  -d '{
+    "register_map": { ... },
+    "firmware_ctxdsl": "context fw { ... }",
+    "formula": "no_enable_mid_transaction"
+  }'
+```
+
+---
+
+## POST /api/v1/codesign/reconcile-labels
+
+HW/SW codesign label-alphabet reconciliation (Document C §C.5 hard gate against silent over-approximation). Refuses to compose `firmware ‖ peripheral` when the two extractions disagree on the rendezvous-label alphabet. Mirrors `mununu codesign reconcile-labels`. **Always returns 200 OK**; the `mismatch` field distinguishes the outcome.
+
+> Source of truth: [`api::handlers::codesign_reconcile_labels_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `firmware_labels` | `string[]` | Yes | Firmware-side rendezvous labels (the C extraction's alphabet). |
+| `peripheral_labels` | `string[]` | Yes | Peripheral-side rendezvous labels (the SV extraction / register-map alphabet). |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `shared` | `string[]` | Shared canonical alphabet (sorted) when the alphabets agree; empty on mismatch. |
+| `mismatch` | `ReconcileMismatch \| null` | `null` when the alphabets reconcile; otherwise `{ firmware_only, peripheral_only }`. See [`codesign::reconcile::ReconcileMismatch`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/codesign/reconcile.rs). |
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/codesign/reconcile-labels \
+  -H "Content-Type: application/json" \
+  -d '{ "firmware_labels": ["reg_write_ctrl", "irq_ack"], "peripheral_labels": ["reg_write_ctrl", "irq_raise"] }'
+```
+
+---
+
+## POST /api/v1/codesign/emit-chaotic-stub
+
+Emit a standalone chaotic-stub CTXDSL document from a register-map sidecar. The result has its own `context { … }` wrapper, ready to drop into a `verify.toml` as a `ctxdsl` source. Mirrors `mununu codesign emit-chaotic-stub`.
+
+> Source of truth: [`api::handlers::codesign_emit_chaotic_stub_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `register_map` | `RegisterMap` | Yes | Parsed register-map JSON sidecar. |
+| `peripheral_automaton` | `string \| null` | No | Override for the peripheral automaton name. Defaults to the uppercased peripheral name; the context-block name is always `<AutomatonName>ChaoticStub`. |
+| `strict` | `boolean` | No | When `true`, refuse to emit and return `400` if the register-map validator reports any issue. Defaults to `false`. |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ctxdsl` | `string` | The standalone chaotic-stub CTXDSL document. |
+| `warnings` | `string[]` | Validation warnings from the register-map validator. Empty when the sidecar is well-formed. |
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/codesign/emit-chaotic-stub \
+  -H "Content-Type: application/json" \
+  -d '{ "register_map": { ... }, "strict": false }'
+```
+
+---
+
 ## GET /api/v1/templates
 
 List available property templates. Templates provide parameterized mu-calculus formula patterns that can be used in `template_ref` fields of verify and synthesize requests.
+
+> Source of truth: [`api::handlers::templates_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 ### Query Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `domain` | `string` | No | Filter by domain: `rtl`, `agentic`, `software`, `synthesis`, `universal` |
+| `domain` | `string` | No | Filter by domain: `rtl`, `agentic`, `software`, `synthesis`, `universal`. |
 
 ### Response Body
 
@@ -675,8 +1193,8 @@ With `domain` filter, returns a filtered array of `PropertyTemplate` objects.
 ### Example
 
 ```bash
-curl http://localhost:8080/api/v1/templates
-curl http://localhost:8080/api/v1/templates?domain=rtl
+curl http://localhost:3000/api/v1/templates
+curl http://localhost:3000/api/v1/templates?domain=rtl
 ```
 
 See [Property Templates](Property-Templates) for the full catalog and usage guide.
@@ -687,7 +1205,7 @@ See [Property Templates](Property-Templates) for the full catalog and usage guid
 
 ### FileContent
 
-Used for both the main context and synthesized controller output.
+Used for the main context, sidecars, and synthesized controller output.
 
 ```json
 {
@@ -705,6 +1223,14 @@ Structurally identical to `FileContent`. Sidecars are merged into the main conte
   "name": "properties.ctxdsl",
   "content": "context example_props { mu_formulas { ... } }"
 }
+```
+
+### PredicateSpecRequest
+
+A register-value equality predicate, shared by `/context/import`, `/btor2/cegar`, and `/sv/cegar`.
+
+```json
+{ "name": "burst_zero", "register": "burst_cnt", "value": 0 }
 ```
 
 ---
@@ -725,8 +1251,11 @@ All endpoints return errors in a consistent format:
 
 | HTTP Status | Code | Meaning |
 |-------------|------|---------|
-| 400 | `BAD_REQUEST` | Invalid input: parse errors, unknown formula/automaton names. |
+| 400 | `BAD_REQUEST` | Invalid input: parse errors, unknown formula/automaton names, both/neither of mutually-exclusive fields, malformed identifiers. |
+| 408 | `REQUEST_TIMEOUT` | The request exceeded the server's 30 s timeout. |
 | 500 | `INTERNAL_ERROR` | Server-side failure during realization, synthesis, or evaluation. |
+
+> Note: `/codesign/reconcile-labels` and `/verify/memory-check` are **advisory** — they return 200 OK with the warning/mismatch in the body rather than a 4xx.
 
 ---
 

--- a/wiki/Adapter-Formats.md
+++ b/wiki/Adapter-Formats.md
@@ -159,7 +159,7 @@ write_btor design.btor
 
 ### How the BTOR2 reader treats the design
 
-Four CLTS-aligned transformations applied at read time (per [`adapter::btor2::bit_blast`](../crates/mununu-core/src/adapter/btor2/bit_blast.rs)):
+Four CLTS-aligned transformations applied at read time (per [`adapter::btor2::bit_blast`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/bit_blast.rs)):
 
 1. **Per-signal labels.** Each transition carries one `<signal>=<value>` label per non-clock input — `transition s0 -> s253 on label rst_0;` — using mununu's native multi-label transition support. Properties refer to individual signals via `[(rst_0)] φ` rather than enumerating compound `env_NNNN` strings. The CLTS alphabet shrinks from `2^N` (compound) to `2N` (per-signal-value) entries.
 2. **Implicit clock.** Each CLTS transition represents one clock edge; `clk` does not appear in the alphabet. The reader auto-detects clock-shaped input names (`clk`, `clock`, `ck`, `clk_i`, `i_clk`, `iclk`, `clki`) and elides them from enumeration. Multi-clock and negedge designs are out of scope for Phase 1 — the reader errors explicitly.
@@ -193,7 +193,7 @@ mununu context eval design.btor --adapter btor2 --formula safety_bad_0 --automat
 
 ### Soundness
 
-- **Bit-blasting is exact** for the operators marked `is_blastable()` in [`btor2::ast::Op`](../crates/mununu-core/src/adapter/btor2/ast.rs).
+- **Bit-blasting is exact** for the operators marked `is_blastable()` in [`btor2::ast::Op`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/ast.rs).
 - **Implicit clock is sound for posedge-only single-clock designs** — multi-clock and negedge are explicitly rejected at read time.
 - **`async2sync` preserves synchronous structure** for both register cells and `chformal`-lowered assertions.
 - **`setundef -zero`** in the Yosys script makes X / undef bits deterministic; X-aware verification is out of mununu's roadmap scope.

--- a/wiki/Agentic-Adapters.md
+++ b/wiki/Agentic-Adapters.md
@@ -1,6 +1,6 @@
 # Agentic Adapters
 
-> **Source of truth:** [`crates/mununu-core/src/adapter/crewai/`](../crates/mununu-core/src/adapter/crewai/), [`crates/mununu-core/src/adapter/langgraph/`](../crates/mununu-core/src/adapter/langgraph/) — surface: CLI+API+UI.
+> **Source of truth:** [`crates/mununu-core/src/adapter/crewai/`](https://github.com/vscorza/mununu/tree/main/crates/mununu-core/src/adapter/crewai/), [`crates/mununu-core/src/adapter/langgraph/`](https://github.com/vscorza/mununu/tree/main/crates/mununu-core/src/adapter/langgraph/) — surface: CLI+API+UI.
 
 Mununu ships **native parsers** for CrewAI and LangGraph workflow exports. Drop a `.crewai.json` / `.langgraph.json` file into the CLI, the HTTP API, or the UI wizard and the corresponding adapter translates it into CTXDSL automata directly — no manual rewrite into XState required.
 
@@ -8,7 +8,7 @@ For broader context on agentic verification (counterexample interpretation, MCP 
 
 ## CrewAI adapter
 
-> **Source of truth:** [`adapter::crewai::CrewaiAdapter`](../crates/mununu-core/src/adapter/crewai/mod.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`adapter::crewai::CrewaiAdapter`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/crewai/mod.rs) — surface: CLI+API+UI.
 
 ### What it accepts
 
@@ -33,11 +33,11 @@ Detection runs on file extension (`.crewai.json` / `.crewai`) and on content (`a
 
 ### How it translates
 
-> **Source of truth:** [`adapter::crewai::translate::to_ir`](../crates/mununu-core/src/adapter/crewai/translate.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`adapter::crewai::translate::to_ir`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/crewai/translate.rs) — surface: CLI+API+UI.
 
 - **One automaton per agent.** States: `Idle -> Executing -> Done -> Idle`. Labels: `agent_<role>_start` (controllable — the supervisor dispatches), `agent_<role>_complete` (uncontrollable — the LLM completes when it completes).
 - **One supervisor automaton.** States `Init -> AfterTask_1 -> ... -> AfterTask_N` driven by `agent_<role>_complete` events in declared task order.
-- **Asynchronous composition** over `[supervisor, agent_1, ..., agent_N]` per [Doc C §C.5 soundness](../docs/design/hw-sw-codesign-extraction.md) — LLM latency is non-deterministic, so synchronous one-step rendezvous is unsound for liveness without explicit fairness.
+- **Asynchronous composition** over `[supervisor, agent_1, ..., agent_N]` per the [agentic adapter soundness notes](https://github.com/vscorza/mununu/blob/main/docs/adapters/agentic.md) — LLM latency is non-deterministic, so synchronous one-step rendezvous is unsound for liveness without explicit fairness.
 - **`__mununu` block overrides** controllability classifications via the same convention as the XState adapter.
 
 `process = "sequential"` is fully modelled; `hierarchical` and `consensual` emit an `ApproximateTranslation` warning and fall back to sequential. Native support for those processes is a planned follow-up.
@@ -52,7 +52,7 @@ Detection runs on file extension (`.crewai.json` / `.crewai`) and on content (`a
 
 ## LangGraph adapter
 
-> **Source of truth:** [`adapter::langgraph::LangGraphAdapter`](../crates/mununu-core/src/adapter/langgraph/mod.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`adapter::langgraph::LangGraphAdapter`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/langgraph/mod.rs) — surface: CLI+API+UI.
 
 ### What it accepts
 
@@ -78,7 +78,7 @@ Three accepted shapes: flat `{nodes, edges}` (canonical), wrapped `{graph: {node
 
 ### How it translates
 
-> **Source of truth:** [`adapter::langgraph::translate::to_ir`](../crates/mununu-core/src/adapter/langgraph/translate.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`adapter::langgraph::translate::to_ir`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/langgraph/translate.rs) — surface: CLI+API+UI.
 
 - **One state per node.** The entry-point node (or the first node if absent) becomes the initial state.
 - **One transition per edge** with label `node_<from>_enter`. Conditional edges get a per-condition suffix: `node_<from>_<condition>_enter`.
@@ -87,7 +87,7 @@ Three accepted shapes: flat `{nodes, edges}` (canonical), wrapped `{graph: {node
 
 ## Property templates for agentic flows
 
-> **Source of truth:** [`adapter::templates::builtin_templates`](../crates/mununu-core/src/adapter/templates/builtin_templates.json) — surface: CLI+API+UI.
+> **Source of truth:** [`adapter::templates::builtin_templates`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/templates/builtin_templates.json) — surface: CLI+API+UI.
 
 Three templates tagged `agentic` in the builtin catalog cover the most common verification questions:
 
@@ -113,7 +113,7 @@ mununu context eval graph.json --adapter langgraph --formula safety
 
 ## HTTP API
 
-> **Source of truth:** [`api::handlers::context_import_handler`](../crates/mununu-core/src/api/handlers.rs) — surface: API.
+> **Source of truth:** [`api::handlers::context_import_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 `POST /api/v1/context/import` accepts `format = "crewai"` or `format = "langgraph"` in addition to the legacy `auto | xstate | systemverilog | sv-yosys | tlsf | aiger | btor2 | promela | extraction` set.
 
@@ -126,13 +126,13 @@ curl -X POST http://127.0.0.1:8080/api/v1/context/import \
 
 ## Web UI
 
-> **Source of truth:** [`mununu-ui/src/types/workflow.ts`](../../mununu-ui/src/types/workflow.ts) — surface: UI.
+> **Source of truth:** [`mununu-ui/src/types/workflow.ts`](https://github.com/vscorza/mununu-ui/blob/main/src/types/workflow.ts) — surface: UI.
 
 The Extraction tab's domain selector exposes **CrewAI Agentic** and **LangGraph Workflow** as dedicated wizards. Drop a `.crewai.json` / `.langgraph.json`, click **Run Translate**, then switch to the Verification tab to evaluate properties on the emitted CTXDSL.
 
 ## End-to-end examples
 
-> **Source of truth:** [`examples/verify/crewai_handoff/`](../examples/verify/crewai_handoff/), [`examples/verify/langgraph_workflow/`](../examples/verify/langgraph_workflow/) — surface: CLI.
+> **Source of truth:** [`examples/verify/crewai_handoff/`](https://github.com/vscorza/mununu/tree/main/examples/verify/crewai_handoff/), [`examples/verify/langgraph_workflow/`](https://github.com/vscorza/mununu/tree/main/examples/verify/langgraph_workflow/) — surface: CLI.
 
 Two verify-framework fixtures exercise the adapters end-to-end through `mununu verify`:
 

--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -290,7 +290,7 @@ mununu context predicates examples/hw/arbiter.ctxdsl --automaton Arbiter
 
 Run the general N-source verification framework against a `verify.toml` manifest. The manifest lists sources (any combination of `ctxdsl`, `xstate`, `crewai`, `langgraph`, `sv-yosys`, `c-codesign`, `extraction`), an alphabet-binding strategy, a composition shape, and properties. See [Verify Project Flow](Verify-Project-Flow.md) for the conceptual model and the `verify.toml` schema.
 
-> Source of truth: [`mununu-cli::handle_verify`](../crates/mununu-cli/src/main.rs) — surface: CLI.
+> Source of truth: [`mununu-cli::handle_verify`](https://github.com/vscorza/mununu/blob/main/crates/mununu-cli/src/main.rs) — surface: CLI.
 
 ```
 mununu verify <CONFIG> [options]
@@ -318,7 +318,7 @@ mununu verify examples/verify/langgraph_workflow/verify.toml --json
 mununu verify examples/verify/uart_codesign_chaotic/verify.toml --strict
 ```
 
-**See also**: every entry in [`examples/verify/`](../examples/verify/) ships a `validate.sh` script that calls `mununu verify` and diffs against a checked-in `transcript.txt` — useful copy-paste starting points.
+**See also**: every entry in [`examples/verify/`](https://github.com/vscorza/mununu/tree/main/examples/verify/) ships a `validate.sh` script that calls `mununu verify` and diffs against a checked-in `transcript.txt` — useful copy-paste starting points.
 
 ---
 

--- a/wiki/Composition.md
+++ b/wiki/Composition.md
@@ -212,9 +212,9 @@ The full example is in `tutorial/examples/04_cross_domain.ctxdsl`.
 
 ## KMTS Composition — Modality Merge (post-R.1)
 
-> **Source of truth:** [`composition::compose`](../crates/mununu-core/src/composition/mod.rs), [`Transition::modality`](../crates/mununu-core/src/clts/mod.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`composition::compose`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/composition/mod.rs), [`Transition::modality`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/clts/mod.rs) — surface: CLI+API+UI.
 
-The synchronous / asynchronous / superset semantics above apply unchanged to Kripke Modal Transition Systems (KMTSes — see [`docs/design/kmts-theory.md`](../docs/design/kmts-theory.md)). What KMTS composition *adds* is **per-axis modality merging**: each transition carries a `TransitionModality` (`Sharp` for both may and must, `MayOnly` for over-approximation only), and the composition operator merges modalities pointwise on each axis.
+The synchronous / asynchronous / superset semantics above apply unchanged to Kripke Modal Transition Systems (KMTSes — see [`docs/design/kmts-theory.md`](https://github.com/vscorza/mununu/blob/main/docs/design/kmts-theory.md)). What KMTS composition *adds* is **per-axis modality merging**: each transition carries a `TransitionModality` (`Sharp` for both may and must, `MayOnly` for over-approximation only), and the composition operator merges modalities pointwise on each axis.
 
 ### Modality merge rule
 
@@ -243,7 +243,7 @@ Composition is purely structural (no SMT at compose time); refinement is congrue
 
 **Preserves:** Per-module abstraction; cross-module verdict soundness *under per-module abstractions*; liveness reasoning under fairness; all CTLS-observable behaviour for Sharp-everywhere KMTSes (the legacy case is a structural special case).
 
-**Does not preserve:** *Tightness* — the composed KMTS may have more `KleeneBot` verdicts than a monolithic predicate abstraction of the flattened system. The architecture doc [§7.2 worked counterexample](../docs/design/native-sv-abstraction.md#§7-compositional-kmts-the-structural-free-lunch) walks through a producer/consumer pair where the composed KMTS returns `KleeneBot` on a safety property because the per-module predicate sets lack a cross-module port-equality predicate; adding `data_eq_on_handshake = (valid ⇒ producer.data_out == consumer.data_in)` to the multi-module sidecar closes the gap.
+**Does not preserve:** *Tightness* — the composed KMTS may have more `KleeneBot` verdicts than a monolithic predicate abstraction of the flattened system. The architecture doc [§7.2 worked counterexample](https://github.com/vscorza/mununu/blob/main/docs/design/native-sv-abstraction.md#§7-compositional-kmts-the-structural-free-lunch) walks through a producer/consumer pair where the composed KMTS returns `KleeneBot` on a safety property because the per-module predicate sets lack a cross-module port-equality predicate; adding `data_eq_on_handshake = (valid ⇒ producer.data_out == consumer.data_in)` to the multi-module sidecar closes the gap.
 
 The KMTS lifter auto-emits canonical port-equality predicates for every declared multi-module connection (`from: "producer.data_out", to: "consumer.data_in"` → `data_eq_on_handshake`). Authors only need to add predicates manually for arbitrated buses, stateful intermediates, and cross-domain CDC bridges.
 
@@ -251,11 +251,11 @@ The KMTS lifter auto-emits canonical port-equality predicates for every declared
 
 For Sharp-everywhere KMTSes (the case the existing examples above all describe — XState, microcode, ctxdsl, agentic adapters all produce `Sharp` transitions exclusively), the modality merge is `Sharp ⊗ Sharp = Sharp` on every composed transition. The 3-valued evaluator (`KleeneDomain`) reduces to the 2-valued one (`BoolDomain`) on a Sharp-everywhere KMTS: `KleeneBot` never appears in the verdict. So the existing producer-consumer and sensor-network examples are unchanged — the new modality machinery is *additive*, not a behavioural change for adapters that don't produce `MayOnly` transitions.
 
-The KMTS lifter (SV / BTOR2 path, post-R.2) is the adapter that produces `MayOnly` transitions, because predicate abstraction creates over-approximation edges that no concrete witness backs. See [`docs/design/native-sv-abstraction.md`](../docs/design/native-sv-abstraction.md) §6 for the design and [`docs/design/predicate-abstraction-recipe.md`](../docs/design/predicate-abstraction-recipe.md) §3 for the predicate-image computation that decides which transitions are `Sharp` vs `MayOnly`.
+The KMTS lifter (SV / BTOR2 path, post-R.2) is the adapter that produces `MayOnly` transitions, because predicate abstraction creates over-approximation edges that no concrete witness backs. See [`docs/design/native-sv-abstraction.md`](https://github.com/vscorza/mununu/blob/main/docs/design/native-sv-abstraction.md) §6 for the design and [`docs/design/predicate-abstraction-recipe.md`](https://github.com/vscorza/mununu/blob/main/docs/design/predicate-abstraction-recipe.md) §3 for the predicate-image computation that decides which transitions are `Sharp` vs `MayOnly`.
 
 ## See Also
 
 - [Verify Project Flow](Verify-Project-Flow) — composition's place in the verify pipeline; the KMTS pipeline highlights.
-- [`docs/design/kmts-theory.md`](../docs/design/kmts-theory.md) — KMTS theory, refinement preorder, 3-valued mu-calculus semantics, preservation theorem.
-- [`docs/design/native-sv-abstraction.md`](../docs/design/native-sv-abstraction.md) §6.5 (composition modality merge) + §7 (compositional KMTS).
-- [`docs/abstraction.md`](../docs/abstraction.md) — the canonical KMTS recipe and the legacy primitives.
+- [`docs/design/kmts-theory.md`](https://github.com/vscorza/mununu/blob/main/docs/design/kmts-theory.md) — KMTS theory, refinement preorder, 3-valued mu-calculus semantics, preservation theorem.
+- [`docs/design/native-sv-abstraction.md`](https://github.com/vscorza/mununu/blob/main/docs/design/native-sv-abstraction.md) §6.5 (composition modality merge) + §7 (compositional KMTS).
+- [`docs/abstraction.md`](https://github.com/vscorza/mununu/blob/main/docs/abstraction.md) — the canonical KMTS recipe and the legacy primitives.

--- a/wiki/Compositional-Extraction-Tutorial.md
+++ b/wiki/Compositional-Extraction-Tutorial.md
@@ -22,15 +22,15 @@ The `mununu` and `mununu-extract` binaries land in `target/release/` and are inv
 
 ## Path A — Public synthetic fixture
 
-The repo ships a minimal worker-race fixture under [examples/ast_extract/typescript/](../examples/ast_extract/typescript/). One `Worker` class with a `_committed` flag, plus a hand-modelled shared file. Two instances of the worker contending over the file is the smallest non-trivial composition that produces a real race witness.
+The repo ships a minimal worker-race fixture under [examples/ast_extract/typescript/](https://github.com/vscorza/mununu/tree/main/examples/ast_extract/typescript/). One `Worker` class with a `_committed` flag, plus a hand-modelled shared file. Two instances of the worker contending over the file is the smallest non-trivial composition that produces a real race witness.
 
 ### Files
 
 | Path | Role |
 |------|------|
-| [examples/ast_extract/typescript/parallel_workers.ts](../examples/ast_extract/typescript/parallel_workers.ts) | Source code (one `Worker` class). |
-| [examples/ast_extract/typescript/parallel_workers_compositional.extract.json](../examples/ast_extract/typescript/parallel_workers_compositional.extract.json) | Extract config with `composition.instances[]`, `composition.resources[]`, and two properties. |
-| [examples/ast_extract/typescript/parallel_workers_compositional.expected.txt](../examples/ast_extract/typescript/parallel_workers_compositional.expected.txt) | Reference verdicts — diff your output against this. |
+| [examples/ast_extract/typescript/parallel_workers.ts](https://github.com/vscorza/mununu/blob/main/examples/ast_extract/typescript/parallel_workers.ts) | Source code (one `Worker` class). |
+| [examples/ast_extract/typescript/parallel_workers_compositional.extract.json](https://github.com/vscorza/mununu/blob/main/examples/ast_extract/typescript/parallel_workers_compositional.extract.json) | Extract config with `composition.instances[]`, `composition.resources[]`, and two properties. |
+| [examples/ast_extract/typescript/parallel_workers_compositional.expected.txt](https://github.com/vscorza/mununu/blob/main/examples/ast_extract/typescript/parallel_workers_compositional.expected.txt) | Reference verdicts — diff your output against this. |
 
 ### Run it
 
@@ -198,7 +198,7 @@ The output is **suggestion-grade**: the user reviews each finding, picks one, an
 
 The Web UI exposes the same flow as a one-click button — see [mununu-ui's local-testing guide](https://github.com/vscorza/mununu-ui/blob/main/docs/phase-b-local-testing.md) for the UI walkthrough.
 
-For coverage, validation results, and known limitations of the Phase B detectors, see the [extraction architecture doc](../docs/architecture/extraction.md#phase-b--pattern-based-auto-detection).
+The Phase B detectors and the concurrency idioms they recognise live in [`concurrency_detect.rs`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/extraction/ast_extract/concurrency_detect.rs) — read the pattern matchers there for the exact coverage and its limits.
 
 ---
 
@@ -224,10 +224,10 @@ npm run dev
 
 1. Open `http://localhost:5173`.
 2. Sidebar → **Extraction** → **Software Extraction** workflow.
-3. **Load Source**: drop or paste [examples/ast_extract/typescript/parallel_workers.ts](../examples/ast_extract/typescript/parallel_workers.ts). The file extension `.ts` is recognised → the Phase B `Suggest from source` button will appear in the compose step.
+3. **Load Source**: drop or paste [examples/ast_extract/typescript/parallel_workers.ts](https://github.com/vscorza/mununu/blob/main/examples/ast_extract/typescript/parallel_workers.ts). The file extension `.ts` is recognised → the Phase B `Suggest from source` button will appear in the compose step.
 4. **Extract Model**: the step renders an `ExtractConfigEditor` JSON textarea.
    - Click **Start from template** to seed a default config (single-class targeting `Worker`, sourced from the loaded filename).
-   - Replace the placeholder `targets[]` block with the real one — easiest path: open [parallel_workers_compositional.extract.json](../examples/ast_extract/typescript/parallel_workers_compositional.extract.json), copy the body, paste it into the editor.
+   - Replace the placeholder `targets[]` block with the real one — easiest path: open [parallel_workers_compositional.extract.json](https://github.com/vscorza/mununu/blob/main/examples/ast_extract/typescript/parallel_workers_compositional.extract.json), copy the body, paste it into the editor.
    - The summary panel below the textarea reports `source.file`, `language`, `targets (N)`, `composition`, and `properties (N)` once the JSON is valid.
    - Click **Run extract**. The backend returns the multi-automaton espec (3 automata for the parallel-workers fixture: `worker_a`, `worker_b`, `shared_file`). The result message reads `Extracted 3 automaton/a. 0 warning(s).`
 5. **Compose Instances**: visual editor over the composition sub-block. Three things you can do here:
@@ -272,9 +272,9 @@ If you need to extend or debug the pipeline:
 
 | Component | Location |
 |-----------|----------|
-| Extract-config schema | [crates/mununu-core/src/adapter/extraction/ast_extract/config.rs](../crates/mununu-core/src/adapter/extraction/ast_extract/config.rs) — `ExtractionConfig`, `CompositionConfig`, `ResourceDecl`. |
-| Per-instance label rewriting | [crates/mununu-core/src/adapter/extraction/ast_extract/mod.rs](../crates/mununu-core/src/adapter/extraction/ast_extract/mod.rs) — `rewrite_labels_for_instance`. |
+| Extract-config schema | [crates/mununu-core/src/adapter/extraction/ast_extract/config.rs](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/extraction/ast_extract/config.rs) — `ExtractionConfig`, `CompositionConfig`, `ResourceDecl`. |
+| Per-instance label rewriting | [crates/mununu-core/src/adapter/extraction/ast_extract/mod.rs](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/extraction/ast_extract/mod.rs) — `rewrite_labels_for_instance`. |
 | Resource → automaton emission | Same file — `build_resource_automaton`. |
-| Composition engine | [crates/mununu-core/src/composition/mod.rs](../crates/mununu-core/src/composition/mod.rs) — alphabet-intersection synchronization. |
-| Phase B detectors | [crates/mununu-core/src/adapter/extraction/ast_extract/concurrency_detect.rs](../crates/mununu-core/src/adapter/extraction/ast_extract/concurrency_detect.rs). |
-| Property templates | [crates/mununu-core/src/adapter/templates/builtin_templates.json](../crates/mununu-core/src/adapter/templates/builtin_templates.json) — `no_clobber`, `clobber_reachable`, `mutual_exclusion`, `bounded_handoff`, `no_lost_update`. |
+| Composition engine | [crates/mununu-core/src/composition/mod.rs](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/composition/mod.rs) — alphabet-intersection synchronization. |
+| Phase B detectors | [crates/mununu-core/src/adapter/extraction/ast_extract/concurrency_detect.rs](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/extraction/ast_extract/concurrency_detect.rs). |
+| Property templates | [crates/mununu-core/src/adapter/templates/builtin_templates.json](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/templates/builtin_templates.json) — `no_clobber`, `clobber_reachable`, `mutual_exclusion`, `bounded_handoff`, `no_lost_update`. |

--- a/wiki/Controller-Modes.md
+++ b/wiki/Controller-Modes.md
@@ -108,7 +108,7 @@ The synthesis options panel in [mununu-ui](https://github.com/your-org/mununu-ui
 
 ## Example: alternation-4 benchmark
 
-The shipped example [`examples/bus_arbiter_retry.ctxdsl`](../examples/bus_arbiter_retry.ctxdsl) is a 4-state bus-arbiter system whose property has alternation depth **4** — two strict mu/nu alternations beyond GR(1). It demonstrates `parity-game` mode running on a formula that's strictly outside the `product-game` mode's correctness guarantee.
+The shipped example [`examples/bus_arbiter_retry.ctxdsl`](https://github.com/vscorza/mununu/blob/main/examples/bus_arbiter_retry.ctxdsl) is a 4-state bus-arbiter system whose property has alternation depth **4** — two strict mu/nu alternations beyond GR(1). It demonstrates `parity-game` mode running on a formula that's strictly outside the `product-game` mode's correctness guarantee.
 
 The property is the **recurrence-after-stability** pattern from the Manna-Pnueli temporal hierarchy (Σ₃-complete; appears in SYNTCOMP `lily-demo` and `amba_decomposed_lock_*`):
 
@@ -140,7 +140,7 @@ All modes happen to agree on realizability for this small system because it admi
 
 ## Example: dual-channel arbiter — memory + strategy selection
 
-[`examples/dual_arbiter_alt4.ctxdsl`](../examples/dual_arbiter_alt4.ctxdsl) extends the bus arbiter with a SECOND independent channel. The property is the conjunction of two recurrence-after-stability obligations (one per channel) — still alternation 4. This example exercises both required behaviours of memory-aware synthesis:
+[`examples/dual_arbiter_alt4.ctxdsl`](https://github.com/vscorza/mununu/blob/main/examples/dual_arbiter_alt4.ctxdsl) extends the bus arbiter with a SECOND independent channel. The property is the conjunction of two recurrence-after-stability obligations (one per channel) — still alternation 4. This example exercises both required behaviours of memory-aware synthesis:
 
 1. **The controller must remember which liveness goal it is currently servicing.** Both channels can be in `Pending`/`Granted`/`Retrying` simultaneously, and the controller must rotate between obligations to make fair progress on both.
 2. **The controller must disable controllable transitions.** Each `Granted` state has multiple outgoing controllables (`release` + `swap`); the synthesized strategy picks one and implicitly disables the others.
@@ -166,6 +166,6 @@ The 17-transition gap between `projection` and `functional` is the most direct e
 
 ## Implementation references
 
-- [`crates/mununu-core/src/context/mod.rs`](../crates/mununu-core/src/context/mod.rs) — `ControllerMode` enum + synthesis branches
-- [`crates/mununu-core/src/mu_calculus/parity_game.rs`](../crates/mununu-core/src/mu_calculus/parity_game.rs) — explicit parity-game construction + Zielonka solver
-- [`crates/mununu-core/tests/soundness.rs`](../crates/mununu-core/tests/soundness.rs) — per-mode regression + cross-mode realizability agreement tests
+- [`crates/mununu-core/src/context/mod.rs`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/context/mod.rs) — `ControllerMode` enum + synthesis branches
+- [`crates/mununu-core/src/mu_calculus/parity_game.rs`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/mu_calculus/parity_game.rs) — explicit parity-game construction + Zielonka solver
+- [`crates/mununu-core/tests/soundness.rs`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/tests/soundness.rs) — per-mode regression + cross-mode realizability agreement tests

--- a/wiki/Predicate-Cube-CEGAR.md
+++ b/wiki/Predicate-Cube-CEGAR.md
@@ -1,6 +1,6 @@
 # Predicate-Cube CEGAR
 
-> **Source of truth:** [`adapter::btor2::cegar::cegar_refine_loop`](../crates/mununu-core/src/adapter/btor2/cegar.rs), [`adapter::btor2::kmts_lift::predicate_cube_lift`](../crates/mununu-core/src/adapter/btor2/kmts_lift.rs), [`mu_calculus::evaluate_tri`](../crates/mununu-core/src/mu_calculus/evaluator.rs) — surface: CLI+API+UI (`mununu btor2 cegar` / `mununu sv cegar`, `POST /api/v1/btor2/cegar` / `POST /api/v1/sv/cegar`, the `/cegar` panel).
+> **Source of truth:** [`adapter::btor2::cegar::cegar_refine_loop`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/cegar.rs), [`adapter::btor2::kmts_lift::predicate_cube_lift`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/kmts_lift.rs), [`mu_calculus::evaluate_tri`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/mu_calculus/evaluator.rs) — surface: CLI+API+UI (`mununu btor2 cegar` / `mununu sv cegar`, `POST /api/v1/btor2/cegar` / `POST /api/v1/sv/cegar`, the `/cegar` panel).
 
 Predicate-cube CEGAR is mununu's **second RTL verification engine**. Where the
 [RTL Verification Pipeline](RTL-Verification-Pipeline) bit-blasts the design into
@@ -42,7 +42,7 @@ one-call variant that runs sv2v + Yosys for you.
 
 ## CLI
 
-> **Source of truth:** the `btor2 cegar` / `sv cegar` subcommands in [`crates/mununu-cli/src/main.rs`](../crates/mununu-cli/src/main.rs) — surface: CLI.
+> **Source of truth:** the `btor2 cegar` / `sv cegar` subcommands in [`crates/mununu-cli/src/main.rs`](https://github.com/vscorza/mununu/blob/main/crates/mununu-cli/src/main.rs) — surface: CLI.
 
 ```bash
 mununu btor2 cegar <design.btor2> \
@@ -86,7 +86,7 @@ Each cube gets one of three verdicts, and the CLI prints the tally as
 
 ## Soundness — the audited-sound fragment
 
-> **Source of truth:** [`mu_calculus::cube_modality_soundness_warnings`](../crates/mununu-core/src/mu_calculus/mod.rs) — surface: CLI+API+UI (the cegar `warnings` channel). Full write-up: [`docs/design/predicate-abstraction-recipe.md`](../docs/design/predicate-abstraction-recipe.md) §4.9.
+> **Source of truth:** [`mu_calculus::cube_modality_soundness_warnings`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/mu_calculus/mod.rs) — surface: CLI+API+UI (the cegar `warnings` channel). Full write-up: [`docs/design/predicate-abstraction-recipe.md`](https://github.com/vscorza/mununu/blob/main/docs/design/predicate-abstraction-recipe.md) §4.9.
 
 A definite verdict transfers soundly for the fragment the cube path actually
 evaluates: **bare (label-agnostic), single-agent (`Control::All`), unbounded**
@@ -117,7 +117,7 @@ warnings:
 
 ## Worked example — Caliptra boot-FSM (CWE-1245)
 
-> **Runnable:** [`examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh`](../examples/verify/sv_yosys_caliptra_rtl_150/) (requires `yosys` + `sv2v` + `z3` on `PATH`). This is mununu's M.4 milestone — full automated CEGAR on real industrial RTL.
+> **Runnable:** [`examples/verify/sv_yosys_caliptra_rtl_150/validate_m4_cegar.sh`](https://github.com/vscorza/mununu/tree/main/examples/verify/sv_yosys_caliptra_rtl_150/) (requires `yosys` + `sv2v` + `z3` on `PATH`). This is mununu's M.4 milestone — full automated CEGAR on real industrial RTL.
 
 The Caliptra `soc_ifc_boot_fsm` holds its state in a 3-bit `boot_fsm_state_e`
 register with five legal encodings (0–4). The bug-bearing `pre_fix` variant has a
@@ -145,7 +145,7 @@ abstraction / CEGAR to convergence.
 
 ## API + UI
 
-- **API:** `POST /api/v1/btor2/cegar` and `POST /api/v1/sv/cegar` ([`crates/mununu-core/src/api/handlers.rs`](../crates/mununu-core/src/api/handlers.rs)) return the per-iteration trace + the `{T, F, ⊥}` verdict + the `warnings` list.
+- **API:** `POST /api/v1/btor2/cegar` and `POST /api/v1/sv/cegar` ([`crates/mununu-core/src/api/handlers.rs`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs)) return the per-iteration trace + the `{T, F, ⊥}` verdict + the `warnings` list.
 - **UI:** the `/cegar` panel renders the verdict with `KleeneBot` iconography, the per-iteration refinement trace, the final predicate set, and the soundness warnings; it round-trips a predicate edit and re-runs.
 
 ## See Also
@@ -153,5 +153,5 @@ abstraction / CEGAR to convergence.
 - [RTL Verification Pipeline](RTL-Verification-Pipeline) — the complementary bit-blast engine
 - [Mu-Calculus Reference](Mu-Calculus-Reference) — `<>` / `[]`, controllability operators, fixpoints
 - [Adapter Formats](Adapter-Formats) — BTOR2 + SystemVerilog import
-- [`docs/design/predicate-abstraction-recipe.md`](../docs/design/predicate-abstraction-recipe.md) — the full operational recipe (predicate seeding, may/must image, CEGAR, §4.9 soundness)
-- [`docs/design/kmts-theory.md`](../docs/design/kmts-theory.md) — KMTS + 3-valued mu-calculus theory
+- [`docs/design/predicate-abstraction-recipe.md`](https://github.com/vscorza/mununu/blob/main/docs/design/predicate-abstraction-recipe.md) — the full operational recipe (predicate seeding, may/must image, CEGAR, §4.9 soundness)
+- [`docs/design/kmts-theory.md`](https://github.com/vscorza/mununu/blob/main/docs/design/kmts-theory.md) — KMTS + 3-valued mu-calculus theory

--- a/wiki/Verify-Project-Flow.md
+++ b/wiki/Verify-Project-Flow.md
@@ -1,6 +1,6 @@
 # Verify Project Flow
 
-> **Source of truth:** [`crates/mununu-core/src/verify/`](../crates/mununu-core/src/verify/) — surface: CLI+API+UI.
+> **Source of truth:** [`crates/mununu-core/src/verify/`](https://github.com/vscorza/mununu/tree/main/crates/mununu-core/src/verify/) — surface: CLI+API+UI.
 
 `mununu verify` is the **general N-source verification framework**. It accepts a `verify.toml` manifest listing any combination of supported sources (C firmware, SystemVerilog RTL, hand-authored CTXDSL, XState JSON, CrewAI / LangGraph JSON, microprograms, …), translates each source through its adapter, applies an alphabet-binding strategy, composes the results, and evaluates a list of properties. Returns a structured [`VerifyReport`](#report-shape) usable from the CLI, the HTTP API, and the web UI.
 
@@ -8,24 +8,24 @@ The codesign C+SV flow, the protocol-spec recipe, and the agentic verification e
 
 ## Conceptual model
 
-> **Source of truth:** [`verify::config::VerifyConfig`](../crates/mununu-core/src/verify/config.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`verify::config::VerifyConfig`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/config.rs) — surface: CLI+API+UI.
 
 A verification project is the tuple `(Sources, AlphabetBinding, Composition, Properties)`:
 
-- **Sources** — N entries, each `{ id, adapter, files, options }`. The `adapter` field names a [`FormatAdapter`](../crates/mununu-core/src/adapter/mod.rs) implementation. Today's dispatch table: `ctxdsl`, `xstate`, `crewai`, `langgraph`, `sv-yosys` (alias `yosys`), `c-codesign`, `extraction`.
+- **Sources** — N entries, each `{ id, adapter, files, options }`. The `adapter` field names a [`FormatAdapter`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/mod.rs) implementation. Today's dispatch table: `ctxdsl`, `xstate`, `crewai`, `langgraph`, `sv-yosys` (alias `yosys`), `c-codesign`, `extraction`.
 
 - **AlphabetBinding** — how labels across sources synchronise:
   - **`direct`** (default) — names must already match across sources.
   - **`renamings`** — explicit `{ from = "source_id.local_label", to = "canonical_label" }` map.
-  - **`register_map`** — derives renamings from a register-map JSON sidecar via [`coupling::rendezvous_label_name`](../crates/mununu-core/src/codesign/coupling.rs); SV-rtl sources get an automatic post-process pass via [`verify::register_map_rewriter::derive_sv_renamings_from_register_map`](../crates/mununu-core/src/verify/register_map_rewriter.rs).
+  - **`register_map`** — derives renamings from a register-map JSON sidecar via [`coupling::rendezvous_label_name`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/codesign/coupling.rs); SV-rtl sources get an automatic post-process pass via [`verify::register_map_rewriter::derive_sv_renamings_from_register_map`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/register_map_rewriter.rs).
 
 - **Composition** — `{ semantics: synchronous | asynchronous | superset, members: [...], name }`. Drives the existing `composition::compose` primitive.
 
-- **Properties** — `[{ name, (template | formula), args, over }]`. Resolved via the builtin [`TemplateRegistry`](../crates/mununu-core/src/adapter/templates/builtin_templates.json) when a template id is given.
+- **Properties** — `[{ name, (template | formula), args, over }]`. Resolved via the builtin [`TemplateRegistry`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/templates/builtin_templates.json) when a template id is given.
 
 ## Pipeline
 
-> **Source of truth:** [`verify::orchestrator::verify_project`](../crates/mununu-core/src/verify/orchestrator.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`verify::orchestrator::verify_project`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/orchestrator.rs) — surface: CLI+API+UI.
 
 ```text
 verify.toml --> parse + validate
@@ -61,7 +61,7 @@ verify.toml --> parse + validate
 
 ## KMTS pipeline highlights (post-R.0 / R.1 / R.2 / R.3)
 
-> **Source of truth:** [`docs/design/native-sv-abstraction.md`](../docs/design/native-sv-abstraction.md) (architecture), [`docs/design/kmts-theory.md`](../docs/design/kmts-theory.md) (theory), [`docs/design/predicate-abstraction-recipe.md`](../docs/design/predicate-abstraction-recipe.md) (practical recipe).
+> **Source of truth:** [`docs/design/native-sv-abstraction.md`](https://github.com/vscorza/mununu/blob/main/docs/design/native-sv-abstraction.md) (architecture), [`docs/design/kmts-theory.md`](https://github.com/vscorza/mununu/blob/main/docs/design/kmts-theory.md) (theory), [`docs/design/predicate-abstraction-recipe.md`](https://github.com/vscorza/mununu/blob/main/docs/design/predicate-abstraction-recipe.md) (practical recipe).
 
 The KMTS pivot replaces the SystemVerilog extraction story end-to-end while leaving non-RTL adapters (XState, microcode, agentic, ctxdsl) unchanged. The four moving parts:
 
@@ -70,11 +70,11 @@ The KMTS pivot replaces the SystemVerilog extraction story end-to-end while leav
 - **3-valued evaluator.** One generic evaluator body monomorphises over the bulk `EvalDomain` trait (associated `Valuation` = whole-state-set representation). `BoolDom` (BitVec) is the 2-valued cheap path; `KleeneDom` (TritSet) the 3-valued one — the truth-lattice (formula semantics) vs information-lattice (fixpoint convergence) distinction is absorbed into `TritSet`'s must/may pair. Verdicts are `KleeneT` / `KleeneF` / `KleeneBot`; `KleeneBot` triggers CEGAR. (Unified onto the single body in IR-track P2.2/P2.3; the earlier per-element `TruthDomain` trait was retired in P2.4.)
 - **CEGAR refinement.** On `KleeneBot`, the lifter lifts the abstract counterexample, SMT-discharges it for spuriousness, and on UNSAT extracts predicate refinements via IC3-IA-style interpolation. Bounded by `cegar_max_rounds` (default 16). Two-axis refinement: predicate addition vs. UF instance concretisation, partitioned by unsat-core symbol kind.
 
-**Singular-pipeline commitment.** As of S.2b the legacy native-SV adapter (the hand-rolled recursive-descent parser + explicit cross-product enumerator) is **deleted**. There is no `--engine native-sv` escape hatch. SV verification has exactly one pipeline — `sv-yosys` (sv2v → Yosys → BTOR2 → bit-blast). Sidecar significant-value discovery moved to `mununu btor2 discover` (which runs over the BTOR2 IR the verify path uses). See [`docs/design/native-sv-abstraction.md`](../docs/design/native-sv-abstraction.md) for the architecture.
+**Singular-pipeline commitment.** As of S.2b the legacy native-SV adapter (the hand-rolled recursive-descent parser + explicit cross-product enumerator) is **deleted**. There is no `--engine native-sv` escape hatch. SV verification has exactly one pipeline — `sv-yosys` (sv2v → Yosys → BTOR2 → bit-blast). Sidecar significant-value discovery moved to `mununu btor2 discover` (which runs over the BTOR2 IR the verify path uses). See [`docs/design/native-sv-abstraction.md`](https://github.com/vscorza/mununu/blob/main/docs/design/native-sv-abstraction.md) for the architecture.
 
 ## Automatic partition (Phase A.3)
 
-> **Source of truth:** [`adapter::partition::classify`](../crates/mununu-core/src/adapter/partition/mod.rs) — surface: CLI+API.
+> **Source of truth:** [`adapter::partition::classify`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/partition/mod.rs) — surface: CLI+API.
 
 SV (`sv-yosys`) and BTOR2 sources run an **automatic cone-of-influence
 pass** during their `dispatch_adapter` translation. The pass walks the
@@ -97,12 +97,12 @@ the COI's reduction effect directly out of the report JSON.
 COI is **exact** (bisimilar on the property's atomic-proposition set), not over-approximation — sound and complete for the full mu-calculus. Independent of the KMTS pivot.
 
 See also:
-[`docs/abstraction.md` §"Automatic cone-of-influence"](../docs/abstraction.md#automatic-cone-of-influence-phase-a3-orthogonal-to-kmts)
+[`docs/abstraction.md` §"Automatic cone-of-influence"](https://github.com/vscorza/mununu/blob/main/docs/abstraction.md#automatic-cone-of-influence-phase-a3-orthogonal-to-kmts)
 for the user-facing guidance.
 
 ## `verify.toml` schema
 
-> **Source of truth:** [`verify::config::VerifyConfig`](../crates/mununu-core/src/verify/config.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`verify::config::VerifyConfig`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/config.rs) — surface: CLI+API+UI.
 
 ```toml
 [project]
@@ -149,7 +149,7 @@ over = "System"
 
 ## Report shape
 
-> **Source of truth:** [`verify::report::VerifyReport`](../crates/mununu-core/src/verify/report.rs) — surface: CLI+API+UI.
+> **Source of truth:** [`verify::report::VerifyReport`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/report.rs) — surface: CLI+API+UI.
 
 ```rust
 pub struct VerifyReport {
@@ -181,7 +181,7 @@ For `BoolDom` (legacy adapters, Sharp-everywhere KMTSes), `verdict` is always `K
 
 ## CLI
 
-> **Source of truth:** [`mununu-cli::handle_verify`](../crates/mununu-cli/src/main.rs) — surface: CLI.
+> **Source of truth:** [`mununu-cli::handle_verify`](https://github.com/vscorza/mununu/blob/main/crates/mununu-cli/src/main.rs) — surface: CLI.
 
 ```bash
 mununu verify <verify.toml>                # human-readable verdict table
@@ -193,7 +193,7 @@ Relative paths in the manifest resolve against the `verify.toml`'s parent direct
 
 ## HTTP API
 
-> **Source of truth:** [`api::handlers::verify_project_handler`](../crates/mununu-core/src/api/handlers.rs) — surface: API.
+> **Source of truth:** [`api::handlers::verify_project_handler`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/api/handlers.rs) — surface: API.
 
 `POST /api/v1/verify`. Body accepts either a pre-parsed `config` JSON object **or** the raw `config_toml` string (exactly one — the handler 400s on both-set or neither-set):
 
@@ -208,24 +208,24 @@ Returns the structured `VerifyReport`. `config_toml` lets thin clients (like the
 
 ## Web UI
 
-> **Source of truth:** [`mununu-ui/src/components/extraction/ExtractionPanel.tsx`](../../mununu-ui/src/components/extraction/ExtractionPanel.tsx) — surface: UI.
+> **Source of truth:** [`mununu-ui/src/components/extraction/ExtractionPanel.tsx`](https://github.com/vscorza/mununu-ui/blob/main/src/components/extraction/ExtractionPanel.tsx) — surface: UI.
 
-The Extraction tab's domain selector exposes **Verify Project (verify.toml)** as a workflow. Drop the manifest, type the server-side base directory, click **Run Verify**. The UI POSTs `{ config_toml, base_dir }` to `/api/v1/verify` and renders the response through [`VerdictTable`](../../mununu-ui/src/components/extraction/VerdictTable.tsx).
+The Extraction tab's domain selector exposes **Verify Project (verify.toml)** as a workflow. Drop the manifest, type the server-side base directory, click **Run Verify**. The UI POSTs `{ config_toml, base_dir }` to `/api/v1/verify` and renders the response through [`VerdictTable`](https://github.com/vscorza/mununu-ui/blob/main/src/components/extraction/VerdictTable.tsx).
 
 ## Examples
 
-> **Source of truth:** [`examples/verify/`](../examples/verify/) — surface: CLI.
+> **Source of truth:** [`examples/verify/`](https://github.com/vscorza/mununu/tree/main/examples/verify/) — surface: CLI.
 
 Each example ships a `verify.toml`, source files, a `validate.sh` script, and a byte-deterministic `transcript.txt`:
 
 | Example | Shape |
 |---|---|
-| [`xstate_pair/`](../examples/verify/xstate_pair/) | Two XState machines composed asynchronously; direct alphabet binding |
-| [`microprogram_plus_sv/`](../examples/verify/microprogram_plus_sv/) | Microcode listing + SV peripheral via direct binding |
-| [`uart_codesign_chaotic/`](../examples/verify/uart_codesign_chaotic/) | C firmware + chaotic-stub peripheral via register-map binding |
-| [`uart_codesign_protocol_spec/`](../examples/verify/uart_codesign_protocol_spec/) | C firmware + hand-authored CTXDSL protocol-spec peripheral |
-| [`crewai_handoff/`](../examples/verify/crewai_handoff/) | Sequential 2-agent CrewAI crew |
-| [`langgraph_workflow/`](../examples/verify/langgraph_workflow/) | Conditional-branching LangGraph StateGraph |
+| [`xstate_pair/`](https://github.com/vscorza/mununu/tree/main/examples/verify/xstate_pair/) | Two XState machines composed asynchronously; direct alphabet binding |
+| [`microprogram_plus_sv/`](https://github.com/vscorza/mununu/tree/main/examples/verify/microprogram_plus_sv/) | Microcode listing + SV peripheral via direct binding |
+| [`uart_codesign_chaotic/`](https://github.com/vscorza/mununu/tree/main/examples/verify/uart_codesign_chaotic/) | C firmware + chaotic-stub peripheral via register-map binding |
+| [`uart_codesign_protocol_spec/`](https://github.com/vscorza/mununu/tree/main/examples/verify/uart_codesign_protocol_spec/) | C firmware + hand-authored CTXDSL protocol-spec peripheral |
+| [`crewai_handoff/`](https://github.com/vscorza/mununu/tree/main/examples/verify/crewai_handoff/) | Sequential 2-agent CrewAI crew |
+| [`langgraph_workflow/`](https://github.com/vscorza/mununu/tree/main/examples/verify/langgraph_workflow/) | Conditional-branching LangGraph StateGraph |
 
 Reproduce any of them:
 


### PR DESCRIPTION
Two wiki follow-ups.

## 1. Broken repo-file links

The wiki used relative `../docs/...`, `../crates/...`, `../examples/...` links. On the GitHub wiki (a separate repo) those resolve to `github.com/vscorza/mununu/docs/...` — a 404 — instead of `.../blob/main/docs/...`. Converted every relative repo-file link across 8 pages to absolute GitHub URLs (`blob/main` for files, `tree/main` for directories), matching the convention the already-correct links use. The three `../../mununu-ui/...` links now point at the mununu-ui repo. **Every target verified to exist on disk.**

Two links were pre-existing content rot (files deleted in #57):
- Agentic-Adapters Doc C §C.5 ref → `docs/adapters/agentic.md` (carries the same async-composition rationale).
- Compositional-Extraction-Tutorial Phase B ref → the live `concurrency_detect.rs` source (no live doc covers it; `auto-extraction-architecture.md` is a different "Phase B").

## 2. API reference refresh

The page documented only **8 of 24** live endpoints. Added full field-level docs for the 16 missing ones (`context/predicates`, `verify/memory-check`, `btor2/cegar`, `sv/cegar`, the 5 `extraction/*`, the 4 `contract/*`, the 3 `codesign/*`), each with a `Source of truth:` anchor. Fixed field drift on the existing 8 (synthesize `template_ref`/`controller_native`; graphs `valuations`/`modality`; verify `hide`/`minimize`/`stubs`; import +6 req / +2 resp fields; verify `cluster_similarity_floor`), plus the 408 timeout row and the advisory-endpoint note.

Verified: all link targets exist, all 23 handler symbols + `create_router` exist, and all 27 in-page anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)