### PR TITLE
feat(XL.6a): sv/extract-sva — the slang SVA front-end across CLI + API

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -946,6 +946,18 @@ enum SvCommand {
     /// then `btor2 cegar`" two-step. Surface peer of the API
     /// `POST /api/v1/sv/cegar` and the extraction-tab SV → CEGAR flow.
     Cegar(SvCegarArgs),
+    /// Extract SystemVerilog Assertions and translate them to mu-calculus
+    /// (Track-H SVA front-end, XL.6a).
+    ///
+    /// Runs the open-source `slang` parser (`slang --ast-json`) over the SV
+    /// source, finds every `assert` / `assume` / `cover property`, and
+    /// translates the supported Tier-1/Tier-2 fragment to mu-calculus formulas
+    /// the verifier can check — emitting each cover's `AG EF` recoverability
+    /// companion and the `$past` shadow registers the formulas need. Anything
+    /// outside the fragment is reported unsupported, never silently dropped.
+    /// No model verification yet (that is `sv verify-auto`). Surface peer of
+    /// `POST /api/v1/sv/extract-sva` + the extraction-tab SVA panel.
+    ExtractSva(SvExtractSvaArgs),
 }
 
 #[derive(Args, Debug)]
@@ -1116,6 +1128,22 @@ struct SvCegarArgs {
     /// CTXDSL to this path (stderr confirmation; stdout stays clean).
     #[arg(long = "emit-ctxdsl", value_name = "PATH")]
     emit_ctxdsl: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct SvExtractSvaArgs {
+    /// Primary SystemVerilog source file (.sv / .v).
+    #[arg(value_name = "SV_FILE")]
+    file: PathBuf,
+    /// Additional SV sources (packages, `include` targets — e.g. the standard
+    /// OpenTitan `prim_assert` macros; the dummy-macro variant silently drops
+    /// all SVA). Staged alongside the primary input + on the include path.
+    /// Repeatable.
+    #[arg(long = "source", value_name = "FILE")]
+    sources: Vec<PathBuf>,
+    /// Print a JSON report instead of the human-readable summary.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -1975,6 +2003,114 @@ fn sv_cegar(args: SvCegarArgs) -> Result<(), String> {
             json: args.json,
         },
     )
+}
+
+/// XL.6a — `mununu sv extract-sva`: run the slang SVA front-end over an SV
+/// source set and print the translated mu-calculus property set.
+fn sv_extract_sva(args: SvExtractSvaArgs) -> Result<(), String> {
+    let primary_name = args
+        .file
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| format!("Invalid SV source path: {}", args.file.display()))?;
+    let primary = std::fs::read_to_string(&args.file)
+        .map_err(|e| format!("Failed to read SV source '{}': {e}", args.file.display()))?;
+    let mut sources: Vec<(String, String)> = vec![(primary_name.to_string(), primary)];
+    for src in &args.sources {
+        let name = src
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| format!("Invalid additional source path: {}", src.display()))?;
+        let body = std::fs::read_to_string(src)
+            .map_err(|e| format!("Failed to read additional source '{}': {e}", src.display()))?;
+        sources.push((name.to_string(), body));
+    }
+
+    let report = mununu_core::adapter::slang::extract::extract_sva(&sources)
+        .map_err(|e| format!("sv extract-sva: {}", e.message))?;
+
+    if args.json {
+        render_extract_sva_json(&report);
+    } else {
+        render_extract_sva_text(&report);
+    }
+    Ok(())
+}
+
+fn sva_kind_str(kind: mununu_core::adapter::slang::translate::SvaKind) -> &'static str {
+    use mununu_core::adapter::slang::translate::SvaKind;
+    match kind {
+        SvaKind::Assert => "assert",
+        SvaKind::Assume => "assume",
+        SvaKind::Cover => "cover",
+    }
+}
+
+fn render_extract_sva_text(report: &mununu_core::adapter::slang::translate::TranslationReport) {
+    println!(
+        "SVA extraction: {} translated, {} unsupported (of {} concurrent assertions)",
+        report.translated.len(),
+        report.unsupported.len(),
+        report.total()
+    );
+    for t in &report.translated {
+        println!("  [{}] {}: {}", sva_kind_str(t.kind), t.name, t.formula);
+        if let Some(c) = &t.recoverability_companion {
+            println!("        recoverability (AG EF): {c}");
+        }
+    }
+    for u in &report.unsupported {
+        let kind = u.kind.map(sva_kind_str).unwrap_or("?");
+        println!("  [unsupported {}] {}: {}", kind, u.name, u.reason);
+    }
+    if !report.required_shadows.is_empty() {
+        let shadows: Vec<String> = report
+            .required_shadows
+            .iter()
+            .map(|s| format!("{}({})", s.base, s.width))
+            .collect();
+        println!("  required __past shadow registers: {}", shadows.join(", "));
+    }
+}
+
+fn render_extract_sva_json(report: &mununu_core::adapter::slang::translate::TranslationReport) {
+    let translated: Vec<serde_json::Value> = report
+        .translated
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "kind": sva_kind_str(t.kind),
+                "formula": t.formula,
+                "recoverability_companion": t.recoverability_companion,
+            })
+        })
+        .collect();
+    let unsupported: Vec<serde_json::Value> = report
+        .unsupported
+        .iter()
+        .map(|u| {
+            serde_json::json!({
+                "name": u.name,
+                "kind": u.kind.map(sva_kind_str),
+                "reason": u.reason,
+            })
+        })
+        .collect();
+    let required_shadows: Vec<serde_json::Value> = report
+        .required_shadows
+        .iter()
+        .map(|s| serde_json::json!({ "base": s.base, "width": s.width }))
+        .collect();
+    let out = serde_json::json!({
+        "translated": translated,
+        "unsupported": unsupported,
+        "required_shadows": required_shadows,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).unwrap_or_else(|_| "{}".to_string())
+    );
 }
 
 /// Shared CEGAR parameters for the CLI handlers. Both `btor2 cegar`
