### PR TITLE
feat(I.1): surface falsifying / undecided cube cells on the CEGAR verdict

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2000,6 +2000,26 @@ struct CegarCliParams<'a> {
 /// Run the predicate-abstraction refinement loop over a BTOR2 design
 /// (`content`) and print the trace + 3-valued verdict. `fixture_label` is
 /// the human-facing source identifier echoed in the report (the BTOR2 path
+/// Track I.1 — render a slice of CEGAR witness cells as JSON
+/// (`[{ "cube_index": i, "valuation": { "<pred>": <bool>, … } }, …]`).
+fn cegar_cells_json(
+    cells: &[mununu_core::adapter::btor2::cegar::WitnessCell],
+) -> serde_json::Value {
+    serde_json::Value::Array(
+        cells
+            .iter()
+            .map(|c| {
+                let valuation: serde_json::Map<String, serde_json::Value> = c
+                    .valuation
+                    .iter()
+                    .map(|(name, holds)| (name.clone(), serde_json::Value::Bool(*holds)))
+                    .collect();
+                serde_json::json!({ "cube_index": c.cube_index, "valuation": valuation })
+            })
+            .collect(),
+    )
+}
+
 /// for `btor2 cegar`, the SV path for `sv cegar`). Shared by both CLI
 /// handlers so identical CEGAR inputs produce identical output.
 fn run_cegar_cli(
@@ -2216,6 +2236,14 @@ fn run_cegar_cli(
         format!("PROPERTY HOLDS — all {t_cells} cell(s) satisfy the formula")
     };
 
+    // Track I.1 (2026-06-24) — make a non-HOLDS verdict actionable: surface the
+    // predicate valuations of the cube cells that falsify the formula, or that
+    // the abstraction cannot decide. Capped so a large cube does not flood the
+    // output; the count above (`f_cells` / `bot_cells`) is the full total.
+    const WITNESS_CAP: usize = 4;
+    let violating_cells = trace.violating_cells(WITNESS_CAP);
+    let undecided_cells = trace.undecided_cells(WITNESS_CAP);
+
     if params.json {
         let summary = serde_json::json!({
             "fixture": fixture_label,
@@ -2230,6 +2258,8 @@ fn run_cegar_cli(
                 "unknown_cells": bot_cells,
             },
             "outcome": outcome,
+            "violating_cells": cegar_cells_json(&violating_cells),
+            "undecided_cells": cegar_cells_json(&undecided_cells),
             "approximant_reuse_enabled": trace.approximant_reuse_enabled,
             "lazy_lift_pending": trace.lazy_lift_pending,
             "warnings": trace.warnings.iter().map(|w| w.message.clone()).collect::<Vec<_>>(),
@@ -2249,6 +2279,24 @@ fn run_cegar_cli(
         println!("  final predicates:  {}", trace.final_predicates.len());
         println!("  verdict cells:     T={t_cells} F={f_cells} ⊥={bot_cells}");
         println!("  outcome:           {outcome}");
+        // Track I.1 — which cube valuations falsify / can't be decided.
+        if bot_cells > 0 && !undecided_cells.is_empty() {
+            println!("  undecided at:");
+            for w in &undecided_cells {
+                println!("    - {{{}}}", w.render());
+            }
+            if bot_cells > undecided_cells.len() {
+                println!("    … and {} more", bot_cells - undecided_cells.len());
+            }
+        } else if f_cells > 0 && !violating_cells.is_empty() {
+            println!("  falsified at:");
+            for w in &violating_cells {
+                println!("    - {{{}}}", w.render());
+            }
+            if f_cells > violating_cells.len() {
+                println!("    … and {} more", f_cells - violating_cells.len());
+            }
+        }
         if !trace.warnings.is_empty() {
             println!("  warnings:");
             for w in &trace.warnings {

--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -487,6 +487,77 @@ pub struct CegarTrace {
         Option<crate::clts::Clts<crate::clts::DefaultStateIdx, crate::clts::DefaultLabelIdx>>,
 }
 
+/// Track I.1 (2026-06-24) — a cube cell that witnesses a non-HOLDS verdict: the
+/// predicate valuation of a cube state whose verdict is `False` (the formula is
+/// falsified there) or `Unknown`/⊥ (the abstraction cannot decide it). The
+/// valuation is decoded from the cube-index bit convention used by
+/// `predicate_cube_lift` — predicate `j` holds in cube `i` iff `(i >> j) & 1 == 1`
+/// (see `kmts_lift.rs` ~line 946) — so it needs no access to the lifted `Clts`.
+///
+/// This turns a bare verdict ("F=4") into something actionable ("falsified at the
+/// cell where `idle=false, err=true`"). It is a *cell* witness, not yet a full
+/// reachability *trace*: the path from init to a falsifying state, and the
+/// sub-formula-level cause (via the parity-game refuter strategy), are the
+/// Track-I.1 follow-up slices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WitnessCell {
+    /// The cube-state index in the lifted KMTS.
+    pub cube_index: usize,
+    /// `(predicate-name, holds)` for every predicate, in declaration order.
+    pub valuation: Vec<(String, bool)>,
+}
+
+impl WitnessCell {
+    /// Render as `idle=false, err=true` (declaration order).
+    pub fn render(&self) -> String {
+        self.valuation
+            .iter()
+            .map(|(name, holds)| format!("{name}={holds}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+fn decode_cube_valuation(index: usize, predicates: &[PredicateSpec]) -> Vec<(String, bool)> {
+    predicates
+        .iter()
+        .enumerate()
+        .map(|(j, p)| (p.name.clone(), (index >> j) & 1 == 1))
+        .collect()
+}
+
+impl CegarTrace {
+    fn witness_cells_for(&self, want: Trit, max: usize) -> Vec<WitnessCell> {
+        let mut out = Vec::new();
+        for i in 0..self.final_verdict.len() {
+            if out.len() >= max {
+                break;
+            }
+            if self.final_verdict.verdict_at(i) == want {
+                out.push(WitnessCell {
+                    cube_index: i,
+                    valuation: decode_cube_valuation(i, &self.final_predicates),
+                });
+            }
+        }
+        out
+    }
+
+    /// Track I.1 — cube cells that **falsify** the formula (definite-`False`),
+    /// each decoded to its predicate valuation. Capped at `max`; pass a large
+    /// value for all. Empty when the property HOLDS or is INDEFINITE everywhere.
+    pub fn violating_cells(&self, max: usize) -> Vec<WitnessCell> {
+        self.witness_cells_for(Trit::False, max)
+    }
+
+    /// Track I.1 — cube cells the abstraction **cannot decide** (`Unknown`/⊥),
+    /// each decoded to its predicate valuation. These are the cells a finer
+    /// predicate set (or CEGAR refinement) would need to resolve. Capped at `max`.
+    pub fn undecided_cells(&self, max: usize) -> Vec<WitnessCell> {
+        self.witness_cells_for(Trit::Unknown, max)
+    }
+}
+
 /// R.5 MVP — Run the CEGAR refinement loop on a BTOR2 fixture +
 /// formula.
 ///
@@ -1471,6 +1542,52 @@ pub fn config_values_to_sidecar_json(entries: &[String]) -> Result<Option<String
 mod tests {
     use super::*;
     use crate::mu_calculus::parser;
+
+    // Track I.1 — a non-HOLDS verdict surfaces the predicate valuation of the
+    // cube cells that falsify the formula (definite-F) or that the abstraction
+    // cannot decide (⊥), decoded from the cube-index bit convention.
+    #[test]
+    fn i1_witness_cells_decode_falsifying_and_undecided_valuations() {
+        use bitvec::prelude::*;
+        // 4 cubes over predicates [idle (bit 0), err (bit 1)]:
+        //   cube0 = F, cube1 = T, cube2 = F, cube3 = ⊥.
+        let must = bitvec![usize, Lsb0; 0, 1, 0, 0];
+        let may = bitvec![usize, Lsb0; 0, 1, 0, 1];
+        let trace = CegarTrace {
+            iterations: Vec::new(),
+            final_verdict: crate::mu_calculus::trit::TritSet::from_parts(must, may),
+            final_predicates: vec![
+                PredicateSpec {
+                    name: "idle".into(),
+                    register: "state_q".into(),
+                    value: 55,
+                },
+                PredicateSpec {
+                    name: "err".into(),
+                    register: "state_q".into(),
+                    value: 41,
+                },
+            ],
+            terminated_with: CegarTermination::Converged,
+            lazy_lift_pending: true,
+            approximant_reuse_enabled: false,
+            warnings: Vec::new(),
+            init_refinement_candidates: Vec::new(),
+            final_clts: None,
+        };
+
+        let viol = trace.violating_cells(10);
+        assert_eq!(viol.len(), 2, "two cube cells falsify the formula");
+        assert_eq!(viol[0].render(), "idle=false, err=false"); // cube0
+        assert_eq!(viol[1].render(), "idle=false, err=true"); // cube2 (the err trap)
+
+        let undec = trace.undecided_cells(10);
+        assert_eq!(undec.len(), 1);
+        assert_eq!(undec[0].render(), "idle=true, err=true"); // cube3
+
+        // The cap is honoured.
+        assert_eq!(trace.violating_cells(1).len(), 1);
+    }
 
     // M.6 parity — the shared `REG=v1,v2,...` parse used by both the CLI
     // `--config-values` flag and the API `config_values` field.

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -810,6 +810,16 @@ fn run_cegar_build_response(params: CegarRunParams<'_>) -> Result<Btor2CegarResp
         value: p.value,
     };
 
+    // Track I.1 — viewer-shape a witness cell (cube index + predicate valuation).
+    // Cap matches the CLI so a large cube does not flood the response; the
+    // `verdict.{false,unknown}_cells` counts carry the full totals.
+    const WITNESS_CELL_CAP: usize = 8;
+    let cell_view =
+        |c: &crate::adapter::btor2::cegar::WitnessCell| crate::api::models::WitnessCellView {
+            cube_index: c.cube_index,
+            valuation: c.valuation.iter().cloned().collect(),
+        };
+
     // CTXDSL Phase 2 (2026-06-22) — opt-in model + formula CTXDSL. When the
     // request set `emit_ctxdsl`, the loop captured the final refined cube
     // `Clts` into `trace.final_clts`; serialize it together with the checked
@@ -863,6 +873,17 @@ fn run_cegar_build_response(params: CegarRunParams<'_>) -> Result<Btor2CegarResp
         lazy_lift_pending: trace.lazy_lift_pending,
         approximant_reuse_enabled: trace.approximant_reuse_enabled,
         warnings: trace.warnings.iter().map(|w| w.message.clone()).collect(),
+        // Track I.1 — surface which cube valuations falsify / can't be decided.
+        violating_cells: trace
+            .violating_cells(WITNESS_CELL_CAP)
+            .iter()
+            .map(&cell_view)
+            .collect(),
+        undecided_cells: trace
+            .undecided_cells(WITNESS_CELL_CAP)
+            .iter()
+            .map(&cell_view)
+            .collect(),
         ctxdsl,
     })
 }

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -957,11 +957,31 @@ pub struct Btor2CegarResponse {
     pub approximant_reuse_enabled: bool,
     /// Soundness / advisory warnings produced during the run.
     pub warnings: Vec<String>,
+    /// Track I.1 (2026-06-24) — cube cells that **falsify** the formula
+    /// (definite-False), each decoded to its predicate valuation. Capped (the
+    /// `verdict.false_cells` count is the full total). Empty unless the outcome
+    /// is VIOLATED. Makes a failing verdict actionable ("falsified where
+    /// `idle=false, err=true`").
+    pub violating_cells: Vec<WitnessCellView>,
+    /// Track I.1 — cube cells the abstraction **cannot decide** (`Unknown`/⊥),
+    /// each decoded to its predicate valuation. Capped (`verdict.unknown_cells`
+    /// is the full total). These are the cells a finer predicate set would need
+    /// to resolve.
+    pub undecided_cells: Vec<WitnessCellView>,
     /// CTXDSL Phase 2 (2026-06-22) — the final refined cube model + the
     /// checked formula as CTXDSL, present only when the request set
     /// `emit_ctxdsl: true`. Omitted from the JSON otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ctxdsl: Option<String>,
+}
+
+/// Track I.1 — a cube cell witnessing a non-HOLDS verdict, viewer-shaped:
+/// the cube index plus the predicate valuation (`name → holds`) at that cell.
+#[derive(Debug, Serialize)]
+pub struct WitnessCellView {
+    pub cube_index: usize,
+    /// Predicate valuation at the cell (`name → holds`), keyed by predicate name.
+    pub valuation: std::collections::BTreeMap<String, bool>,
 }
 
 /// One CEGAR iteration, viewer-shaped.


### PR DESCRIPTION
## Track I.1 (actionable verdicts) — slice 1

A non-HOLDS CEGAR verdict previously showed only cell counts (`F=4`). Now it names **which predicate valuations** falsify the formula (definite-False) or the abstraction cannot decide (⊥). For V.7-c's reset-held recoverability run this turns *"VIOLATED, 4 cells"* into:

```
  falsified at:
    - {idle=false, err=true}
    - …
```

— pointing straight at the Error trap.

### Mechanism (no new evaluation, no `Clts` access)

The cube-state index is a predicate bitmask (`predicate j` holds in cube `i` iff `(i >> j) & 1 == 1`, per `kmts_lift.rs`), so a cell's valuation decodes from `final_verdict` + `final_predicates`:

- `cegar::WitnessCell` + `CegarTrace::violating_cells(max)` / `undecided_cells(max)` (capped so a large cube doesn't flood output; the verdict cell counts carry the full totals).
- CLI `btor2 cegar` / `sv cegar`: a "falsified at:" / "undecided at:" block (text) + `violating_cells` / `undecided_cells` arrays (`--json`).
- API `Btor2CegarResponse` gains `violating_cells` / `undecided_cells` (`WitnessCellView { cube_index, valuation }`).
- **Paired UI PR (mununu-ui #24)** renders them in `CegarTraceView`.

### Scope

This is the **cell-witness** slice. The full reachability *trace* (init → falsifying state) and the sub-formula-level cause (via the parity-game refuter strategy) are the Track-I.1 follow-up slices; I.2's "eager witness in the verdict pass" folds in here; I.3 (auto EF→AG EF) builds on this output.

Test: `i1_witness_cells_decode_falsifying_and_undecided_valuations`. Full mununu-core lib green (1846); workspace clippy + fmt clean; pre-push `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)