### PR TITLE
feat(B.2 / V.7-b): uart_tx recoverability showcase with a compound idle

### DIFF
--- a/examples/verify/v7b_uart_recoverability/README.md
+++ b/examples/verify/v7b_uart_recoverability/README.md
@@ -1,0 +1,97 @@
+# `v7b_uart_recoverability` — recoverability of a real OpenTitan FSM, with a compound idle (AG EF idle)
+
+> **Status: PASS.** Asks whether OpenTitan's `uart_tx` can always drain a frame and
+> get back to idle — a recoverability (branching-time `AG EF`) question — over a
+> predicate abstraction of the real RTL, where **idle is a compound condition over
+> two registers**. The correct design holds; a one-line planted bug makes idle
+> unreachable. §Phase 7 V-track / Track-B recoverability showcase (the compound-idle
+> companion to the state-enum [`v7_csrng_recoverability`](../v7_csrng_recoverability/)).
+
+> **Claims integrity.** `uart_tx.sv` is real OpenTitan RTL (Apache-2.0), vendored and
+> pinned under [`../m1_opentitan_uart_tx/source/`](../m1_opentitan_uart_tx/source/)
+> (M.1); this fixture reuses it for the **correct** variant. The **bug** variant
+> ([`source/uart_tx_stuck.sv`](source/uart_tx_stuck.sv)) is a deliberately broken
+> copy with a **single planted line**. What follows is a **demonstration of a
+> property class on real silicon, not a vulnerability finding** — OpenTitan's real
+> UART is correct; the planted bug exists only to show the property distinguishing a
+> recoverable design from a non-recoverable one.
+
+## The question
+
+A transmitter that has started sending a frame should always be able to finish and
+return to idle. As a temporal property that is `AG EF idle` — "on all paths (`AG`),
+idle remains reachable (`EF`)". mununu writes it as a fixpoint:
+
+```
+recoverable        = mu X. (idle || <> X)            # EF idle  — idle reachable from here
+always_recoverable = nu Y. (recoverable && [] Y)     # AG EF idle — ...from every reachable state
+```
+
+What makes this fixture distinct from the csrng showcase is `idle`. csrng's idle is a
+single state-enum value (`state_q == MainSmIdle`). uart_tx has **no idle state
+register** — its `idle` output is *derived*, and the meaningful "fully returned to
+idle" condition spans two registers:
+
+```
+idle = (bit_cnt_q == 0) && (sreg_q == 2047)   # frame counter drained AND shift register back to its idle pattern (11'h7ff)
+```
+
+That is a **compound predicate**, declared in [`source/idle.mununu.json`](source/idle.mununu.json).
+Because the sampling representative can't realise a conjunction, the cube lift routes
+compounds through the eager all-pairs SMT may-relation plus **SMT hyper-must edges**
+(B.1 + B.2), so the alternating-fixpoint (νμ) verdict comes back **clean-sound** — no
+soundness-tag.
+
+## What the verdict depends on
+
+uart_tx self-recovers (a correct frame always drains), so — unlike csrng — the
+contrast is **bug-vs-fix**, not reset-dependence. We tie `tx_enable = 1` and
+`rst_ni = 1` (actively transmitting, no external reset) so the verdict reflects the
+design's *own* ability to drain a frame:
+
+| Variant | `always_recoverable` | Reading |
+|---|---|---|
+| upstream `uart_tx` | **definite-TRUE** (`T=4, F=0`) | the bit counter decrements each baud tick, so every started frame drains back to idle |
+| planted-bug `uart_tx_stuck` | **definite-FALSE** (`T=1, F=3`) | the one-line change removes the decrement (`bit_cnt_d = bit_cnt_q` instead of `bit_cnt_q - 4'h1`), so a started frame never drains and idle is unreachable mid-frame |
+
+The planted line is the only difference between the two modules:
+
+```systemverilog
+// upstream (correct):              // planted bug (uart_tx_stuck.sv):
+bit_cnt_d = bit_cnt_q - 4'h1;       bit_cnt_d = bit_cnt_q;   // never re-arms
+```
+
+Both verdicts are **definite** (no `KleeneBot`) and sound for the model — the
+GKMTS hyper-must edges (`--must-edge-inference smt-hyper-must`) make the νμ verdict
+monotone under refinement (Shoham–Grumberg LMCS 2007), so the Bruns–Godefroid
+preservation result carries the definite abstract verdict back to the concrete design.
+
+## Why this is worth showing
+
+Two things SVA cannot do directly, in one fixpoint over an abstraction of the real
+module:
+
+1. **A branching property** — `AG EF idle` quantifies over the reachable state space
+   ("from *every* state, idle is *still* reachable"), not over individual traces. SVA
+   is linear-time, so this needs an auxiliary monitor FSM or a tool-specific deadlock
+   check.
+2. **A compound idle over multiple registers** — the recoverability target is
+   `(bit_cnt_q == 0) && (sreg_q == 2047)`, decided soundly as one cube dimension via
+   the SMT may/hyper-must path rather than reduced to a single signal.
+
+## Reproduce
+
+```bash
+LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli
+LIBRARY_PATH=/usr/local/opt/z3/lib bash examples/verify/v7b_uart_recoverability/validate.sh
+```
+
+Expected: `always_recoverable` HOLDS on upstream `uart_tx` and is VIOLATED on the
+planted-bug variant, with no soundness-tag → `V.7-b VALIDATION PASSED`. Requires
+`sv2v` and `yosys` on `PATH`.
+
+## See also
+
+- [`m1_opentitan_uart_tx`](../m1_opentitan_uart_tx/) — the source of the vendored RTL (M.1 milestone)
+- [`v7_csrng_recoverability`](../v7_csrng_recoverability/) — the state-enum recoverability companion (reset-dependence contrast)
+- [`sv_yosys_caliptra_rtl_150`](../sv_yosys_caliptra_rtl_150/) — M.4, the predicate-cube CEGAR safety verdict on Caliptra (the depth-1 companion to this branching property)