@@ -3433,6 +3569,7 @@ fn handle_sv(command: SvCommand) -> Result<(), String> {
         SvCommand::Validate(args) => sv_validate(args),
         SvCommand::Discover(args) => sv_discover(args),
         SvCommand::Cegar(args) => sv_cegar(args),
+        SvCommand::ExtractSva(args) => sv_extract_sva(args),
     }
 }
 

--- a/crates/mununu-core/src/adapter/slang/extract.rs
+++ b/crates/mununu-core/src/adapter/slang/extract.rs
@@ -1,0 +1,143 @@
+//! XL.6a — SVA extraction orchestration (SV source → translated property set).
+//!
+//! Ties the three XL.1/XL.3 pieces — [`locate_slang`], [`run_ast_json`], and
+//! [`translate_ast_json`] — into one string-in / [`TranslationReport`]-out
+//! helper, so the SVA front-end is reachable from a user-facing surface (the
+//! `sv/extract-sva` CLI subcommand + HTTP endpoint + UI panel).
+//!
+//! In-memory SV sources are staged into one temp dir, which is also slang's
+//! include path so a `` `include `` of a sibling source resolves (e.g. real
+//! OpenTitan RTL `` `include "prim_assert.sv" `` when the standard macros are
+//! passed alongside — the dummy-macro variant silently drops all SVA, the XL.0
+//! gotcha). The temp dir is removed when the call returns.
+
+use std::path::PathBuf;
+
+use crate::adapter::slang::translate::{TranslationReport, translate_ast_json};
+use crate::adapter::slang::{locate_slang, run_ast_json};
+use crate::adapter::{AdapterError, AdapterErrorKind};
+
+/// Extract + translate every concurrent SVA assertion from a set of in-memory
+/// SV sources. `sources` is `(file_name, content)` pairs; the first is the
+/// primary. Returns the [`TranslationReport`] (translated formulas + their
+/// recoverability companions, honestly-recorded unsupported assertions, and the
+/// `__past` shadow registers the translated formulas need).
+///
+/// `Err` if no sources are given, slang is not installed (a structured
+/// `UnsupportedConstruct` error — the feature degrades, it never panics), or
+/// slang emits no AST.
+pub fn extract_sva(sources: &[(String, String)]) -> Result<TranslationReport, AdapterError> {
+    if sources.is_empty() {
+        return Err(AdapterError {
+            kind: AdapterErrorKind::ParseError,
+            message: "adapter/slang/extract: no SV sources provided".to_string(),
+            location: None,
+        });
+    }
+
+    // Probe slang first, so a missing binary errors cleanly before we stage.
+    let bin = locate_slang()?;
+
+    let dir = ScopedTempDir::new()?;
+
+    let mut files: Vec<PathBuf> = Vec::with_capacity(sources.len());
+    for (name, content) in sources {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| AdapterError {
+                kind: AdapterErrorKind::ParseError,
+                message: format!("adapter/slang/extract: could not stage `{name}`: {e}"),
+                location: None,
+            })?;
+        }
+        std::fs::write(&path, content).map_err(|e| AdapterError {
+            kind: AdapterErrorKind::ParseError,
+            message: format!("adapter/slang/extract: could not write `{name}`: {e}"),
+            location: None,
+        })?;
+        files.push(path);
+    }
+
+    // The staging dir doubles as the include search path.
+    let include_dirs = vec![dir.path().to_path_buf()];
+    let json = run_ast_json(&bin, &files, &include_dirs)?;
+    translate_ast_json(&json)
+    // `dir` drops here → temp files removed.
+}
+
+/// A per-call temp dir with Drop cleanup (`tempfile` is a dev-only dep, so the
+/// library hand-rolls this, mirroring `adapter::yosys`'s private `TempDir`).
+struct ScopedTempDir {
+    path: PathBuf,
+}
+
+impl ScopedTempDir {
+    fn new() -> Result<Self, AdapterError> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::time::{SystemTime, UNIX_EPOCH};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!(
+            "mununu-slang-sva-{}-{}-{}",
+            std::process::id(),
+            nanos,
+            seq
+        ));
+        std::fs::create_dir_all(&path).map_err(|e| AdapterError {
+            kind: AdapterErrorKind::ParseError,
+            message: format!("adapter/slang/extract: could not create temp dir: {e}"),
+            location: None,
+        })?;
+        Ok(ScopedTempDir { path })
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for ScopedTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_sources_is_an_error() {
+        let err = extract_sva(&[]).expect_err("no sources must error");
+        assert_eq!(err.kind, AdapterErrorKind::ParseError);
+        assert!(err.message.contains("no SV sources"));
+    }
+
+    #[test]
+    #[ignore = "requires the slang CLI (MUNUNU_SLANG_PATH or $PATH); run with --ignored"]
+    fn extracts_inline_sva_end_to_end() {
+        let sv = (
+            "tiny.sv".to_string(),
+            "module tiny (input logic clk, input logic a, input logic b);\n\
+             ap: assert property (@(posedge clk) a |-> b);\n\
+             cp: cover property (@(posedge clk) a && b);\n\
+             endmodule\n"
+                .to_string(),
+        );
+        let report = extract_sva(&[sv]).expect("extract");
+        assert_eq!(report.total(), 2, "one assert + one cover");
+        assert_eq!(report.unsupported.len(), 0, "both are Tier-1");
+        // The cover carries its recoverability companion (XL.2).
+        assert!(
+            report
+                .translated
+                .iter()
+                .any(|t| t.recoverability_companion.is_some()),
+            "the cover should carry an AG-EF recoverability companion"
+        );
+    }
+}

