### PR TITLE
feat(XL.6b follow-up): enum-constant resolution + graceful verify-auto degradation

### DIFF
--- a/crates/mununu-core/src/adapter/slang/translate.rs
+++ b/crates/mununu-core/src/adapter/slang/translate.rs
@@ -136,6 +136,13 @@ pub fn translate_ast_json(json: &str) -> Result<TranslationReport, AdapterError>
     let mut found: Vec<(String, &Value)> = Vec::new();
     collect_assertions(&root, "design", &mut found);
 
+    // XL.6b follow-up — enum-constant resolution. slang keeps an enum-member
+    // reference (e.g. `MainSmError`) as a `NamedValue`, NOT folded to its value,
+    // so `state_q == MainSmError` reads as signal-vs-signal. Map every enum
+    // member to its integer value so the pre-pass can rewrite those references
+    // to integer literals (enum-typed FSMs are ubiquitous in real RTL).
+    let enum_values = collect_enum_values(&root);
+
     let mut report = TranslationReport::default();
     for (idx, (module, node)) in found.iter().enumerate() {
         let name = format!("{module}_sva_{idx}");
@@ -160,6 +167,9 @@ pub fn translate_ast_json(json: &str) -> Result<TranslationReport, AdapterError>
             });
             continue;
         };
+        // Rewrite enum-member references to integer literals before translating.
+        let spec = resolve_enum_refs(spec, &enum_values);
+        let spec = &spec;
         match translate_one(spec, kind) {
             Ok(formula) => {
                 // XL.2: a cover's `EF φ` gets its `AG EF φ` recoverability lens.
@@ -212,6 +222,68 @@ fn collect_assertions<'a>(node: &'a Value, enclosing: &str, out: &mut Vec<(Strin
             }
         }
         _ => {}
+    }
+}
+
+/// XL.6b follow-up — collect every enum member's integer value (`name → value`)
+/// from the `--ast-json` `EnumValue` nodes (`value` is an SV literal like
+/// `6'b101001`). Lets [`resolve_enum_refs`] fold enum-member references in
+/// comparisons (`state_q == MainSmError`) to integer literals.
+fn collect_enum_values(node: &Value) -> std::collections::HashMap<String, i64> {
+    fn walk(n: &Value, out: &mut std::collections::HashMap<String, i64>) {
+        match n {
+            Value::Object(m) => {
+                if m.get("kind").and_then(Value::as_str) == Some("EnumValue")
+                    && let Some(name) = m.get("name").and_then(Value::as_str)
+                    && let Some(v) = m
+                        .get("value")
+                        .and_then(Value::as_str)
+                        .and_then(parse_sv_literal)
+                {
+                    out.entry(name.to_string()).or_insert(v);
+                }
+                for v in m.values() {
+                    walk(v, out);
+                }
+            }
+            Value::Array(a) => {
+                for v in a {
+                    walk(v, out);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut out = std::collections::HashMap::new();
+    walk(node, &mut out);
+    out
+}
+
+/// XL.6b follow-up — deep-clone an expression tree, replacing every `NamedValue`
+/// referencing an enum member (by name, in `enums`) with an `IntegerLiteral` of
+/// its value. A signal *of* an enum type (e.g. `state_q`) is not an enum-member
+/// name, so it is left untouched — only the constants fold.
+fn resolve_enum_refs(node: &Value, enums: &std::collections::HashMap<String, i64>) -> Value {
+    match node {
+        Value::Object(m) => {
+            if m.get("kind").and_then(Value::as_str) == Some("NamedValue")
+                && let Some(sym) = m.get("symbol").and_then(Value::as_str)
+                && let Some(&v) = enums.get(sym.rsplit(' ').next().unwrap_or(sym))
+            {
+                return serde_json::json!({
+                    "kind": "IntegerLiteral",
+                    "constant": v.to_string(),
+                    "value": v.to_string(),
+                });
+            }
+            let mut obj = serde_json::Map::new();
+            for (k, v) in m {
+                obj.insert(k.clone(), resolve_enum_refs(v, enums));
+            }
+            Value::Object(obj)
+        }
+        Value::Array(a) => Value::Array(a.iter().map(|v| resolve_enum_refs(v, enums)).collect()),
+        other => other.clone(),
     }
 }
 
@@ -1085,6 +1157,43 @@ mod tests {
                 },
             ],
             "required_shadows must dedup by base + carry width"
+        );
+    }
+
+    #[test]
+    fn enum_member_comparison_resolves_to_literal() {
+        // `state_q == MainSmError` where MainSmError is an enum member with value
+        // 6'b101001 (=41). The package's EnumValue node carries the value; the
+        // pre-pass folds the NamedValue reference to `41` so it translates.
+        let doc = serde_json::json!({
+            "members": [
+                {"kind": "EnumValue", "name": "MainSmError", "value": "6'b101001"}
+            ],
+            "body": {
+                "kind": "ConcurrentAssertion",
+                "assertionKind": "Assert",
+                "propertySpec": {
+                    "kind": "Simple",
+                    "expr": {
+                        "kind": "BinaryOp", "op": "Equality",
+                        "left":  {"kind": "NamedValue", "symbol": "1 state_q", "type": "csrng_pkg::main_sm_state_e"},
+                        "right": {"kind": "NamedValue", "symbol": "2 MainSmError", "type": "csrng_pkg::main_sm_state_e"}
+                    }
+                }
+            }
+        });
+        let report = translate_ast_json(&doc.to_string()).expect("valid");
+        assert_eq!(
+            report.unsupported.len(),
+            0,
+            "unsupported: {:?}",
+            report.unsupported
+        );
+        assert_eq!(report.translated.len(), 1);
+        assert!(
+            report.translated[0].formula.contains("state_q == 41"),
+            "enum member must fold to its value (41); got {}",
+            report.translated[0].formula
         );
     }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -291,10 +291,21 @@ pub fn verify_auto(
         e.message = format!("verify_auto: SV → BTOR2: {}", e.message);
         e
     })?;
