### PR TITLE
feat(H-track): bind real-RTL state atoms in verify-auto (H.A + H.C)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1185,6 +1185,11 @@ struct SvVerifyAutoArgs {
     /// reset is pinned inactive so the running design is verified).
     #[arg(long = "no-gate-reset")]
     no_gate_reset: bool,
+    /// Disable auto-injection of behavioral stubs for cut flop primitives
+    /// (e.g. OpenTitan's `prim_sparse_fsm_flop`). By default a cut flop is
+    /// stubbed so its register survives the lift; pass this to leave it cut.
+    #[arg(long = "no-auto-stub-flops")]
+    no_auto_stub_flops: bool,
     /// Print a JSON report instead of the human-readable summary.
     #[arg(long)]
     json: bool,
@@ -2201,6 +2206,7 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         max_iterations: args.max_iterations,
         must_edge_inference,
         gate_reset: !args.no_gate_reset,
+        auto_stub_flops: !args.no_auto_stub_flops,
     };
 
     let report = verify_auto(&sources, &yopts, &opts)
@@ -2245,6 +2251,12 @@ fn render_verify_auto_text(report: &mununu_core::adapter::slang::verify_auto::Au
         println!(
             "  black-boxed (cut to free inputs — provide source to model): {}",
             report.diagnostics.blackboxed_modules.join(", ")
+        );
+    }
+    if !report.diagnostics.auto_provided_stubs.is_empty() {
+        println!(
+            "  auto-stubbed flop primitives (behavioral model injected): {}",
+            report.diagnostics.auto_provided_stubs.join(", ")
         );
     }
     if !report.diagnostics.gated_resets.is_empty() {
@@ -2312,6 +2324,7 @@ fn render_verify_auto_json(report: &mununu_core::adapter::slang::verify_auto::Au
             "state_register_count": report.diagnostics.state_register_count,
             "blackboxed_modules": report.diagnostics.blackboxed_modules,
             "gated_resets": report.diagnostics.gated_resets,
+            "auto_provided_stubs": report.diagnostics.auto_provided_stubs,
         },
     });
     println!(

--- a/crates/mununu-core/src/adapter/btor2/parser.rs
+++ b/crates/mununu-core/src/adapter/btor2/parser.rs
@@ -565,6 +565,105 @@ pub fn resolve_state_by_symbol(file: &Btor2File, symbol: &str) -> Option<Nid> {
     best.map(|(nid, _)| nid)
 }
 
+/// H.A — resolve a signal name to the state cell it is a **value-identical
+/// alias** of, or `None` when it is not such an alias.
+///
+/// Stricter than [`resolve_state_by_symbol`], which finds *any* state in the
+/// signal's cone. A combinational function of state (an `eq`/`or` output flag
+/// such as `main_sm_err_o`) is in a state's cone but is NOT value-equal to it,
+/// so binding it to the state's value yields a spurious verdict. This resolver
+/// follows only value-preserving edges and returns `None` for anything else,
+/// so the verify-auto seeder binds a name only when reading the state cell's
+/// value is correct.
+///
+/// Followed edges:
+/// - the state itself; an `output` of a passthrough; `uext`/`sext` by 0 (a
+///   Yosys rename);
+/// - when `allow_reset_mux` is set, an `ite(cond, A, B)` where exactly one of
+///   `A`/`B` resolves to a state via passthrough and the other is a constant —
+///   the async-reset register mux that `async2sync` emits (`q = !rst ? state :
+///   resetval`). The constant (reset-value) branch is taken only during reset,
+///   which the verify-auto path pins inactive, so the register's value equals
+///   the state then. Pass `false` when the reset is not pinned.
+pub fn resolve_state_alias(file: &Btor2File, symbol: &str, allow_reset_mux: bool) -> Option<Nid> {
+    let start = file.lines.iter().find_map(|l| match &l.node {
+        Node::State {
+            symbol: Some(s), ..
+        }
+        | Node::Op {
+            symbol: Some(s), ..
+        }
+        | Node::Output {
+            symbol: Some(s), ..
+        } if s == symbol => Some(l.nid),
+        _ => None,
+    })?;
+    let mut visited = std::collections::HashSet::new();
+    follow_state_alias(file, start, allow_reset_mux, &mut visited)
+}
+
+fn follow_state_alias(
+    file: &Btor2File,
+    nid: Nid,
+    allow_reset_mux: bool,
+    visited: &mut std::collections::HashSet<Nid>,
+) -> Option<Nid> {
+    use crate::adapter::btor2::ast::Op;
+    if !visited.insert(nid) {
+        return None;
+    }
+    let line = file.lookup(nid)?;
+    match &line.node {
+        Node::State { .. } => Some(nid),
+        Node::Output { signal, .. } => {
+            follow_state_alias(file, signal.nid(), allow_reset_mux, visited)
+        }
+        Node::Op { op, args, .. } => match op {
+            // `uext`/`sext` by 0 = a pure rename (same width, same value).
+            Op::Uext | Op::Sext if line.immediates.first() == Some(&0) && args.len() == 1 => {
+                follow_state_alias(file, args[0].nid(), allow_reset_mux, visited)
+            }
+            // Async-reset register mux: exactly one branch is the state (via
+            // passthrough), the other a constant (the reset value).
+            Op::Ite if allow_reset_mux && args.len() == 3 => {
+                let then_nid = args[1].nid();
+                let else_nid = args[2].nid();
+                let then_state =
+                    follow_state_alias(file, then_nid, allow_reset_mux, &mut visited.clone());
+                let else_state =
+                    follow_state_alias(file, else_nid, allow_reset_mux, &mut visited.clone());
+                match (then_state, else_state) {
+                    (Some(s), None) if resolves_to_const(file, else_nid) => Some(s),
+                    (None, Some(s)) if resolves_to_const(file, then_nid) => Some(s),
+                    _ => None,
+                }
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// True when `nid` is a constant, or a `uext`/`sext`-by-0 passthrough of one
+/// (the shape `async2sync` gives a reset value).
+fn resolves_to_const(file: &Btor2File, nid: Nid) -> bool {
+    use crate::adapter::btor2::ast::Op;
+    match file.lookup(nid).map(|l| (&l.node, l)) {
+        Some((Node::Const { .. }, _)) => true,
+        Some((
+            Node::Op {
+                op: Op::Uext | Op::Sext,
+                args,
+                ..
+            },
+            l,
+        )) if l.immediates.first() == Some(&0) && args.len() == 1 => {
+            resolves_to_const(file, args[0].nid())
+        }
+        _ => false,
+    }
+}
+
 /// BFS backward from a set of starting operands until a `State` node
 /// is reached. Returns `(state_nid, distance)` where `distance`
 /// counts Op hops (starting at 1 for direct operands of the seed).
@@ -814,6 +913,34 @@ mod tests {
                    5 ite 1 2 4 3\n6 output 5 tx\n";
         let file = parse(src).expect("parse");
         assert_eq!(resolve_state_by_symbol(&file, "tx"), Some(4));
+    }
+
+    #[test]
+    fn resolve_state_alias_follows_reset_mux_and_uext0() {
+        // bit_cnt_q = uext-0(ite(rst_n, state5, const3)) — the async-reset
+        // register mux + a Yosys `uext _ _ 0` rename, the shape `async2sync`
+        // emits. It is value-identical to state 5 while reset is inactive.
+        let src = "1 sort bitvec 1\n2 sort bitvec 4\n3 const 2 0000\n4 input 1 rst_n\n\
+                   5 state 2\n6 ite 2 4 5 3\n7 uext 2 6 0 bit_cnt_q\n";
+        let file = parse(src).expect("parse");
+        // Reset-mux following on (reset pinned): resolves to the state.
+        assert_eq!(resolve_state_alias(&file, "bit_cnt_q", true), Some(5));
+        // Reset-mux following off: the `ite` is not a pure passthrough → None.
+        assert_eq!(resolve_state_alias(&file, "bit_cnt_q", false), None);
+    }
+
+    #[test]
+    fn resolve_state_alias_rejects_combinational_function() {
+        // err_o = output(eq(state, const)) — a combinational FUNCTION of state,
+        // not a value-identical alias. `resolve_state_alias` must return None
+        // (binding it to the state's value would be a spurious verdict — the
+        // csrng `main_sm_err_o` soundness case), even though the looser
+        // `resolve_state_by_symbol` finds the state in its cone.
+        let src = "1 sort bitvec 1\n2 sort bitvec 4\n3 const 2 0101\n\
+                   4 state 2\n5 eq 1 4 3\n6 output 5 err_o\n";
+        let file = parse(src).expect("parse");
+        assert_eq!(resolve_state_alias(&file, "err_o", true), None);
+        assert_eq!(resolve_state_by_symbol(&file, "err_o"), Some(4));
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/slang/mod.rs
+++ b/crates/mununu-core/src/adapter/slang/mod.rs
@@ -25,6 +25,7 @@ use std::process::Command;
 use crate::adapter::{AdapterError, AdapterErrorKind};
 
 pub mod extract;
+pub mod prim_stubs;
 pub mod translate;
 pub mod verify_auto;
 

--- a/crates/mununu-core/src/adapter/slang/prim_stubs.rs
+++ b/crates/mununu-core/src/adapter/slang/prim_stubs.rs
@@ -1,0 +1,117 @@
+//! H.C — behavioral stubs for OpenTitan flop primitives, auto-injected by
+//! [`verify_auto`](crate::adapter::slang::verify_auto) when the lift reports the
+//! corresponding module was cut (instantiated with no body).
+//!
+//! OpenTitan wraps registers in `prim_flop`-family primitives whose bodies are
+//! not in a single-module source set. Yosys then leaves them as dangling
+//! undefined-module cells and the register vanishes from the lift (the csrng
+//! `prim_sparse_fsm_flop` case). These stubs model the **verification-relevant**
+//! behavior — an async-reset register whose output is the registered input —
+//! and intentionally drop the security hardening (sparse-encoding alerts), which
+//! is orthogonal to functional/temporal properties over the registered state.
+//!
+//! **Soundness.** Each stub is an *exact* behavioral model of the flop's
+//! datapath (`state_o`/`q_o` = the async-reset register of `state_i`/`d_i`); it
+//! adds a real register, never an abstraction. The dropped hardening only
+//! removes alert side-channels, not the registered value the SVA reasons about.
+//! Auto-injection is reported in the verify-auto diagnostics so it is never
+//! silent.
+
+/// Behavioral `prim_sparse_fsm_flop` — the OpenTitan FSM-state flop. Interface
+/// matches the `PRIM_FLOP_SPARSE_FSM` macro's non-SIMULATION instantiation
+/// (`crates/.../prim_flop_macros.sv`): params `StateEnumT/Width/ResetValue/
+/// EnableAlertTriggerSVA`, ports `clk_i/rst_ni/state_i/state_o`.
+const PRIM_SPARSE_FSM_FLOP: &str = r#"// Auto-injected behavioral model (mununu verify-auto H.C). Models the
+// registered datapath of OpenTitan's prim_sparse_fsm_flop; drops the
+// sparse-encoding security hardening (orthogonal to FSM-state properties).
+module prim_sparse_fsm_flop #(
+  parameter type               StateEnumT            = logic,
+  parameter int                Width                 = 1,
+  parameter logic [Width-1:0]  ResetValue            = '0,
+  parameter bit                EnableAlertTriggerSVA = 1
+) (
+  input  logic             clk_i,
+  input  logic             rst_ni,
+  input  logic [Width-1:0] state_i,
+  output logic [Width-1:0] state_o
+);
+  logic [Width-1:0] state_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) state_q <= ResetValue;
+    else         state_q <= state_i;
+  end
+  assign state_o = state_q;
+endmodule
+"#;
+
+/// Behavioral `prim_flop` — the plain OpenTitan register primitive. Interface
+/// matches the `PRIM_FLOP` macro: params `Width/ResetValue`, ports
+/// `clk_i/rst_ni/d_i/q_o`.
+const PRIM_FLOP: &str = r#"// Auto-injected behavioral model (mununu verify-auto H.C). Models the
+// registered datapath of OpenTitan's prim_flop.
+module prim_flop #(
+  parameter int               Width      = 1,
+  parameter logic [Width-1:0] ResetValue = '0
+) (
+  input  logic             clk_i,
+  input  logic             rst_ni,
+  input  logic [Width-1:0] d_i,
+  output logic [Width-1:0] q_o
+);
+  logic [Width-1:0] q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) q <= ResetValue;
+    else         q <= d_i;
+  end
+  assign q_o = q;
+endmodule
+"#;
+
+/// The behavioral stub SV for a known flop-primitive module, or `None` if there
+/// is no stub for `module_name`. `module_name` is the de-mangled module name
+/// (sv2v's `_<HEX>_<HEX>` parameter suffix already stripped — see
+/// [`crate::adapter::yosys`]'s undefined-cell detection).
+pub fn behavioral_stub(module_name: &str) -> Option<&'static str> {
+    match module_name {
+        "prim_sparse_fsm_flop" => Some(PRIM_SPARSE_FSM_FLOP),
+        "prim_flop" => Some(PRIM_FLOP),
+        _ => None,
+    }
+}
+
+/// For a set of cut (undefined-body) module names, return the
+/// `(file_name, stub_sv)` sources to inject for those that have a behavioral
+/// stub. The file name is `<module>.sv`. Deterministic order (sorted by name).
+pub fn stubs_for_cut_modules(cut: &[String]) -> Vec<(String, String)> {
+    let mut names: Vec<&String> = cut.iter().collect();
+    names.sort();
+    names.dedup();
+    names
+        .into_iter()
+        .filter_map(|m| behavioral_stub(m).map(|sv| (format!("{m}.sv"), sv.to_string())))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_flop_primitives_have_stubs() {
+        assert!(behavioral_stub("prim_sparse_fsm_flop").is_some());
+        assert!(behavioral_stub("prim_flop").is_some());
+        assert!(behavioral_stub("some_user_module").is_none());
+    }
+
+    #[test]
+    fn stubs_for_cut_modules_filters_and_names() {
+        let cut = vec![
+            "prim_sparse_fsm_flop".to_string(),
+            "user_blackbox".to_string(),
+        ];
+        let stubs = stubs_for_cut_modules(&cut);
+        assert_eq!(stubs.len(), 1, "only the known prim is stubbed");
+        assert_eq!(stubs[0].0, "prim_sparse_fsm_flop.sv");
+        assert!(stubs[0].1.contains("module prim_sparse_fsm_flop"));
+    }
+}

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -87,6 +87,12 @@ pub struct ModelDiagnostics {
     /// from the formulas). Empty when reset-gating is off or no `disable iff`
     /// reset was recognized. Each entry is `"<signal>=<inactive_value>"`.
     pub gated_resets: Vec<String>,
+    /// Flop-primitive modules that were cut (instantiated with no body) and for
+    /// which verify-auto auto-injected a behavioral stub so the register
+    /// survives the lift (H.C — e.g. OpenTitan's `prim_sparse_fsm_flop`). The
+    /// stub is an exact behavioral model of the flop datapath; auto-injection is
+    /// reported here so it is never silent.
+    pub auto_provided_stubs: Vec<String>,
 }
 
 /// Result of an automated SVA verification run.
@@ -143,6 +149,14 @@ pub struct VerifyAutoOptions {
     /// SVA, so it is on by default; set `false` to keep the guard and leave
     /// the reset free.
     pub gate_reset: bool,
+    /// When `true` (default), if the first lift cuts a known flop primitive
+    /// (instantiated with no body — e.g. OpenTitan's `prim_sparse_fsm_flop`),
+    /// verify-auto injects a behavioral stub for it and re-lifts, so the
+    /// register survives and its state atoms become bindable (H.C). The stub is
+    /// an exact behavioral model of the flop datapath; the auto-injection is
+    /// reported in `diagnostics.auto_provided_stubs`. Set `false` to leave cut
+    /// flops cut (reported in `blackboxed_modules`).
+    pub auto_stub_flops: bool,
 }
 
 impl Default for VerifyAutoOptions {
@@ -151,6 +165,7 @@ impl Default for VerifyAutoOptions {
             max_iterations: 16,
             must_edge_inference: MustEdgeInference::Off,
             gate_reset: true,
+            auto_stub_flops: true,
         }
     }
 }
