### PR TITLE
test(H-track): SVA e2e validation image + real-csrng measurement + name undefined-module cuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,22 @@ For CI-exact reproduction inside the pinned dev container, see [`docs/dev-contai
 
 The `security-audit` CI job runs `cargo audit`. The `dependency-check` job is non-blocking.
 
+### SVA-verification e2e validation (slang) `[REFERENCE]` (added 2026-06-27)
+
+The SVA front-end (`mununu sv extract-sva` / `mununu sv verify-auto`) shells out to **slang** (SystemVerilog elaboration), **sv2v**, and **yosys**. Per the subprocess-tools-are-not-bundled policy, these are NOT in `mununu-dev`, so the slang-gated end-to-end tests are `#[ignore]`d and do not run in `make ci`. Their mechanisms are covered by non-ignored unit tests; the `#[ignore]` tests validate the full chain when the tools are present.
+
+**Run them in the `mununu-sva` image** (`docker/Dockerfile.sva` — extends `mununu-dev` with pinned slang + sv2v + yosys):
+
+```bash
+docker build -f docker/Dockerfile.dev -t mununu-dev .     # once (or on toolchain bump)
+docker build -f docker/Dockerfile.sva -t mununu-sva .     # once
+docker volume create mununu-target                        # once (warm cargo cache)
+docker run --rm -v "$(pwd)":/work -v mununu-target:/cargo-target \
+  mununu-sva cargo test -p mununu-core --lib --all-features e2e_ -- --ignored --nocapture
+```
+
+**Host caveat.** slang ships prebuilts only for `linux-x86_64` and `macos-arm64`. On an Intel (x86_64) macOS host there is no native slang binary, and the workspace's `z3-sys` link also differs from the dev image — so the Linux `mununu-sva` image (which runs natively on x86_64 hosts) is the supported way to run these tests there. The `e2e_csrng_real_sva_verdict_breakdown` test reads only vendored fixtures (`examples/verify/m2_opentitan_csrng_main_sm` + the standard prim_assert macros from `examples/verify/m0_opentitan_prim_arbiter`), so it is fully reproducible.
+
 ### Pre-push workspace check (added 2026-06-08)
 
 **Rule.** Before `git push`, when a commit touches a field of a struct with multiple construction sites (`OriginalTransition`, `TransitionSpec`, `SignalAnnotation`, `CegarOptions`, `PredicateCubeLiftOptions`, `TransitionDecl`, etc.), run the CI-equivalent workspace check:

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -73,11 +73,12 @@ pub struct ModelDiagnostics {
     /// state was cut (see [`Self::blackboxed_modules`]) — properties over the
     /// cut registers are then SKIPPED rather than verified.
     pub state_register_count: usize,
-    /// Modules instantiated without a body (auto-black-boxed by Yosys) — their
-    /// outputs were cut to free inputs by `cutpoint -blackbox`. This is a sound
-    /// over-approximation, but a register hidden behind one of these (e.g. an
-    /// FSM wrapped in `prim_sparse_fsm_flop`) is **not** modeled as state, so
-    /// every property over it is SKIPPED. Surfacing the cut here is the
+    /// Modules instantiated without a body — either auto-black-boxed by Yosys
+    /// (outputs cut to free inputs by `cutpoint -blackbox`) or left as a
+    /// dangling undefined-module cell (e.g. an FSM wrapped in OpenTitan's
+    /// `prim_sparse_fsm_flop`, whose register then vanishes from the lift).
+    /// Both are sound, but a register hidden behind one is **not** modeled as
+    /// state, so every property over it is SKIPPED. Surfacing it here is the
     /// "stop-silent-cut" half: the cut is no longer invisible. The fix is to
     /// provide the missing module source(s).
     pub blackboxed_modules: Vec<String>,
@@ -110,9 +111,9 @@ fn unseedable_skip_reason(unseedable: &[String], diag: &ModelDiagnostics) -> Str
     );
     if !diag.blackboxed_modules.is_empty() {
         format!(
-            "{base}. Root cause: the lift black-boxed {} module(s) with no body ({}) — \
-             registers they drive were cut to free inputs and are not modeled as state. \
-             Provide the missing module source(s) to model them.",
+            "{base}. Root cause: {} module(s) instantiated with no body ({}) — \
+             registers they drive are not modeled as state. Provide the missing \
+             module source(s) to model them.",
             diag.blackboxed_modules.len(),
             diag.blackboxed_modules.join(", ")
         )
@@ -868,6 +869,25 @@ mod tests {
         assert!(
             report.properties.len() >= 2,
             "both csrng ASSERTs (CsrngMainErrorStStable_A, CsrngMainErrorOutput_A) translate"
+        );
+        // The csrng FSM is wrapped in `prim_sparse_fsm_flop` (body not in the
+        // source set), so it is cut and the lift has no state registers. The
+        // diagnostic must NAME the cut module (undefined-module-cell detection)
+        // rather than only reporting "no state registers" — that is the
+        // actionable root cause (provide the flop's source).
+        assert!(
+            report
+                .diagnostics
+                .blackboxed_modules
+                .iter()
+                .any(|m| m.contains("prim_sparse_fsm_flop")),
+            "the cut prim_sparse_fsm_flop should be named in diagnostics; got {:?}",
+            report.diagnostics.blackboxed_modules
+        );
+        // Reset-gating fires on the macro's `disable iff (rst_ni)`.
+        assert_eq!(
+            report.diagnostics.gated_resets,
+            vec!["rst_ni=1".to_string()]
         );
     }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -775,6 +775,103 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires slang + sv2v + Yosys + z3 (use the mununu-sva docker image); run with --ignored"]
+    fn e2e_csrng_real_sva_verdict_breakdown() {
+        // Real OpenTitan csrng_main_sm SVA end-to-end through verify-auto. Reads
+        // the vendored fixtures: the csrng sources from the M.2 fixture + the
+        // STANDARD prim_assert macros from the M.0 prim_arbiter fixture (the
+        // csrng dir's own prim_assert.sv is the dummy variant that drops all
+        // SVA — the XL.0 gotcha). Prints the verdict breakdown; this is the
+        // honest measurement of "how many real csrng SVA does verify-auto
+        // prove?" — see the diagnostics for the root cause of any SKIP.
+        use crate::adapter::btor2::kmts_lift::MustEdgeInference;
+        use std::path::PathBuf;
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/verify");
+        let csrng = root.join("m2_opentitan_csrng_main_sm/source");
+        let prim = root.join("m0_opentitan_prim_arbiter/source");
+        let read = |p: PathBuf| {
+            std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+        };
+        let sources = vec![
+            (
+                "csrng_main_sm.sv".to_string(),
+                read(csrng.join("csrng_main_sm.sv")),
+            ),
+            ("csrng_pkg.sv".to_string(), read(csrng.join("csrng_pkg.sv"))),
+            (
+                "prim_assert.sv".to_string(),
+                read(prim.join("prim_assert.sv")),
+            ),
+            (
+                "prim_assert_standard_macros.svh".to_string(),
+                read(prim.join("prim_assert_standard_macros.svh")),
+            ),
+            (
+                "prim_assert_sec_cm.svh".to_string(),
+                read(prim.join("prim_assert_sec_cm.svh")),
+            ),
+            (
+                "prim_flop_macros.sv".to_string(),
+                read(prim.join("prim_flop_macros.sv")),
+            ),
+        ];
+        let yopts = YosysOptions {
+            top: Some("csrng_main_sm".to_string()),
+            use_sv2v: true,
+            // The lift (sv2v + Yosys) resolves `\`include`s and packages from
+            // `additional_sources` (staged + used as the sv2v include path);
+            // `sources` itself only feeds slang's extraction.
+            additional_sources: sources[1..].to_vec(),
+            ..Default::default()
+        };
+        let report = verify_auto(
+            &sources,
+            &yopts,
+            &VerifyAutoOptions {
+                must_edge_inference: MustEdgeInference::SmtHyperMust,
+                ..Default::default()
+            },
+        )
+        .expect("verify_auto runs on csrng");
+
+        eprintln!("\n=== csrng_main_sm verify-auto breakdown ===");
+        eprintln!(
+            "translated: {}   unsupported: {}",
+            report.properties.len(),
+            report.unsupported.len()
+        );
+        eprintln!(
+            "diagnostics: state_registers={}  blackboxed={:?}  gated_resets={:?}",
+            report.diagnostics.state_register_count,
+            report.diagnostics.blackboxed_modules,
+            report.diagnostics.gated_resets,
+        );
+        let (mut holds, mut violated, mut unknown, mut skipped) = (0, 0, 0, 0);
+        for p in &report.properties {
+            eprintln!("  [{:?}] {}: {:?}", p.kind, p.name, p.outcome);
+            match p.outcome {
+                VerifyOutcome::Holds => holds += 1,
+                VerifyOutcome::Violated { .. } => violated += 1,
+                VerifyOutcome::Unknown { .. } => unknown += 1,
+                VerifyOutcome::Skipped { .. } => skipped += 1,
+            }
+        }
+        eprintln!("HOLDS={holds} VIOLATED={violated} UNKNOWN={unknown} SKIPPED={skipped}");
+        for (n, r) in &report.unsupported {
+            eprintln!("  unsupported {n}: {r}");
+        }
+
+        // Honest invariant: the real OpenTitan SVA is in-fragment and
+        // translates (the `$stable` / `|=>` / `|->` + enum + disable-iff forms).
+        // Whether a property reaches a DEFINITE verdict depends on whether its
+        // state survives the lift — the diagnostics above attribute any SKIP.
+        assert!(
+            report.properties.len() >= 2,
+            "both csrng ASSERTs (CsrngMainErrorStStable_A, CsrngMainErrorOutput_A) translate"
+        );
+    }
+
+    #[test]
     #[ignore = "requires slang + sv2v + Yosys + z3; run with --ignored"]
     fn e2e_fsm_holds_and_violated_verdicts() {
         // A 2-bit FSM reset to 0, cycling 0→1→2→0. Two state-safety properties:

--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -458,26 +458,86 @@ pub fn sv_to_btor2(content: &str, yopts: &YosysOptions) -> Result<String, Adapte
 }
 
 /// Like [`sv_to_btor2`] but additionally returns the names of modules the lift
-/// **black-boxed** — instantiated in the design but with no body in the source
-/// set, so Yosys auto-declared them `(* blackbox *)` and `cutpoint -blackbox`
-/// replaced their outputs with free inputs.
+/// could **not model** because they were instantiated with no body in the
+/// source set. Two flavours, both reported:
 ///
-/// This is sound (a free input over-approximates an unknown driver), but a
-/// register hidden behind such a module (e.g. an FSM wrapped in OpenTitan's
-/// `prim_sparse_fsm_flop`) is **not** modeled as a state cell — so it cannot be
-/// abstracted or verified. [`verify_auto`](crate::adapter::slang::verify_auto)
-/// surfaces this list as a diagnostic so the cut is visible rather than silent,
-/// and the user can provide the missing module source.
+/// 1. Modules Yosys auto-declared `(* blackbox *)`, whose outputs
+///    `cutpoint -blackbox` replaced with free inputs.
+/// 2. **Undefined-module cells** — an instance whose module type has no
+///    definition (e.g. OpenTitan's `prim_sparse_fsm_flop`, instantiated by the
+///    `PRIM_FLOP_SPARSE_FSM` macro). Yosys leaves these as dangling cell
+///    references (not blackbox *modules*), so `flatten` cannot inline them and
+///    any register they drive vanishes from the lifted model entirely.
+///
+/// Both are sound (an unmodeled driver becomes free / undefined, never a
+/// fabricated definite value), but a register hidden behind one is **not**
+/// modeled as a state cell, so it cannot be abstracted or verified.
+/// [`verify_auto`](crate::adapter::slang::verify_auto) surfaces this list as a
+/// diagnostic so the cut is visible rather than silent, and the user can
+/// provide the missing module source.
 pub fn sv_to_btor2_with_blackboxes(
     content: &str,
     yopts: &YosysOptions,
 ) -> Result<(String, Vec<String>), AdapterError> {
     let artifacts = run_sv_flatten_btor2(content, yopts)?;
-    let blackboxes: Vec<String> = parse_blackbox_modules(&artifacts.hier_json)
-        .into_iter()
-        .map(|b| b.name)
-        .collect();
-    Ok((artifacts.btor2, blackboxes))
+    let mut names: std::collections::BTreeSet<String> =
+        parse_blackbox_modules(&artifacts.hier_json)
+            .into_iter()
+            .map(|b| b.name)
+            .collect();
+    names.extend(parse_undefined_module_cells(&artifacts.hier_json));
+    Ok((artifacts.btor2, names.into_iter().collect()))
+}
+
+/// Scan the pre-flatten hierarchy JSON for cells whose `type` references a
+/// module with no definition in the design (instantiated, no body) and is not a
+/// Yosys built-in (`$...`) cell. These dangling cell references are NOT declared
+/// blackbox *modules*, so [`parse_blackbox_modules`] misses them, yet they are
+/// the dominant real-world "cut FSM" cause (OpenTitan's `prim_sparse_fsm_flop`).
+/// Names are de-mangled of sv2v's parameter-specialisation suffix for
+/// readability and returned sorted + deduped.
+fn parse_undefined_module_cells(hier_json: &str) -> Vec<String> {
+    let root: serde_json::Value = match serde_json::from_str(hier_json) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let Some(modules) = root.get("modules").and_then(|m| m.as_object()) else {
+        return Vec::new();
+    };
+    let defined: std::collections::HashSet<&str> = modules.keys().map(String::as_str).collect();
+    let mut undefined: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for body in modules.values() {
+        let Some(cells) = body.get("cells").and_then(|c| c.as_object()) else {
+            continue;
+        };
+        for cell in cells.values() {
+            if let Some(ty) = cell.get("type").and_then(|t| t.as_str())
+                && !ty.starts_with('$')
+                && !defined.contains(ty)
+            {
+                undefined.insert(strip_sv2v_mangle(ty).to_string());
+            }
+        }
+    }
+    undefined.into_iter().collect()
+}
+
+/// Strip sv2v's parameter-specialisation suffix (`_<HEX>_<HEX>`, two trailing
+/// uppercase-hex groups of ≥ 4 chars) from a mangled module name, so e.g.
+/// `prim_sparse_fsm_flop_B4CDB_707CE` reads as `prim_sparse_fsm_flop` in
+/// diagnostics. Conservative: only strips when both trailing groups match the
+/// exact sv2v shape; otherwise returns the name unchanged.
+fn strip_sv2v_mangle(name: &str) -> &str {
+    let is_hex4 = |s: &str| s.len() >= 4 && s.chars().all(|c| c.is_ascii_hexdigit());
+    if let Some((head, last)) = name.rsplit_once('_')
+        && is_hex4(last)
+        && let Some((stem, mid)) = head.rsplit_once('_')
+        && is_hex4(mid)
+        && !stem.is_empty()
+    {
+        return stem;
+    }
+    name
 }
 
 /// One submodule's translated output, as returned by
@@ -2630,5 +2690,52 @@ endmodule
             "error should name sv2v; got: {}",
             err.message
         );
+    }
+
+    #[test]
+    fn strip_sv2v_mangle_demangles_param_suffix() {
+        // sv2v's `_<HEX>_<HEX>` parameter-specialisation suffix is stripped.
+        assert_eq!(
+            strip_sv2v_mangle("prim_sparse_fsm_flop_B4CDB_707CE"),
+            "prim_sparse_fsm_flop"
+        );
+        // A plain module name is untouched.
+        assert_eq!(
+            strip_sv2v_mangle("prim_sparse_fsm_flop"),
+            "prim_sparse_fsm_flop"
+        );
+        // A name with only one trailing hex group is untouched (not the sv2v shape).
+        assert_eq!(strip_sv2v_mangle("foo_DEAD"), "foo_DEAD");
+    }
+
+    #[test]
+    fn parse_undefined_module_cells_finds_dangling_instance() {
+        // A module that instantiates an undefined cell type (the csrng
+        // prim_sparse_fsm_flop shape) — yosys leaves it as a dangling cell, not
+        // a blackbox module, so it must be found via the cell scan.
+        let hier = r#"{
+          "modules": {
+            "top": {
+              "cells": {
+                "u_state_regs": { "type": "prim_sparse_fsm_flop_B4CDB_707CE" },
+                "an_and": { "type": "$and" },
+                "u_sub": { "type": "defined_sub" }
+              }
+            },
+            "defined_sub": { "cells": {} }
+          }
+        }"#;
+        let found = parse_undefined_module_cells(hier);
+        assert_eq!(
+            found,
+            vec!["prim_sparse_fsm_flop".to_string()],
+            "only the undefined, non-builtin, de-mangled cell type is reported"
+        );
+    }
+
+    #[test]
+    fn parse_undefined_module_cells_empty_for_self_contained() {
+        let hier = r#"{"modules":{"top":{"cells":{"a":{"type":"$dff"},"b":{"type":"sub"}}},"sub":{"cells":{}}}}"#;
+        assert!(parse_undefined_module_cells(hier).is_empty());
     }
 }

