### PR TITLE
docs(U.5): document the unified predicate-cube lift entry + true up anchors

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -36,6 +36,47 @@
 //! interface those phases plug into; today it ships the enrichment
 //! shape and a fixture-sweep regression so the post-R.3 evaluator
 //! has something to read.
+//!
+//! ## Predicate-cube lift architecture (U.1–U.4 unification, 2026-06-26)
+//!
+//! The predicate-cube path (the R.2.5+ cap-bypassing lift; distinct from
+//! the R.2 post-hoc enrichment above) has **one** public entry and one
+//! shared per-cube body, after the lift-unification refactor:
+//!
+//! - [`lift_predicate_cube`] — the single gated entry the CEGAR loop +
+//!   verify orchestrator call. Runs the compound soundness gate
+//!   ([`ensure_compound_lift_supported`]) once, then dispatches on
+//!   [`LiftStrategy`](crate::adapter::btor2::cegar::LiftStrategy):
+//!   `Eager` → [`predicate_cube_lift`], `Lazy` → [`LazyLift`] +
+//!   [`materialize_clts_from_lazy`].
+//! - [`cube_sampling_edges`] — the ONE per-cube sampling body (canonical
+//!   representative → input-combo enumeration → UF-rep simulate →
+//!   predicate re-evaluation → target cube), shared by the eager
+//!   sampling loop + the lazy [`compute_cube_outgoing_edges`]. Returns
+//!   `(target, LabelDescriptor)` pairs deduped by `(target, descriptor)`,
+//!   which reproduces both effective edge sets. **The eager and lazy
+//!   sampling lifts cannot diverge** — the
+//!   `u1_eager_lazy_differential_equivalence` test asserts they produce
+//!   byte-identical CLTSes.
+//! - [`apply_sampled_must_inference`] — the ONE sampled-target must-edge
+//!   post-pass (`SamplingConfluence` / `SmtPerTarget{,Standard}` /
+//!   `SmtHyperMust`), shared by both paths.
+//!
+//! **Strategy matrix.** The may-relation has two shapes:
+//! - `MayEdgeInference::SmtAllPairs` — sound global all-pairs SMT
+//!   may-relation. **Eager-only** (a global Z3 query, not a per-cube
+//!   one) and the **only** path that honours compound predicates (via
+//!   the `SmtEncode` seam + `PredicateLike::expr`).
+//! - `MayEdgeInference::Off` (sampling) — the per-cube
+//!   [`cube_sampling_edges`] body; simple `register==value` atoms only.
+//!   Runs on both Eager + Lazy and is the eager≡lazy equivalence corpus.
+//!
+//! **Compound rule.** Compound predicates (`compound_exprs`) require
+//! `Eager` + `SmtAllPairs`: the sampling representative inverse can't
+//! realise e.g. `a==0 && b==0`, and the lazy body never consults
+//! `compound_exprs`. [`ensure_compound_lift_supported`] enforces this at
+//! the entry (and via thin defensive copies in `predicate_cube_lift` +
+//! `LazyLift::from_btor2` for the ~39 direct callers).
 
 use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant};