@@ -167,9 +182,16 @@ struct Seeded {
 
 /// The minimal H.1 — derive cube predicates from a formula's `Node::Predicate`
 /// atoms. Each predicate is named exactly the atom string (so the evaluator's
-/// name-match binds the atom to its cube bit). An atom whose registers are not
-/// all in `state_cells` is recorded as unseedable.
-fn seed_from_formula(formula: &Formula, state_cells: &HashSet<String>) -> Seeded {
+/// name-match binds the atom to its cube bit). An atom whose registers do not
+/// all resolve to a state cell (per `is_state`) is recorded as unseedable.
+///
+/// `is_state(name)` returns true when `name` resolves to a lifted state cell —
+/// either directly (the symbol is on a `state` line) or via the BTOR2
+/// alias-resolution BFS (H.A: a `uext`/`Output` alias whose register Yosys'
+/// `flatten` left unnamed on the `state` line). The lift's
+/// `resolve_predicate_registers` canonicalises the same alias, so a name the
+/// seeder accepts here also binds downstream.
+fn seed_from_formula(formula: &Formula, is_state: impl Fn(&str) -> bool) -> Seeded {
     let mut out = Seeded::default();
     let mut seen: HashSet<&str> = HashSet::new();
     for node in formula.nodes() {
@@ -181,7 +203,7 @@ fn seed_from_formula(formula: &Formula, state_cells: &HashSet<String>) -> Seeded
         }
         match parse_predicate_expr(atom) {
             Ok(expr) => {
-                if expr.registers().iter().any(|r| !state_cells.contains(r)) {
+                if expr.registers().iter().any(|r| !is_state(r)) {
                     out.unseedable.push(atom.clone());
                     continue;
                 }
@@ -203,7 +225,7 @@ fn seed_from_formula(formula: &Formula, state_cells: &HashSet<String>) -> Seeded
             // A bare identifier atom (`parse_predicate_expr` needs an operator):
             // a 1-bit boolean signal `sig` ≡ `sig == 1`. Seedable iff a state cell.
             Err(_) => {
-                if state_cells.contains(atom) {
+                if is_state(atom) {
                     out.specs.push(PredicateSpec {
                         name: atom.clone(),
                         register: atom.clone(),
@@ -375,11 +397,33 @@ pub fn verify_auto(
     // lift also reports modules it black-boxed (instantiated, no body) — those
     // are surfaced in `diagnostics.blackboxed_modules` so a cut FSM (the
     // `prim_sparse_fsm_flop`-class root cause) is visible, not silent.
-    let (btor2, blackboxed_modules) = sv_to_btor2_with_blackboxes(primary_content, yosys_opts)
-        .map_err(|mut e| {
+    let (mut btor2, mut blackboxed_modules) =
+        sv_to_btor2_with_blackboxes(primary_content, yosys_opts).map_err(|mut e| {
             e.message = format!("verify_auto: SV → BTOR2: {}", e.message);
             e
         })?;
+    // H.C — if the first lift cut a known flop primitive, inject a behavioral
+    // stub for it and re-lift so the register survives (e.g. OpenTitan's
+    // `prim_sparse_fsm_flop`). Only stubs ACTUALLY-cut modules (no collision
+    // with designs that provide their own body).
+    if opts.auto_stub_flops {
+        let stubs = crate::adapter::slang::prim_stubs::stubs_for_cut_modules(&blackboxed_modules);
+        if !stubs.is_empty() {
+            let mut yopts2 = yosys_opts.clone();
+            yopts2.additional_sources.extend(stubs.iter().cloned());
+            let (b2, bb2) =
+                sv_to_btor2_with_blackboxes(primary_content, &yopts2).map_err(|mut e| {
+                    e.message = format!("verify_auto: SV → BTOR2 (with flop stubs): {}", e.message);
+                    e
+                })?;
+            btor2 = b2;
+            blackboxed_modules = bb2;
+            report.diagnostics.auto_provided_stubs = stubs
+                .iter()
+                .map(|(name, _)| name.trim_end_matches(".sv").to_string())
+                .collect();
+        }
+    }
     report.diagnostics.blackboxed_modules = blackboxed_modules;
     // Augment only the `__past` shadows whose base resolves to a BTOR2 state
     // cell. A base the lift renamed away (the SVA name not matching the lifted
@@ -431,6 +475,21 @@ pub fn verify_auto(
     // design's reset state (else it defaults to cube_0 = all-predicates-false).
     let init_values = state_cell_init_values(&file);
 
+    // H.A — a name is cube-bindable if it is a state-cell symbol directly OR a
+    // value-identical alias of one (`resolve_state_alias`): a `uext`/`sext`-0
+    // rename, or the async-reset register mux that `async2sync` puts around the
+    // state (e.g. `state_q` over the auto-stubbed flop). The strict resolver
+    // rejects combinational *functions* of state (an `eq`/`or` output like
+    // `main_sm_err_o`) — binding those to the state's value would be a spurious
+    // verdict. The reset-mux edge is followed only when the reset is pinned
+    // (gated_resets non-empty), which makes the register value equal the state.
+    let reset_pinned = !report.diagnostics.gated_resets.is_empty();
+    let resolves_to_state = |name: &str| -> bool {
+        state_cells.contains(name)
+            || crate::adapter::btor2::parser::resolve_state_alias(&file, name, reset_pinned)
+                .is_some()
+    };
+
     // 4. Per property: seed → CEGAR → verdict.
     for t in &extraction.translated {
         let formula = match mu_parser::parse(&t.formula) {
@@ -449,7 +508,7 @@ pub fn verify_auto(
             }
         };
 
-        let seeded = seed_from_formula(&formula, &state_cells);
+        let seeded = seed_from_formula(&formula, resolves_to_state);
         if !seeded.unseedable.is_empty() {
             let reason = unseedable_skip_reason(&seeded.unseedable, &report.diagnostics);
             report.properties.push(PropertyVerdict {
@@ -597,7 +656,7 @@ mod tests {
     fn seeds_simple_state_predicate() {
         // `nu X. ((state == 5) && [] X)` over a state cell → one simple spec.
         let f = mu_parser::parse("nu X. ((state == 5) && [] X)").unwrap();
-        let s = seed_from_formula(&f, &cells(&["state"]));
+        let s = seed_from_formula(&f, |n| cells(&["state"]).contains(n));
         assert_eq!(s.specs.len(), 1, "one simple reg==val spec");
         assert_eq!(s.specs[0].name, "state == 5");
         assert_eq!(s.specs[0].register, "state");
@@ -610,7 +669,7 @@ mod tests {
     fn seeds_relational_predicate_as_compound() {
         // `$stable` shape: `state == state__past` → a compound (REL), both state cells.
         let f = mu_parser::parse("nu X. ((state == state__past) && [] X)").unwrap();
-        let s = seed_from_formula(&f, &cells(&["state", "state__past"]));
+        let s = seed_from_formula(&f, |n| cells(&["state", "state__past"]).contains(n));
         assert!(s.specs.is_empty(), "relational atom is not a simple spec");
         assert_eq!(s.compounds.len(), 1, "one compound (relational) predicate");
         assert_eq!(s.compounds[0].0, "state == state__past");
@@ -634,7 +693,7 @@ mod tests {
     fn gates_atoms_over_non_state_signals() {
         // `gnt_o != 0` and `ready_i` over IO signals (not state cells) → unseedable.
         let f = mu_parser::parse("nu X. (((gnt_o != 0) || ready_i) && [] X)").unwrap();
-        let s = seed_from_formula(&f, &cells(&["state_q"])); // neither IO signal is a state cell
+        let s = seed_from_formula(&f, |n| cells(&["state_q"]).contains(n)); // neither IO signal is a state cell
         assert!(
             s.unseedable.contains(&"gnt_o != 0".to_string()),
             "IO comparison atom must be unseedable; got {:?}",
@@ -650,7 +709,7 @@ mod tests {
     #[test]
     fn bare_one_bit_state_signal_seeds_eq_one() {
         let f = mu_parser::parse("nu X. (busy && [] X)").unwrap();
-        let s = seed_from_formula(&f, &cells(&["busy"]));
+        let s = seed_from_formula(&f, |n| cells(&["busy"]).contains(n));
         assert_eq!(s.specs.len(), 1);
         assert_eq!(s.specs[0].name, "busy");
         assert_eq!(s.specs[0].value, 1, "bare boolean state signal ≡ sig == 1");
@@ -664,6 +723,7 @@ mod tests {
             state_register_count: 0,
             blackboxed_modules: vec!["prim_sparse_fsm_flop".to_string()],
             gated_resets: Vec::new(),
+            auto_provided_stubs: Vec::new(),
         };
         let reason = unseedable_skip_reason(&["state_q == 41".to_string()], &diag);
         assert!(reason.contains("state_q == 41"), "carries the symptom");
@@ -683,6 +743,7 @@ mod tests {
             state_register_count: 0,
             blackboxed_modules: Vec::new(),
             gated_resets: Vec::new(),
+            auto_provided_stubs: Vec::new(),
         };
         let reason = unseedable_skip_reason(&["foo == 1".to_string()], &diag);
         assert!(
@@ -698,6 +759,7 @@ mod tests {
             state_register_count: 3,
             blackboxed_modules: Vec::new(),
             gated_resets: Vec::new(),
+            auto_provided_stubs: Vec::new(),
         };
         let reason = unseedable_skip_reason(&["gnt_o != 0".to_string()], &diag);
         assert!(reason.contains("gnt_o != 0"));
@@ -858,36 +920,72 @@ mod tests {
             }
         }
         eprintln!("HOLDS={holds} VIOLATED={violated} UNKNOWN={unknown} SKIPPED={skipped}");
+        eprintln!(
+            "auto_provided_stubs: {:?}",
+            report.diagnostics.auto_provided_stubs
+        );
         for (n, r) in &report.unsupported {
             eprintln!("  unsupported {n}: {r}");
         }
 
-        // Honest invariant: the real OpenTitan SVA is in-fragment and
-        // translates (the `$stable` / `|=>` / `|->` + enum + disable-iff forms).
-        // Whether a property reaches a DEFINITE verdict depends on whether its
-        // state survives the lift — the diagnostics above attribute any SKIP.
         assert!(
             report.properties.len() >= 2,
             "both csrng ASSERTs (CsrngMainErrorStStable_A, CsrngMainErrorOutput_A) translate"
         );
-        // The csrng FSM is wrapped in `prim_sparse_fsm_flop` (body not in the
-        // source set), so it is cut and the lift has no state registers. The
-        // diagnostic must NAME the cut module (undefined-module-cell detection)
-        // rather than only reporting "no state registers" — that is the
-        // actionable root cause (provide the flop's source).
+        // H.C — the FSM's `prim_sparse_fsm_flop` (no body in the source set) is
+        // auto-stubbed with a behavioral model, so it is NO LONGER reported as
+        // cut and the state register survives.
         assert!(
             report
                 .diagnostics
-                .blackboxed_modules
+                .auto_provided_stubs
                 .iter()
                 .any(|m| m.contains("prim_sparse_fsm_flop")),
-            "the cut prim_sparse_fsm_flop should be named in diagnostics; got {:?}",
+            "prim_sparse_fsm_flop should be auto-stubbed; got stubs={:?} blackboxed={:?}",
+            report.diagnostics.auto_provided_stubs,
             report.diagnostics.blackboxed_modules
+        );
+        assert!(
+            report.diagnostics.state_register_count >= 1,
+            "with the flop stubbed, the FSM state register survives; got {}",
+            report.diagnostics.state_register_count
         );
         // Reset-gating fires on the macro's `disable iff (rst_ni)`.
         assert_eq!(
             report.diagnostics.gated_resets,
             vec!["rst_ni=1".to_string()]
+        );
+        // H.A — `state_q` (a `uext`-0 alias of the async-reset register mux)
+        // now binds, so the pure-state `$stable` property reaches a verdict
+        // instead of SKIP. (Here ⊥: the auto-seeded predicate set is too coarse
+        // to decide `state_q==Error |=> $stable(state_q)`.)
+        assert!(
+            report.properties.iter().any(|p| {
+                p.formula.contains("state_q == state_q__past")
+                    && !matches!(p.outcome, VerifyOutcome::Skipped { .. })
+            }),
+            "the $stable state property should bind + reach a verdict; got {:?}",
+            report
+                .properties
+                .iter()
+                .map(|p| &p.outcome)
+                .collect::<Vec<_>>()
+        );
+        // SOUNDNESS — no spurious counterexample. A combinational output like
+        // `main_sm_err_o` must NOT be mis-bound to the state register (which
+        // would wrongly report VIOLATED); the strict alias resolver excludes it,
+        // so it is honestly SKIPPED instead.
+        assert!(
+            !report
+                .properties
+                .iter()
+                .any(|p| matches!(p.outcome, VerifyOutcome::Violated { .. })),
+            "no spurious VIOLATED from over-resolving a combinational output; got {:?}",
+            report
+                .properties
+                .iter()
+                .map(|p| &p.outcome)
+                .collect::<Vec<_>>()
         );
     }
 
@@ -991,6 +1089,32 @@ mod tests {
             report.diagnostics.blackboxed_modules.is_empty(),
             "no prim_flop primitive to cut; got {:?}",
             report.diagnostics.blackboxed_modules
+        );
+        // H.A — the state atoms (`state_q == k`, `cnt_q == k`) now BIND (via the
+        // value-alias resolver), so they no longer appear in any SKIP reason;
+        // only the genuine IO/config antecedents (`cfg_enable_i`, `trigger_*`,
+        // `cnt_clr`, `event_detected_*`) remain unbindable (the H.B frontier).
+        for p in &report.properties {
+            if let VerifyOutcome::Skipped { reason } = &p.outcome {
+                assert!(
+                    !reason.contains("state_q ==") && !reason.contains("cnt_q =="),
+                    "state atoms should bind, not appear in a SKIP reason; got: {reason}"
+                );
+            }
+        }
+        // SOUNDNESS — no spurious counterexample (combinational outputs like
+        // `event_detected_o` are excluded by the strict resolver, not mis-bound).
+        assert!(
+            !report
+                .properties
+                .iter()
+                .any(|p| matches!(p.outcome, VerifyOutcome::Violated { .. })),
+            "no spurious VIOLATED; got {:?}",
+            report
+                .properties
+                .iter()
+                .map(|p| &p.outcome)
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -773,6 +773,7 @@ pub async fn sv_verify_auto_handler(
         max_iterations: request.max_iterations.unwrap_or(16),
         must_edge_inference,
         gate_reset: request.gate_reset.unwrap_or(true),
+        auto_stub_flops: request.auto_stub_flops.unwrap_or(true),
     };
 
     let report = verify_auto(&sources, &yopts, &opts).map_err(|e| ApiError::BadRequest {
@@ -830,6 +831,7 @@ pub async fn sv_verify_auto_handler(
             state_register_count: report.diagnostics.state_register_count,
             blackboxed_modules: report.diagnostics.blackboxed_modules.clone(),
             gated_resets: report.diagnostics.gated_resets.clone(),
+            auto_provided_stubs: report.diagnostics.auto_provided_stubs.clone(),
         },
     }))
 }

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1017,6 +1017,11 @@ pub struct SvVerifyAutoRequest {
     /// to keep the guard and leave the reset free.
     #[serde(default)]
     pub gate_reset: Option<bool>,
+    /// Auto-inject behavioral stubs for cut flop primitives (e.g. OpenTitan's
+    /// `prim_sparse_fsm_flop`) so the register survives the lift (default
+    /// `true`). Set `false` to leave cut flops reported as black-boxed.
+    #[serde(default)]
+    pub auto_stub_flops: Option<bool>,
 }
 
 /// Response for `/api/v1/sv/verify-auto`.
@@ -1044,6 +1049,9 @@ pub struct ModelDiagnosticsView {
     /// with their `disable iff` guards dropped from the formulas. Empty when
     /// reset-gating is off or no `disable iff` reset was recognized.
     pub gated_resets: Vec<String>,
+    /// Cut flop-primitive modules for which a behavioral stub was auto-injected
+    /// so the register survives the lift (e.g. `prim_sparse_fsm_flop`).
+    pub auto_provided_stubs: Vec<String>,
 }
 
 /// One property's auto-verification verdict (mirrors `PropertyVerdict`).


### PR DESCRIPTION
## What

Makes the no-sidecar verify-auto produce **real verdicts on OpenTitan SVA whose state was previously unbindable** — and does it **soundly**. Two coupled pieces, validated end-to-end in the `mununu-sva` image on csrng + sysrst.

### H.C — auto-stub cut flop primitives
OpenTitan wraps FSM state in `prim_sparse_fsm_flop` (no body in a single-module source set) → the lift cut it → **zero state registers** (the csrng blocker). New `adapter/slang/prim_stubs.rs` carries behavioral models of the flop datapath (async-reset register; security hardening dropped — orthogonal to the registered value). `verify_auto` detects cut primitives from the undefined-cell diagnostic and (default `auto_stub_flops`) injects the matching stub + re-lifts (two-pass; only actually-cut modules → no collision). → **csrng `state_registers` 0 → 2**, reported in `diagnostics.auto_provided_stubs`.

### H.A — value-alias resolution in the seeder
After `flatten`/`async2sync`, a register's name lands on a `uext`-0 alias of the async-reset mux, not the `state` line, so `state_q == k` atoms didn't bind. New `parser::resolve_state_alias` follows value-preserving edges (`uext`/`sext`-0, and the async-reset `ite(cond, state, resetval)` — sound because verify-auto pins the reset) to the state cell, but **rejects combinational functions of state** (an `eq`/`or` output like `main_sm_err_o`). That strictness is the **soundness gate**: binding a function-of-state to the state's value would be a spurious verdict (the loose `resolve_state_by_symbol` would have done exactly that — and did, in an intermediate run that wrongly reported VIOLATED).

## Measured (mununu-sva image)
- **csrng**: 2/2 translate; `state_q`/`$stable` atoms now bind → `sva_0` reaches a verdict (⊥ — auto-seeded predicates too coarse to prove `state_q==Error |=> $stable`); `sva_1` honestly SKIPPED on the combinational `main_sm_err_o` (**no spurious VIOLATED**).
- **sysrst**: `state_q`/`cnt_q` bind; the only remaining SKIPs are the genuine IO/config antecedents (`cfg_enable_i`, `trigger_*`, `cnt_clr`).

So real-RTL state binding works, soundly. The remaining gap to a **definite** verdict is **H.B** (IO/combinational-output atoms) + predicate-seeding depth.

## Tests / parity
- Unit tests: strict resolver (alias resolves; combinational function rejected) + stub registry.
- e2e assertions lock in state-binding + the **no-spurious-verdict** invariant.
- Surface parity: `auto_stub_flops` flag + `auto_provided_stubs` diagnostic across API + CLI (`--no-auto-stub-flops`) + UI (companion PR).
- Full `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)