--- a/docker/Dockerfile.sva
+++ b/docker/Dockerfile.sva
@@ -1,0 +1,64 @@
+# SVA-verification validation image — extends `mununu-dev` with the external
+# SystemVerilog toolchain (slang + sv2v + yosys) so the slang-gated
+# `verify-auto` / `extract-sva` e2e tests (normally `#[ignore]`d because the
+# tools are contributor-installed, not bundled) can run end-to-end. The Rust
+# toolchain, libz3 (linked), and the cargo cache volume all come from
+# `mununu-dev`; this image only adds the EDA front-ends.
+#
+# Why a separate image: per the project's "subprocess tools are not bundled"
+# policy, slang/sv2v/yosys stay out of `mununu-dev` (the build/test image). This
+# image is opt-in, for reproducing the SVA e2e validation on any host (including
+# Intel macOS, where slang ships no native prebuilt — this Linux/x86_64 image
+# runs natively there).
+#
+# Build (mununu-dev must exist first — see docs/dev-container.md):
+#   docker build -f docker/Dockerfile.dev -t mununu-dev .
+#   docker build -f docker/Dockerfile.sva -t mununu-sva .
+#
+# Run the slang-gated e2e tests (mount source + warm cargo cache volume):
+#   docker volume create mununu-target   # once
+#   docker run --rm -v "$(pwd)":/work -v mununu-target:/cargo-target \
+#     mununu-sva cargo test -p mununu-core --lib --all-features -- --ignored
+FROM mununu-dev:latest
+
+# Pin the toolchain versions for reproducibility.
+ARG SLANG_VERSION=v11.0
+ARG SV2V_VERSION=v0.0.13
+
+# libz3-dev (z3-sys links system libz3; some base images predate
+# `mununu-dev`'s libz3-dev layer, so install it here too) + unzip for the
+# sv2v release archive. yosys comes from oss-cad-suite below — the Debian
+# `yosys` package (0.23) is too old for the lift's `cutpoint -blackbox`.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libz3-dev \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# yosys (recent, with `cutpoint -blackbox`) from the sibling RTL image's
+# oss-cad-suite. Reuses the locally-built `hw-verif:latest` (the same
+# toolchain `target-executor` uses for Verilator) rather than re-downloading
+# the ~1GB suite. The binaries are self-contained (rpath to its own lib), so
+# only PATH needs prepending — no global LD_LIBRARY_PATH (which would shadow
+# the system libz3 the Rust binary loads).
+COPY --from=hw-verif:latest /opt/oss-cad-suite /opt/oss-cad-suite
+ENV PATH="/opt/oss-cad-suite/bin:${PATH}"
+
+# slang (SystemVerilog elaboration → --ast-json) — Linux x86_64 prebuilt.
+RUN curl -fsSL -o /tmp/slang.tar.gz \
+        "https://github.com/MikePopoloski/slang/releases/download/${SLANG_VERSION}/slang-linux-x86_64.tar.gz" \
+    && mkdir -p /tmp/slang && tar xzf /tmp/slang.tar.gz -C /tmp/slang \
+    && find /tmp/slang -name slang -type f -exec cp {} /usr/local/bin/slang \; \
+    && chmod +x /usr/local/bin/slang \
+    && rm -rf /tmp/slang /tmp/slang.tar.gz \
+    && slang --version
+
+# sv2v (SystemVerilog-2017 → Verilog-2005 normaliser) — Linux prebuilt.
+RUN curl -fsSL -o /tmp/sv2v.zip \
+        "https://github.com/zachjs/sv2v/releases/download/${SV2V_VERSION}/sv2v-Linux.zip" \
+    && mkdir -p /tmp/sv2v && unzip -q /tmp/sv2v.zip -d /tmp/sv2v \
+    && find /tmp/sv2v -name sv2v -type f -exec cp {} /usr/local/bin/sv2v \; \
+    && chmod +x /usr/local/bin/sv2v \
+    && rm -rf /tmp/sv2v /tmp/sv2v.zip \
+    && sv2v --version
+
+WORKDIR /work