--- a/docs/design/predicate-abstraction-recipe.md
+++ b/docs/design/predicate-abstraction-recipe.md
@@ -151,6 +151,17 @@ Per-module image computation cost (worst case): `O(|S^#|^2)` may-queries + `O(|R
 
 Termination is straightforward: the image computation is a fixed-point over the may set seeded by the initial abstract states, iterating until no new abstract state is discovered. Bounded by `2^|P|`.
 
+### §3d The unified lift entry (eager / lazy / compound routing)
+
+> Source of truth: [`lift_predicate_cube`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L1870) + [`ensure_compound_lift_supported`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L1803) — surface: (CLI+API+UI) via `mununu btor2 cegar` / `POST /api/v1/btor2/cegar` / the `/cegar` panel.
+
+Both the may-mode (§3b) and must-mode (§3a) images are reached through **one** gated entry, `lift_predicate_cube(predicates, btor2, opts, lift_opts, strategy)`, which the CEGAR loop and the sv-yosys verify orchestrator call. It runs the compound soundness gate once, then dispatches:
+
+- `LiftStrategy::Eager` → `predicate_cube_lift` (materialises `2^|P|` cubes; the full-fidelity path; the only path that honours **compound predicates** via the `SmtAllPairs` seam).
+- `LiftStrategy::Lazy` → `LazyLift` + `materialize_clts_from_lazy` (per-cube on-demand; **identical CLTS to Eager** on the sampling path — asserted by the `u1_eager_lazy_differential_equivalence` test; does not support compounds).
+
+The two strategies share one per-cube sampling body (`cube_sampling_edges`) and one sampled-target must post-pass (`apply_sampled_must_inference`), so they cannot diverge. **Compound rule:** a non-empty `compound_exprs` requires `Eager` + `may = SmtAllPairs` — the sampling representative inverse can't realise compound atoms (e.g. `a==0 && b==0`), and the lazy body never consults `compound_exprs`; `ensure_compound_lift_supported` rejects the unsupported combinations at the entry.
+
 ## §4 CEGAR loop with two-axis refinement
 
 When the KleeneDomain evaluator returns `KleeneBot` on a property, the abstract model is too coarse to give a definite verdict. CEGAR (Clarke, Grumberg, Jha, Lu, Veith — CAV 2000, *Counterexample-Guided Abstraction Refinement*) responds by extracting a refinement signal from the abstract counterexample and adding predicates to the model. The mununu lifter's CEGAR loop has two distinguishing features: it operates over a 3-valued verdict (instead of the original 2-valued setting), and it refines on *two axes* (predicate set + UF wrapping set) rather than one.
@@ -253,7 +264,7 @@ The architecture doc §6.9 catalogues these as part of the broader soundness sto
 
 ### §4.9 The audited-sound cube fragment
 
-> Source of truth: [`predicate_cube_lift`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L1504) + [`evaluate_tri`](../../crates/mununu-core/src/mu_calculus/evaluator.rs#L792) + [`cube_modality_soundness_warnings`](../../crates/mununu-core/src/mu_calculus/mod.rs#L284) — surface: (CLI+API+UI) via `mununu btor2 cegar` / `POST /api/v1/btor2/cegar` / the `/cegar` panel.
+> Source of truth: [`predicate_cube_lift`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L1918) + [`evaluate_tri`](../../crates/mununu-core/src/mu_calculus/evaluator.rs#L792) + [`cube_modality_soundness_warnings`](../../crates/mununu-core/src/mu_calculus/mod.rs#L284) — surface: (CLI+API+UI) via `mununu btor2 cegar` / `POST /api/v1/btor2/cegar` / the `/cegar` panel.
 
 A `KleeneT` / `KleeneF` verdict on the predicate cube is only *sound* — i.e.
 guaranteed to transfer to the concrete RTL by the §4.5 preservation theorem
@@ -274,7 +285,7 @@ process-algebra world (the explicit-CLTS path), not the cube.
    (under-approximation, the must-step-preservation premise). Established by a
    differential test against an independent concrete oracle
    ([`simulate_one_step`](../../crates/mununu-core/src/adapter/btor2/bit_blast.rs)):
-   [`po1_cube_brackets_concrete_*`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L3076).
+   [`po1_cube_brackets_concrete_*`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L3105).
 2. **The evaluator computes the §4.3 semantics** — the production `KleeneDom`
    modal step equals the Bruns–Godefroid 3-valued modal definition for every
    `{Sharp, MayOnly} × {T, F}` edge configuration. Established by an enumerated

--- a/docs/design/recoverability-vs-sva.md
+++ b/docs/design/recoverability-vs-sva.md
@@ -68,7 +68,7 @@ the discriminating case).
 
 ### 3.1 Sound `AG EF` over a predicate abstraction
 
-> Source of truth: [`predicate_cube_lift`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L1504) + [`cegar_refine_loop`](../../crates/mununu-core/src/adapter/btor2/cegar.rs#L697) — surface: (CLI+API+UI)
+> Source of truth: [`predicate_cube_lift`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L1918) + [`cegar_refine_loop`](../../crates/mununu-core/src/adapter/btor2/cegar.rs#L697) — surface: (CLI+API+UI)
 
 mununu lifts a BTOR2 design into a **predicate cube** (abstract states are
 elements of `2^|P|` over a declared predicate set `P`, not the bit-blast state
@@ -88,7 +88,7 @@ A definite `AG EF` answer needs *must*-edges (an under-approximation of the
 transition relation) for the inner `EF`, supplied by SMT-proved must / hyper-must
 inference rather than sampling:
 
-> Source of truth: [`MustEdgeInference::SmtHyperMust`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L443) — surface: CLI (`--must-edge-inference smt-hyper-must`)
+> Source of truth: [`MustEdgeInference::SmtHyperMust`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L547) — surface: CLI (`--must-edge-inference smt-hyper-must`)
 
 The verdict, soundness, and the audited modal fragment it holds over
 (`Control::All`, bare `<>`/`[]`, unbounded) are developed in

--- a/docs/design/sts-ir.md
+++ b/docs/design/sts-ir.md
@@ -89,12 +89,44 @@ functions — **DR0 changes no behaviour and rewires no call site**:
   edge." That is exactly `StepEval::step` in a loop bounded by `state_vars()` widths. `bit_blast`
   becomes the *Enumerate edge-strategy* over any `StepEval`, not a BTOR2-specific engine.
 - **`predicate_cube_lift` → `SmtEncode` (SmtImage strategy).** The `MayEdgeInference::SmtAllPairs`
-  block at `kmts_lift.rs:1634` *is* `SmtEncode::may_edges`. Behind the trait it becomes
+  block at `kmts_lift.rs:2119` *is* `SmtEncode::may_edges`. Behind the trait it becomes
   `for (i,j) in sts.may_edges(&predicates, t) { builder.transition(..MayOnly..) }` — the lift no
   longer parses BTOR2 or touches Z3; it consumes an `&dyn SmtEncode`.
 
 Both consumption paths produce the *same* `Clts` (a Sharp CLTS is a degenerate KMTS), fed to the
 one evaluator family (`BoolDom` cheap path / `KleeneDom` sound-abstraction path).
+
+### 4.1 The unified predicate-cube lift entry (U.1–U.4, 2026-06-26)
+
+The predicate-cube lift had **two** implementations with verbatim-duplicated
+per-cube logic — the eager `predicate_cube_lift` and the lazy `LazyLift` +
+`materialize_clts_from_lazy`. The lift-unification refactor consolidated them so
+they share one core and dispatch through one gated entry:
+
+| Concern | Where it lives now |
+|---|---|
+| eager-vs-lazy dispatch + compound gate | one `lift_predicate_cube(predicates, btor2, opts, lift_opts, strategy)` entry |
+| per-cube sampling (representative → simulate → re-evaluate → target cube) | one `cube_sampling_edges()`, shared by the eager loop + lazy `compute_cube_outgoing_edges` |
+| sampled-target must post-pass (4 strategies) | one `apply_sampled_must_inference()`, shared by both |
+| `SmtAllPairs` may + SMT must (compound-aware) | **eager-only** — a global Z3 query, not per-cube |
+
+**Strategy decision.** The may-relation is one of:
+
+- `SmtAllPairs` — sound global all-pairs SMT may-relation (`SmtEncode::may_edges`).
+  Eager-only (global query); the only path that honours **compound predicates**
+  (via `PredicateLike::expr`).
+- `Off` (sampling) — the per-cube `cube_sampling_edges` body; simple
+  `register==value` atoms only; runs on both Eager + Lazy.
+
+**Eager ≡ Lazy guarantee.** On the sampling path the eager and lazy lifts produce
+byte-identical CLTSes — asserted by the `u1_eager_lazy_differential_equivalence`
+test (the permanent anti-divergence guard). `SmtAllPairs` is outside this
+equivalence (it is eager-only-global).
+
+**Compound rule.** Compound predicates require `Eager` + `SmtAllPairs`. The
+sampling representative inverse can't realise `a==0 && b==0`, and the lazy body
+never consults `compound_exprs`; `ensure_compound_lift_supported()` enforces this
+at the entry (and via thin defensive copies in each impl for direct callers).
 
 ## 5. Z3 scope & batching (why `may_edges` is batched, not per-pair)
 


### PR DESCRIPTION
## What

U.5 of the predicate-cube-lift unification — documents the one-entry /
one-body architecture that U.1–U.4 shipped, and trues up the
`Source of truth:` anchors that drifted as those PRs moved code.

Docs/comment-only — no code logic change.

## Changes

- **`kmts_lift.rs` module `//!` doc** — new "Predicate-cube lift
  architecture (U.1–U.4 unification)" section: the gated
  `lift_predicate_cube` entry, the shared `cube_sampling_edges` +
  `apply_sampled_must_inference` bodies, the eager≡lazy guarantee (the
  `u1_eager_lazy_differential_equivalence` test), the SmtAllPairs-eager-only
  note, and the compound rule + gate location.
