### PR TITLE
feat(H-track): H.E — sound combinational-atom foundation (cone-classified)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2803,6 +2803,7 @@ fn btor2_discover(args: Btor2DiscoverArgs) -> Result<(), String> {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         }
     };
 

--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -722,15 +722,24 @@ pub fn cegar_refine_loop(
         compound_exprs.insert(spec.name.clone(), expr);
         current_predicates.push(spec);
     }
-    let effective_may = if compound_exprs.is_empty() {
-        cegar_opts.may_edge_inference
-    } else {
+    // H.E.2 — derived combinational predicates (labeled per cube via SMT, NOT
+    // cube dimensions). They do NOT go into `current_predicates` (the cube index
+    // is unchanged); the lift writes their per-cube label into
+    // `state_3valued_predicates`. Like compounds, they require the eager
+    // SmtAllPairs lift (the labeling pass is SMT-based).
+    let derived_predicates = sidecar_combinational_predicates(adapter_options);
+    // SmtAllPairs + Eager are forced when EITHER compound OR derived predicates
+    // are present (both are SMT-seam-only paths).
+    let smt_seam_required = !compound_exprs.is_empty() || !derived_predicates.is_empty();
+    let effective_may = if smt_seam_required {
         crate::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs
-    };
-    let effective_strategy = if compound_exprs.is_empty() {
-        cegar_opts.lift_strategy
     } else {
+        cegar_opts.may_edge_inference
+    };
+    let effective_strategy = if smt_seam_required {
         LiftStrategy::Eager
+    } else {
+        cegar_opts.lift_strategy
     };
     if !compound_exprs.is_empty()
         && (cegar_opts.may_edge_inference
@@ -848,6 +857,11 @@ pub fn cegar_refine_loop(
         // declared → preserves the simple-atom path). The lift honours these via
         // the SmtEncode seam's `PredicateLike::expr`.
         compound_exprs: compound_exprs.clone(),
+        // H.E.2 — derived combinational predicates parsed from the sidecar
+        // (empty when none declared). The lift labels each per cube via the
+        // SmtEncode seam's `combinational_labels` pass and writes the label into
+        // `state_3valued_predicates` (NOT a cube dimension).
+        derived_predicates: derived_predicates.clone(),
     };
 
     for iteration in 0..=cegar_opts.max_iterations {
@@ -1731,6 +1745,31 @@ pub fn sidecar_compound_predicates(
         ));
     }
     out
+}
+
+/// H.E.2 (2026-06-28) — read `combinational_predicates` from the SvAnnotation
+/// sidecar into derived-label [`PredicateSpec`]s (`name` = the formula atom,
+/// `register` = the combinational signal's symbol, `value`). The cube lift
+/// labels each per cube via the SMT `combinational_labels` pass — they are NOT
+/// cube dimensions, so they never enter `current_predicates` / the cube index.
+/// Empty when there is no sidecar or no `combinational_predicates` declared.
+pub fn sidecar_combinational_predicates(options: &AdapterOptions) -> Vec<PredicateSpec> {
+    let Some(json) = &options.sidecar_json else {
+        return Vec::new();
+    };
+    let Ok(ann) =
+        serde_json::from_str::<crate::adapter::systemverilog::annotation::SvAnnotation>(json)
+    else {
+        return Vec::new();
+    };
+    ann.combinational_predicates
+        .iter()
+        .map(|d| PredicateSpec {
+            name: d.name.clone(),
+            register: d.signal.clone(),
+            value: d.value,
+        })
+        .collect()
 }
 
 /// Parse `--config-values`-style `REG=v1,v2,...` entries into the synthetic

--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -436,6 +436,19 @@ pub struct PredicateCubeLiftOptions {
     /// Default empty preserves the pre-B.1 simple-atom behaviour exactly.
     pub compound_exprs:
         std::collections::HashMap<String, crate::adapter::btor2::predicate_expr::PredicateExpr>,
+    /// H.E.2 (combinational outputs, 2026-06-28) — **derived combinational
+    /// predicates**: `register == value` atoms whose `register` is a
+    /// *combinational node* (an `eq`/`or`/… output of state, e.g. csrng's
+    /// `main_sm_err_o`), NOT a cube dimension. Approach B
+    /// (free-input-atoms.md §4): rather than make a determined signal a free
+    /// dimension, the lift LABELS it per cube via
+    /// [`crate::adapter::sts_ir::SmtEncode::combinational_labels`] — KleeneT/F
+    /// where the cube pins it, KleeneBot where it doesn't — writing the label
+    /// into `state_3valued_predicates` (keyed by the predicate `name`, so the
+    /// evaluator binds the formula atom). These do NOT enlarge the cube space
+    /// (`2^|predicates|` is unchanged). Default empty preserves pre-H.E
+    /// behaviour.
+    pub derived_predicates: Vec<PredicateSpec>,
 }
 
 impl Default for PredicateCubeLiftOptions {
@@ -447,6 +460,7 @@ impl Default for PredicateCubeLiftOptions {
             may_edge_inference: MayEdgeInference::Off,
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         }
     }
 }
@@ -2074,6 +2088,32 @@ pub fn predicate_cube_lift(
         }
     }
 
+    // H.E.2 — derived combinational predicate labels (Approach B). A
+    // combinational atom is NOT a cube dimension; its per-cube KleeneT/F/Bot
+    // label is decided by SMT (`combinational_labels`) over the cube's dimension
+    // predicates + the signal's encoded BV, then written into
+    // `state_3valued_predicates` keyed by the predicate name (the evaluator binds
+    // the formula atom by name). Independent of the may/must edge policy; the
+    // cube space is unchanged (these are labels, not dimensions).
+    if !lift_opts.derived_predicates.is_empty() {
+        use crate::adapter::sts_ir::{BtorSts, SmtEncode};
+        let cube_preds = cube_predicates(&predicates, &lift_opts.compound_exprs);
+        let empty_exprs: std::collections::HashMap<
+            String,
+            crate::adapter::btor2::predicate_expr::PredicateExpr,
+        > = std::collections::HashMap::new();
+        let derived_cube = cube_predicates(&lift_opts.derived_predicates, &empty_exprs);
+        let labels = BtorSts::new(&file).combinational_labels(&cube_preds, &derived_cube, 5_000);
+        for (cube_idx, d_idx, label) in labels {
+            if let (Some(&sid), Some(d)) = (
+                state_ids.get(cube_idx),
+                lift_opts.derived_predicates.get(d_idx),
+            ) {
+                builder.with_3valued_predicate(sid, &d.name, label);
+            }
+        }
+    }
+
     // R.2.5 predicate-image MVP — emit MayOnly edges between cubes.
     //
     // For each cube_i, build a "canonical representative" concrete
@@ -2765,6 +2805,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, SMALL_BTOR2, &AdapterOptions::default(), &opts);
         assert!(result.is_err());
@@ -3332,6 +3373,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
 
         // Baseline: SmtAllPairs may, no must → MayOnly only, zero promotions.
@@ -3395,6 +3437,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let lifted = predicate_cube_lift(preds, toggle, &AdapterOptions::default(), &opts)
             .expect("SmtAllPairs + SmtHyperMust lift");
@@ -3453,6 +3496,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
             compound_exprs,
