### PR TITLE
ci(E.5): cargo-deny license gate on the linked crate graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,23 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      # Copyleft gate on the LINKED crate graph (deny.toml). Fails if any
+      # dependency's license isn't in the permissive allow-list — protects the
+      # Mununu Non-Commercial License from GPL/AGPL/LGPL contamination. External
+      # CLI tools (yosys/sv2v/cvc5/Verilator/slang) are subprocesses, not linked,
+      # so they're out of scope here (see docs/external-tools.md).
+      - name: Check dependency licenses
+        run: cargo deny check licenses
+
   unused-deps:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ authors = ["Mariano Cerrutti <vscorza@gmail.com>"]
 description = "CLTS Verification Tool - Formal verification for reactive systems"
 repository = "https://github.com/vscorza/mununu"
 license-file = "LICENSE"
+# Mununu Non-Commercial License → never publishable to crates.io. Also marks this
+# as a private/own crate so the cargo-deny license gate skips it (deny.toml).
+publish = false
 keywords = ["formal-verification", "reactive-systems", "model-checking", "synthesis", "ltl"]
 categories = ["science", "algorithms", "development-tools"]
 

--- a/crates/mununu-cli/Cargo.toml
+++ b/crates/mununu-cli/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Mariano Cerrutti <vscorza@gmail.com>"]
 description = "Mununu CLI — command-line interface for verification and synthesis"
 repository = "https://github.com/vscorza/mununu"
 license-file = "../../LICENSE"
+# Mununu Non-Commercial License → not for crates.io; marks this a private/own
+# crate so the cargo-deny license gate skips it (deny.toml).
+publish = false
 
 [[bin]]
 name = "mununu"

--- a/crates/mununu-core/Cargo.toml
+++ b/crates/mununu-core/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Mariano Cerrutti <vscorza@gmail.com>"]
 description = "Mununu core library — verification engine, adapters, composition, evaluation"
 repository = "https://github.com/vscorza/mununu"
 license-file = "../../LICENSE"
+# Mununu Non-Commercial License → not for crates.io; marks this a private/own
+# crate so the cargo-deny license gate skips it (deny.toml).
+publish = false
 
 [dependencies]
 # Core

--- a/crates/mununu-extract/Cargo.toml
+++ b/crates/mununu-extract/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Mariano Cerrutti <vscorza@gmail.com>"]
 description = "Mununu extraction frontend — AST-based model extraction from source code"
 repository = "https://github.com/vscorza/mununu"
 license-file = "../../LICENSE"
+# Mununu Non-Commercial License → not for crates.io; marks this a private/own
+# crate so the cargo-deny license gate skips it (deny.toml).
+publish = false
 
 [[bin]]
 name = "mununu-extract"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,47 @@
+# cargo-deny configuration — dependency LICENSE gate (roadmap E.5, 2026-06-26).
+#
+# Guards mununu's "Mununu Non-Commercial License" against copyleft contamination
+# in the LINKED Cargo crate graph — the real license-poisoning vector. (The
+# external CLI tools mununu invokes — yosys / sv2v / cvc5 / Verilator / slang /
+# circt-verilog — are SUBPROCESSES = "mere aggregation", so they do not
+# contaminate mununu's license regardless of their own license; see
+# docs/external-tools.md. The only linked native dep, Z3, is MIT.)
+#
+# Run locally:  cargo deny check licenses
+# CI gate:      the `license-check` job in .github/workflows/ci.yml
+#
+# Policy: deny-by-default. Any crate whose SPDX license is NOT in `allow` fails
+# the check. A copyleft crate (GPL/AGPL/LGPL/SSPL) would therefore fail here —
+# which is exactly the protection we want, because GPL forbids the added
+# "non-commercial" restriction mununu's license imposes.
+
+[licenses]
+# Permissive licenses only. Add an entry ONLY after confirming it is genuinely
+# permissive (or weak/file-level copyleft that does not contaminate the larger
+# work, e.g. MPL-2.0 used unmodified).
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "CC0-1.0",
+    "MPL-2.0",
+]
+confidence-threshold = 0.8
+# Several allowed licenses above aren't currently used by any crate — that's
+# intentional future-proofing (they're all clearly permissive, so a new dep
+# under one shouldn't break CI). Don't warn about the unused entries, so a
+# genuinely new/unexpected license stands out.
+unused-allowed-license = "allow"
+
+# The workspace's own crates (mununu-core / mununu-cli / mununu-extract) carry
+# `license-file = LICENSE` (the non-SPDX Mununu Non-Commercial License), so they
+# have no SPDX expression for cargo-deny to classify. Skip our own code; this
+# gate is about THIRD-PARTY linked crates.
+[licenses.private]
+ignore = true


### PR DESCRIPTION
## What

A `cargo-deny` license gate that protects the **Mununu Non-Commercial License**
from copyleft (GPL/AGPL/LGPL/SSPL) contamination in the dependency graph that
actually **links into the binary** — the real license-poisoning vector for a Rust
project. Closes roadmap **E.5** (surfaced by the license-risk review).

External CLI tools mununu invokes (yosys / sv2v / cvc5 / Verilator / slang /
circt-verilog) are **subprocesses** = "mere aggregation", so they cannot
contaminate mununu's license regardless of their own — out of scope here. The only
linked native dependency, **Z3, is MIT**.

## How

- **`deny.toml`** — deny-by-default license policy: any crate whose SPDX license
  isn't in the permissive allow-list (MIT / Apache-2.0 [+LLVM-exception] / BSD /
  ISC / Zlib / Unicode / CC0 / MPL-2.0) fails. A copyleft crate would fail the gate
  — exactly the protection wanted, since GPL forbids the "non-commercial"
  restriction mununu's license adds.
- **`publish = false`** on all four workspace crates — a non-commercially-licensed
  crate is never publishable to crates.io anyway, and it marks them private/own so
  the gate skips them (they use the non-SPDX `license-file = LICENSE`, which
  cargo-deny can't classify).
- **`ci.yml`** — new `license-check` job (taiki-e/install-action + cargo-deny),
  mirroring the `unused-deps` job.

## Verification

`cargo deny check licenses` → **`licenses ok` (exit 0)** — the current linked crate
graph is entirely permissive; **no copyleft present**. `cargo metadata` parses;
workflow YAML validated. Config/CI only — no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)