- **`docs/design/sts-ir.md` §4.1 (new)** — the unified-entry table, the
  may-strategy decision (SmtAllPairs-global vs sampling-per-cube), the
  eager≡lazy guarantee, the compound-requires-Eager+SmtAllPairs rule.
  Trued up the stale inline `kmts_lift.rs:1634` ref → `:2119`.
- **`docs/design/predicate-abstraction-recipe.md` §3d (new)** — the gated
  entry + strategy matrix + compound routing, with a Source-of-truth
  anchor. Fixed the drifted §4.9 anchor (`predicate_cube_lift`
  `#L1504` → `#L1918`) + the inline po1 ref (`#L3076` → `#L3105`).
- **`docs/design/recoverability-vs-sva.md`** — fixed two drifted anchors
  (`predicate_cube_lift` `#L1504` → `#L1918`; `SmtHyperMust`
  `#L443` → `#L547`).

## Verification

Every `Source of truth:` anchor touched or created was verified to
resolve to its cited symbol (manual line-by-line check). `cargo fmt
--check` clean; `cargo doc` produces no new errors (broken-intra-doc-link
warnings are `#[warn]`-level and consistent with the existing pattern;
`make ci` does not run `cargo doc`). `native-sv-abstraction.md` needs no
change — it does not reference the lift internals or the eager/lazy split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)