--- a/crates/mununu-core/src/adapter/slang/mod.rs
+++ b/crates/mununu-core/src/adapter/slang/mod.rs
@@ -24,6 +24,7 @@ use std::process::Command;
 
 use crate::adapter::{AdapterError, AdapterErrorKind};
 
+pub mod extract;
 pub mod translate;
 
 /// Handle to a discovered slang binary + its parsed version (diagnostic only;

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -677,6 +677,67 @@ pub async fn sv_cegar_handler(
     Ok(Json(run_cegar_build_response(params)?))
 }
 
+/// XL.6a — `POST /api/v1/sv/extract-sva`. Runs the slang SVA front-end over the
+/// SV source(s) and returns the translated mu-calculus property set (formulas +
+/// recoverability companions + honestly-recorded unsupported assertions + the
+/// `__past` shadows the formulas need). No model verification (that is
+/// `/sv/verify-auto`). Surface peer of the CLI `mununu sv extract-sva`.
+pub async fn sv_extract_sva_handler(
+    Json(request): Json<SvExtractSvaRequest>,
+) -> ApiResult<Json<SvExtractSvaResponse>> {
+    use crate::adapter::slang::extract::extract_sva;
+    use crate::adapter::slang::translate::SvaKind;
+
+    fn kind_str(k: SvaKind) -> String {
+        match k {
+            SvaKind::Assert => "assert".to_string(),
+            SvaKind::Assume => "assume".to_string(),
+            SvaKind::Cover => "cover".to_string(),
+        }
+    }
+
+    let mut sources: Vec<(String, String)> = vec![("top.sv".to_string(), request.source.clone())];
+    for f in &request.additional_sources {
+        sources.push((f.name.clone(), f.content.clone()));
+    }
+
+    let report = extract_sva(&sources).map_err(|e| ApiError::BadRequest {
+        message: format!("SVA extraction (slang): {}", e.message),
+        details: None,
+    })?;
+
+    let response = SvExtractSvaResponse {
+        translated: report
+            .translated
+            .iter()
+            .map(|t| TranslatedAssertionView {
+                name: t.name.clone(),
+                kind: kind_str(t.kind),
+                formula: t.formula.clone(),
+                recoverability_companion: t.recoverability_companion.clone(),
+            })
+            .collect(),
+        unsupported: report
+            .unsupported
+            .iter()
+            .map(|u| UnsupportedAssertionView {
+                name: u.name.clone(),
+                kind: u.kind.map(kind_str),
+                reason: u.reason.clone(),
+            })
+            .collect(),
+        required_shadows: report
+            .required_shadows
+            .iter()
+            .map(|s| ShadowSignalView {
+                base: s.base.clone(),
+                width: s.width,
+            })
+            .collect(),
+    };
+    Ok(Json(response))
+}
+
 /// Shared parameters for the CEGAR run/report logic, sourced identically
 /// from [`Btor2CegarRequest`] (raw BTOR2) and [`SvCegarRequest`] (SV
 /// lifted to BTOR2 first).

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -937,6 +937,57 @@ pub struct SvCegarRequest {
     pub emit_ctxdsl: bool,
 }
 
