### PR TITLE
feat(I.1): explain an undecided CEGAR verdict with candidate registers

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2266,6 +2266,8 @@ fn run_cegar_cli(
                 "steps": cegar_cells_json(&ct.steps),
                 "ends_in_trap": ct.ends_in_trap,
             })),
+            // Track I.1 (undecided-explanation) — load-bearing registers for ⊥ cells.
+            "refinement_candidates": trace.init_refinement_candidates,
             "approximant_reuse_enabled": trace.approximant_reuse_enabled,
             "lazy_lift_pending": trace.lazy_lift_pending,
             "warnings": trace.warnings.iter().map(|w| w.message.clone()).collect::<Vec<_>>(),
@@ -2319,6 +2321,16 @@ fn run_cegar_cli(
             for (i, w) in ct.steps.iter().enumerate() {
                 println!("    {i}. {{{}}}", w.render());
             }
+        }
+        // Track I.1 (undecided-explanation) — when ⊥ cells remain, name the
+        // registers the failure subgame flagged as load-bearing; adding
+        // predicates over them (or promoting their init policy) may resolve it.
+        if bot_cells > 0 && !trace.init_refinement_candidates.is_empty() {
+            println!(
+                "  undecided because the abstraction can't decide {bot_cells} cell(s); \
+                 try predicates over: {}",
+                trace.init_refinement_candidates.join(", ")
+            );
         }
         if !trace.warnings.is_empty() {
             println!("  warnings:");

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -892,6 +892,9 @@ fn run_cegar_build_response(params: CegarRunParams<'_>) -> Result<Btor2CegarResp
                 ends_in_trap: ct.ends_in_trap,
             }
         }),
+        // Track I.1 (undecided-explanation) — registers the failure subgame
+        // flagged as load-bearing for the remaining ⊥ cells (empty ⇒ omitted).
+        refinement_candidates: trace.init_refinement_candidates.clone(),
         ctxdsl,
     })
 }

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -974,6 +974,14 @@ pub struct Btor2CegarResponse {
     /// the JSON unless the property is actually violated at the initial cell.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub counterexample: Option<CounterTraceView>,
+    /// Track I.1 (undecided-explanation slice, 2026-06-24) — when the final
+    /// verdict still carries ⊥ (unknown) cells, the registers the failure
+    /// subgame flagged as load-bearing for those indefinite verdicts (deduped,
+    /// from `CegarTrace::init_refinement_candidates`). The actionable "why
+    /// undecided": adding predicates over these registers — or promoting their
+    /// init policy — may resolve the abstraction. Omitted when empty.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub refinement_candidates: Vec<String>,
     /// CTXDSL Phase 2 (2026-06-22) — the final refined cube model + the
     /// checked formula as CTXDSL, present only when the request set
     /// `emit_ctxdsl: true`. Omitted from the JSON otherwise.


### PR DESCRIPTION
Track I.1 undecided-explanation slice — the ⊥ half of "actionable verdicts". Slice 1 (#142) surfaced *which* cube cells the abstraction cannot decide (the ⊥ cells); this slice surfaces *what to add* to resolve them.

## What

When the final verdict still carries ⊥ (unknown) cells, the response now names the registers the failure subgame flagged as load-bearing — already computed in `CegarTrace::init_refinement_candidates` (R-Y5), but previously surfaced nowhere (only a per-iteration `had_failure_subgame` bool reached the API).

- **CLI** — `undecided because the abstraction can't decide N cell(s); try predicates over: reg1, reg2` + a `refinement_candidates` JSON array.
- **API** — `Btor2CegarResponse.refinement_candidates: Vec<String>` (omitted from JSON when empty).
- **UI** — paired mununu-ui PR (#26) renders a "Why undecided" block.

Together slices 1 + 3 complete task 1's ⊥ half: slice 1 says *where*, this slice says *what to add*. The deeper sub-formula-level cause via the parity-game refuter strategy is a separate, deferred I.1 slice.

## Verification

`cargo fmt --check`, workspace `cargo clippy --all-features --all-targets`, and the pre-push workspace check all green. The field is a clone of the already-tested `init_refinement_candidates`, exercised end-to-end via the CLI (correctly omitted on a converged-violated run with no ⊥ cells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)