--- a/examples/verify/v7b_uart_recoverability/source/idle.mununu.json
+++ b/examples/verify/v7b_uart_recoverability/source/idle.mununu.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "mununu_sv_annotation_v1",
+  "module": "uart_tx",
+  "compound_predicates": [
+    {
+      "name": "idle",
+      "expr": "bit_cnt_q == 0 && sreg_q == 2047"
+    }
+  ]
+}

--- a/examples/verify/v7b_uart_recoverability/source/uart_tx_stuck.sv
+++ b/examples/verify/v7b_uart_recoverability/source/uart_tx_stuck.sv
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: UART Transmit Module — PLANTED-BUG DEMO VARIANT.
+//
+// ============================================================================
+// CLAIMS INTEGRITY: this is a DELIBERATELY BROKEN copy of OpenTitan's
+// `uart_tx.sv` (vendored under ../../m1_opentitan_uart_tx/source/, upstream
+// 21f062eb67c8749fec263739cd0f1eea14560a15). The ONLY change from the upstream
+// module is the one line flagged "PLANTED BUG" below: the bit counter no longer
+// decrements, so a started transmission never drains back to idle. This is a
+// DESIGN-PATTERN DEMONSTRATION of the recoverability property class — it is NOT
+// a finding about OpenTitan's real UART, which is correct. Do not cite this as a
+// vulnerability.
+// ============================================================================
+//
+
+module uart_tx (
+  input               clk_i,
+  input               rst_ni,
+
+  input               tx_enable,
+  input               tick_baud_x16,
+  input  logic        parity_enable,
+
+  input               wr,
+  input  logic        wr_parity,
+  input   [7:0]       wr_data,
+  output              idle,
+
+  output logic        tx
+);
+
+
+  logic    [3:0] baud_div_q;
+  logic          tick_baud_q;
+
+  logic    [3:0] bit_cnt_q, bit_cnt_d;
+  logic   [10:0] sreg_q, sreg_d;
+  logic          tx_q, tx_d;
+
+  assign tx = tx_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      baud_div_q  <= 4'h0;
+      tick_baud_q <= 1'b0;
+    end else if (tick_baud_x16) begin
+      {tick_baud_q, baud_div_q} <= {1'b0,baud_div_q} + 5'h1;
+    end else begin
+      tick_baud_q <= 1'b0;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      bit_cnt_q <= 4'h0;
+      sreg_q    <= 11'h7ff;
+      tx_q      <= 1'b1;
+    end else begin
+      bit_cnt_q <= bit_cnt_d;
+      sreg_q    <= sreg_d;
+      tx_q      <= tx_d;
+    end
+  end
+
+  always_comb begin
+    if (!tx_enable) begin
+      bit_cnt_d = 4'h0;
+      sreg_d    = 11'h7ff;
+      tx_d      = 1'b1;
+    end else begin
+      bit_cnt_d = bit_cnt_q;
+      sreg_d    = sreg_q;
+      tx_d      = tx_q;
+      if (wr) begin
+        sreg_d    = {1'b1, (parity_enable ? wr_parity : 1'b1), wr_data, 1'b0};
+        bit_cnt_d = (parity_enable ? 4'd11 : 4'd10);
+      end else if (tick_baud_q && (bit_cnt_q != 4'h0)) begin
+        sreg_d    = {1'b1, sreg_q[10:1]};
+        tx_d      = sreg_q[0];
+        bit_cnt_d = bit_cnt_q;  // PLANTED BUG: upstream is `bit_cnt_q - 4'h1`.
+                                // The counter never re-arms, so a started frame
+                                // never drains and the FSM cannot return to idle.
+      end
+    end
+  end
+
+  assign idle = (tx_enable) ? (bit_cnt_q == 4'h0) : 1'b1;
+
+endmodule

--- a/examples/verify/v7b_uart_recoverability/validate.sh
+++ b/examples/verify/v7b_uart_recoverability/validate.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# validate.sh — V.7-b recoverability showcase on OpenTitan uart_tx, with a
+# COMPOUND idle predicate.
+#
+# Asks a branching-time question SVA cannot state: "while transmitting, can the
+# UART always drain its frame and get back to idle?" — i.e. recoverability,
+#     always_recoverable = nu Y. ((mu X. (idle || <> X)) && [] Y)   (AG EF idle)
+# over a predicate abstraction of the real RTL. Unlike the csrng showcase
+# (V.7-c), uart_tx's idle is NOT a single state-enum value — it is a COMPOUND
+# condition over two registers:
+#     idle = (bit_cnt_q == 0) && (sreg_q == 2047)   # counter drained AND shift reg back to its idle pattern
+# declared in source/idle.mununu.json. The cube lift routes compounds through the
+# eager SmtAllPairs may-relation + SMT hyper-must edges (B.1 + B.2), so the
+# alternating-fixpoint (νμ) verdict is clean-sound — no soundness-tag.
+#
+# The contrast is bug-vs-fix, NOT reset-dependence (uart_tx self-recovers, so
+# both reset variants of the correct design hold). We tie tx_enable=1 and
+# rst_ni=1 (actively transmitting, no external reset) so the verdict reflects the
+# design's OWN ability to drain a frame:
+#
+#   * upstream uart_tx              -> always_recoverable HOLDS (definite-TRUE):
+#       the bit counter decrements each baud tick, so every started frame drains
+#       back to idle.
+#   * planted-bug uart_tx_stuck.sv -> always_recoverable VIOLATED (definite-FALSE):
+#       the ONE-LINE change removes the decrement, so a started frame never drains
+#       and the FSM cannot return to idle.
+#
+# Both verdicts are definite (no KleeneBot) and sound for the model
+# (Bruns-Godefroid preservation; the GKMTS hyper-must edges make the νμ verdict
+# monotone under refinement per Shoham-Grumberg LMCS 2007).
+#
+# Pedigree: uart_tx.sv is real OpenTitan RTL (Apache-2.0), vendored + pinned
+# under ../m1_opentitan_uart_tx/source/ (M.1). This fixture reuses that source
+# for the correct variant and ships a deliberately broken copy
+# (source/uart_tx_stuck.sv) for the bug variant. The planted bug is a
+# DESIGN-PATTERN DEMONSTRATION of the recoverability property class, NOT a
+# vulnerability finding — OpenTitan's real UART is correct.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+GOOD="examples/verify/m1_opentitan_uart_tx/source/uart_tx.sv"
+BUG="examples/verify/v7b_uart_recoverability/source/uart_tx_stuck.sv"
+SIDECAR="examples/verify/v7b_uart_recoverability/source/idle.mununu.json"
+MUNUNU="${MUNUNU:-./target/debug/mununu}"
+export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu not found at ${MUNUNU} — build with: LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in sv2v yosys; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "validate.sh: required tool '${tool}' not on PATH" >&2; exit 2; }
+done
+
+OUT="$(mktemp -d -t mununu-v7b-XXXXXX)"
+FORMULA='nu Y. ((mu X. (idle || <> X)) && [] Y)'
+# Bootstrap predicate (busy = mid-frame) + the compound idle from the sidecar +
+# SMT hyper-must edges for a clean-sound νμ verdict.
+ARGS=(--predicate busy:bit_cnt_q=10 --sidecar "${SIDECAR}" --must-edge-inference smt-hyper-must)
+
+# Lift one variant to BTOR2 with tx_enable + rst_ni tied (actively transmitting,
+# no external reset) and run CEGAR.
+run_variant() {
+  local name="$1" src="$2"
+  sv2v "${src}" > "${OUT}/${name}.v" 2>"${OUT}/${name}.sv2v.err"
+  yosys -q -p "read_verilog -sv ${OUT}/${name}.v; hierarchy -check -top uart_tx; proc; \
+               flatten; connect -set tx_enable 1'b1; connect -set rst_ni 1'b1; \
+               async2sync; dffunmap; setundef -anyconst; write_btor ${OUT}/${name}.btor2" \
+    2>"${OUT}/${name}.yosys.err"
+  "${MUNUNU}" btor2 cegar "${OUT}/${name}.btor2" --formula "${FORMULA}" "${ARGS[@]}" \
+    > "${OUT}/${name}.out" 2>&1 || true
+  grep -iE "verdict cells|outcome" "${OUT}/${name}.out" || true
+}
+
+cell() { grep "verdict cells" "${OUT}/$1.out" | sed -E "s/.*$2=([0-9]+).*/\1/"; }
+
+echo "=== V.7-b — recoverability of OpenTitan uart_tx (AG EF idle, compound idle) ==="
+echo
+echo "--- upstream uart_tx (correct) — expect HOLDS ---"
+run_variant good "${GOOD}"
+echo
+echo "--- planted-bug uart_tx_stuck (counter never re-arms) — expect VIOLATED ---"
+run_variant bug "${BUG}"
+echo
+
+GOOD_T="$(cell good T)"; GOOD_F="$(cell good F)"
+BUG_T="$(cell bug T)"; BUG_F="$(cell bug F)"
+
+ok=1
+if [[ "${GOOD_F}" != "0" || "${GOOD_T:-0}" -lt 1 ]]; then
+  echo "FAIL: upstream uart_tx expected HOLDS (T>=1, F=0), got T=${GOOD_T} F=${GOOD_F}" >&2; ok=0
+fi
+if [[ "${BUG_F:-0}" -lt 1 ]]; then
+  echo "FAIL: planted-bug uart_tx_stuck expected VIOLATED (F>=1), got T=${BUG_T} F=${BUG_F}" >&2; ok=0
+fi
+# Clean-sound guard: neither verdict may carry the B.3.b νμ soundness-tag (the
+# hyper-must edges from B.2 must have fired).
+if grep -qiE "alternation depth .* no MustHyperOnly" "${OUT}/good.out" "${OUT}/bug.out"; then
+  echo "FAIL: a verdict carried the B.3.b soundness-tag — hyper-must edges did not fire" >&2; ok=0
+fi
+[[ "${ok}" == "1" ]] || { rm -rf "${OUT}"; exit 1; }
+
+rm -rf "${OUT}"
+echo "=== V.7-b VALIDATION PASSED ==="
+echo "The correct uart_tx can always drain a frame back to idle; the one-line"
+echo "planted bug (counter never re-arms) makes idle unreachable mid-frame —"
+echo "mununu states and soundly decides this branching (AG EF) recoverability"
+echo "property with a COMPOUND idle predicate on real OpenTitan RTL, definite"
+echo "both ways and free of any soundness-tag."


### PR DESCRIPTION
## What

The compound-idle companion to V.7-c's state-enum recoverability — the last
piece of B.2. Asks `AG EF idle` over a predicate abstraction of real
OpenTitan `uart_tx`, where idle is a **compound over two registers**:

```
idle = (bit_cnt_q == 0) && (sreg_q == 2047)
```

(declared in `source/idle.mununu.json`). The cube lift routes the compound
through the eager SmtAllPairs may-relation + SMT hyper-must edges (B.1 + B.2),
so the νμ verdict is **clean-sound** — no B.3.b soundness-tag.

## Contrast (bug-vs-fix; uart_tx self-recovers, so no reset-dependence)

With `tx_enable` + `rst_ni` tied (actively transmitting, no external reset):

| Variant | `AG EF idle` | Reading |
|---|---|---|
| upstream `uart_tx` (reused from M.1) | **HOLDS** (T=4, F=0) | frames drain to idle |
| planted-bug `uart_tx_stuck.sv` | **VIOLATED** (T=1, F=3) | one-line change (`bit_cnt_d = bit_cnt_q` vs `… - 4'h1`) → counter never re-arms → idle unreachable mid-frame |

Both definite (no `KleeneBot`); `validate.sh` guards that neither verdict carries
the B.3.b soundness-tag (i.e. the hyper-must edges fired).

## Claims integrity

The planted bug is a **design-pattern demonstration** of the recoverability
property class on real silicon, **not a vulnerability finding** — OpenTitan's UART
is correct. The bug variant keeps the Apache-2.0 header + an explicit planted-bug
provenance note (derived from M.1's pinned upstream commit). The correct variant
reuses M.1's vendored `uart_tx.sv` rather than re-vendoring.

## Validation

`validate.sh` PASSES end-to-end (sv2v + yosys + `btor2 cegar`): upstream HOLDS,
planted-bug VIOLATED, no soundness-tag → `V.7-b VALIDATION PASSED`. Examples-only
(no Rust change). Requires `sv2v`, `yosys`, `z3` on PATH (manual showcase fixture,
not run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)