+/// XL.6a — SVA-extraction endpoint (`POST /api/v1/sv/extract-sva`). Mirrors the
+/// CLI `mununu sv extract-sva`: runs the slang SVA front-end over the SV
+/// source(s) and returns the translated mu-calculus property set. slang is a
+/// full SV-2017 parser, so no sv2v / Yosys / `top` is needed; no model
+/// verification happens here (that is `/sv/verify-auto`).
+#[derive(Debug, Deserialize)]
+pub struct SvExtractSvaRequest {
+    /// SystemVerilog primary source content.
+    pub source: String,
+    /// Additional SV sources (packages / `include` targets — e.g. the standard
+    /// OpenTitan `prim_assert` macros), staged alongside + on the include path.
+    #[serde(default)]
+    pub additional_sources: Vec<FileContent>,
+}
+
+/// Response for `/api/v1/sv/extract-sva` — mirrors
+/// [`crate::adapter::slang::translate::TranslationReport`].
+#[derive(Debug, Serialize)]
+pub struct SvExtractSvaResponse {
+    pub translated: Vec<TranslatedAssertionView>,
+    pub unsupported: Vec<UnsupportedAssertionView>,
+    pub required_shadows: Vec<ShadowSignalView>,
+}
+
+/// A successfully translated assertion (mirrors `TranslatedAssertion`).
+#[derive(Debug, Serialize)]
+pub struct TranslatedAssertionView {
+    pub name: String,
+    /// `"assert"` | `"assume"` | `"cover"`.
+    pub kind: String,
+    /// mu-calculus formula (parses via the evaluator's parser).
+    pub formula: String,
+    /// XL.2 `AG EF` recoverability companion — `Some` only for covers.
+    pub recoverability_companion: Option<String>,
+}
+
+/// An assertion outside the supported fragment (mirrors `UnsupportedAssertion`).
+#[derive(Debug, Serialize)]
+pub struct UnsupportedAssertionView {
+    pub name: String,
+    pub kind: Option<String>,
+    pub reason: String,
+}
+
+/// A `__past` shadow register a translated formula needs (mirrors `ShadowSignal`).
+#[derive(Debug, Serialize)]
+pub struct ShadowSignalView {
+    pub base: String,
+    pub width: u32,
+}
+
 /// U.0 — CEGAR refinement trace, JSON-shaped for the refinement-trace
 /// viewer. Mirrors [`crate::adapter::btor2::cegar::CegarTrace`].
 #[derive(Debug, Serialize)]

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -114,6 +114,13 @@ fn create_router() -> Router {
         // the CLI `mununu sv cegar`; lets the extraction-tab SV workflow
         // run CEGAR without a manual emit-btor2-per-module step.
         .route("/api/v1/sv/cegar", post(handlers::sv_cegar_handler))
+        // Track-H SVA front-end (XL.6a) — slang extracts + translates the
+        // design's SVA to mu-calculus. Surface peer of `mununu sv extract-sva`
+        // and the extraction-tab SVA panel. No verification (that is verify-auto).
+        .route(
+            "/api/v1/sv/extract-sva",
+            post(handlers::sv_extract_sva_handler),
+        )
         .route(
             "/api/v1/verify/memory-check",
             post(handlers::memory_check_handler),

--- a/docs/external-tools.md
+++ b/docs/external-tools.md
@@ -18,6 +18,7 @@ This document is the single canonical place describing each optional tool: what 
 | [SymbiYosys (sby)](#sby--symbiyosys) | Verification oracle on RTL fixtures | Bundled with Yosys via OSS-CAD-Suite | Bundled with Yosys | `MUNUNU_SBY_PATH` |
 | [CVC5](#cvc5) | Craig interpolation predicate source (`--predicate-source craig`) | `brew install cvc5` | `apt install cvc5` (Debian 12+ / Ubuntu 24.04+) | `MUNUNU_CVC5_PATH` |
 | [Verilator](#verilator) | Reset-state simulation seeding (R-S2b, sidecar `simulate_reset`) | `brew install verilator` | `apt install verilator` | `MUNUNU_VERILATOR_PATH` |
+| [slang](#slang) | SVA front-end (`sv extract-sva` / `POST /api/v1/sv/extract-sva`) | release tarball / build from source | release tarball / build from source | `MUNUNU_SLANG_PATH` |
 | [circt-verilog](#circt-verilog) | Alternative extraction frontend (`mununu-extract circt`) | build CIRCT / release tarball | build CIRCT / release tarball | n/a (pipe input) |
 
 Every **discovered** tool above (all but Z3, which is linked, and circt-verilog, which is a pipe-input producer) follows the same discovery pattern: the `MUNUNU_<TOOL>_PATH` env var is checked first; if absent, the bare binary name is invoked via `$PATH`. On a per-process basis — mununu does not cache discovery results across CLI invocations.
@@ -258,15 +259,65 @@ discovery and no in-mununu version check — the user supplies the MLIR. CIRCT i
 Apache-2.0 (with the LLVM exception); as upstream tooling whose output mununu
 consumes, it imposes no obligation on mununu.
 
-> **Note (Track H / slang).** The SVA-verification front-end uses the standalone
-> **`slang`** CLI (`slang --ast-json`) as a discovered subprocess (the cvc5 pattern),
-> *not* circt-verilog — see the roadmap XL.0 decision. The `slang` adapter
-> ([`adapter/slang/mod.rs::locate_slang`](../crates/mununu-core/src/adapter/slang/mod.rs#L48)
-> + the Tier-1 translator in `adapter/slang/translate.rs`) is shipped, but is not
-> yet reachable from a user-facing surface — it is wired into a CLI/API/UI command
-> by the Track-H endpoint (roadmap XL.6). A full `## slang` section with a
-> `> Source of truth:` anchor lands here then (Documentation Traceability requires
-> the anchor to be surface-reachable first).
+---
+
+## slang
+
+> Source of truth: [`adapter/slang/mod.rs::locate_slang`](../crates/mununu-core/src/adapter/slang/mod.rs#L48) — surface: CLI+API
+
+[slang](https://github.com/MikePopoloski/slang) is an open-source, full-featured
+SystemVerilog-2017 compiler front-end (MIT-licensed). Mununu uses it as a **discovered
+subprocess** (the cvc5 / sv2v / Yosys pattern) to parse **SystemVerilog Assertions** out
+of RTL: `slang --ast-json` serialises the elaborated design — including `assert` /
+`assume` / `cover property` — as a structured AST, which mununu's Tier-1/Tier-2 translator
+([`adapter/slang/translate.rs`](../crates/mununu-core/src/adapter/slang/translate.rs))
+lowers to mu-calculus formulas the verifier can check.
+
+slang is the right choice (the roadmap XL.0 decision) over circt-verilog because it runs a
+**real SV preprocessor**: OpenTitan's `` `ASSERT `` macros and `` `include `` directives
+expand correctly, which tree-sitter (no preprocessor) and sv2v (drops concurrent
+assertions) cannot do.
+
+Used by:
+- `mununu sv extract-sva` (CLI) and `POST /api/v1/sv/extract-sva` (API) — the SVA
+  front-end: extract + translate a design's assertions to mu-calculus (Tier-1 boolean /
+  `|->` / `|=>` / `disable iff` / `cover`, the XL.1c reductions, the XL.2 `EF`→`AG EF`
+  recoverability companion, and the XL.3 Tier-2 history `$past`/`$stable`/`$rose`/`$fell`).
+
+### macOS / Linux
+The [slang releases](https://github.com/MikePopoloski/slang/releases) page ships pre-built
+Linux x86_64 and macOS arm64 binaries. Download, extract, and either copy `slang` to
+`/usr/local/bin/` or set `MUNUNU_SLANG_PATH` to the extracted binary.
+
+### Build from source
+```bash
+git clone https://github.com/MikePopoloski/slang
+cd slang
+cmake -B build && cmake --build build --target slang_driver -j
+# The produced binary at build/bin/slang; copy to $PATH or set MUNUNU_SLANG_PATH.
+```
+
+### Discovery
+1. `MUNUNU_SLANG_PATH` env var (explicit override).
+2. `slang` on `$PATH`.
+
+A successful probe parses the version from `slang --version` (diagnostic only; mununu does
+not gate on the version).
+
+### Missing-tool behaviour
+
+When SVA extraction is requested but slang isn't found at runtime, mununu returns a
+structured error naming the missing tool + the install instructions. The SVA-extraction
+feature degrades gracefully — model verification and mununu-annotation properties are
+unaffected (they don't need slang). This is the cvc5 precedent.
+
+### Pattern B (deployment)
+
+slang is **not** bundled in mununu artifacts or installed by `docker/Dockerfile.dev`;
+contributors install it locally per the above, and CI uses the Linux prebuilt. This
+mirrors the subprocess discipline for sv2v / Yosys / SBY / CVC5 — all contributor-installed,
+none linked. As a subprocess whose output mununu consumes, slang's MIT license imposes no
+obligation on mununu ("mere aggregation"; see the licensing posture above).
 
 ---
 


### PR DESCRIPTION
## XL.6a — `sv/extract-sva` surface

Makes the Track-H SVA translator reachable from a user-facing surface for the first time: **SV source(s) → slang → translated mu-calculus property set.** (UI client + panel ship as the paired mununu-ui PR, per the cegar #78/#15 precedent.)

### Core
`adapter/slang/extract.rs::extract_sva(sources)` ties `locate_slang` + `run_ast_json` + `translate_ast_json`. Stages the in-memory sources into one temp dir (also slang's include path, so `` `include `` of a sibling resolves) with Drop cleanup — `tempfile` is dev-only, so a small hand-rolled `ScopedTempDir` mirroring `adapter::yosys`. Returns the `TranslationReport` (translated formulas + XL.2 recoverability companions + honestly-recorded unsupported assertions + XL.3 `__past` shadow requirements).

### CLI
`mununu sv extract-sva <file> [--source ...] [--json]`. slang is a full SV-2017 parser, so no sv2v/Yosys/`top`. Human + JSON renderers.

### API
`POST /api/v1/sv/extract-sva` (handler + `SvExtractSvaRequest`/`SvExtractSvaResponse` + the `TranslatedAssertionView`/`UnsupportedAssertionView`/`ShadowSignalView` mirrors + route). Same core helper as the CLI → the surfaces stay in lockstep.

### Docs
With `locate_slang` now surface-reachable, the deferred `## slang` section in `docs/external-tools.md` lands (Source-of-truth anchor, surface CLI+API) + the quick-summary table row.

### Scope
No model verification yet — that's **XL.6b** (`sv/verify-auto`: per-property augment → lift → cegar, H.1-gated).

### Validation
Against real slang: `mununu sv extract-sva` on the Tier-2 fixture → **5/5 translated** with shadow atoms + `required __past shadow registers: state_q(6), v(1)`; `--json` emits the structured report; tier1 → assert/assume/cover with the cover's recoverability companion. 1 new unit test + an `#[ignore]`d e2e (slang required); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)