### PR TITLE
feat(H-track): reset-gating for verify-auto (disable iff → pin reset inactive)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1180,6 +1180,11 @@ struct SvVerifyAutoArgs {
     /// verdicts (the recoverability case); default `off`.
     #[arg(long, value_enum, default_value_t = MustEdgeInferenceArg::Off)]
     must_edge_inference: MustEdgeInferenceArg,
+    /// Disable reset-gating: keep `disable iff (reset)` guards in the formulas
+    /// and leave the reset input free (by default the guard is dropped and the
+    /// reset is pinned inactive so the running design is verified).
+    #[arg(long = "no-gate-reset")]
+    no_gate_reset: bool,
     /// Print a JSON report instead of the human-readable summary.
     #[arg(long)]
     json: bool,
@@ -2195,6 +2200,7 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
     let opts = VerifyAutoOptions {
         max_iterations: args.max_iterations,
         must_edge_inference,
+        gate_reset: !args.no_gate_reset,
     };
 
     let report = verify_auto(&sources, &yopts, &opts)
@@ -2239,6 +2245,12 @@ fn render_verify_auto_text(report: &mununu_core::adapter::slang::verify_auto::Au
         println!(
             "  black-boxed (cut to free inputs — provide source to model): {}",
             report.diagnostics.blackboxed_modules.join(", ")
+        );
+    }
+    if !report.diagnostics.gated_resets.is_empty() {
+        println!(
+            "  reset-gated (pinned inactive): {}",
+            report.diagnostics.gated_resets.join(", ")
         );
     }
     for p in &report.properties {
@@ -2299,6 +2311,7 @@ fn render_verify_auto_json(report: &mununu_core::adapter::slang::verify_auto::Au
         "diagnostics": {
             "state_register_count": report.diagnostics.state_register_count,
             "blackboxed_modules": report.diagnostics.blackboxed_modules,
+            "gated_resets": report.diagnostics.gated_resets,
         },
     });
     println!(

--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -25,6 +25,7 @@ pub mod cegar;
 pub mod dep_graph;
 pub mod kmts_lift;
 pub mod parser;
+pub mod pin;
 pub mod predicate_expr;
 pub mod r_s8_encoder;
 pub mod shadow;

--- a/crates/mununu-core/src/adapter/btor2/pin.rs
+++ b/crates/mununu-core/src/adapter/btor2/pin.rs
@@ -1,0 +1,139 @@
+//! Reset-gating — pin BTOR2 input signals to a constant value.
+//!
+//! The slang translator (PR B) recognizes `disable iff (reset)` guards, drops
+//! them from the property body, and reports the reset signal + the value that
+//! makes the disable condition false (reset *inactive*). This module is the
+//! model half of that contract: it rewrites the named input(s) to a constant so
+//! the design is verified only while not in reset — the general, in-process form
+//! of V.7-c's `connect -set rst_ni 1'b1`.
+//!
+//! A free reset input would otherwise let the model explore reset-asserted
+//! transitions, where a property body that assumes "not in reset" can falsely
+//! fail; pinning the reset inactive matches SVA `disable iff` semantics.
+//!
+//! It works at the BTOR2 **text** level — a `<nid> input <sid> <name>` line for
+//! a pinned signal becomes `<nid> one <sid> <name>` (value 1) or
+//! `<nid> zero <sid> <name>` (value 0). The nid is preserved, so every existing
+//! reference to the input now sees the constant; the input simply ceases to be a
+//! free variable. This is **exact** (a real constant tie, not an abstraction)
+//! and composes with [`crate::adapter::btor2::kmts_lift::predicate_cube_lift`] /
+//! [`crate::adapter::btor2::bit_blast`], both of which re-parse the text.
+//!
+//! Reset signals are 1-bit, so only `zero`/`one` constants are emitted; a pin
+//! value other than 0 is treated as 1.
+
+use std::collections::HashMap;
+
+/// Rewrite each `input` line whose symbol matches a `(name, value)` pin into a
+/// constant of that value. Returns the rewritten BTOR2 text and the list of
+/// inputs that were actually found and pinned (as `"<name>=<value>"`), so the
+/// caller can report only the resets it genuinely pinned (a recognized reset
+/// signal that does not appear as a BTOR2 input is silently not pinned — the
+/// honest signal that it was optimized/renamed away).
+pub fn pin_inputs_to_constants(content: &str, pins: &[(String, u64)]) -> (String, Vec<String>) {
+    if pins.is_empty() {
+        return (content.to_string(), Vec::new());
+    }
+    let want: HashMap<&str, u64> = pins.iter().map(|(n, v)| (n.as_str(), *v)).collect();
+    let mut pinned: Vec<String> = Vec::new();
+    let mut out = String::with_capacity(content.len() + 16);
+
+    for line in content.lines() {
+        if let Some(rewritten) = try_pin_line(line, &want) {
+            // `<name>=<value>` for the diagnostic; recover the matched name/value
+            // from the original line's symbol token.
+            if let Some(sym) = line.split_whitespace().nth(3)
+                && let Some(val) = want.get(sym)
+            {
+                pinned.push(format!("{sym}={val}"));
+            }
+            out.push_str(&rewritten);
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    (out, pinned)
+}
+
+/// If `line` is `<nid> input <sid> <symbol> …` and `symbol` is a wanted pin,
+/// return the rewritten constant line; otherwise `None`.
+fn try_pin_line(line: &str, want: &HashMap<&str, u64>) -> Option<String> {
+    let mut toks = line.split_whitespace();
+    let nid = toks.next()?;
+    if toks.next()? != "input" {
+        return None;
+    }
+    let sid = toks.next()?;
+    let sym = toks.next()?;
+    // A bare `<nid> input <sid>` (no symbol) cannot be matched by name; `;`
+    // means the next token is a comment, not a symbol.
+    if sym == ";" {
+        return None;
+    }
+    let value = *want.get(sym)?;
+    let konst = if value == 0 { "zero" } else { "one" };
+    Some(format!("{nid} {konst} {sid} {sym}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pins_active_low_reset_to_one_keeps_state() {
+        // A minimal FSM BTOR2 with a free `rst_n` input driving a reset mux.
+        let btor2 = "1 sort bitvec 1\n\
+                     2 input 1 clk\n\
+                     3 input 1 rst_n\n\
+                     4 sort bitvec 2\n\
+                     5 state 4 state\n\
+                     6 const 4 00\n\
+                     12 ite 4 3 11 6\n\
+                     13 next 4 5 12\n";
+        let (out, pinned) = pin_inputs_to_constants(btor2, &[("rst_n".into(), 1)]);
+        assert!(out.contains("3 one 1 rst_n"), "rst_n pinned to one: {out}");
+        assert!(!out.contains("3 input 1 rst_n"), "no longer a free input");
+        assert!(out.contains("5 state 4 state"), "state register preserved");
+        assert!(out.contains("2 input 1 clk"), "other inputs untouched");
+        assert_eq!(pinned, vec!["rst_n=1".to_string()]);
+    }
+
+    #[test]
+    fn pins_active_high_reset_to_zero() {
+        let btor2 = "1 sort bitvec 1\n2 input 1 rst\n";
+        let (out, pinned) = pin_inputs_to_constants(btor2, &[("rst".into(), 0)]);
+        assert!(
+            out.contains("2 zero 1 rst"),
+            "active-high reset → zero: {out}"
+        );
+        assert_eq!(pinned, vec!["rst=0".to_string()]);
+    }
+
+    #[test]
+    fn unmatched_pin_is_reported_as_not_pinned() {
+        // A recognized reset that is not a BTOR2 input (renamed/optimized away)
+        // is not pinned, and the returned list reflects that.
+        let btor2 = "1 sort bitvec 1\n2 input 1 clk\n";
+        let (out, pinned) = pin_inputs_to_constants(btor2, &[("rst_n".into(), 1)]);
+        assert_eq!(out, "1 sort bitvec 1\n2 input 1 clk\n");
+        assert!(pinned.is_empty(), "nothing matched: {pinned:?}");
+    }
+
+    #[test]
+    fn empty_pins_is_identity() {
+        let btor2 = "1 sort bitvec 1\n2 input 1 clk\n".to_string();
+        let (out, pinned) = pin_inputs_to_constants(&btor2, &[]);
+        assert_eq!(out, btor2);
+        assert!(pinned.is_empty());
+    }
+
+    #[test]
+    fn input_without_symbol_is_left_alone() {
+        // `3 input 1` (no symbol) can't be matched by name.
+        let btor2 = "1 sort bitvec 1\n3 input 1\n".to_string();
+        let (out, pinned) = pin_inputs_to_constants(&btor2, &[("rst_n".into(), 1)]);
+        assert!(out.contains("3 input 1\n"));
+        assert!(pinned.is_empty());
+    }
+}

--- a/crates/mununu-core/src/adapter/slang/extract.rs
+++ b/crates/mununu-core/src/adapter/slang/extract.rs
@@ -13,7 +13,9 @@
 
 use std::path::PathBuf;
 
-use crate::adapter::slang::translate::{TranslationReport, translate_ast_json};
+use crate::adapter::slang::translate::{
+    TranslateOptions, TranslationReport, translate_ast_json_with_options,
+};
 use crate::adapter::slang::{locate_slang, run_ast_json};
 use crate::adapter::{AdapterError, AdapterErrorKind};
 
@@ -27,6 +29,16 @@ use crate::adapter::{AdapterError, AdapterErrorKind};
 /// `UnsupportedConstruct` error — the feature degrades, it never panics), or
 /// slang emits no AST.
 pub fn extract_sva(sources: &[(String, String)]) -> Result<TranslationReport, AdapterError> {
+    extract_sva_with_options(sources, &TranslateOptions::default())
+}
+
+/// Like [`extract_sva`] but honoring [`TranslateOptions`] — e.g. `gate_reset`
+/// to drop `disable iff` guards so the verify-auto consumer can pin the reset
+/// input inactive at the model level.
+pub fn extract_sva_with_options(
+    sources: &[(String, String)],
+    opts: &TranslateOptions,
+) -> Result<TranslationReport, AdapterError> {
     if sources.is_empty() {
         return Err(AdapterError {
             kind: AdapterErrorKind::ParseError,
@@ -61,7 +73,7 @@ pub fn extract_sva(sources: &[(String, String)]) -> Result<TranslationReport, Ad
     // The staging dir doubles as the include search path.
     let include_dirs = vec![dir.path().to_path_buf()];
     let json = run_ast_json(&bin, &files, &include_dirs)?;
-    translate_ast_json(&json)
+    translate_ast_json_with_options(&json, opts)
     // `dir` drops here → temp files removed.
 }
 

--- a/crates/mununu-core/src/adapter/slang/translate.rs
+++ b/crates/mununu-core/src/adapter/slang/translate.rs
@@ -107,6 +107,19 @@ pub struct ShadowSignal {
     pub width: u32,
 }
 
+/// A reset signal recognized in a `disable iff (...)` guard: the input to pin
+/// to verify the running (post-reset) design.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResetSignal {
+    /// The reset input signal name (matches the lifted BTOR2 input).
+    pub signal: String,
+    /// The value that makes the disable condition FALSE — i.e. reset *inactive*
+    /// (the design running). `1` for active-low (`disable iff (!rst_n)`); `0`
+    /// for active-high (`disable iff (rst)`). Pin the input here so the body is
+    /// verified only while not in reset, matching `disable iff` semantics.
+    pub inactive_value: u64,
+}
+
 /// Result of translating a whole `--ast-json` document.
 #[derive(Debug, Clone, Default)]
 pub struct TranslationReport {
@@ -116,6 +129,25 @@ pub struct TranslationReport {
     /// (deduped by base). The XL.3b BTOR2 augmentation consumes this; an empty
     /// vec means no Tier-2 history was used.
     pub required_shadows: Vec<ShadowSignal>,
+    /// Reset signals recognized in `disable iff` guards (deduped). Always
+    /// recorded; whether the guard is dropped from the formula is controlled by
+    /// [`TranslateOptions::gate_reset`]. The verify-auto path pins these inputs
+    /// inactive at the model level.
+    pub reset_signals: Vec<ResetSignal>,
+}
+
+/// Options controlling translation.
+#[derive(Debug, Clone, Default)]
+pub struct TranslateOptions {
+    /// When `true`, a recognizable `disable iff (reset)` guard is **dropped**
+    /// from the property body — the consumer is expected to pin the reset input
+    /// inactive at the model level instead (the general form of V.7-c's
+    /// `connect -set rst_ni 1'b1`). Dropping the guard removes the otherwise
+    /// unbindable reset-input atom, so the body becomes a pure state-cell
+    /// property. When `false` (default), the guard is kept as
+    /// `(reset_cond || body)`. Either way, detected resets are recorded in
+    /// [`TranslationReport::reset_signals`].
+    pub gate_reset: bool,
 }
 
 impl TranslationReport {
@@ -127,6 +159,15 @@ impl TranslationReport {
 
 /// Translate every concurrent assertion in a slang `--ast-json` document.
 pub fn translate_ast_json(json: &str) -> Result<TranslationReport, AdapterError> {
+    translate_ast_json_with_options(json, &TranslateOptions::default())
+}
+
+/// Translate every concurrent assertion, honoring [`TranslateOptions`] (e.g.
+/// `gate_reset` to drop `disable iff` guards for model-level reset pinning).
+pub fn translate_ast_json_with_options(
+    json: &str,
+    opts: &TranslateOptions,
+) -> Result<TranslationReport, AdapterError> {
     let root: Value = serde_json::from_str(json).map_err(|e| AdapterError {
         kind: AdapterErrorKind::ParseError,
         message: format!("adapter/slang/translate: --ast-json is not valid JSON: {e}"),
@@ -170,7 +211,7 @@ pub fn translate_ast_json(json: &str) -> Result<TranslationReport, AdapterError>
         // Rewrite enum-member references to integer literals before translating.
         let spec = resolve_enum_refs(spec, &enum_values);
         let spec = &spec;
-        match translate_one(spec, kind) {
+        match translate_one(spec, kind, opts, &mut report.reset_signals) {
             Ok(formula) => {
                 // XL.2: a cover's `EF φ` gets its `AG EF φ` recoverability lens.
                 // (Omitted if the companion somehow fails to parse — never ship
@@ -322,8 +363,13 @@ fn collect_shadow_signals(node: &Value, out: &mut Vec<ShadowSignal>) {
 
 /// Translate one assertion's `propertySpec` to a full mu-calculus formula, then
 /// validate it parses. `Err(reason)` for any out-of-fragment construct.
-fn translate_one(spec: &Value, kind: SvaKind) -> Result<String, String> {
-    let body = property_body(spec)?;
+fn translate_one(
+    spec: &Value,
+    kind: SvaKind,
+    opts: &TranslateOptions,
+    reset_signals: &mut Vec<ResetSignal>,
+) -> Result<String, String> {
+    let body = property_body(spec, opts, reset_signals)?;
     let formula = match kind {
         SvaKind::Assert | SvaKind::Assume => format!("nu X. (({body}) && [] X)"),
         SvaKind::Cover => format!("mu X. (({body}) || <> X)"),
@@ -349,17 +395,94 @@ fn recoverability_companion_formula(ef_formula: &str) -> Result<String, String> 
     Ok(companion)
 }
 
+/// Recognize a `disable iff` condition that is a single (possibly negated,
+/// possibly `!= 0`-wrapped) reset signal, and return the signal + the value
+/// that makes the condition FALSE (reset inactive). Returns `None` for complex
+/// conditions — those are left as a kept guard rather than gated, so we never
+/// silently mis-pin a multi-signal disable condition.
+///
+/// Recognized shapes (the dominant SVA idioms):
+/// - `rst` (1-bit `NamedValue`) → active-high; inactive value `0`.
+/// - `!rst_n` (`LogicalNot`/`BitwiseNot` of a 1-bit signal) → active-low;
+///   inactive value `1`.
+/// - `(<lhs>) !== '0` (`Inequality`/`CaseInequality` with a `0` RHS — the
+///   OpenTitan ``ASSERT`` macro form) → same polarity as `<lhs>`.
+fn extract_reset_signal(cond: &Value) -> Option<ResetSignal> {
+    let cond = unwrap(cond);
+    let kind = cond.get("kind").and_then(Value::as_str)?;
+    match kind {
+        "NamedValue" => {
+            if signal_width(cond) != 1 {
+                return None;
+            }
+            let name = signal_name(cond).ok()?;
+            Some(ResetSignal {
+                signal: name.to_string(),
+                inactive_value: 0,
+            })
+        }
+        "UnaryOp" => {
+            let op = cond.get("op").and_then(Value::as_str)?;
+            if !matches!(op, "LogicalNot" | "BitwiseNot") {
+                return None;
+            }
+            let operand = unwrap(child(cond, "operand").ok()?);
+            if operand.get("kind").and_then(Value::as_str)? != "NamedValue"
+                || signal_width(operand) != 1
+            {
+                return None;
+            }
+            let name = signal_name(operand).ok()?;
+            Some(ResetSignal {
+                signal: name.to_string(),
+                inactive_value: 1,
+            })
+        }
+        // `(<lhs>) !== '0` — the `!= 0` wrapper preserves the LHS's truth, so
+        // the reset polarity is the LHS's.
+        "BinaryOp" => {
+            let op = cond.get("op").and_then(Value::as_str)?;
+            if !matches!(op, "Inequality" | "CaseInequality") {
+                return None;
+            }
+            let right = unwrap(child(cond, "right").ok()?);
+            if sv_integer(right) != Some(0) {
+                return None;
+            }
+            extract_reset_signal(child(cond, "left").ok()?)
+        }
+        _ => None,
+    }
+}
+
 /// Translate an `AssertionExpr` into the per-step propositional body (the part
 /// inside `nu X. (BODY && []X)` / `mu X. (BODY || <>X)`).
-fn property_body(spec: &Value) -> Result<String, String> {
+fn property_body(
+    spec: &Value,
+    opts: &TranslateOptions,
+    reset_signals: &mut Vec<ResetSignal>,
+) -> Result<String, String> {
     let k = spec.get("kind").and_then(Value::as_str).unwrap_or("?");
     match k {
         // `@(posedge clk) P` — one CLTS step is one clock edge; strip the clock.
-        "Clocking" => property_body(child(spec, "expr")?),
+        "Clocking" => property_body(child(spec, "expr")?, opts, reset_signals),
         // `disable iff (r) P` — vacuously true while disabled: `(r || body)`.
+        // When `gate_reset` and the condition is a recognizable single-signal
+        // reset, drop the guard (consumer pins the reset inactive at the model
+        // level) and record the reset signal. Detected resets are recorded
+        // regardless of gating.
         "DisableIff" => {
-            let cond = bool_expr(child(spec, "condition")?)?;
-            let inner = property_body(child(spec, "expr")?)?;
+            let cond_node = child(spec, "condition")?;
+            let inner = property_body(child(spec, "expr")?, opts, reset_signals)?;
+            if let Some(rs) = extract_reset_signal(cond_node) {
+                if !reset_signals.contains(&rs) {
+                    reset_signals.push(rs);
+                }
+                if opts.gate_reset {
+                    return Ok(inner);
+                }
+            }
+            let cond = bool_expr(cond_node)?;
             Ok(format!("({cond} || {inner})"))
         }
         // `a |-> b` / `a |=> b` — left/right are boolean (Tier-1 `Simple`).
@@ -812,7 +935,13 @@ mod tests {
             "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
             "right": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}
         });
-        let f = translate_one(&spec, SvaKind::Assert).expect("translates");
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
         assert_eq!(f, "nu X. (((!(a) || b)) && [] X)");
         crate::mu_calculus::parser::parse(&f).expect("parses");
     }
@@ -826,7 +955,13 @@ mod tests {
             "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
             "right": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}
         });
-        let f = translate_one(&spec, SvaKind::Assert).expect("translates");
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
         assert!(f.contains("[] b"), "|=> must put b under a next ([]): {f}");
         crate::mu_calculus::parser::parse(&f).expect("parses");
     }
@@ -840,7 +975,13 @@ mod tests {
             "expr": {"kind": "UnaryOp", "op": "BitwiseXor",
                      "operand": {"kind": "NamedValue", "symbol": "1 req", "type": "logic[7:0]"}}
         });
-        let err = translate_one(&spec, SvaKind::Assert).expect_err("must reject");
+        let err = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect_err("must reject");
         assert!(err.contains("parity"), "got: {err}");
     }
 
@@ -855,7 +996,13 @@ mod tests {
                  "operand": {"kind": "NamedValue", "symbol": "1 gnt_o", "type": "logic[7:0]"}}},
             "right": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 ready_i"}}
         });
-        let f = translate_one(&spec, SvaKind::Assert).expect("translates");
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
         assert!(f.contains("(gnt_o != 0)"), "reduction-or → != 0; got {f}");
         assert!(f.contains("ready_i"));
         crate::mu_calculus::parser::parse(&f).expect("parses");
@@ -891,7 +1038,8 @@ mod tests {
             },
             "expr": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 a"}}
         });
-        let body = property_body(&spec).expect("translates");
+        let body = property_body(&spec, &TranslateOptions::default(), &mut Vec::new())
+            .expect("translates");
         assert_eq!(body, "((!(rst_ni)) || a)");
     }
 
@@ -981,8 +1129,69 @@ mod tests {
                           "operand": {"kind": "NamedValue", "symbol": "1 rst_n"}},
             "expr": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 a"}}
         });
-        let body = property_body(&spec).expect("translates");
+        let body = property_body(&spec, &TranslateOptions::default(), &mut Vec::new())
+            .expect("translates");
         assert_eq!(body, "((!(rst_n)) || a)");
+
+        // With reset-gating the guard is dropped and the reset is recorded.
+        let mut resets = Vec::new();
+        let gated = property_body(&spec, &TranslateOptions { gate_reset: true }, &mut resets)
+            .expect("translates");
+        assert_eq!(gated, "a", "gate_reset drops the disable-iff guard");
+        assert_eq!(
+            resets,
+            vec![ResetSignal {
+                signal: "rst_n".to_string(),
+                inactive_value: 1,
+            }],
+            "active-low reset recorded with inactive value 1"
+        );
+    }
+
+    #[test]
+    fn extract_reset_signal_recognizes_common_idioms() {
+        // active-high `disable iff (rst)` → inactive value 0.
+        let active_high = serde_json::json!({"kind": "NamedValue", "symbol": "1 rst"});
+        assert_eq!(
+            extract_reset_signal(&active_high),
+            Some(ResetSignal {
+                signal: "rst".to_string(),
+                inactive_value: 0
+            })
+        );
+        // active-low `disable iff (!rst_n)` → inactive value 1.
+        let active_low = serde_json::json!({
+            "kind": "UnaryOp", "op": "LogicalNot",
+            "operand": {"kind": "NamedValue", "symbol": "1 rst_n"}
+        });
+        assert_eq!(
+            extract_reset_signal(&active_low),
+            Some(ResetSignal {
+                signal: "rst_n".to_string(),
+                inactive_value: 1
+            })
+        );
+        // OpenTitan macro `(!rst_ni) !== '0` → same polarity as the LHS (1).
+        let macro_form = serde_json::json!({
+            "kind": "BinaryOp", "op": "CaseInequality",
+            "left": {"kind": "UnaryOp", "op": "LogicalNot",
+                     "operand": {"kind": "NamedValue", "symbol": "1 rst_ni", "type": "logic"}},
+            "right": {"kind": "UnbasedUnsizedIntegerLiteral", "value": "1'b0"}
+        });
+        assert_eq!(
+            extract_reset_signal(&macro_form),
+            Some(ResetSignal {
+                signal: "rst_ni".to_string(),
+                inactive_value: 1
+            })
+        );
+        // A multi-signal condition is NOT recognized (left as a kept guard).
+        let complex = serde_json::json!({
+            "kind": "BinaryOp", "op": "LogicalOr",
+            "left": {"kind": "NamedValue", "symbol": "1 rst"},
+            "right": {"kind": "NamedValue", "symbol": "2 clr"}
+        });
+        assert_eq!(extract_reset_signal(&complex), None);
     }
 
     #[test]
@@ -1038,6 +1247,8 @@ mod tests {
                          "right": {"kind": "IntegerLiteral", "value": "55", "constant": "55"}}
             }),
             SvaKind::Cover,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
         )
         .expect("cover translates");
         let companion = recoverability_companion_formula(&ef).expect("companion forms + parses");

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -31,8 +31,8 @@ use std::collections::HashSet;
 
 use crate::adapter::btor2::kmts_lift::{MayEdgeInference, MustEdgeInference, PredicateSpec};
 use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr, parse_predicate_expr};
-use crate::adapter::slang::extract::extract_sva;
-use crate::adapter::slang::translate::SvaKind;
+use crate::adapter::slang::extract::extract_sva_with_options;
+use crate::adapter::slang::translate::{SvaKind, TranslateOptions};
 use crate::adapter::yosys::YosysOptions;
 use crate::adapter::{AdapterError, AdapterErrorKind};
 use crate::mu_calculus::{Formula, Node};
@@ -81,6 +81,11 @@ pub struct ModelDiagnostics {
     /// "stop-silent-cut" half: the cut is no longer invisible. The fix is to
     /// provide the missing module source(s).
     pub blackboxed_modules: Vec<String>,
+    /// Reset inputs that were pinned inactive at the model level so the body is
+    /// verified only while not in reset (the `disable iff` guards were dropped
+    /// from the formulas). Empty when reset-gating is off or no `disable iff`
+    /// reset was recognized. Each entry is `"<signal>=<inactive_value>"`.
+    pub gated_resets: Vec<String>,
 }
 
 /// Result of an automated SVA verification run.
@@ -129,6 +134,14 @@ pub struct VerifyAutoOptions {
     /// Must-edge inference policy passed to each property's CEGAR run. Default
     /// `Off`; `SmtHyperMust` gives sound νμ verdicts (the recoverability case).
     pub must_edge_inference: MustEdgeInference,
+    /// When `true` (default), `disable iff (reset)` guards are dropped from the
+    /// formulas and the recognized reset inputs are pinned inactive at the
+    /// model level (so the body is verified only while not in reset, matching
+    /// SVA `disable iff` semantics). This removes the otherwise-unbindable
+    /// reset-input atom that would force a SKIP. The dominant idiom in real
+    /// SVA, so it is on by default; set `false` to keep the guard and leave
+    /// the reset free.
+    pub gate_reset: bool,
 }
 
 impl Default for VerifyAutoOptions {
@@ -136,6 +149,7 @@ impl Default for VerifyAutoOptions {
         Self {
             max_iterations: 16,
             must_edge_inference: MustEdgeInference::Off,
+            gate_reset: true,
         }
     }
 }
@@ -321,8 +335,15 @@ pub fn verify_auto(
     })?;
     let _ = primary_name;
 
