### PR TITLE
fix(ctxdsl): bind var==value mu-calculus atoms over hand-authored variables

### DIFF
--- a/crates/mununu-core/src/context_dsl/realize.rs
+++ b/crates/mununu-core/src/context_dsl/realize.rs
@@ -3011,11 +3011,38 @@ fn build_clts_from_unrolled(
     // Add states from unrolled CLTS and mark initial states
     for state in &unrolled.states {
         let state_name = state.state_name();
-        builder.state(&state_name);
+        let state_id = builder.state_id_or_insert(&state_name);
 
         // Mark as initial if the state's location was initial in the original automaton
         if initial_location_names.contains(&state.location) {
             builder.initial(&state_name);
+        }
+
+        // Variable-binding fix (2026-06-23): emit numeric per-state
+        // valuations from the unrolled `AbstractState`'s integer variable
+        // bindings, so the abstract-states wiring later in this module
+        // (gated on `clts_valuations_are_numeric`) binds `var == value`
+        // formula atoms to actual integer values — the same machinery the
+        // BTOR2 bit-blaster's `build_state_valuations` already feeds. Before
+        // this, hand-authored CTXDSL variable-value atoms fell through the
+        // "predicate-not-found → empty bitset" under-approximation and
+        // silently evaluated false. Only `IntConstant` bindings are emitted
+        // (numeric, i64-parseable); bool / interval / non-constant
+        // abstractions are skipped so the all-numeric gate stays honest.
+        if let Some(state_id) = state_id {
+            let valuation: std::collections::BTreeMap<String, String> = state
+                .variables
+                .iter()
+                .filter_map(|(var, val)| match val {
+                    crate::abstraction::value::AbstractValue::IntConstant(n) => {
+                        Some((var.clone(), n.to_string()))
+                    }
+                    _ => None,
+                })
+                .collect();
+            if !valuation.is_empty() {
+                builder.with_valuation_for_state(state_id, valuation);
+            }
         }
     }
 

--- a/crates/mununu-core/tests/ctxdsl_variable_atom_binding.rs
+++ b/crates/mununu-core/tests/ctxdsl_variable_atom_binding.rs
@@ -1,0 +1,74 @@
+//! Regression test for the CTXDSL variable-value atom-binding fix (2026-06-23).
+//!
+//! Before the fix, a mu-calculus atom of the shape `var == value` over a
+//! **hand-authored CTXDSL variable** silently evaluated `false` — the unroll
+//! path (`abstraction::unrolling`) incorporated variable values into the state
+//! *identity* but never emitted numeric per-state valuations, so the
+//! `realize` abstract-states wiring (gated on `clts_valuations_are_numeric`)
+//! never fired and the atom fell through the "predicate-not-found → empty
+//! bitset" under-approximation. (Demonstrated: even `v == 0` at the initial
+//! state where `v = 0` returned false.)
+//!
+//! The fix has `build_clts_from_unrolled` emit each unrolled `AbstractState`'s
+//! `IntConstant` variable bindings via `with_valuation_for_state`, reusing the
+//! same numeric-binding machinery the BTOR2 bit-blaster already feeds. This
+//! test pins that `var == value` atoms now bind on the realize → evaluate path.
+
+use mununu_core::context_dsl;
+
+const SRC: &str = r#"
+context T {
+    automata {
+        automaton T {
+            variables { var v : i64 = 0; }
+            states { state A initial; state B; }
+            transitions {
+                transition A -> B on label go effects { v = 1; };
+                transition B -> B on label idle;
+            }
+        }
+    }
+    mu_formulas {
+        // v == 1 is reachable (after `go`); v == 0 holds at the initial state.
+        formula v_reach { over T; body = mu X. (v == 1 || <> X); }
+        formula v_init  { over T; body = v == 0; }
+    }
+}
+"#;
+
+#[test]
+fn ctxdsl_variable_value_atoms_bind_after_unroll() {
+    let doc = context_dsl::parse(SRC).expect("parse");
+    let realized = context_dsl::realize_context(&doc, &[]).expect("realize");
+    let over = realized
+        .context
+        .clts_names()
+        .first()
+        .cloned()
+        .expect("at least one realized automaton");
+    let clts = realized.context.clts(&over).expect("clts present");
+    let env = realized.environment_for(&over);
+    let inits: Vec<_> = clts.initial_states().iter().copied().collect();
+    assert!(!inits.is_empty(), "automaton has an initial state");
+
+    let holds_at_init = |fname: &str| -> bool {
+        let rf = realized.formulas.get(fname).expect("formula declared");
+        let result = realized
+            .context
+            .evaluate_mu(&over, &rf.formula, &env, None)
+            .expect("evaluate_mu");
+        inits
+            .iter()
+            .all(|sid| result.get(sid.index()).map(|b| *b).unwrap_or(false))
+    };
+
+    assert!(
+        holds_at_init("v_reach"),
+        "`v == 1` must be reachable — the atom must bind to the unrolled variable value, \
+         not fall through to silent-false"
+    );
+    assert!(
+        holds_at_init("v_init"),
+        "`v == 0` must hold at the initial state where v = 0 — proves the atom binds"
+    );
+}


### PR DESCRIPTION
Closes the silent-`false` footgun where a mu-calculus atom `var == value` over a **hand-authored CTXDSL variable** evaluated `false` even when true — e.g. `v == 0` at the initial state where `v = 0`. (Surfaced while building V.2; it's why the V-track fixtures use explicit-state encoding.)

## Root cause
The unroll path (`abstraction::unrolling`) incorporated variable values into the state **identity** but never emitted numeric per-state valuations. The `realize` abstract-states wiring that binds `signal == const` atoms is gated on `clts_valuations_are_numeric` and was fed **only** by the BTOR2 bit-blaster's `build_state_valuations` (load-bearing for M.4). Hand-authored CTXDSL variables therefore produced no numeric valuation → the atom fell through the "predicate-not-found → empty bitset" under-approximation → silent `false`.

## Fix
`build_clts_from_unrolled` (`context_dsl/realize.rs`) now emits each unrolled `AbstractState`'s `IntConstant` variable bindings via `with_valuation_for_state`, reusing the exact numeric-binding machinery the bit-blaster already uses. Localized (~20 LOC). Only `IntConstant` is emitted — bool / interval / non-constant abstractions are skipped so the all-numeric gate stays honest; **models without integer variables are unchanged.**

## Verification
- `var == value` atoms now bind on **both** paths: `verify` (composition) — `v==1 reachable` + `v==0 at init` both `true`; and `context eval` (single automaton) — 1/1 both.
- Full `cargo test -p mununu-core` green — **0 regressions**.
- Regression test: `tests/ctxdsl_variable_atom_binding.rs` (parse → realize → `evaluate_mu`).

## Effect
Hand-authored CTXDSL **data-dependent properties** (`var == value`) now verify correctly. Explicit-state encoding (what V.0/V.2/V.4 use) is still fine but no longer *required* for value checks. Remaining edges (separate follow-ups if needed): a model mixing numeric vars + non-numeric explicit valuations still trips the all-numeric gate; bool/interval-abstracted variables don't bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)