### PR TITLE
feat(B.1): thread compound predicates through the cube lift (reachable)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -798,6 +798,7 @@ pub fn cegar_refine_loop(
         // lift expands the initial-state set per R-S8's
         // hyper-must initial semantics.
         config_values: crate::adapter::btor2::r_s8_encoder::sidecar_config_values(adapter_options),
+        compound_exprs: std::collections::HashMap::new(),
     };
 
     for iteration in 0..=cegar_opts.max_iterations {

--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -293,6 +293,49 @@ pub struct PredicateSpec {
     pub value: u64,
 }
 
+/// B.1 (increment 3b) — a predicate paired with its optional compound
+/// expression, the slice element the SMT may/must edge seam consumes.
+/// A `Some` expr makes [`crate::adapter::btor2::smt_must_edge::PredicateLike::expr`]
+/// return it, so 3a's `build_pred_constraint` encodes the compound boolean
+/// instead of the simple `register == value` atom; `None` is the simple atom
+/// (behaviour-preserving). Built by [`cube_predicates`] from a `PredicateSpec`
+/// list + the lift options' `compound_exprs` map, in predicates order (cube
+/// bit `i` = `predicates[i]`).
+pub struct CubePredicate<'a> {
+    spec: &'a PredicateSpec,
+    expr: Option<&'a crate::adapter::btor2::predicate_expr::PredicateExpr>,
+}
+
+impl crate::adapter::btor2::smt_must_edge::PredicateLike for CubePredicate<'_> {
+    fn register(&self) -> &str {
+        &self.spec.register
+    }
+    fn value(&self) -> u64 {
+        self.spec.value
+    }
+    fn expr(&self) -> Option<&crate::adapter::btor2::predicate_expr::PredicateExpr> {
+        self.expr
+    }
+}
+
+/// B.1 — pair each predicate with its compound expr (if its name is in
+/// `compound_exprs`), preserving order so cube bit `i` stays `predicates[i]`.
+fn cube_predicates<'a>(
+    predicates: &'a [PredicateSpec],
+    compound_exprs: &'a std::collections::HashMap<
+        String,
+        crate::adapter::btor2::predicate_expr::PredicateExpr,
+    >,
+) -> Vec<CubePredicate<'a>> {
+    predicates
+        .iter()
+        .map(|spec| CubePredicate {
+            spec,
+            expr: compound_exprs.get(&spec.name),
+        })
+        .collect()
+}
+
 /// R.2.5 — Options for [`predicate_cube_lift`].
 #[derive(Debug, Clone)]
 pub struct PredicateCubeLiftOptions {
@@ -333,6 +376,25 @@ pub struct PredicateCubeLiftOptions {
     /// Default empty preserves the pre-R-Y7 single-initial-cube
     /// behaviour exactly.
     pub config_values: std::collections::HashMap<String, Vec<u64>>,
+    /// B.1 (increment 3b, 2026-06-25) — compound predicates, keyed by
+    /// predicate **name** (the `PredicateSpec::name` of a predicate also
+    /// present in the `predicates` list). When a predicate's name appears
+    /// here, its cube-dimension truth is decided by the
+    /// [`crate::adapter::btor2::predicate_expr::PredicateExpr`] (a boolean
+    /// combination of register comparisons) rather than the simple
+    /// `register == value` atom — see [`CubePredicate`].
+    ///
+    /// **Soundness gate:** because the cube→representative-registers
+    /// *inverse* (the sampling may-edge path) is only sound for simple
+    /// atoms, a non-empty `compound_exprs` REQUIRES
+    /// `may_edge_inference == MayEdgeInference::SmtAllPairs` (the lift
+    /// errors otherwise) — compounds are routed exclusively through the
+    /// SMT may/must edge construction, which honours them via
+    /// `PredicateLike::expr()`.
+    ///
+    /// Default empty preserves the pre-B.1 simple-atom behaviour exactly.
+    pub compound_exprs:
+        std::collections::HashMap<String, crate::adapter::btor2::predicate_expr::PredicateExpr>,
 }
 
 impl Default for PredicateCubeLiftOptions {
@@ -343,6 +405,7 @@ impl Default for PredicateCubeLiftOptions {
             must_edge_inference: MustEdgeInference::Off,
             may_edge_inference: MayEdgeInference::Off,
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         }
     }
 }