+    // Augment only the `__past` shadows whose base resolves to a BTOR2 state
+    // cell. A base the lift renamed away (the SVA name not matching the lifted
+    // register) would hard-error `augment_with_past_shadows`, aborting the whole
+    // run; instead we skip it here and the properties that need its `__past`
+    // atom are SKIPPED below (the atom finds no state cell). Graceful per-design
+    // degradation, not an abort.
+    let pre_file = crate::adapter::btor2::parser::parse(&btor2).map_err(|mut e| {
+        e.message = format!("verify_auto: parse lifted BTOR2: {}", e.message);
+        e
+    })?;
     let shadow_bases: Vec<&str> = extraction
         .required_shadows
         .iter()
         .map(|s| s.base.as_str())
+        .filter(|b| crate::adapter::btor2::parser::resolve_state_by_symbol(&pre_file, b).is_some())
         .collect();
     let btor2 = augment_with_past_shadows(&btor2, &shadow_bases)?;
 


### PR DESCRIPTION
## XL.6b follow-up — enum constants + graceful degradation

Two improvements found running verify-auto on **real OpenTitan csrng** SVA.

### 1. Enum-constant resolution (translator)
slang keeps an enum-member reference (`MainSmError`) as a `NamedValue`, **not** folded to its value, so `state_q == MainSmError` read as signal-vs-signal and was rejected. A pre-pass (`collect_enum_values` from the AST `EnumValue` nodes + `resolve_enum_refs`) folds enum-member references to integer literals before translating — resolving **by name**, so a signal *of* an enum type (`state_q`) is untouched; only the constants fold.

Enum-typed FSMs are ubiquitous in real RTL. This takes csrng's SVA from **0 → 2 translated** — `state_q == MainSmError |=> $stable(state_q)` now lowers fully: enum→41, `$stable`→relational (`state_q == state_q__past`), disable-iff gate, `|=>` next.

### 2. Graceful verify-auto degradation
`augment_with_past_shadows` hard-errors when a `__past` base doesn't resolve to a BTOR2 state cell, which aborted the whole run. verify-auto now pre-filters shadow bases to those that resolve (`resolve_state_by_symbol`) and augments only those; properties needing an unresolvable shadow are **SKIPPED with a reason** instead of aborting.

### Tests
`enum_member_comparison_resolves_to_literal` (folds `6'b101001` → 41) + the existing 31 slang tests pass; clippy clean.

### Honest finding (recorded for follow-up)
The csrng `$stable` **verdict** isn't yet achievable via the fully-automated flow: verify-auto translates it fully but **SKIPS** verification because (a) `state_q` (the SVA name) doesn't resolve to a state cell in `sv_to_btor2`'s lifted BTOR2 (a register-naming mismatch the hand-tuned V.7-c yosys flow sidestepped — needs the STS-IR `resolve_register` seam wired into shadow-augment + seeder, or an aligned yosys naming flow), and (b) the disable-iff `rst_ni` is a top-level input atom (the IO-atom limitation; the full verdict needs reset constraining like V.7-c's `connect -set rst_ni 1'b1`). The **translation** of real OpenTitan SVA is fully proven; the **automated verdict** needs these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)