### PR DESCRIPTION
## What

Answers "does verify-auto prove the csrng SVA end-to-end, and how many?" with a **reproducible measurement**, plus the diagnostic improvement it motivated.

### Validation infra
- `docker/Dockerfile.sva` — extends `mununu-dev` with pinned **slang v11 + sv2v v0.0.13 + yosys 0.60** (oss-cad-suite, COPYed from the sibling `hw-verif` image; Debian's yosys 0.23 lacks the lift's `cutpoint -blackbox`) + `libz3-dev`. Runs natively on x86_64 hosts — incl. Intel macOS, where slang ships no native prebuilt.
- `e2e_csrng_real_sva_verdict_breakdown` — reads only vendored fixtures (csrng from M.2 + standard prim_assert macros from M.0) and prints the verdict breakdown.
- CLAUDE.md §"SVA-verification e2e validation (slang)" — how to build + run.

### Measured csrng answer (in the `mununu-sva` image)
```
translated: 2   unsupported: 0
diagnostics: state_registers=0  blackboxed=["prim_sparse_fsm_flop"]  gated_resets=["rst_ni=1"]
HOLDS=0 VIOLATED=0 UNKNOWN=0 SKIPPED=2
```
- **2/2 real OpenTitan ASSERTs translate** (`$stable`, `|=>`, `|->`, enum `MainSmError`→41, disable-iff).
- **reset-gating fires** (the disable-iff `rst_ni` is recognized + pinned).
- **0/2 reach a definite verdict** — the FSM `state_q` is cut (`prim_sparse_fsm_flop` has no body), so the lift has no state registers.

### Diagnostic improvement (motivated by the measurement)
`blackboxed_modules` previously only caught Yosys `(* blackbox *)` modules — it missed the dominant cut: an **undefined-module cell** (yosys leaves `prim_sparse_fsm_flop` as a dangling cell, never a blackbox module). New `parse_undefined_module_cells` + sv2v-suffix de-mangling fold it into the diagnostic, so the SKIP now reads:

> *"prim_sparse_fsm_flop instantiated with no body — registers they drive are not modeled as state. Provide the missing module source(s)."*

instead of the vaguer "no state registers".

## Net

Translation of real OpenTitan csrng SVA is **proven end-to-end**; the automated *verdict* is honestly blocked on prim-flop-cut handling (provide `prim_sparse_fsm_flop.sv` / conditional cutpoint — multi-session, OpenTitan-specific), now a **named, actionable** gap. The plain-FSM e2e (HOLDS/VIOLATED) and the reset-gating SKIP→HOLDS e2e both pass, confirming verify-auto produces definite verdicts when the FSM survives the lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)