### PR TITLE
test(V.7-c): recoverability showcase on OpenTitan csrng_main_sm (AG EF idle)

### DIFF
--- a/examples/verify/v7_csrng_recoverability/README.md
+++ b/examples/verify/v7_csrng_recoverability/README.md
@@ -1,0 +1,76 @@
+# `v7_csrng_recoverability` — recoverability of a real OpenTitan FSM (AG EF idle)
+
+> **Status: PASS.** Asks whether OpenTitan's `csrng_main_sm` can always return to
+> its `MainSmIdle` state — a recoverability (branching-time `AG EF`) question — over
+> a predicate abstraction of the real RTL, and gets a definite answer that depends
+> on whether reset is available. §Phase 7 V-track / Track-B recoverability showcase.
+
+> **Claims integrity.** `csrng_main_sm.sv` is real OpenTitan RTL (Apache-2.0),
+> vendored and pinned under [`../m2_opentitan_csrng_main_sm/source/`](../m2_opentitan_csrng_main_sm/source/)
+> (this fixture reuses that source rather than re-vendoring it). What follows is a
+> **demonstration of a property class on real silicon, not a vulnerability finding**:
+> the reset-dependence it surfaces is the design's *intended* recovery behaviour
+> (the SEC_CM sparse-FSM-plus-alert pattern relies on reset to leave the error
+> state). The value here is being able to *state and soundly decide* that branching
+> property at all.
+
+## The question
+
+A control FSM that must never wedge raises a natural question: from any state it
+can reach, can it still get back to a known-good idle state? That is recoverability,
+and as a temporal property it is `AG EF idle` — "on all paths (`AG`), idle remains
+reachable (`EF`)". mununu writes it as a fixpoint:
+
+```
+recoverable        = mu X. (idle || <> X)            # EF idle  — idle reachable from here
+always_recoverable = nu Y. (recoverable && [] Y)     # AG EF idle — ...from every reachable state
+```
+
+with `idle = (state_q == MainSmIdle)` and `err = (state_q == MainSmError)`
+(`MainSmIdle = 6'b110111 = 55`, `MainSmError = 6'b101001 = 41`). It is evaluated
+over a predicate-cube abstraction of the BTOR2 the standard sv2v + Yosys flow
+produces, through the CEGAR path with SMT-proved (hyper-)must edges
+(`--must-edge-inference smt-hyper-must`).
+
+## What the verdict depends on
+
+The answer turns on whether reset is in play, and that turns out to be the whole
+point:
+
+| Setup | `always_recoverable` | Reading |
+|---|---|---|
+| reset available (`rst_ni` free) | **definite-TRUE** (`T=4`) | asserting reset returns the FSM to `MainSmIdle` from any state, so idle is always reachable again |
+| reset held inactive (`rst_ni` tied `1'b1`) | **definite-FALSE** (`T=0, F=4`) | once reset is withheld, `MainSmError` and the unreachable sparse encodings become permanent traps |
+
+Both verdicts are **definite** (no `KleeneBot`) and sound for the model — they
+sit inside the audited `Control::All` / bare-modality / unbounded fragment, where
+the Bruns–Godefroid preservation result carries a definite abstract verdict back
+to the concrete design. Read together they say something precise and honest about
+the RTL: csrng's ability to return to idle rests on reset, which is exactly what
+its security-hardened state machine is built to do.
+
+## Why this is worth showing
+
+`AG EF idle` is a branching property: it quantifies over the reachable state space
+("from *every* state, idle is *still* reachable"), not over individual execution
+traces. SystemVerilog Assertions are linear-time, so this question cannot be
+written directly in SVA — the usual route is an auxiliary monitor FSM or a
+tool-specific deadlock check. Here it is one fixpoint, decided over an abstraction
+of the real module, with the three-valued machinery reporting `⊥` ("not enough
+abstraction to decide") rather than guessing when it cannot.
+
+## Reproduce
+
+```bash
+LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli
+LIBRARY_PATH=/usr/local/opt/z3/lib bash examples/verify/v7_csrng_recoverability/validate.sh
+```
+
+Expected: `always_recoverable` HOLDS with reset available and is VIOLATED with
+reset held → `V.7-c VALIDATION PASSED`. Requires `sv2v` and `yosys` on `PATH`.
+
+## See also
+
+- [`m2_opentitan_csrng_main_sm`](../m2_opentitan_csrng_main_sm/) — the source of the vendored RTL (M.2 milestone)
+- [`sv_yosys_caliptra_rtl_150`](../sv_yosys_caliptra_rtl_150/) — M.4, the predicate-cube CEGAR safety verdict on Caliptra (the depth-1 companion to this branching property)
+- [`v1_noc_mesh_4router`](../v1_noc_mesh_4router/) — the same νμ liveness shape on an exact CTXDSL model

--- a/examples/verify/v7_csrng_recoverability/validate.sh
+++ b/examples/verify/v7_csrng_recoverability/validate.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# validate.sh — V.7-c recoverability showcase on OpenTitan csrng_main_sm.
+#
+# Asks a branching-time question SVA cannot state: "from every reachable state,
+# can the FSM still get back to MainSmIdle?" — i.e. recoverability,
+#     always_recoverable = nu Y. ((mu X. (idle || <> X)) && [] Y)   (AG EF idle)
+# over a predicate abstraction of the real RTL, with idle = (state_q == MainSmIdle)
+# and err = (state_q == MainSmError), via the predicate-cube CEGAR path with
+# SMT-proved (hyper-)must edges.
+#
+# The verdict depends entirely on whether reset is available, and that is the
+# honest, interesting result — NOT a bug. csrng's recovery story rests on reset,
+# exactly as its SEC_CM sparse-FSM-plus-alert design intends:
+#
+#   * reset available (rst_ni free)      -> always_recoverable HOLDS (definite-TRUE):
+#       asserting reset returns the FSM to MainSmIdle from any state.
+#   * reset held inactive (rst_ni tied)  -> always_recoverable VIOLATED (definite-FALSE):
+#       the MainSmError state and the unreachable sparse encodings become
+#       permanent traps once reset is taken away.
+#
+# Both verdicts are definite (no KleeneBot) and sound for the model (Bruns-Godefroid
+# preservation over the audited Control::All / bare-modality / unbounded fragment).
+#
+# Pedigree: csrng_main_sm.sv is real OpenTitan RTL (Apache-2.0), vendored + pinned
+# under ../m2_opentitan_csrng_main_sm/source/ (M.2). This fixture reuses that
+# source rather than re-vendoring it. The recoverability property is a
+# design-pattern demonstration of the property class on real silicon, not a
+# vulnerability finding — the reset-dependence it surfaces is intended behaviour.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+SRC="examples/verify/m2_opentitan_csrng_main_sm/source"
+MUNUNU="${MUNUNU:-./target/debug/mununu}"
+export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu not found at ${MUNUNU} — build with: LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in sv2v yosys; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "validate.sh: required tool '${tool}' not on PATH" >&2; exit 2; }
+done
+
+OUT="$(mktemp -d -t mununu-v7c-XXXXXX)"
+FORMULA='nu Y. ((mu X. (idle || <> X)) && [] Y)'
+PREDS=(--predicate idle:state_q=55 --predicate err:state_q=41 --must-edge-inference smt-hyper-must)
+
+# MainSmIdle = 6'b110111 = 55 ; MainSmError = 6'b101001 = 41 (csrng_pkg.sv).
+sv2v -I"${SRC}" "${SRC}/csrng_pkg.sv" "${SRC}/csrng_main_sm.sv" > "${OUT}/csrng.v" 2>"${OUT}/sv2v.err"
+
+# Lift one variant to BTOR2 (reset free, or reset tied inactive) and run CEGAR.
+run_variant() {
+  local variant="$1" tie=""
+  [[ "${variant}" == "held" ]] && tie="connect -set rst_ni 1'b1;"
+  yosys -q -p "read_verilog -sv ${OUT}/csrng.v; hierarchy -check -top csrng_main_sm; proc; \
+               flatten; ${tie} async2sync; dffunmap; setundef -anyconst; write_btor ${OUT}/${variant}.btor2" \
+    2>"${OUT}/${variant}.yosys.err"
+  "${MUNUNU}" btor2 cegar "${OUT}/${variant}.btor2" --formula "${FORMULA}" "${PREDS[@]}" \
+    > "${OUT}/${variant}.out" 2>&1 || true
+  grep -iE "verdict cells|outcome" "${OUT}/${variant}.out" || true
+}
+
+cell() { grep "verdict cells" "${OUT}/$1.out" | sed -E "s/.*$2=([0-9]+).*/\1/"; }
+
+echo "=== V.7-c — recoverability of OpenTitan csrng_main_sm (AG EF MainSmIdle) ==="
+echo
+echo "--- reset available (rst_ni free) — expect HOLDS ---"
+run_variant free
+echo
+echo "--- reset held inactive (rst_ni tied 1'b1) — expect VIOLATED ---"
+run_variant held
+echo
+
+FREE_T="$(cell free T)"; FREE_F="$(cell free F)"
+HELD_T="$(cell held T)"; HELD_F="$(cell held F)"
+
+ok=1
+if [[ "${FREE_F}" != "0" || "${FREE_T:-0}" -lt 1 ]]; then
+  echo "FAIL: reset-available expected HOLDS (T>=1, F=0), got T=${FREE_T} F=${FREE_F}" >&2; ok=0
+fi
+if [[ "${HELD_T}" != "0" || "${HELD_F:-0}" -lt 1 ]]; then
+  echo "FAIL: reset-held expected VIOLATED (T=0, F>=1), got T=${HELD_T} F=${HELD_F}" >&2; ok=0
+fi
+[[ "${ok}" == "1" ]] || { rm -rf "${OUT}"; exit 1; }
+
+rm -rf "${OUT}"
+echo "=== V.7-c VALIDATION PASSED ==="
+echo "Recovery to MainSmIdle holds while reset is available and fails once reset is"
+echo "withheld — mununu states and soundly decides this branching (AG EF) property"
+echo "on real OpenTitan RTL, with definite verdicts both ways."