@@ -1558,6 +1621,38 @@ pub fn predicate_cube_lift(
     // unresolvable names still error.
     resolve_predicate_registers(&file, &mut predicates)?;
 
+    // B.1 (increment 3b) — compound-predicate gate. Every `compound_exprs`
+    // key must name a predicate in the list (else the expr is orphaned), and
+    // because the cube→representative-registers *inverse* (the sampling
+    // may-edge path) is only sound for simple atoms, compounds REQUIRE the
+    // all-pairs SMT may-relation. We route compounds exclusively through the
+    // SMT may/must seam (which honours them via `PredicateLike::expr`).
+    if !lift_opts.compound_exprs.is_empty() {
+        let names: std::collections::HashSet<&str> =
+            predicates.iter().map(|p| p.name.as_str()).collect();
+        for key in lift_opts.compound_exprs.keys() {
+            if !names.contains(key.as_str()) {
+                return Err(AdapterError {
+                    kind: crate::adapter::AdapterErrorKind::IrConsistencyError,
+                    location: None,
+                    message: format!(
+                        "adapter/btor2/predicate_cube_lift: compound_exprs key '{key}' names no predicate in the predicate set"
+                    ),
+                });
+            }
+        }
+        if !matches!(lift_opts.may_edge_inference, MayEdgeInference::SmtAllPairs) {
+            return Err(AdapterError {
+                kind: crate::adapter::AdapterErrorKind::UnsupportedConstruct,
+                location: None,
+                message: "adapter/btor2/predicate_cube_lift: compound predicates require \
+                          may_edge_inference = SmtAllPairs (the sampling representative is sound \
+                          only for simple register==value atoms)"
+                    .to_string(),
+            });
+        }
+    }
+
     // 2. Cube count check — `2^|P|` must fit `max_cube_count`. For
     //    |P| > 63 the shift overflows so we cap at 63 explicitly.
     let p = predicates.len();
@@ -1711,9 +1806,14 @@ pub fn predicate_cube_lift(
         // behaviour-preserving and de-dups the inlined loop onto the
         // single seam implementation `predicate_cube_lift` now shares
         // with `BtorSts::may_edges` and the lazy must-edge passes.
+        // B.1 (increment 3b) — pair each predicate with its compound expr (if
+        // any) so the seam encodes compounds via `PredicateLike::expr`. With no
+        // compounds every expr is None → identical to passing `&predicates`
+        // (behaviour-preserving for the simple SmtAllPairs path).
+        let cube_preds = cube_predicates(&predicates, &lift_opts.compound_exprs);
         let may_edges: Vec<(usize, usize)> = {
             use crate::adapter::sts_ir::{BtorSts, SmtEncode};
-            BtorSts::new(&file).may_edges(&predicates, 5_000)
+            BtorSts::new(&file).may_edges(&cube_preds, 5_000)
         };
         for (i, j) in may_edges {
             builder.transition_ids_with_modality(
@@ -1746,7 +1846,7 @@ pub fn predicate_cube_lift(
         // (`!SmtAllPairs`) path below.
         if !matches!(lift_opts.must_edge_inference, MustEdgeInference::Off) {
             use crate::adapter::sts_ir::{BtorSts, SmtEncode};
-            let must_edges = BtorSts::new(&file).must_edges(&predicates, 5_000);
+            let must_edges = BtorSts::new(&file).must_edges(&cube_preds, 5_000);
             let promoted = must_edges.len();
             for (i, j) in must_edges {
                 builder.transition_ids_with_modality(
@@ -2689,6 +2789,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::Off,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, SMALL_BTOR2, &AdapterOptions::default(), &opts);
         assert!(result.is_err());
@@ -3255,6 +3356,7 @@ mod tests {
             must_edge_inference: must,
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
 
         // Baseline: SmtAllPairs may, no must → MayOnly only, zero promotions.
@@ -3297,6 +3399,88 @@ mod tests {
     }
 
     #[test]
+    fn b1_compound_predicate_lifts_via_smt_all_pairs() {
+        // B.1 (3b) — compound predicate flows end-to-end through the lift.
+        // a:=0 (always), b:=in_b. Compound idle=(a==0 && b==0). cube_0 =
+        // {idle false}, cube_1 = {idle true}. Because b can be 1, a non-idle
+        // state can STAY non-idle (in_b=1), so the may-edge cube_0→cube_0
+        // exists ONLY because of the `&& b==0` conjunct — the a==0-only atom
+        // would lack it (a:=0 always ⇒ next a==0 ⇒ never stays non-idle).
+        let btor2 = "1 sort bitvec 1\n2 input 1 in_b\n3 state 1 a\n4 state 1 b\n5 zero 1\n6 init 1 3 5\n7 init 1 4 5\n8 next 1 3 5\n9 next 1 4 2\n";
+        let mut compound_exprs = std::collections::HashMap::new();
+        compound_exprs.insert(
+            "idle".to_string(),
+            crate::adapter::btor2::predicate_expr::PredicateExpr::And(
+                Box::new(crate::adapter::btor2::predicate_expr::PredicateExpr::eq(
+                    "a", 0,
+                )),
+                Box::new(crate::adapter::btor2::predicate_expr::PredicateExpr::eq(
+                    "b", 0,
+                )),
+            ),
+        );
+        let opts = PredicateCubeLiftOptions {
+            max_cube_count: 1024,
+            max_input_bits: 8,
+            must_edge_inference: MustEdgeInference::Off,
+            may_edge_inference: MayEdgeInference::SmtAllPairs,
+            config_values: std::collections::HashMap::new(),
+            compound_exprs,
+        };
+        let preds = vec![PredicateSpec {
+            name: "idle".into(),
+            // Placeholder register; the compound expr drives the cube truth.
+            register: "a".into(),
+            value: 0,
+        }];
+        let result = predicate_cube_lift(preds, btor2, &AdapterOptions::default(), &opts)
+            .expect("compound lift via SmtAllPairs");
+        let cube0 = result.clts.state_id("cube_0").expect("cube_0 exists");
+        let targets: Vec<usize> = result
+            .clts
+            .outgoing(cube0)
+            .iter()
+            .map(|t| t.target().index())
+            .collect();
+        assert!(
+            targets.contains(&0),
+            "compound idle=(a==0 && b==0) with b:=in_b must have may-edge cube_0→cube_0 \
+             (in_b=1 keeps it non-idle) — the conjunct the a==0-only atom would miss; got {targets:?}"
+        );
+    }
+
+    #[test]
+    fn b1_compound_predicate_requires_smt_all_pairs() {
+        // The 3b gate: compounds + a non-SmtAllPairs may-source must error,
+        // because the cube→representative-registers inverse (sampling) is sound
+        // only for simple register==value atoms.
+        let btor2 = "1 sort bitvec 1\n2 state 1 a\n3 zero 1\n4 init 1 2 3\n5 next 1 2 3\n";
+        let mut compound_exprs = std::collections::HashMap::new();
+        compound_exprs.insert(
+            "p".to_string(),
+            crate::adapter::btor2::predicate_expr::PredicateExpr::eq("a", 0),
+        );
+        let opts = PredicateCubeLiftOptions {
+            // Sampling (Off) — disallowed when compounds are present.
+            may_edge_inference: MayEdgeInference::Off,
+            compound_exprs,
+            ..Default::default()
+        };
+        let preds = vec![PredicateSpec {
+            name: "p".into(),
+            register: "a".into(),
+            value: 0,
+        }];
+        let err = predicate_cube_lift(preds, btor2, &AdapterOptions::default(), &opts)
+            .expect_err("compound + sampling must error");
+        assert!(
+            err.message.contains("compound predicates require"),
+            "expected the SmtAllPairs gate error; got: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn predicate_image_mvp_max_input_bits_zero_disables_edges() {
         // Setting max_input_bits = 0 recovers the legacy R.2.5 MVP
         // behaviour (cube states but no edges; predicate_image_pending
@@ -3313,6 +3497,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::Off,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("ok");
@@ -3380,6 +3565,7 @@ mod tests {
             may_edge_inference: Default::default(),
 
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -3421,6 +3607,7 @@ mod tests {
             may_edge_inference: Default::default(),
 
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -3463,6 +3650,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::SmtPerTarget,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -3520,6 +3708,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::SmtPerTarget,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -3550,6 +3739,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::SmtPerTarget,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let mut lazy =
             LazyLift::from_btor2(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
@@ -3608,6 +3798,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::SmtPerTargetStandard,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(
             preds.clone(),
@@ -3643,6 +3834,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::SmtPerTarget,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let mvp_result =
             predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &mvp_opts)
@@ -3682,6 +3874,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::SmtHyperMust,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("lift succeeds");
@@ -3719,6 +3912,7 @@ mod tests {
                 must_edge_inference: variant,
                 may_edge_inference: Default::default(),
                 config_values: std::collections::HashMap::new(),
+                compound_exprs: std::collections::HashMap::new(),
             };
             let result = predicate_cube_lift(
                 preds.clone(),
@@ -3758,6 +3952,7 @@ mod tests {
                 must_edge_inference: variant,
                 may_edge_inference: Default::default(),
                 config_values: std::collections::HashMap::new(),
+                compound_exprs: std::collections::HashMap::new(),
             };
             let mut lazy = LazyLift::from_btor2(
                 preds.clone(),
@@ -3911,6 +4106,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::SamplingConfluence,
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &adapter_opts, &lift_opts)
             .expect("lift succeeds");
@@ -3987,6 +4183,7 @@ mod tests {
             may_edge_inference: Default::default(),
 
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4020,6 +4217,7 @@ mod tests {
             may_edge_inference: Default::default(),
 
             config_values: std::collections::HashMap::new(),
+            compound_exprs: std::collections::HashMap::new(),
         };
         let mut lazy =
             LazyLift::from_btor2(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
@@ -4106,6 +4304,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::Off,
             may_edge_inference: Default::default(),
             config_values,
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4140,6 +4339,7 @@ mod tests {
             must_edge_inference: MustEdgeInference::Off,
             may_edge_inference: Default::default(),
             config_values,
+            compound_exprs: std::collections::HashMap::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -22,7 +22,8 @@
 //! Neither trait surface names a BTOR2 or Z3 type: state/input structure
 //! is [`StsVar`] (name + width); the concrete step is name-keyed
 //! `HashMap<String, u128>`; the SMT predicate-image is expressed over
-//! [`PredicateSpec`] (a frontend-agnostic `{name, register, value}`) and
+//! [`PredicateSpec`](crate::adapter::btor2::kmts_lift::PredicateSpec) (a
+//! frontend-agnostic `{name, register, value}`) and
 //! returns plain cube-index pairs. A future non-RTL frontend that can
 //! emit these two semantics inherits both abstraction policies + the
 //! KMTS evaluator + CEGAR with no new abstraction code (the P4/P5 goal).
@@ -31,7 +32,7 @@ use std::collections::HashMap;
 
 use crate::adapter::AdapterError;
 use crate::adapter::btor2::ast::{Btor2File, Node};
-use crate::adapter::btor2::kmts_lift::PredicateSpec;
+use crate::adapter::btor2::smt_must_edge::PredicateLike;
 use crate::adapter::btor2::{bit_blast, parser};
 
 /// A typed state or input variable of a symbolic transition system.
@@ -146,7 +147,11 @@ pub trait SmtEncode: SymbolicTransitionSystem {
     /// The must-relation (`∀∀` / `∀∃` / hyper-must) follows the same
     /// shape over the same encoding (`smt_must_edge::smt_per_target_must_*`);
     /// DR0 ships only the may-relation to prove the seam.
-    fn may_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)>;
+    fn may_edges<P: PredicateLike + Sync>(
+        &self,
+        predicates: &[P],
+        timeout_ms: u32,
+    ) -> Vec<(usize, usize)>;
 
     /// P1 #3 (IR-unification track) — sound under-approximating
     /// **must-relation** over predicate cubes, the canonical ∀∃ KMTS
@@ -169,7 +174,11 @@ pub trait SmtEncode: SymbolicTransitionSystem {
     /// the stricter ∀∀ form and the generalised hyper-must form remain
     /// available directly via `smt_must_edge::smt_per_target_must_check`
     /// / `smt_hyper_must_check` on the sampling-candidate path.
-    fn must_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)>;
+    fn must_edges<P: PredicateLike + Sync>(
+        &self,
+        predicates: &[P],
+        timeout_ms: u32,
+    ) -> Vec<(usize, usize)>;
 }
 
 /// The BTOR2 implementation of the STS-IR seam — a thin borrow over a
@@ -246,7 +255,11 @@ impl StepEval for BtorSts<'_> {
 }
 
 impl SmtEncode for BtorSts<'_> {
-    fn may_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)> {
+    fn may_edges<P: PredicateLike + Sync>(
+        &self,
+        predicates: &[P],
+        timeout_ms: u32,
+    ) -> Vec<(usize, usize)> {
         use crate::adapter::btor2::kmts_lift::encode_design_for_lift;
         use crate::adapter::btor2::smt_must_edge::{
             SmtMayVerdict, build_register_nid_map, smt_per_target_may_check,
@@ -286,7 +299,11 @@ impl SmtEncode for BtorSts<'_> {
         })
     }
 
-    fn must_edges(&self, predicates: &[PredicateSpec], timeout_ms: u32) -> Vec<(usize, usize)> {
+    fn must_edges<P: PredicateLike + Sync>(
+        &self,
+        predicates: &[P],
+        timeout_ms: u32,
+    ) -> Vec<(usize, usize)> {
         use crate::adapter::btor2::kmts_lift::encode_design_for_lift;
         use crate::adapter::btor2::smt_must_edge::{
             SmtMustVerdict, build_register_nid_map, smt_per_target_must_check_standard,
@@ -329,6 +346,7 @@ impl SmtEncode for BtorSts<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adapter::btor2::kmts_lift::PredicateSpec;
 
     // A 1-bit register `q` with `q' = en`, plus an input `en`. Exercises
     // both the state/input metadata and the concrete-step delegation.

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -522,6 +522,7 @@ fn run_controllability_aware_lift(
         must_edge_inference: MustEdgeInference::Off,
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
+        compound_exprs: std::collections::HashMap::new(),
     };
 
     let lift_result =

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -1070,6 +1070,7 @@ fn dispatch_sv_predicate_cube(
         must_edge_inference: MustEdgeInference::SmtPerTargetStandard,
         may_edge_inference: MayEdgeInference::SmtAllPairs,
         config_values: crate::adapter::btor2::r_s8_encoder::sidecar_config_values(opts),
+        compound_exprs: std::collections::HashMap::new(),
     };
     let result = predicate_cube_lift(predicates, &btor2, opts, &lift_opts)
         .map_err(|err| translate_err(format!("predicate-cube lift: {}", err.message)))?;

--- a/crates/mununu-core/tests/v6_controllability_kmts.rs
+++ b/crates/mununu-core/tests/v6_controllability_kmts.rs
@@ -87,6 +87,7 @@ fn v6_amba_arbiter_lifts_with_controllability_aware_dual_labels() {
         must_edge_inference: MustEdgeInference::Off,
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
+        compound_exprs: std::collections::HashMap::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)
@@ -161,6 +162,7 @@ fn v6_amba_arbiter_lifts_with_mayonly_transitions_present() {
         must_edge_inference: MustEdgeInference::Off,
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
+        compound_exprs: std::collections::HashMap::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)
@@ -244,6 +246,7 @@ fn v6_amba_arbiter_controllability_aware_skips_smt_post_pass() {
         must_edge_inference: MustEdgeInference::SmtPerTarget,
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
+        compound_exprs: std::collections::HashMap::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)


### PR DESCRIPTION
Increment 3b — makes compound predicates reachable end-to-end through `predicate_cube_lift` (#149/3a made the SMT constraint layer capable; this wires them in).

## Design B (side map — avoids the ~140-site `PredicateSpec` edit)

- `PredicateCubeLiftOptions.compound_exprs: HashMap<name, PredicateExpr>` carries compounds by predicate name (default empty → pre-B.1 behavior).
- New `CubePredicate { spec, expr }` impls `PredicateLike` with `expr() = Some` for compounds; `cube_predicates()` builds the slice in predicates order (cube bit i = predicates[i]).
- The STS-IR seam (`SmtEncode::may_edges`/`must_edges`) is now generic over `P: PredicateLike + Sync` (was `&[PredicateSpec]`), so the lift passes `&[CubePredicate]` and each compound is encoded via 3a's `build_pred_constraint`. `BtorSts` is never a trait object → the generic method is safe; existing `&[PredicateSpec]` callers are unchanged (`PredicateSpec: PredicateLike`).
- The two SmtAllPairs seam calls pass the CubePredicate slice; with no compounds every `expr` is `None` → identical to before (behavior-preserving).

## Soundness gate

A non-empty `compound_exprs` **requires** `may_edge_inference == SmtAllPairs` (errors otherwise) + validates every key names a real predicate — the cube→representative-registers *inverse* (sampling) is sound only for simple atoms, so compounds route exclusively through the SMT may/must seam.

## Tests

2 integration tests: a compound `idle=(a==0 && b==0)` (with `b:=in_b`) lifts via SmtAllPairs and produces the `cube_0→cube_0` may-edge that exists **only** because of the `&& b==0` conjunct (the `a==0`-only atom would miss it); and the gate rejects compounds + sampling. The 24 `PredicateCubeLiftOptions` sites updated additively. fmt + clippy (`--all-targets`) clean.

## Next (3c)

Sidecar `predicates: [{name, expr}]` field → `parse_predicate_expr` → `compound_exprs` (the user surface), read via `AdapterOptions` like `config_values` (no `CegarOptions` churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)