-    // 1. Extract + translate the SVA.
-    let extraction = extract_sva(sources)?;
+    // 1. Extract + translate the SVA. When reset-gating, the `disable iff`
+    // guards are dropped from the formulas and the recognized reset signals are
+    // reported (we pin them inactive in the lift below).
+    let extraction = extract_sva_with_options(
+        sources,
+        &TranslateOptions {
+            gate_reset: opts.gate_reset,
+        },
+    )?;
 
     let mut report = AutoVerifyReport {
         unsupported: extraction
@@ -335,6 +356,19 @@ pub fn verify_auto(
     if extraction.translated.is_empty() {
         return Ok(report);
     }
+
+    // Reset inputs to pin inactive (reset-gating) — applied to the lifted BTOR2
+    // below via `pin_inputs_to_constants`. Empty when gating is off or no
+    // `disable iff` reset was recognized.
+    let reset_pins: Vec<(String, u64)> = if opts.gate_reset {
+        extraction
+            .reset_signals
+            .iter()
+            .map(|rs| (rs.signal.clone(), rs.inactive_value))
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     // 2. SV → flattened BTOR2, then 3. augment the `__past` shadow flops. The
     // lift also reports modules it black-boxed (instantiated, no body) — those
@@ -363,6 +397,15 @@ pub fn verify_auto(
         .filter(|b| crate::adapter::btor2::parser::resolve_state_by_symbol(&pre_file, b).is_some())
         .collect();
     let btor2 = augment_with_past_shadows(&btor2, &shadow_bases)?;
+
+    // Pin recognized reset inputs inactive so the (un-guarded) bodies are
+    // verified only while not in reset (the model-level half of reset-gating).
+    // `gated_resets` records only the resets actually found + pinned in the
+    // BTOR2 — a recognized reset that the lift renamed/optimized away is left
+    // unpinned rather than misreported.
+    let (btor2, pinned_resets) =
+        crate::adapter::btor2::pin::pin_inputs_to_constants(&btor2, &reset_pins);
+    report.diagnostics.gated_resets = pinned_resets;
 
     // State-cell symbols of the augmented design — the seedable-atom universe.
     let file = crate::adapter::btor2::parser::parse(&btor2).map_err(|mut e| {
@@ -619,6 +662,7 @@ mod tests {
         let diag = ModelDiagnostics {
             state_register_count: 0,
             blackboxed_modules: vec!["prim_sparse_fsm_flop".to_string()],
+            gated_resets: Vec::new(),
         };
         let reason = unseedable_skip_reason(&["state_q == 41".to_string()], &diag);
         assert!(reason.contains("state_q == 41"), "carries the symptom");
@@ -637,6 +681,7 @@ mod tests {
         let diag = ModelDiagnostics {
             state_register_count: 0,
             blackboxed_modules: Vec::new(),
+            gated_resets: Vec::new(),
         };
         let reason = unseedable_skip_reason(&["foo == 1".to_string()], &diag);
         assert!(
@@ -651,6 +696,7 @@ mod tests {
         let diag = ModelDiagnostics {
             state_register_count: 3,
             blackboxed_modules: Vec::new(),
+            gated_resets: Vec::new(),
         };
         let reason = unseedable_skip_reason(&["gnt_o != 0".to_string()], &diag);
         assert!(reason.contains("gnt_o != 0"));
@@ -669,6 +715,63 @@ mod tests {
         let err = verify_auto(&[], &YosysOptions::default(), &VerifyAutoOptions::default())
             .expect_err("no sources");
         assert_eq!(err.kind, AdapterErrorKind::ParseError);
+    }
+
+    #[test]
+    #[ignore = "requires slang + sv2v + Yosys + z3; run with --ignored"]
+    fn e2e_reset_gating_turns_a_skip_into_a_verdict() {
+        // A 2-bit FSM cycling 0→1→2→0, with an active-low-reset-guarded
+        // assertion `disable iff (!rst_n) state != 3`. With reset-gating ON
+        // (default) the guard is dropped, rst_n is pinned inactive, and the
+        // body `state != 3` is a state-cell property → HOLDS. With gating OFF
+        // the `!rst_n` IO atom is unbindable → SKIPPED. This is the headline
+        // before/after that the reset-gating fix delivers.
+        let sv = "module fsm (input logic clk, input logic rst_n);\n\
+                  logic [1:0] state;\n\
+                  always_ff @(posedge clk) begin\n\
+                    if (!rst_n) state <= 2'd0;\n\
+                    else state <= (state == 2'd2) ? 2'd0 : state + 2'd1;\n\
+                  end\n\
+                  ok: assert property (@(posedge clk) disable iff (!rst_n) state != 2'd3);\n\
+                  endmodule\n";
+        let sources = vec![("fsm.sv".to_string(), sv.to_string())];
+        let yopts = YosysOptions {
+            top: Some("fsm".to_string()),
+            use_sv2v: true,
+            ..Default::default()
+        };
+
+        // Reset-gating ON (default): the guard is dropped + rst_n pinned.
+        let gated = verify_auto(&sources, &yopts, &VerifyAutoOptions::default())
+            .expect("verify_auto runs with reset-gating");
+        assert_eq!(gated.properties.len(), 1);
+        assert!(
+            matches!(gated.properties[0].outcome, VerifyOutcome::Holds),
+            "reset-gated `state != 3` should HOLD; got {:?}",
+            gated.properties[0].outcome
+        );
+        assert_eq!(
+            gated.diagnostics.gated_resets,
+            vec!["rst_n=1".to_string()],
+            "active-low reset pinned inactive"
+        );
+
+        // Reset-gating OFF: the `!rst_n` IO atom is unbindable → SKIPPED.
+        let ungated = verify_auto(
+            &sources,
+            &yopts,
+            &VerifyAutoOptions {
+                gate_reset: false,
+                ..Default::default()
+            },
+        )
+        .expect("verify_auto runs without reset-gating");
+        assert!(
+            matches!(ungated.properties[0].outcome, VerifyOutcome::Skipped { .. }),
+            "without gating the reset atom forces a SKIP; got {:?}",
+            ungated.properties[0].outcome
+        );
+        assert!(ungated.diagnostics.gated_resets.is_empty());
     }
 
     #[test]

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -772,6 +772,7 @@ pub async fn sv_verify_auto_handler(
     let opts = VerifyAutoOptions {
         max_iterations: request.max_iterations.unwrap_or(16),
         must_edge_inference,
+        gate_reset: request.gate_reset.unwrap_or(true),
     };
 
     let report = verify_auto(&sources, &yopts, &opts).map_err(|e| ApiError::BadRequest {
@@ -828,6 +829,7 @@ pub async fn sv_verify_auto_handler(
         diagnostics: ModelDiagnosticsView {
             state_register_count: report.diagnostics.state_register_count,
             blackboxed_modules: report.diagnostics.blackboxed_modules.clone(),
+            gated_resets: report.diagnostics.gated_resets.clone(),
         },
     }))
 }

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1012,6 +1012,11 @@ pub struct SvVerifyAutoRequest {
     /// gives sound νμ verdicts).
     #[serde(default)]
     pub must_edge_inference: Option<String>,
+    /// Reset-gating: drop recognized `disable iff (reset)` guards and pin the
+    /// reset input inactive at the model level (default `true`). Set `false`
+    /// to keep the guard and leave the reset free.
+    #[serde(default)]
+    pub gate_reset: Option<bool>,
 }
 
 /// Response for `/api/v1/sv/verify-auto`.
@@ -1035,6 +1040,10 @@ pub struct ModelDiagnosticsView {
     /// Modules instantiated without a body, cut to free inputs (registers they
     /// drive are not modeled as state). Empty for a self-contained design.
     pub blackboxed_modules: Vec<String>,
+    /// Reset inputs pinned inactive at the model level (`"<signal>=<value>"`),
+    /// with their `disable iff` guards dropped from the formulas. Empty when
+    /// reset-gating is off or no `disable iff` reset was recognized.
+    pub gated_resets: Vec<String>,
 }
 
 /// One property's auto-verification verdict (mirrors `PropertyVerdict`).


### PR DESCRIPTION
## What

`disable iff (reset)` is the dominant real-SVA idiom, but it placed an **unbindable reset-input atom** into every translated formula: the cube abstraction binds over *state cells* only, so `((!rst_ni) || body)` was **SKIPPED** (the `rst_ni` atom is a primary input, not a state cell). Reset-gating turns that SKIP into a real verdict on the running (post-reset) design — the general form of V.7-c's manual `connect -set rst_ni 1'b1`.

## Changes

**Translator (slang)**
- `extract_reset_signal` recognizes the single-signal reset idioms in a `disable iff` condition: `rst` (active-high → inactive `0`), `!rst_n` (active-low → inactive `1`), and the OpenTitan `` `ASSERT ``-macro form `(!rst_ni) !== '0` (same polarity as the LHS). Complex conditions are left as a kept guard (never mis-pinned).
- `TranslateOptions { gate_reset }`: drops the recognized guard from the body and records the reset in `TranslationReport::reset_signals`. New options-aware entry points (`translate_ast_json_with_options`, `extract_sva_with_options`) keep the existing extract-sva surface unchanged.

**Model (BTOR2)**
- New `btor2::pin::pin_inputs_to_constants` rewrites a reset `input` line to a `one`/`zero` constant (nid preserved → every reference sees the constant). Exact, keeps the state register, composes with the cube/bit-blast re-parse. A yosys `connect -set` approach was rejected: without `opt` it's a no-op; with `opt -purge` it deletes the unobserved state register.

**verify-auto**
- `VerifyAutoOptions::gate_reset` (default `true`): extract with gating, pin the recognized resets in the lifted BTOR2, and report the ones *actually pinned* in `diagnostics.gated_resets` (a recognized reset the lift renamed/optimized away is left unpinned, not misreported).

**Surface parity**: CLI `--no-gate-reset` + `gated_resets` render; `/api/v1/sv/verify-auto` request `gate_reset` + response `diagnostics.gated_resets`; UI gate-reset checkbox + diagnostics render (mununu-ui companion PR).

## Tests

- Reset-idiom recognition + guard-dropping (translator unit tests).
- BTOR2 pin rewrite: state-preservation, active-low/high, unmatched-pin honesty, identity (unit tests). The rewrite was also validated empirically against the real sv2v+Yosys FSM lift.
- `#[ignore]` e2e demonstrating SKIP→HOLDS with gating on vs off.
- Full `make ci` green locally.

Builds on #171 (diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)