### PR DESCRIPTION
## Recoverability on real OpenTitan RTL — a branching property SVA can't state

States and soundly decides a recoverability question — *"from every reachable state, can `csrng_main_sm` still return to `MainSmIdle`?"* — as the fixpoint `nu Y. ((mu X. (idle || <> X)) && [] Y)` (i.e. `AG EF idle`), over a predicate abstraction of the real RTL, via the predicate-cube CEGAR path with SMT-proved hyper-must edges (`--must-edge-inference smt-hyper-must`).

### The verdict depends on reset — and that's the honest result

| Setup | `always_recoverable` | Reading |
|---|---|---|
| reset available (`rst_ni` free) | **HOLDS** (definite-TRUE, `T=4`) | asserting reset returns the FSM to `MainSmIdle` from any state |
| reset held inactive (`rst_ni` tied `1'b1`) | **VIOLATED** (definite-FALSE, `T=0/F=4`) | `MainSmError` + the unreachable sparse encodings become permanent traps once reset is withheld |

Both verdicts are **definite** (no `KleeneBot`) and sound for the model (Bruns–Godefroid preservation over the audited `Control::All` / bare-modality / unbounded fragment). `AG EF` is a branching-time property and isn't expressible in SVA (linear-time), so this normally needs an auxiliary monitor FSM or a tool-specific deadlock mode; here it's one fixpoint, decided over an abstraction of the actual module.

### Claims integrity

`csrng_main_sm.sv` is real OpenTitan RTL (Apache-2.0), reused from the M.2 fixture (no re-vendoring). This is a **demonstration of the property class on real silicon, not a vulnerability finding** — the reset-dependence it surfaces is the design's *intended* recovery behaviour (the SEC_CM sparse-FSM-plus-alert pattern relies on reset to leave the error state).

### Files

`validate.sh` (sv2v + Yosys, two variants, asserts both verdicts) + `README.md`. Requires `sv2v`/`yosys`/`z3`. No Rust touched; pre-push `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)