+            derived_predicates: Vec::new(),
         };
         let preds = vec![PredicateSpec {
             name: "idle".into(),
@@ -3491,6 +3535,7 @@ mod tests {
             // Sampling (Off) — disallowed when compounds are present.
             may_edge_inference: MayEdgeInference::Off,
             compound_exprs,
+            derived_predicates: Vec::new(),
             ..Default::default()
         };
         let preds = vec![PredicateSpec {
@@ -3529,6 +3574,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
             compound_exprs,
+            derived_predicates: Vec::new(),
         };
         let preds = vec![PredicateSpec {
             name: "stable".into(),
@@ -3677,6 +3723,7 @@ mod tests {
                     may_edge_inference: MayEdgeInference::Off,
                     config_values: std::collections::HashMap::new(),
                     compound_exprs: std::collections::HashMap::new(),
+                    derived_predicates: Vec::new(),
                 };
                 let eager = predicate_cube_lift(
                     preds.clone(),
@@ -3734,6 +3781,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::Off,
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let eager = lift_predicate_cube(
             preds.clone(),
@@ -3774,6 +3822,7 @@ mod tests {
             // Even with SmtAllPairs, Lazy can't honour compounds.
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             compound_exprs,
+            derived_predicates: Vec::new(),
             ..Default::default()
         };
         let preds = vec![PredicateSpec {
@@ -3815,6 +3864,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("ok");
@@ -3883,6 +3933,7 @@ mod tests {
 
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -3925,6 +3976,7 @@ mod tests {
 
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -3968,6 +4020,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4026,6 +4079,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4057,6 +4111,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let mut lazy =
             LazyLift::from_btor2(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
@@ -4116,6 +4171,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(
             preds.clone(),
@@ -4152,6 +4208,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let mvp_result =
             predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &mvp_opts)
@@ -4192,6 +4249,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("lift succeeds");
@@ -4230,6 +4288,7 @@ mod tests {
                 may_edge_inference: Default::default(),
                 config_values: std::collections::HashMap::new(),
                 compound_exprs: std::collections::HashMap::new(),
+                derived_predicates: Vec::new(),
             };
             let result = predicate_cube_lift(
                 preds.clone(),
@@ -4270,6 +4329,7 @@ mod tests {
                 may_edge_inference: Default::default(),
                 config_values: std::collections::HashMap::new(),
                 compound_exprs: std::collections::HashMap::new(),
+                derived_predicates: Vec::new(),
             };
             let mut lazy = LazyLift::from_btor2(
                 preds.clone(),
@@ -4424,6 +4484,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &adapter_opts, &lift_opts)
             .expect("lift succeeds");
@@ -4501,6 +4562,7 @@ mod tests {
 
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4535,6 +4597,7 @@ mod tests {
 
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let mut lazy =
             LazyLift::from_btor2(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
@@ -4622,6 +4685,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values,
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4657,6 +4721,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values,
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");

--- a/crates/mununu-core/src/adapter/btor2/parser.rs
+++ b/crates/mununu-core/src/adapter/btor2/parser.rs
@@ -507,6 +507,53 @@ fn trace_to_state(file: &Btor2File, args: &[crate::adapter::btor2::ast::Operand]
 /// declaring a more specific `drives` value. Multiple candidates
 /// reaching the *same* state are deduplicated — only distinct state
 /// NIDs trigger the ambiguity guard.
+/// H.E (combinational classification, 2026-06-28) — does the combinational cone
+/// rooted at `start` reach a primary `Input`? Traverses the transitive fan-in
+/// (following `Op` args + side-effect operands), stopping at `State` cells and
+/// `Const` leaves — a register's *current* value is state, not a primary input,
+/// so states are cone leaves and are NOT recursed through.
+///
+/// Splits combinational signals for the predicate-cube path: **input-dependent**
+/// ones (`trigger_active = (trigger_i == 0)` → reaches `trigger_i`) must route
+/// through the FREE-INPUT machinery (source-pin / target-free, so the may/must
+/// edges respect the signal's value), while **state-only** ones
+/// (`event_detected_o = f(state_q)`) are sound as derived per-cube labels.
+/// Treating an input-dependent combinational as a state-determined label is
+/// unsound (it produced the spurious VIOLATED on sysrst sva_6 / sva_9).
+pub fn cone_reaches_input(file: &Btor2File, start: Nid) -> bool {
+    let mut seen: std::collections::HashSet<Nid> = std::collections::HashSet::new();
+    let mut work: Vec<Nid> = vec![start];
+    while let Some(nid) = work.pop() {
+        if !seen.insert(nid) {
+            continue;
+        }
+        let Some(line) = file.lookup(nid) else {
+            continue;
+        };
+        match &line.node {
+            Node::Input { .. } => return true,
+            // State cells + constants are cone leaves.
+            Node::State { .. } | Node::Const { .. } | Node::Sort { .. } => {}
+            Node::Op { args, .. } => {
+                for a in args {
+                    work.push(a.nid());
+                }
+            }
+            Node::Init { value, .. } | Node::Next { value, .. } => work.push(value.nid()),
+            Node::Bad { signal }
+            | Node::Constraint { signal }
+            | Node::Fair { signal }
+            | Node::Output { signal, .. } => work.push(signal.nid()),
+            Node::Justice { signals } => {
+                for s in signals {
+                    work.push(s.nid());
+                }
+            }
+        }
+    }
+    false
+}
+
 pub fn resolve_state_by_symbol(file: &Btor2File, symbol: &str) -> Option<Nid> {
     let mut best: Option<(Nid, usize)> = None;
     let mut tied: bool = false;
@@ -988,5 +1035,29 @@ mod tests {
                    6 ite 1 2 5 3\n7 uext 1 6 0 winner\n";
         let file = parse(src).expect("parse");
         assert_eq!(resolve_state_by_symbol(&file, "winner"), Some(4));
+    }
+
+    #[test]
+    fn cone_reaches_input_distinguishes_input_dependent_from_state_only() {
+        // `trig_active = !in_a` (nid 5) — combinational of the INPUT in_a.
+        // `err = (q == 0)` via `eq` (nid 7) — combinational of the STATE q only.
+        let src = "1 sort bitvec 1\n\
+                   2 input 1 in_a\n\
+                   3 state 1 q\n\
+                   4 zero 1\n\
+                   5 not 1 2 trig_active\n\
+                   6 eq 1 3 4 err\n\
+                   7 next 1 3 3\n";
+        let file = parse(src).expect("parse");
+        // input-dependent: `trig_active` (nid 5) reaches the input `in_a`.
+        assert!(
+            cone_reaches_input(&file, 5),
+            "trig_active = !in_a is input-dependent"
+        );
+        // state-only: `err` (nid 6) reaches only the state cell `q`, no input.
+        assert!(
+            !cone_reaches_input(&file, 6),
+            "err = (q == 0) is state-only"
+        );
     }
 }

--- a/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
+++ b/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
@@ -600,6 +600,91 @@ where
     }
 }
 
+/// H.E.2 — the per-cube label of a **derived combinational predicate**
+/// (`signal == value`, where `signal` is a combinational node, NOT a cube
+/// dimension). Approach B (free-input-atoms.md §4): a combinational signal's
+/// value is a *determined function* of (state, inputs), so rather than make it a
+/// free cube dimension we LABEL it per cube — KleeneT/F where the cube pins it,
+/// KleeneBot where it doesn't.
+///
+/// `cube_bits` + `cube_predicates` define the cube C (its *dimension*
+/// predicates, over state + free inputs); `signal_nid` is the combinational
+/// node's NID (its current-cycle BV is `view.curr_signal(signal_nid)`).
+///
+/// Decides, over all concrete states ⊨ C (current cycle):
+/// - `UNSAT(C ∧ signal != value)` → `KleeneT` (always `value` in C);
+/// - `UNSAT(C ∧ signal == value)` → `KleeneF` (never `value` in C);
+/// - else → `KleeneBot` (the cube doesn't pin it — honest).
+///
+/// **Soundness:** a definite KleeneT/F is a sound label (standard 3-valued
+/// preservation); a dimension predicate whose constraint can't be built is
+/// *omitted*, which only widens C (a superset) — KleeneT/F over a superset still
+/// hold on the cube (subset), and the widening can only push toward KleeneBot,
+/// never toward a false-definite. Timeout → conservative `KleeneBot`.
+///
+/// **Caller must hold a [`z3::with_z3_config`] scope.**
+pub fn smt_combinational_label<P: PredicateLike>(
+    view: &Btor2SmtView,
+    cube_bits: u64,
+    cube_predicates: &[P],
+    nid_map: &HashMap<String, Nid>,
+    signal_nid: Nid,
+    value: u64,
+    timeout_ms: u32,
+) -> crate::clts::Tristate {
+    use crate::clts::Tristate;
+    let Some(sig) = view.curr_signal(signal_nid) else {
+        return Tristate::KleeneBot;
+    };
+    // Cube C = conjunction of the dimension predicates at this cube's polarities,
+    // over the current cycle. A predicate whose constraint can't be built is
+    // omitted (sound — only widens C; see the doc note).
+    let mut cube: Vec<z3::ast::Bool> = Vec::new();
+    for (b, pred) in cube_predicates.iter().enumerate() {
+        let polarity = (cube_bits >> b) & 1 == 1;
+        if let Some(c) = build_pred_constraint(view, nid_map, pred, false, polarity) {
+            cube.push(c);
+        }
+    }
+    let val_bv = z3::ast::BV::from_u64(value, sig.get_size());
+    let eq = sig.eq(&val_bv);
+
+    let check = |extra: &z3::ast::Bool| -> z3::SatResult {
+        let solver = z3::Solver::new();
+        let mut params = z3::Params::new();
+        params.set_u32("timeout", timeout_ms);
+        solver.set_params(&params);
+        for c in &cube {
+            solver.assert(c);
+        }
+        solver.assert(extra);
+        solver.check()
+    };
+
+    // SOUNDNESS GUARD (H.E.2, 2026-06-28) — empty/unreachable cube. If the cube's
+    // own dimension constraints are UNSAT (no concrete state satisfies them), then
+    // BOTH `C ∧ signal == value` and `C ∧ signal != value` are trivially UNSAT, and
+    // the `KleeneF` check below would fire SPURIOUSLY — a definite label on an empty
+    // cube. That spurious definite is what fabricated the VIOLATED on shipped
+    // OpenTitan SVA (the `!trigger_active` antecedents). An empty cube has no
+    // states, so its label is meaningless: return KleeneBot (honest "undetermined").
+    // A definite KleeneT/F is only emitted for a NON-empty cube below, where it is
+    // a sound fact over that cube's concrete states.
+    if matches!(check(&z3::ast::Bool::from_bool(true)), z3::SatResult::Unsat) {
+        return Tristate::KleeneBot;
+    }
+    // never == value?  UNSAT(C ∧ signal == value) → KleeneF.
+    if matches!(check(&eq), z3::SatResult::Unsat) {
+        return Tristate::KleeneF;
+    }
+    // always == value?  UNSAT(C ∧ signal != value) → KleeneT.
+    if matches!(check(&eq.not()), z3::SatResult::Unsat) {
+        return Tristate::KleeneT;
+    }
+    // Both satisfiable (mixed), or undecided → honest KleeneBot.
+    Tristate::KleeneBot
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mununu-core/src/adapter/sidecar/btor2_resolver.rs
+++ b/crates/mununu-core/src/adapter/sidecar/btor2_resolver.rs
@@ -120,6 +120,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         }
     }
 

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
@@ -82,9 +82,9 @@ impl std::fmt::Display for EncodeError {
 
 impl std::error::Error for EncodeError {}
 
-/// A signal exposed by the encoded design — state cell or input.
-/// Carries the human-readable symbol (when the BTOR2 file declared
-/// one) and the bit-width.
+/// A signal exposed by the encoded design — state cell, input, or
+/// (H.E.1) a named **combinational** node. Carries the human-readable
+/// symbol (when the BTOR2 file declared one) and the bit-width.
 #[derive(Debug, Clone)]
 pub struct EncodedSignal {
     pub nid: Nid,
@@ -97,6 +97,12 @@ pub struct EncodedSignal {
 pub enum SignalKind {
     State,
     Input,
+    /// H.E.1 — a named combinational node (an `Op`/output that is neither
+    /// a `state` cell nor an `input`). Its current-cycle Z3 BV is in
+    /// [`Btor2SmtView::signal_bvs`]; its value is a *determined function* of
+    /// (state, inputs), so the predicate-image labels it per cube (Approach B,
+    /// free-input-atoms.md §4) rather than treating it as a free cube dimension.
+    Combinational,
 }
 
 /// Output of [`encode_design`]. Holds the Z3 bit-vector handles for
@@ -127,8 +133,17 @@ pub struct Btor2SmtView {
     /// `state_curr_arr` over `s_next`.
     pub state_next_arr: HashMap<Nid, z3::ast::Array>,
     /// Per-signal metadata for callers that need to round-trip
-    /// names / widths back to the sidecar.
+    /// names / widths back to the sidecar. Includes State, Input, and
+    /// (H.E.1) named Combinational nodes.
     pub signals: Vec<EncodedSignal>,
+    /// H.E.1 — current-cycle Z3 BV of **every** node the encode walk
+    /// computed (the retained backend cache), keyed by NID. A combinational
+    /// signal's value is `signal_bvs[nid]` over `state_curr` + `inputs`. The
+    /// per-cube combinational-label pass (H.E.2) reads these to decide each
+    /// derived predicate's KleeneT/F/Bot label per cube. State/input nodes are
+    /// also present (their curr BV); `state_curr`/`inputs` remain the canonical
+    /// maps for those.
+    pub signal_bvs: HashMap<Nid, z3::ast::BV>,
     /// The conjoined transition relation `T(s, s') = ⋀ s_next == next(...)`.
     pub transition: z3::ast::Bool,
 }
@@ -142,6 +157,14 @@ impl Btor2SmtView {
     /// Look up the current-step BV for a state-cell NID.
     pub fn curr_state(&self, nid: Nid) -> Option<&z3::ast::BV> {
         self.state_curr.get(&nid)
+    }
+
+    /// H.E.1 — look up the current-step BV for ANY node by NID (state cell,
+    /// input, or combinational signal), from the retained encode cache. The
+    /// per-cube combinational-label pass uses this to read a derived predicate's
+    /// signal value.
+    pub fn curr_signal(&self, nid: Nid) -> Option<&z3::ast::BV> {
+        self.signal_bvs.get(&nid)
     }
 
     /// Bit-width of a signal by NID.
@@ -293,6 +316,7 @@ pub fn encode_design_with_theory(
         state_next_arr,
         inputs,
         signals,
+        signal_bvs: HashMap::new(),
         transition: z3::ast::Bool::from_bool(true),
     };
     let mut backend = Z3Backend::from_view(file, &view);
@@ -310,6 +334,41 @@ pub fn encode_design_with_theory(
         },
     })?;
     view.transition = backend.transition(&view)?;
+
+    // H.E.1 — retain the backend's per-node BV cache (current-cycle value of
+    // every walked node) so the per-cube combinational-label pass (H.E.2) can
+    // read a derived predicate's signal value, and register each *named*
+    // combinational node (an Op/output that is neither a state cell nor an
+    // input) as a `SignalKind::Combinational` signal so the nid-map builder +
+    // seeder classifier can discover it. Behaviour-preserving: existing callers
+    // read only `state_curr`/`state_next`/`inputs` + State/Input `signals`.
+    let cache = std::mem::take(&mut backend.cache);
+    // Register each named combinational node — an `Op` carrying its OWN symbol
+    // that is neither a state cell nor an input. NB: read the Op line's own
+    // `symbol` field, NOT `collect_symbols` (whose pass-2 traces Op symbols back
+    // to the *state* nid they alias — the wrong target for a genuine
+    // combinational node like `main_sm_err_o`).
+    for line in &file.lines {
+        let Node::Op {
+            symbol: Some(name), ..
+        } = &line.node
+        else {
+            continue;
+        };
+        let nid = line.nid;
+        if view.state_curr.contains_key(&nid) || view.inputs.contains_key(&nid) {
+            continue;
+        }
+        if let Some(bv) = cache.get(&nid) {
+            view.signals.push(EncodedSignal {
+                nid,
+                width: bv.get_size(),
+                symbol: Some(name.clone()),
+                kind: SignalKind::Combinational,
+            });
+        }
+    }
+    view.signal_bvs = cache;
     Ok(view)
 }
 
@@ -1214,6 +1273,48 @@ mod tests {
             assert_eq!(view.state_next_arr.len(), 1);
             // The BV input registers are still present.
             assert!(view.inputs.values().count() >= 3, "we + addr + wdata");
+        });
+    }
+
+    // H.E.1 — a named combinational node `g = q & en` (NID 4). The encode must
+    // retain its current-cycle BV in `signal_bvs` and register it as a
+    // `SignalKind::Combinational` signal.
+    const COMB_BTOR2: &str =
+        "1 sort bitvec 1\n2 state 1 q\n3 input 1 en\n4 and 1 2 3 g\n5 next 1 2 3\n";
+
+    #[test]
+    fn h_e_1_retains_combinational_signal_bv_and_metadata() {
+        let file = parse(COMB_BTOR2).expect("parse combinational fixture");
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = encode_design_with_theory(&file, Theory::BvOnly).expect("encode");
+            // The combinational node `g` (NID 4) has a retained current-cycle BV.
+            assert!(
+                view.curr_signal(4).is_some(),
+                "combinational node g (nid 4) must be in signal_bvs"
+            );
+            // It is registered as a Combinational signal with its symbol + width.
+            let g = view
+                .signals
+                .iter()
+                .find(|s| s.symbol.as_deref() == Some("g"))
+                .expect("g registered in signals");
+            assert_eq!(g.kind, SignalKind::Combinational);
+            assert_eq!(g.nid, 4);
+            assert_eq!(g.width, 1);
+            // State / input nodes keep their canonical kinds (not reclassified).
+            assert!(
+                view.signals
+                    .iter()
+                    .any(|s| s.symbol.as_deref() == Some("q") && s.kind == SignalKind::State),
+                "q stays State"
+            );
+            assert!(
+                view.signals
+                    .iter()
+                    .any(|s| s.symbol.as_deref() == Some("en") && s.kind == SignalKind::Input),
+                "en stays Input"
+            );
         });
     }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -180,6 +180,19 @@ impl Default for VerifyAutoOptions {
 /// Auto-seeded predicates for one formula: simple `reg == value` specs, compound
 /// `(name, expr)` pairs (relational / `!=` / boolean combinations), and the atom
 /// strings that could NOT be seeded (reference a non-state, non-input signal).
+/// H.E — how a combinational signal's value is determined, deciding how it binds:
+/// - `InputDependent` — its cone reaches a primary input (`trigger_active =
+///   !trigger_i`). Routed through the FREE-INPUT path (a free cube dimension,
+///   source-pin / target-free), so the may/must edges respect it. Treating it as
+///   a state-cube label is unsound (the sysrst sva_6 / sva_9 spurious VIOLATED).
+/// - `StateOnly` — a pure function of state (`event_detected_o = f(state_q)`).
+///   Sound as a derived per-cube 3-valued label (Approach B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CombKind {
+    InputDependent,
+    StateOnly,
+}
+
 #[derive(Debug, Clone, Default)]
 struct Seeded {
     specs: Vec<PredicateSpec>,
@@ -230,10 +243,57 @@ fn seed_from_formula(
     formula: &Formula,
     is_state: impl Fn(&str) -> bool,
     is_input: impl Fn(&str) -> bool,
-    is_combinational: impl Fn(&str) -> bool,
+    combinational_kind: impl Fn(&str) -> Option<CombKind>,
 ) -> Seeded {
     let mut out = Seeded::default();
     let mut seen: HashSet<&str> = HashSet::new();
+    // Route one simple `register == value` (or bare-boolean ≡ `== 1`) atom by
+    // the provenance of its register:
+    // - state cell → cube dimension (H.A);
+    // - free input → cube dimension, free at init (H.B);
+    // - input-dependent combinational → cube dimension via the free-input path
+    //   (H.E: source-pin / target-free, recorded in `input_registers`);
+    // - state-only combinational → derived per-cube label (H.E Approach B);
+    // - otherwise → unseedable (never a misleading verdict).
+    let seed_simple = |out: &mut Seeded, atom: &str, register: &str, value: u64| {
+        if is_state(register) {
+            out.specs.push(PredicateSpec {
+                name: atom.to_string(),
+                register: register.to_string(),
+                value,
+            });
+        } else if is_input(register) {
+            out.input_registers.insert(register.to_string());
+            out.specs.push(PredicateSpec {
+                name: atom.to_string(),
+                register: register.to_string(),
+                value,
+            });
+        } else {
+            match combinational_kind(register) {
+                Some(CombKind::StateOnly) => {
+                    // Sound: a combinational function of STATE only. Its value at
+                    // every cube (including must/may targets) is determined by
+                    // that cube's own state dimensions, so a derived per-cube
+                    // 3-valued label (NOT a cube dimension) is sound.
+                    out.derived.push(PredicateSpec {
+                        name: atom.to_string(),
+                        register: register.to_string(),
+                        value,
+                    });
+                }
+                // DEFERRED (sound SKIP): a combinational function of a FREE INPUT
+                // (`trigger_active = !trigger_i`). Neither the static label nor a
+                // free cube dimension is sound for the MUST relation here — the
+                // next-cycle value is `f(state_next, next_input)`, not freely both
+                // flavours, so `target-free` fabricates must-edges (the sysrst
+                // sva_6/sva_9 spurious VIOLATED). The sound fix needs the
+                // next-cycle combinational cache (compute the value at source AND
+                // target); until then SKIP, never a misleading verdict.
+                Some(CombKind::InputDependent) | None => out.unseedable.push(atom.to_string()),
+            }
+        }
+    };
     for node in formula.nodes() {
         let Node::Predicate(atom) = node else {
             continue;
@@ -243,38 +303,12 @@ fn seed_from_formula(
         }
         match parse_predicate_expr(atom) {
             Ok(expr) => match &expr {
-                // Simple `reg == value` → a direct PredicateSpec cube bit, over
-                // a state cell OR (H.B) a free input.
+                // Simple `reg == value` → routed by `seed_simple`.
                 PredicateExpr::Cmp {
                     register,
                     op: CmpOp::Eq,
                     value,
-                } => {
-                    if is_state(register) {
-                        out.specs.push(PredicateSpec {
-                            name: atom.clone(),
-                            register: register.clone(),
-                            value: *value,
-                        });
-                    } else if is_input(register) {
-                        out.input_registers.insert(register.clone());
-                        out.specs.push(PredicateSpec {
-                            name: atom.clone(),
-                            register: register.clone(),
-                            value: *value,
-                        });
-                    } else if is_combinational(register) {
-                        // H.E — a determined combinational signal: a derived
-                        // per-cube label, NOT a cube dimension.
-                        out.derived.push(PredicateSpec {
-                            name: atom.clone(),
-                            register: register.clone(),
-                            value: *value,
-                        });
-                    } else {
-                        out.unseedable.push(atom.clone());
-                    }
-                }
+                } => seed_simple(&mut out, atom, register, *value),
                 // Relational / `!=` / boolean combination → compound predicate.
                 // The compound SMT branch reads state BVs only, so every
                 // referenced register must be a state cell.
@@ -287,34 +321,8 @@ fn seed_from_formula(
                 }
             },
             // A bare identifier atom (`parse_predicate_expr` needs an operator):
-            // a 1-bit boolean signal `sig` ≡ `sig == 1`. Seedable as a state
-            // cell or (H.B) a free input.
-            Err(_) => {
-                if is_state(atom) {
-                    out.specs.push(PredicateSpec {
-                        name: atom.clone(),
-                        register: atom.clone(),
-                        value: 1,
-                    });
-                } else if is_input(atom) {
-                    out.input_registers.insert(atom.clone());
-                    out.specs.push(PredicateSpec {
-                        name: atom.clone(),
-                        register: atom.clone(),
-                        value: 1,
-                    });
-                } else if is_combinational(atom) {
-                    // H.E — bare combinational boolean `sig` ≡ `sig == 1`,
-                    // labeled per cube (derived), not a dimension.
-                    out.derived.push(PredicateSpec {
-                        name: atom.clone(),
-                        register: atom.clone(),
-                        value: 1,
-                    });
-                } else {
-                    out.unseedable.push(atom.clone());
-                }
-            }
+            // a 1-bit boolean signal `sig` ≡ `sig == 1`.
+            Err(_) => seed_simple(&mut out, atom, atom, 1),
         }
     }
     out
@@ -616,25 +624,38 @@ pub fn verify_auto(
     let is_input = |name: &str| -> bool { input_symbols.contains(name) };
 
     // H.E (combinational outputs) — named combinational nodes: an `Op` carrying
-    // its OWN symbol that is neither a state cell (incl. value-alias, checked via
-    // `resolves_to_state` precedence below) nor an input. A simple atom over one
-    // of these (csrng's `main_sm_err_o`, sysrst's `trigger_active` /
-    // `event_detected_*` / `cnt_clr`) is admitted as a DERIVED per-cube label
-    // (Approach B), not a cube dimension. `is_state` is consulted first in the
-    // seeder, so a state value-alias (which is also an Op with a symbol) binds as
-    // state, not combinational.
-    let combinational_symbols: HashSet<String> = file
-        .lines
-        .iter()
-        .filter_map(|l| match &l.node {
-            crate::adapter::btor2::ast::Node::Op {
-                symbol: Some(s), ..
-            } => Some(s.clone()),
-            _ => None,
+    // its OWN symbol that is neither a state cell (incl. value-alias, via
+    // `resolves_to_state` precedence in the seeder) nor an input. Each is
+    // classified by its CONE (`cone_reaches_input`):
+    // - **input-dependent** (`trigger_active = !trigger_i`) → routed through the
+    //   FREE-INPUT path (a free cube dimension, source-pin / target-free) so the
+    //   may/must edges respect it — SOUND (treating it as a state-cube label is
+    //   what produced the sysrst sva_6 / sva_9 spurious VIOLATED);
+    // - **state-only** (`event_detected_o = f(state_q)`) → a DERIVED per-cube
+    //   3-valued label (Approach B).
+    // `is_state` is consulted first in the seeder, so a state value-alias (also
+    // an Op with a symbol) binds as state, not combinational.
+    let combinational_nid: std::collections::HashMap<String, crate::adapter::btor2::ast::Nid> =
+        file.lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                crate::adapter::btor2::ast::Node::Op {
+                    symbol: Some(s), ..
+                } if !state_cells.contains(s) && !input_symbols.contains(s) => {
+                    Some((s.clone(), l.nid))
+                }
+                _ => None,
+            })
+            .collect();
+    let combinational_kind = |name: &str| -> Option<CombKind> {
+        combinational_nid.get(name).map(|&nid| {
+            if crate::adapter::btor2::parser::cone_reaches_input(&file, nid) {
+                CombKind::InputDependent
+            } else {
+                CombKind::StateOnly
+            }
         })
-        .filter(|s| !state_cells.contains(s) && !input_symbols.contains(s))
-        .collect();
-    let is_combinational = |name: &str| -> bool { combinational_symbols.contains(name) };
+    };
 
     // 4. Per property: seed → CEGAR → verdict.
     for t in &extraction.translated {
@@ -654,7 +675,7 @@ pub fn verify_auto(
             }
         };
 
-        let seeded = seed_from_formula(&formula, resolves_to_state, is_input, is_combinational);
+        let seeded = seed_from_formula(&formula, resolves_to_state, is_input, combinational_kind);
         if !seeded.unseedable.is_empty() {
             let reason = unseedable_skip_reason(&seeded.unseedable, &report.diagnostics);
             report.properties.push(PropertyVerdict {
@@ -839,7 +860,7 @@ mod tests {
     fn seeds_simple_state_predicate() {
         // `nu X. ((state == 5) && [] X)` over a state cell → one simple spec.
         let f = mu_parser::parse("nu X. ((state == 5) && [] X)").unwrap();
-        let s = seed_from_formula(&f, |n| cells(&["state"]).contains(n), |_| false, |_| false);
+        let s = seed_from_formula(&f, |n| cells(&["state"]).contains(n), |_| false, |_| None);
         assert_eq!(s.specs.len(), 1, "one simple reg==val spec");
         assert_eq!(s.specs[0].name, "state == 5");
         assert_eq!(s.specs[0].register, "state");
@@ -856,7 +877,7 @@ mod tests {
             &f,
             |n| cells(&["state", "state__past"]).contains(n),
             |_| false,
-            |_| false,
+            |_| None,
         );
         assert!(s.specs.is_empty(), "relational atom is not a simple spec");
         assert_eq!(s.compounds.len(), 1, "one compound (relational) predicate");
@@ -884,12 +905,7 @@ mod tests {
         let f = mu_parser::parse("nu X. (((gnt_o != 0) || ready_i) && [] X)").unwrap();
         // Neither IO signal is a state cell, and (here) none is a free input
         // either → both unseedable.
-        let s = seed_from_formula(
-            &f,
-            |n| cells(&["state_q"]).contains(n),
-            |_| false,
-            |_| false,
-        );
+        let s = seed_from_formula(&f, |n| cells(&["state_q"]).contains(n), |_| false, |_| None);
         assert!(
             s.unseedable.contains(&"gnt_o != 0".to_string()),
             "IO comparison atom must be unseedable; got {:?}",
@@ -905,7 +921,7 @@ mod tests {
     #[test]
     fn bare_one_bit_state_signal_seeds_eq_one() {
         let f = mu_parser::parse("nu X. (busy && [] X)").unwrap();
-        let s = seed_from_formula(&f, |n| cells(&["busy"]).contains(n), |_| false, |_| false);
+        let s = seed_from_formula(&f, |n| cells(&["busy"]).contains(n), |_| false, |_| None);
         assert_eq!(s.specs.len(), 1);
         assert_eq!(s.specs[0].name, "busy");
         assert_eq!(s.specs[0].value, 1, "bare boolean state signal ≡ sig == 1");
@@ -923,7 +939,7 @@ mod tests {
             &f,
             |n| cells(&["state"]).contains(n),
             |n| cells(&["cfg_enable_i"]).contains(n),
-            |_| false,
+            |_| None,
         );
         assert!(
             s.unseedable.is_empty(),
@@ -949,7 +965,7 @@ mod tests {
             &f,
             |_| false,
             |n| cells(&["trigger_i"]).contains(n),
-            |_| false,
+            |_| None,
         );
         assert_eq!(s.specs.len(), 1);
         assert_eq!(s.specs[0].name, "trigger_i");
@@ -988,7 +1004,7 @@ mod tests {
             &f,
             |_| false,
             |n| cells(&["cfg_enable_i"]).contains(n),
-            |_| false,
+            |_| None,
         );
         assert!(s.specs.is_empty());
         assert!(s.compounds.is_empty());
@@ -1008,7 +1024,12 @@ mod tests {
             &f,
             |_| false,
             |_| false,
-            |n| cells(&["main_sm_err_o"]).contains(n),
+            // state-only combinational → derived label
+            |n| {
+                cells(&["main_sm_err_o"])
+                    .contains(n)
+                    .then_some(CombKind::StateOnly)
+            },
         );
         assert!(s.specs.is_empty(), "combinational is not a cube dimension");
         assert!(s.compounds.is_empty());
@@ -1025,7 +1046,11 @@ mod tests {
             &f,
             |_| false,
             |_| false,
-            |n| cells(&["err_code"]).contains(n),
+            |n| {
+                cells(&["err_code"])
+                    .contains(n)
+                    .then_some(CombKind::StateOnly)
+            },
         );
         assert_eq!(s.derived.len(), 1);
         assert_eq!(s.derived[0].register, "err_code");
@@ -1043,10 +1068,44 @@ mod tests {
             &f,
             |n| cells(&["sig"]).contains(n),
             |_| false,
-            |n| cells(&["sig"]).contains(n),
+            |n| cells(&["sig"]).contains(n).then_some(CombKind::StateOnly),
         );
         assert_eq!(s.specs.len(), 1, "state precedence → a cube dimension");
         assert!(s.derived.is_empty());
+    }
+
+    #[test]
+    fn h_e_input_dependent_combinational_is_skipped_soundly() {
+        // `trigger_active = !trigger_i` — combinational of a FREE INPUT. DEFERRED:
+        // neither a derived state-cube label nor a free dimension is sound for the
+        // MUST relation (the next-cycle value f(state_next, next_input) isn't
+        // freely both flavours → target-free fabricates must-edges). So it is
+        // SKIPPED (never a misleading verdict) until the next-cycle-cache fix.
+        let f = mu_parser::parse("nu X. ((trigger_active && (state == 2)) && [] X)").unwrap();
+        let s = seed_from_formula(
+            &f,
+            |n| cells(&["state"]).contains(n),
+            |_| false,
+            |n| {
+                cells(&["trigger_active"])
+                    .contains(n)
+                    .then_some(CombKind::InputDependent)
+            },
+        );
+        assert!(s.derived.is_empty(), "not a derived label");
+        assert!(
+            !s.input_registers.contains("trigger_active"),
+            "NOT routed as a free dimension (unsound for must)"
+        );
+        assert!(
+            !s.specs.iter().any(|p| p.register == "trigger_active"),
+            "not a cube dimension"
+        );
+        assert!(
+            s.unseedable.contains(&"trigger_active".to_string()),
+            "input-dependent combinational is soundly SKIPPED: {:?}",
+            s.unseedable
+        );
     }
 
     #[test]
@@ -1539,8 +1598,25 @@ mod tests {
                 .any(|p| p.formula.contains("cnt_q >= cfg_")),
             "H.D translated a `signal >= signal` (cnt_q >= cfg_*_timer_i)"
         );
-        // SOUNDNESS — no spurious counterexample (combinational outputs like
-        // `event_detected_o` are excluded by the strict resolver, not mis-bound).
+        // SOUNDNESS — no spurious counterexample. This is the H.E soundness
+        // anchor: an INPUT-DEPENDENT combinational antecedent (`trigger_active =
+        // !trigger_i`, etc.) is SKIPPED (its register reaches a free input via
+        // `cone_reaches_input`, so it is deferred to the next-cycle-cache
+        // must-edge fix), NEVER bound as a state-cube label or free dimension —
+        // both of which fabricated a VIOLATED on these shipped OpenTitan
+        // assertions. `sva_6` (`DetectStDropOut`: `state==DetectSt && !trigger_active
+        // && cfg |=> state==IdleSt`) is the canonical case it must not VIOLATE.
+        let sva6 = report
+            .properties
+            .iter()
+            .find(|p| p.name == "sysrst_ctrl_detect_sva_6")
+            .expect("sva_6 present");
+        assert!(
+            matches!(sva6.outcome, VerifyOutcome::Skipped { .. }),
+            "sva_6's input-dependent combinational `trigger_active` is soundly \
+             SKIPPED (deferred), not a spurious VIOLATED; got {:?}",
+            sva6.outcome
+        );
         assert!(
             !report
                 .properties

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -192,6 +192,12 @@ struct Seeded {
     /// across **all** of its initial polarities. See
     /// `docs/design/free-input-atoms.md`. Empty ⇒ the pre-H.B state-only shape.
     input_registers: HashSet<String>,
+    /// H.E (combinational outputs) — **derived** combinational predicates: a
+    /// simple atom whose register is a combinational node (e.g. csrng's
+    /// `main_sm_err_o`), NOT a cube dimension. The lift labels each per cube via
+    /// SMT (Approach B). Threaded to `cegar_refine_loop` through the synthesised
+    /// sidecar's `combinational_predicates`. Empty ⇒ the pre-H.E shape.
+    derived: Vec<PredicateSpec>,
 }
 
 /// The minimal H.1 (+ H.B) — derive cube predicates from a formula's
@@ -224,6 +230,7 @@ fn seed_from_formula(
     formula: &Formula,
     is_state: impl Fn(&str) -> bool,
     is_input: impl Fn(&str) -> bool,
+    is_combinational: impl Fn(&str) -> bool,
 ) -> Seeded {
     let mut out = Seeded::default();
     let mut seen: HashSet<&str> = HashSet::new();
@@ -252,6 +259,14 @@ fn seed_from_formula(
                     } else if is_input(register) {
                         out.input_registers.insert(register.clone());
                         out.specs.push(PredicateSpec {
+                            name: atom.clone(),
+                            register: register.clone(),
+                            value: *value,
+                        });
+                    } else if is_combinational(register) {
+                        // H.E — a determined combinational signal: a derived
+                        // per-cube label, NOT a cube dimension.
+                        out.derived.push(PredicateSpec {
                             name: atom.clone(),
                             register: register.clone(),
                             value: *value,
@@ -288,6 +303,14 @@ fn seed_from_formula(
                         register: atom.clone(),
                         value: 1,
                     });
+                } else if is_combinational(atom) {
+                    // H.E — bare combinational boolean `sig` ≡ `sig == 1`,
+                    // labeled per cube (derived), not a dimension.
+                    out.derived.push(PredicateSpec {
+                        name: atom.clone(),
+                        register: atom.clone(),
+                        value: 1,
+                    });
                 } else {
                     out.unseedable.push(atom.clone());
                 }
@@ -306,6 +329,7 @@ fn seed_from_formula(
 /// fictitious init. Returns `None` when there is nothing to emit.
 fn synth_sidecar_json(
     compounds: &[(String, PredicateExpr)],
+    derived: &[PredicateSpec],
     referenced: &std::collections::BTreeSet<String>,
     init_values: &std::collections::HashMap<String, u64>,
 ) -> Option<String> {
@@ -315,6 +339,13 @@ fn synth_sidecar_json(
         // re-parses via `parse_predicate_expr` (REL handles `reg == reg`).
         .map(|(name, _)| serde_json::json!({ "name": name, "expr": name }))
         .collect();
+    // H.E — derived combinational predicates: `cegar_refine_loop` reads these
+    // into `lift_opts.derived_predicates`; the lift labels each per cube via the
+    // SMT `combinational_labels` pass (NOT a cube dimension).
+    let combinational_decls: Vec<serde_json::Value> = derived
+        .iter()
+        .map(|d| serde_json::json!({ "name": d.name, "signal": d.register, "value": d.value }))
+        .collect();
     let signals: Vec<serde_json::Value> = referenced
         .iter()
         .filter_map(|r| {
@@ -323,13 +354,14 @@ fn synth_sidecar_json(
                 .map(|v| serde_json::json!({ "name": r, "config_values": [v] }))
         })
         .collect();
-    if compound_decls.is_empty() && signals.is_empty() {
+    if compound_decls.is_empty() && combinational_decls.is_empty() && signals.is_empty() {
         return None;
     }
     serde_json::to_string(&serde_json::json!({
         "module": "cegar",
         "source": "verify_auto.btor2",
         "compound_predicates": compound_decls,
+        "combinational_predicates": combinational_decls,
         "signals": signals,
     }))
     .ok()
@@ -583,6 +615,27 @@ pub fn verify_auto(
         .collect();
     let is_input = |name: &str| -> bool { input_symbols.contains(name) };
 
+    // H.E (combinational outputs) — named combinational nodes: an `Op` carrying
+    // its OWN symbol that is neither a state cell (incl. value-alias, checked via
+    // `resolves_to_state` precedence below) nor an input. A simple atom over one
+    // of these (csrng's `main_sm_err_o`, sysrst's `trigger_active` /
+    // `event_detected_*` / `cnt_clr`) is admitted as a DERIVED per-cube label
+    // (Approach B), not a cube dimension. `is_state` is consulted first in the
+    // seeder, so a state value-alias (which is also an Op with a symbol) binds as
+    // state, not combinational.
+    let combinational_symbols: HashSet<String> = file
+        .lines
+        .iter()
+        .filter_map(|l| match &l.node {
+            crate::adapter::btor2::ast::Node::Op {
+                symbol: Some(s), ..
+            } => Some(s.clone()),
+            _ => None,
+        })
+        .filter(|s| !state_cells.contains(s) && !input_symbols.contains(s))
+        .collect();
+    let is_combinational = |name: &str| -> bool { combinational_symbols.contains(name) };
+
     // 4. Per property: seed → CEGAR → verdict.
     for t in &extraction.translated {
         let formula = match mu_parser::parse(&t.formula) {
@@ -601,7 +654,7 @@ pub fn verify_auto(
             }
         };
 
-        let seeded = seed_from_formula(&formula, resolves_to_state, is_input);
+        let seeded = seed_from_formula(&formula, resolves_to_state, is_input, is_combinational);
         if !seeded.unseedable.is_empty() {
             let reason = unseedable_skip_reason(&seeded.unseedable, &report.diagnostics);
             report.properties.push(PropertyVerdict {
@@ -614,13 +667,14 @@ pub fn verify_auto(
             continue;
         }
         let predicate_count = seeded.specs.len() + seeded.compounds.len();
-        if predicate_count == 0 {
+        if predicate_count == 0 && seeded.derived.is_empty() {
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
                 kind: t.kind,
                 formula: t.formula.clone(),
                 outcome: VerifyOutcome::Skipped {
-                    reason: "no state-cell predicate atoms to seed the cube".to_string(),
+                    reason: "no state-cell / combinational predicate atoms to seed the cube"
+                        .to_string(),
                 },
                 seeded_predicates: Vec::new(),
             });
@@ -629,6 +683,7 @@ pub fn verify_auto(
 
         let mut seeded_names: Vec<String> = seeded.specs.iter().map(|s| s.name.clone()).collect();
         seeded_names.extend(seeded.compounds.iter().map(|(n, _)| n.clone()));
+        seeded_names.extend(seeded.derived.iter().map(|d| d.name.clone()));
 
         // Compounds OR free inputs ⇒ force the SmtAllPairs eager lift.
         // Compounds: the only compound-aware may path. Free inputs (H.B): the
@@ -639,6 +694,10 @@ pub fn verify_auto(
         // `cegar_refine_loop` re-checks the compound gate.
         let has_compounds = !seeded.compounds.is_empty();
         let has_inputs = !seeded.input_registers.is_empty();
+        // H.E — derived combinational predicates are labeled per cube by the
+        // SMT `combinational_labels` pass, which also requires the SmtAllPairs
+        // eager lift (precise state edges + the encoded view).
+        let has_derived = !seeded.derived.is_empty();
         let cegar_opts = CegarOptions {
             max_iterations: opts.max_iterations,
             predicate_source: PredicateSource::WeakestPrecondition,
@@ -648,7 +707,7 @@ pub fn verify_auto(
             smart_uf_cap: true,
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: opts.must_edge_inference,
-            may_edge_inference: if has_compounds || has_inputs {
+            may_edge_inference: if has_compounds || has_inputs || has_derived {
                 MayEdgeInference::SmtAllPairs
             } else {
                 MayEdgeInference::Off
@@ -667,7 +726,12 @@ pub fn verify_auto(
             }
         }
         let adapter_options = AdapterOptions {
-            sidecar_json: synth_sidecar_json(&seeded.compounds, &referenced, &init_values),
+            sidecar_json: synth_sidecar_json(
+                &seeded.compounds,
+                &seeded.derived,
+                &referenced,
+                &init_values,
+            ),
             ..Default::default()
         };
         // Env sized to the cube space: simple specs + the sidecar compounds
@@ -775,7 +839,7 @@ mod tests {
     fn seeds_simple_state_predicate() {
         // `nu X. ((state == 5) && [] X)` over a state cell → one simple spec.
         let f = mu_parser::parse("nu X. ((state == 5) && [] X)").unwrap();
-        let s = seed_from_formula(&f, |n| cells(&["state"]).contains(n), |_| false);
+        let s = seed_from_formula(&f, |n| cells(&["state"]).contains(n), |_| false, |_| false);
         assert_eq!(s.specs.len(), 1, "one simple reg==val spec");
         assert_eq!(s.specs[0].name, "state == 5");
         assert_eq!(s.specs[0].register, "state");
@@ -792,6 +856,7 @@ mod tests {
             &f,
             |n| cells(&["state", "state__past"]).contains(n),
             |_| false,
+            |_| false,
         );
         assert!(s.specs.is_empty(), "relational atom is not a simple spec");
         assert_eq!(s.compounds.len(), 1, "one compound (relational) predicate");
@@ -806,7 +871,8 @@ mod tests {
             [("state".to_string(), 0), ("state__past".to_string(), 0)]
                 .into_iter()
                 .collect();
-        let json = synth_sidecar_json(&s.compounds, &referenced, &inits).expect("sidecar json");
+        let json =
+            synth_sidecar_json(&s.compounds, &[], &referenced, &inits).expect("sidecar json");
         assert!(json.contains("compound_predicates"));
         assert!(json.contains("state == state__past"));
         assert!(json.contains("config_values"), "init pins present: {json}");
@@ -818,7 +884,12 @@ mod tests {
         let f = mu_parser::parse("nu X. (((gnt_o != 0) || ready_i) && [] X)").unwrap();
         // Neither IO signal is a state cell, and (here) none is a free input
         // either → both unseedable.
-        let s = seed_from_formula(&f, |n| cells(&["state_q"]).contains(n), |_| false);
+        let s = seed_from_formula(
+            &f,
+            |n| cells(&["state_q"]).contains(n),
+            |_| false,
+            |_| false,
+        );
         assert!(
             s.unseedable.contains(&"gnt_o != 0".to_string()),
             "IO comparison atom must be unseedable; got {:?}",
@@ -834,7 +905,7 @@ mod tests {
     #[test]
     fn bare_one_bit_state_signal_seeds_eq_one() {
         let f = mu_parser::parse("nu X. (busy && [] X)").unwrap();
-        let s = seed_from_formula(&f, |n| cells(&["busy"]).contains(n), |_| false);
+        let s = seed_from_formula(&f, |n| cells(&["busy"]).contains(n), |_| false, |_| false);
         assert_eq!(s.specs.len(), 1);
         assert_eq!(s.specs[0].name, "busy");
         assert_eq!(s.specs[0].value, 1, "bare boolean state signal ≡ sig == 1");
@@ -852,6 +923,7 @@ mod tests {
             &f,
             |n| cells(&["state"]).contains(n),
             |n| cells(&["cfg_enable_i"]).contains(n),
+            |_| false,
         );
         assert!(
             s.unseedable.is_empty(),
@@ -873,7 +945,12 @@ mod tests {
     #[test]
     fn h_b_bare_input_boolean_seeds_eq_one_as_free() {
         let f = mu_parser::parse("nu X. (trigger_i && [] X)").unwrap();
-        let s = seed_from_formula(&f, |_| false, |n| cells(&["trigger_i"]).contains(n));
+        let s = seed_from_formula(
+            &f,
+            |_| false,
+            |n| cells(&["trigger_i"]).contains(n),
+            |_| false,
+        );
         assert_eq!(s.specs.len(), 1);
         assert_eq!(s.specs[0].name, "trigger_i");
         assert_eq!(s.specs[0].value, 1, "bare boolean input ≡ sig == 1");
@@ -907,7 +984,12 @@ mod tests {
         // `cfg_enable_i != 0` (a Ne, routed to the compound branch) over an
         // input is unseedable even though the same atom as `== 0` would seed.
         let f = mu_parser::parse("nu X. ((cfg_enable_i != 0) && [] X)").unwrap();
-        let s = seed_from_formula(&f, |_| false, |n| cells(&["cfg_enable_i"]).contains(n));
+        let s = seed_from_formula(
+            &f,
+            |_| false,
+            |n| cells(&["cfg_enable_i"]).contains(n),
+            |_| false,
+        );
         assert!(s.specs.is_empty());
         assert!(s.compounds.is_empty());
         assert!(
@@ -915,6 +997,56 @@ mod tests {
             "input inside a compound is unseedable: {:?}",
             s.unseedable
         );
+    }
+
+    #[test]
+    fn h_e_admits_combinational_bare_atom_as_derived() {
+        // csrng `main_sm_err_o` — a combinational output, neither state nor input
+        // — is admitted as a DERIVED per-cube label (Approach B), not a spec.
+        let f = mu_parser::parse("nu X. (main_sm_err_o && [] X)").unwrap();
+        let s = seed_from_formula(
+            &f,
+            |_| false,
+            |_| false,
+            |n| cells(&["main_sm_err_o"]).contains(n),
+        );
+        assert!(s.specs.is_empty(), "combinational is not a cube dimension");
+        assert!(s.compounds.is_empty());
+        assert!(s.unseedable.is_empty(), "not skipped: {:?}", s.unseedable);
+        assert_eq!(s.derived.len(), 1, "one derived combinational predicate");
+        assert_eq!(s.derived[0].name, "main_sm_err_o");
+        assert_eq!(s.derived[0].value, 1, "bare boolean ≡ == 1");
+    }
+
+    #[test]
+    fn h_e_admits_combinational_eq_value_as_derived() {
+        let f = mu_parser::parse("nu X. ((err_code == 3) && [] X)").unwrap();
+        let s = seed_from_formula(
+            &f,
+            |_| false,
+            |_| false,
+            |n| cells(&["err_code"]).contains(n),
+        );
+        assert_eq!(s.derived.len(), 1);
+        assert_eq!(s.derived[0].register, "err_code");
+        assert_eq!(s.derived[0].value, 3);
+        assert!(s.specs.is_empty() && s.unseedable.is_empty());
+    }
+
+    #[test]
+    fn h_e_state_takes_precedence_over_combinational() {
+        // A name classified as BOTH state and combinational binds as STATE (a
+        // value-alias of state is also an Op-with-symbol; `is_state` is checked
+        // first), so it stays a cube dimension, never a derived label.
+        let f = mu_parser::parse("nu X. (sig && [] X)").unwrap();
+        let s = seed_from_formula(
+            &f,
+            |n| cells(&["sig"]).contains(n),
+            |_| false,
+            |n| cells(&["sig"]).contains(n),
+        );
+        assert_eq!(s.specs.len(), 1, "state precedence → a cube dimension");
+        assert!(s.derived.is_empty());
     }
 
     #[test]
@@ -972,7 +1104,7 @@ mod tests {
     fn no_sidecar_when_nothing_to_emit() {
         let empty_refs = std::collections::BTreeSet::new();
         let empty_inits = std::collections::HashMap::new();
-        assert!(synth_sidecar_json(&[], &empty_refs, &empty_inits).is_none());
+        assert!(synth_sidecar_json(&[], &[], &empty_refs, &empty_inits).is_none());
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -209,6 +209,22 @@ pub trait SmtEncode: SymbolicTransitionSystem {
         may_edges: &[(usize, usize)],
         timeout_ms: u32,
     ) -> Vec<(usize, Vec<usize>)>;
+
+    /// H.E.2 — per-cube labels for **derived combinational predicates** (Approach
+    /// B). `cube_predicates` are the cube *dimensions* (state + free inputs,
+    /// indices `0..2^|cube_predicates|`); `derived` are the combinational
+    /// predicates to label (their `register()` names a combinational node, NOT a
+    /// dimension). Returns `(cube_index, derived_index, label)` for every (cube,
+    /// derived) pair: KleeneT/F where the cube pins the signal, KleeneBot where it
+    /// doesn't (or on encoder failure / timeout — the conservative, honest
+    /// label). The lift writes these into `state_3valued_predicates` so the
+    /// evaluator binds the formula atom by name.
+    fn combinational_labels<P: PredicateLike + Sync>(
+        &self,
+        cube_predicates: &[P],
+        derived: &[P],
+        timeout_ms: u32,
+    ) -> Vec<(usize, usize, crate::clts::Tristate)>;
 }
 
 /// The BTOR2 implementation of the STS-IR seam — a thin borrow over a
@@ -438,6 +454,76 @@ impl SmtEncode for BtorSts<'_> {
                 }
             }
             edges
+        })
+    }
+
+    fn combinational_labels<P: PredicateLike + Sync>(
+        &self,
+        cube_predicates: &[P],
+        derived: &[P],
+        timeout_ms: u32,
+    ) -> Vec<(usize, usize, crate::clts::Tristate)> {
+        use crate::adapter::btor2::kmts_lift::encode_design_for_lift;
+        use crate::adapter::btor2::smt_must_edge::{
+            build_register_nid_map_with_inputs, smt_combinational_label,
+        };
+        use crate::adapter::sidecar::predicate_image::btor2_encode::SignalKind;
+        use crate::clts::Tristate;
+
+        if derived.is_empty() {
+            return Vec::new();
+        }
+        let n_cubes = 1usize << cube_predicates.len();
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = match encode_design_for_lift(self.file) {
+                Ok(v) => v,
+                // Encoder failure → every derived predicate is conservatively
+                // KleeneBot in every cube (honest "couldn't determine").
+                Err(_) => {
+                    let mut out = Vec::with_capacity(n_cubes * derived.len());
+                    for i in 0..n_cubes {
+                        for d in 0..derived.len() {
+                            out.push((i, d, Tristate::KleeneBot));
+                        }
+                    }
+                    return out;
+                }
+            };
+            let nid_map = build_register_nid_map_with_inputs(&view);
+            // Resolve each derived predicate's signal name → its combinational
+            // node NID (own-symbol match in the view's Combinational signals).
+            let derived_nids: Vec<Option<_>> = derived
+                .iter()
+                .map(|d| {
+                    view.signals
+                        .iter()
+                        .find(|s| {
+                            s.kind == SignalKind::Combinational
+                                && s.symbol.as_deref() == Some(d.register())
+                        })
+                        .map(|s| s.nid)
+                })
+                .collect();
+            let mut out = Vec::with_capacity(n_cubes * derived.len());
+            for i in 0..n_cubes {
+                for (d_idx, d) in derived.iter().enumerate() {
+                    let label = match derived_nids[d_idx] {
+                        Some(nid) => smt_combinational_label(
+                            &view,
+                            i as u64,
+                            cube_predicates,
+                            &nid_map,
+                            nid,
+                            d.value(),
+                            timeout_ms,
+                        ),
+                        None => Tristate::KleeneBot,
+                    };
+                    out.push((i, d_idx, label));
+                }
+            }
+            out
         })
     }
 }
@@ -684,6 +770,46 @@ mod tests {
         assert!(
             !edges.contains(&(0, 1)) && !edges.contains(&(0, 3)),
             "source in_a=1 must NOT reach reg_a'==0 — the source input pin is load-bearing"
+        );
+    }
+
+    // H.E.2 — a state-only combinational signal `g = !q` (NID 3). With cube
+    // dimension `q == 1`, the derived label `g == 1` is DETERMINED per cube:
+    // q==1 ⇒ g==0 (KleeneF for g==1); q==0 ⇒ g==1 (KleeneT).
+    const COMB_LABEL_BTOR2: &str =
+        "1 sort bitvec 1\n2 state 1 q\n3 not 1 2 g\n4 zero 1\n5 init 1 2 4\n6 next 1 2 2\n";
+
+    #[test]
+    fn btor_sts_combinational_labels_determined_by_state_cube() {
+        use crate::clts::Tristate;
+        let file = parser::parse(COMB_LABEL_BTOR2).expect("parse combinational-label fixture");
+        let sts = BtorSts::new(&file);
+        let cube_preds = vec![PredicateSpec {
+            name: "q == 1".into(),
+            register: "q".into(),
+            value: 1,
+        }];
+        let derived = vec![PredicateSpec {
+            name: "g == 1".into(),
+            register: "g".into(), // the combinational node's own symbol
+            value: 1,
+        }];
+        let labels: std::collections::HashMap<(usize, usize), Tristate> = sts
+            .combinational_labels(&cube_preds, &derived, 5_000)
+            .into_iter()
+            .map(|(c, d, t)| ((c, d), t))
+            .collect();
+        // cube 0 = (q==1 false ⇒ q==0) ⇒ g = !0 = 1 ⇒ g==1 is KleeneT.
+        assert_eq!(
+            labels.get(&(0, 0)),
+            Some(&Tristate::KleeneT),
+            "q==0 ⇒ g==1 true"
+        );
+        // cube 1 = (q==1 true) ⇒ g = !1 = 0 ⇒ g==1 is KleeneF.
+        assert_eq!(
+            labels.get(&(1, 0)),
+            Some(&Tristate::KleeneF),
+            "q==1 ⇒ g==1 false"
         );
     }
 }

--- a/crates/mununu-core/src/adapter/systemverilog/annotation.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/annotation.rs
@@ -260,6 +260,35 @@ pub struct SvAnnotation {
     /// Default empty — preserves behaviour for every existing fixture.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub compound_predicates: Vec<CompoundPredicateDecl>,
+
+    /// H.E.2 (combinational outputs, 2026-06-28) — **derived combinational
+    /// predicates**: `signal == value` atoms whose `signal` is a *combinational
+    /// node* (an `eq`/`or`/… output of state, e.g. csrng's `main_sm_err_o`), NOT
+    /// a cube dimension. The cube lift labels each per cube via SMT (Approach B,
+    /// free-input-atoms.md §4) — KleeneT/F where the cube pins the signal,
+    /// KleeneBot where it doesn't — writing the label into
+    /// `state_3valued_predicates` so the evaluator binds the formula atom by
+    /// name. These do NOT enlarge the cube space. Like compounds, they require
+    /// the eager SmtAllPairs lift (the labeling pass is SMT-based).
+    ///
+    /// Default empty — preserves behaviour for every existing fixture.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub combinational_predicates: Vec<CombinationalPredicateDecl>,
+}
+
+/// H.E.2 (2026-06-28) — one derived combinational predicate declaration for the
+/// predicate-cube path. [`crate::adapter::btor2::sidecar_combinational_predicates`]
+/// reads these into [`crate::adapter::btor2::kmts_lift::PredicateCubeLiftOptions::derived_predicates`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CombinationalPredicateDecl {
+    /// Predicate name = the formula atom string (the `state_3valued_predicates`
+    /// key the evaluator binds by name), e.g. `"main_sm_err_o"`.
+    pub name: String,
+    /// The combinational node's symbol in the lifted BTOR2 (its own `Op` symbol).
+    pub signal: String,
+    /// Value the predicate checks: it holds iff `signal == value` (bare boolean
+    /// atom ⇒ `value = 1`).
+    pub value: u64,
 }
 
 /// IR-track P3.2 (2026-06-22) — one register-value equality predicate
@@ -1817,6 +1846,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         }
     }
 
@@ -2457,6 +2487,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2526,6 +2557,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2670,6 +2702,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2823,6 +2856,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2923,6 +2957,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -523,6 +523,7 @@ fn run_controllability_aware_lift(
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
 
     let lift_result =

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -1071,6 +1071,7 @@ fn dispatch_sv_predicate_cube(
         may_edge_inference: MayEdgeInference::SmtAllPairs,
         config_values: crate::adapter::btor2::r_s8_encoder::sidecar_config_values(opts),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
     // U.4 — route the verify-path lift through the single gated entry
     // (always Eager for this non-CEGAR path; the entry runs the compound

--- a/crates/mununu-core/tests/v6_controllability_kmts.rs
+++ b/crates/mununu-core/tests/v6_controllability_kmts.rs
@@ -88,6 +88,7 @@ fn v6_amba_arbiter_lifts_with_controllability_aware_dual_labels() {
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)
@@ -163,6 +164,7 @@ fn v6_amba_arbiter_lifts_with_mayonly_transitions_present() {
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)
@@ -247,6 +249,7 @@ fn v6_amba_arbiter_controllability_aware_skips_smt_post_pass() {
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)


### PR DESCRIPTION
## H.E — sound combinational-atom foundation

Binds combinational SVA atoms in the no-sidecar `verify-auto` path, classified by their **cone** so the binding is sound. **Honest scope:** this ships the sound *foundation* + classifier + a no-spurious-VIOLATED guard. On the two OpenTitan anchors it converts **zero** combinational SKIPs to *definite* verdicts — the actual verdict conversion is deferred to two follow-ups (below).

### Root cause of the earlier spurious VIOLATED (sysrst sva_6/sva_9)
NOT a translation gap — the translations are faithful. It was a **provenance misclassification**: `trigger_active = (trigger_i == 0)` is combinational of a **free input**, not of state. Both shortcuts are unsound for it:
- static state-cube derived label — the cube can't pin a free input;
- free cube dimension — `target-free` is sound for a *raw* input (next value independently free) but NOT for a combinational-of-input (next value `f(state_next, next_input)`) → it fabricates must-edges (this made it *worse*: 6 VIOLATEDs).

### Sound resolution — `parser::cone_reaches_input`
Classify a combinational signal by whether its cone reaches a primary input:
- **state-only** (`event_detected_o = f(state_q)`) → derived per-cube 3-valued label (Approach B); sound (value determined by the cube's own state, at every cube incl. must/may targets).
- **input-dependent** (`trigger_active` / `trigger_event` / `cnt_clr`) → **soundly SKIPPED**, deferred to the next-cycle-cache fix. Never a misleading verdict.

### Components
`cone_reaches_input` (parser) · encode infra (`Btor2SmtView::signal_bvs` + `SignalKind::Combinational` + `curr_signal`) · `smt_combinational_label` (+ empty-cube guard) · `SmtEncode::combinational_labels` seam · `predicate_cube_lift` derived-label pass · `SvAnnotation.combinational_predicates` + `sidecar_combinational_predicates` reader · cone-based seeder routing (`CombKind`).

### Validated (`mununu-sva` docker — all 5 e2e PASS)
sysrst HOLDS=1 (sva_0, H.B intact), **VIOLATED=0**, combinational antecedents soundly SKIP; csrng unchanged. Unit + seam tests (cone classifier, `combinational_labels` KleeneT/F by state cube, seeder routing, encode infra). Full lib suite (2063) + 5 e2e green; clippy + fmt clean; pre-push `make ci` green.

### Deferred follow-ups (the actual verdict conversion)
- **H.E.f1 — next-cycle combinational cache** (the deep fix): the may/must edge checks must COMPUTE the combinational signal's value at *both* source and target (evaluate the node over `state_next` + fresh next-inputs), not free, not a static label. Unblocks the input-dependent combinational antecedents soundly.
- **H.E.f2 — output-line combinational signals**: `main_sm_err_o` / `event_detected_*` are `output` lines (not named `Op` nodes), so the classifier misses them. Unblocks csrng `main_sm_err_o` + sysrst sva_1/10/11/12.

### Surface
No public `verify_auto` API change; `SvAnnotation` gains an optional `combinational_predicates` field (default empty, backward-compatible). No mununu-ui PR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)