### PR TITLE
H.U.3 soundness doc + H.O.0.1: internal exact oracle core

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/concrete_oracle.rs
+++ b/crates/mununu-core/src/adapter/btor2/concrete_oracle.rs
@@ -1,0 +1,309 @@
+//! H.O.0 — internal exact oracle for verify-auto verdicts (increment 1).
+//!
+//! The 2026-06-29 soundness review found we have **no independent check** that a
+//! DEFINITE verify-auto verdict is correct — and a spurious `HOLDS` (silently
+//! claiming a property holds) is more dangerous than a spurious `VIOLATED` and
+//! nothing catches it. This module is the cheapest oracle: it computes a safety
+//! property's **concrete** truth by bounded reachability enumeration (mununu's
+//! own exact one-step semantics, no abstraction), so a cube-path `HOLDS` that the
+//! concrete design contradicts is caught.
+//!
+//! **Scope (increment 1).** The `AG (signal ⋈ value)` fragment over a **state
+//! register** signal — input-independent, exactly where a spurious HOLDS on the
+//! state-predicate cube core would surface. Combinational / input atoms (which
+//! need input quantification) and the `|=>` (`AX`) shape are later increments
+//! (H.O.0.2+). The reachability is **sound for finding violations** always, and
+//! **sound for concluding AG-true** only when the full input space was
+//! enumerated (`!bounded`); a `bounded` result never concludes true.
+//!
+//! Not wired into the production path — a validation oracle, consumed by the
+//! verify-auto e2e/regression tests (`AgOracle` ⟷ the cube verdict).
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::adapter::AdapterError;
+use crate::adapter::btor2::ast::{ConstValue, Node};
+use crate::adapter::btor2::parser::{self, bv_width};
+use crate::adapter::btor2::predicate_expr::CmpOp;
+use crate::adapter::btor2::{ast::Btor2File, bit_blast};
+
+/// Bounded reachable set of concrete register valuations.
+#[derive(Debug, Clone)]
+pub struct Reachability {
+    /// Reachable register-state valuations (keyed by state-cell symbol).
+    pub states: Vec<BTreeMap<String, u128>>,
+    /// True when enumeration was capped (by `max_states`) or some input could
+    /// not be exhaustively enumerated (wider than `max_input_bits`). A bounded
+    /// reachability can still witness a violation, but cannot conclude AG-true.
+    pub bounded: bool,
+}
+
+/// The concrete `AG (atom)` verdict from bounded reachability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgOracle {
+    /// The atom holds at every reachable state AND the full input space was
+    /// enumerated — `AG atom` is concretely TRUE.
+    Holds,
+    /// A reachable state violates the atom — `AG atom` is concretely FALSE.
+    /// Carries the witness register valuation.
+    Violated(BTreeMap<String, u128>),
+    /// No violation found, but enumeration was bounded — inconclusive for TRUE
+    /// (the oracle can refute a cube-HOLDS but not confirm it here).
+    Inconclusive,
+}
+
+/// State-cell symbols of the design.
+fn state_cells(file: &Btor2File) -> Vec<(String, u32)> {
+    let symbols = parser::collect_symbols(file);
+    file.lines
+        .iter()
+        .filter_map(|l| match &l.node {
+            Node::State { sort, .. } => {
+                let name = symbols.get(&l.nid)?.clone();
+                let w = bv_width(file, *sort).unwrap_or(0);
+                Some((name, w))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Init value of each state cell (from BTOR2 `init` lines, default 0 — the
+/// `setundef -zero` power-up).
+fn init_valuation(file: &Btor2File) -> BTreeMap<String, u128> {
+    let symbols = parser::collect_symbols(file);
+    let mut init_of: HashMap<crate::adapter::btor2::ast::Nid, u128> = HashMap::new();
+    for line in &file.lines {
+        if let Node::Init { state, value, .. } = &line.node
+            && let Some(cl) = file.lookup(value.nid())
+            && let Node::Const { sort, value: cv } = &cl.node
+        {
+            init_of.insert(*state, const_to_u128(file, *sort, cv));
+        }
+    }
+    let mut out = BTreeMap::new();
+    for line in &file.lines {
+        if matches!(line.node, Node::State { .. })
+            && let Some(name) = symbols.get(&line.nid)
+        {
+            out.insert(name.clone(), init_of.get(&line.nid).copied().unwrap_or(0));
+        }
+    }
+    out
+}
+
+fn const_to_u128(file: &Btor2File, sort: crate::adapter::btor2::ast::Nid, cv: &ConstValue) -> u128 {
+    match cv {
+        ConstValue::Zero => 0,
+        ConstValue::One => 1,
+        ConstValue::Ones => {
+            let w = bv_width(file, sort).unwrap_or(0);
+            if w == 0 || w >= 128 {
+                u128::MAX
+            } else {
+                (1u128 << w) - 1
+            }
+        }
+        ConstValue::Dec(d) => *d as u128,
+        ConstValue::Bin(b) => u128::from_str_radix(b, 2).unwrap_or(0),
+        ConstValue::Hex(h) => u128::from_str_radix(h, 16).unwrap_or(0),
+    }
+}
+
+/// 1-bit primary input symbols (the enumerable environment).
+fn boolean_inputs(file: &Btor2File) -> (Vec<String>, bool) {
+    let symbols = parser::collect_symbols(file);
+    let mut bool_ins = Vec::new();
+    let mut has_wide = false;
+    for line in &file.lines {
+        if let Node::Input { sort, .. } = &line.node {
+            let w = bv_width(file, *sort).unwrap_or(0);
+            match (w, symbols.get(&line.nid)) {
+                (1, Some(name)) => bool_ins.push(name.clone()),
+                // a wide (>1-bit) input we will NOT exhaustively enumerate →
+                // reachability becomes bounded (sound only for finding violations).
+                _ => has_wide = true,
+            }
+        }
+    }
+    bool_ins.sort();
+    (bool_ins, has_wide)
+}
+
+/// BFS the reachable concrete register-states from init, simulating one step over
+/// every combination of the (1-bit) primary inputs. Bounded by `max_states`; a
+/// wide input or hitting the cap sets `bounded`.
+pub fn reachable_register_states(
+    file: &Btor2File,
+    max_states: usize,
+    max_input_bits: usize,
+) -> Result<Reachability, AdapterError> {
+    let (bool_ins, has_wide) = boolean_inputs(file);
+    let n_in = bool_ins.len().min(max_input_bits);
+    // bounded if a wide input exists, or we capped the input bits we enumerate.
+    let mut bounded = has_wide || bool_ins.len() > max_input_bits;
+    let n_combos: usize = 1usize << n_in;
+
+    let init = init_valuation(file);
+    let mut seen: HashSet<Vec<(String, u128)>> = HashSet::new();
+    // `order` doubles as the BFS queue (walked by `head`) and the result list.
+    let mut order: Vec<BTreeMap<String, u128>> = Vec::new();
+    let key = |s: &BTreeMap<String, u128>| -> Vec<(String, u128)> {
+        s.iter().map(|(k, v)| (k.clone(), *v)).collect()
+    };
+    seen.insert(key(&init));
+    order.push(init);
+
+    let mut head = 0;
+    while head < order.len() {
+        if order.len() >= max_states {
+            bounded = true;
+            break;
+        }
+        let state = order[head].clone();
+        head += 1;
+        let regs: HashMap<String, u128> = state.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        for combo in 0..n_combos {
+            let inputs: HashMap<String, u128> = bool_ins
+                .iter()
+                .take(n_in)
+                .enumerate()
+                .map(|(b, name)| (name.clone(), ((combo >> b) & 1) as u128))
+                .collect();
+            let next = bit_blast::simulate_one_step(file, &regs, &inputs)?;
+            let next_sorted: BTreeMap<String, u128> = next.into_iter().collect();
+            if seen.insert(key(&next_sorted)) {
+                if order.len() < max_states {
+                    order.push(next_sorted);
+                } else {
+                    bounded = true;
+                }
+            }
+        }
+    }
+    Ok(Reachability {
+        states: order,
+        bounded,
+    })
+}
+
+fn cmp_holds(op: CmpOp, lhs: u128, rhs: u128) -> bool {
+    match op {
+        CmpOp::Eq => lhs == rhs,
+        CmpOp::Ne => lhs != rhs,
+        CmpOp::Lt => lhs < rhs,
+        CmpOp::Le => lhs <= rhs,
+        CmpOp::Gt => lhs > rhs,
+        CmpOp::Ge => lhs >= rhs,
+    }
+}
+
+/// Concrete `AG (signal ⋈ value)` oracle over a **state-register** signal. The
+/// signal must be a state cell (input-independent); a non-state signal returns an
+/// error (out of increment-1 scope). Reads each reachable state's register value
+/// directly — no abstraction.
+pub fn ag_state_atom(
+    file: &Btor2File,
+    signal: &str,
+    op: CmpOp,
+    value: u128,
+    max_states: usize,
+    max_input_bits: usize,
+) -> Result<AgOracle, AdapterError> {
+    if !state_cells(file).iter().any(|(n, _)| n == signal) {
+        return Err(AdapterError {
+            kind: crate::adapter::AdapterErrorKind::IrConsistencyError,
+            location: None,
+            message: format!(
+                "concrete_oracle::ag_state_atom: `{signal}` is not a state cell \
+                 (increment 1 covers state-register safety atoms only)"
+            ),
+        });
+    }
+    let reach = reachable_register_states(file, max_states, max_input_bits)?;
+    for st in &reach.states {
+        let v = st.get(signal).copied().unwrap_or(0);
+        if !cmp_holds(op, v, value) {
+            return Ok(AgOracle::Violated(st.clone()));
+        }
+    }
+    if reach.bounded {
+        Ok(AgOracle::Inconclusive)
+    } else {
+        Ok(AgOracle::Holds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::parser::parse;
+
+    // A 2-bit FSM cycling 0→1→2→0 (caps at 2, never reaches 3), input-free in
+    // the next-state (deterministic). `state` is a 2-bit register.
+    //   next(state) = (state == 2) ? 0 : state + 1
+    // BTOR2: 1 sort2, 2 state, consts, the ite chain.
+    const CYCLE_FSM: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 state 2 state
+4 zero 2
+5 one 2
+6 constd 2 2
+7 eq 1 3 6
+8 add 2 3 5
+9 ite 2 7 4 8
+10 next 2 3 9
+11 init 2 3 4
+";
+
+    #[test]
+    fn reachability_enumerates_the_cycle() {
+        let file = parse(CYCLE_FSM).expect("parse cycle fsm");
+        let r = reachable_register_states(&file, 64, 8).expect("reach");
+        let vals: std::collections::HashSet<u128> = r.states.iter().map(|s| s["state"]).collect();
+        // reachable states: 0, 1, 2 (never 3). Fully enumerated (no inputs).
+        assert_eq!(
+            vals,
+            [0, 1, 2].into_iter().collect(),
+            "0→1→2→0 cycle, 3 unreachable"
+        );
+        assert!(!r.bounded, "no inputs ⇒ full enumeration");
+    }
+
+    #[test]
+    fn ag_holds_for_unreachable_value() {
+        let file = parse(CYCLE_FSM).expect("parse");
+        // AG (state != 3) — 3 is unreachable → HOLDS (full enumeration).
+        assert_eq!(
+            ag_state_atom(&file, "state", CmpOp::Ne, 3, 64, 8).unwrap(),
+            AgOracle::Holds
+        );
+    }
+
+    #[test]
+    fn ag_violated_for_reachable_value() {
+        let file = parse(CYCLE_FSM).expect("parse");
+        // AG (state != 1) — 1 IS reachable → VIOLATED, with the witness.
+        match ag_state_atom(&file, "state", CmpOp::Ne, 1, 64, 8).unwrap() {
+            AgOracle::Violated(st) => assert_eq!(st["state"], 1),
+            other => panic!("expected Violated(state=1), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ag_le_bound_holds() {
+        let file = parse(CYCLE_FSM).expect("parse");
+        // AG (state <= 2) — every reachable state ≤ 2 → HOLDS.
+        assert_eq!(
+            ag_state_atom(&file, "state", CmpOp::Le, 2, 64, 8).unwrap(),
+            AgOracle::Holds
+        );
+    }
+
+    #[test]
+    fn non_state_signal_is_rejected() {
+        let file = parse(CYCLE_FSM).expect("parse");
+        assert!(ag_state_atom(&file, "not_a_state", CmpOp::Eq, 0, 64, 8).is_err());
+    }
+}

--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -22,6 +22,7 @@
 pub mod ast;
 pub mod bit_blast;
 pub mod cegar;
+pub mod concrete_oracle;
 pub mod dep_graph;
 pub mod kmts_lift;
 pub mod parser;

--- a/docs/design/predicate-image-soundness.md
+++ b/docs/design/predicate-image-soundness.md
@@ -1,0 +1,229 @@
+# Predicate-image soundness — mapping mununu's cube/edge construction to the theorem
+
+> Status: planning. The construction this doc argues sound is **evolving** toward
+> the uniform predicate-image (H.U); §5 marks, per case, what is shipped-and-sound,
+> what is shipped-as-foundation-only, and what is gap. This doc is the artifact the
+> 2026-06-29 soundness review found missing: we cited the *evaluator's* preservation
+> theorem but never argued our *abstraction* meets its hypotheses. Until H.O (the
+> oracle harness) lands, every DEFINITE verify-auto verdict on real RTL is an
+> internal claim — this doc is the soundness *argument*; the oracle is the
+> soundness *evidence*.
+
+## Contents
+
+1. [Why this doc exists](#1-why-this-doc-exists)
+2. [The objects](#2-the-objects)
+3. [The theorem we rely on](#3-the-theorem-we-rely-on)
+4. [The predicate-image construction](#4-the-predicate-image-construction)
+5. [Per-case soundness ledger](#5-per-case-soundness-ledger)
+6. [The must relation, inputs, and controllability](#6-the-must-relation-inputs-and-controllability)
+7. [What is argued vs verified vs gap](#7-what-is-argued-vs-verified-vs-gap)
+8. [References](#8-references)
+
+---
+
+## 1. Why this doc exists
+
+> Concept: the soundness of a 3-valued predicate abstraction is *by construction*
+> when the abstract may/must relations are, respectively, a sound over- and
+> under-approximation of the concrete transition relation. The mis-steps the
+> H.E arc hit (a derived label that the cube could not pin; a `target-free`
+> encoding that fabricated must-edges for a combinational-of-input signal) were
+> all cases where the *construction* silently violated that precondition. The
+> fix is not another special case — it is to make the construction uniform
+> (§4) so the precondition holds by inspection of one rule, and to write *this*
+> argument so it is checkable rather than rediscovered via spurious verdicts.
+
+mununu's verification core abstracts a symbolic transition system (a BTOR2
+design, frontend-agnostic via the STS-IR seam) into a **Kripke Modal Transition
+System (KMTS)** whose states are **predicate cubes**, then evaluates the modal
+μ-calculus over it with a **3-valued** (`KleeneT` / `KleeneF` / `KleeneBot`)
+evaluator. The whole point is: a *definite* verdict (`KleeneT` or `KleeneF`) on
+the abstraction transfers to the concrete design at every alternation depth, so
+we get sound safety **and** liveness/recoverability verdicts on designs too large
+to enumerate. This doc states the construction precisely and argues the transfer.
+
+## 2. The objects
+
+**Concrete system.** A symbolic transition system `M = (S, I, T)` over state
+variables (latches) and inputs:
+- states `S` = valuations of the latches;
+- a one-step relation `T(s, i, s')` relating current latch state `s` + input `i`
+  to next latch state `s'` (the BTOR2 `next` functions; combinational signals are
+  *terms* `g(s, i)`, not separate state);
+- initial states `I`.
+
+> Source of truth: [`Btor2SmtView`](../../crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs) — surface: API (the SMT encode of `T` + the per-node term BVs).
+
+**Predicates.** `P = {p_0, …, p_{n-1}}`, each `p_k` a Boolean over a **term**
+`t_k` of the design — `t_k` may be a latch (`state_q`), an input (`cfg_enable_i`),
+or a combinational expression (`trigger_active = (trigger_i == 0)`), and the atom
+is `t_k ⋈ v` for `⋈ ∈ {==, !=, <, ≤, >, ≥}` or a Boolean combination thereof.
+
+> Source of truth: [`PredicateSpec`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs) + [`PredicateExpr`](../../crates/mununu-core/src/adapter/btor2/predicate_expr.rs) — surface: API.
+
+**Abstraction.** An abstract state is a **cube** `c ∈ {0,1}^n` (bit `k` = the
+truth of `p_k`). The concretization `γ(c) = { s | ∀k. p_k(s) = c_k }`. The
+abstract KMTS carries two transition relations with `R_must ⊆ R_may`:
+- `R_may` — an **over**-approximation: `(c, c') ∈ R_may` whenever *some* concrete
+  transition crosses from `γ(c)` to `γ(c')`;
+- `R_must` — an **under**-approximation: `(c, c') ∈ R_must` only when *every*
+  concrete state in `γ(c)` has a successor in `γ(c')` (∀∃; the GKMTS hyper-must
+  generalises the target to a set).
+
+> Source of truth: [`predicate_cube_lift`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs) — surface: API (builds the cube `Clts` + edges).
+
+## 3. The theorem we rely on
+
+> Concept: 3-valued μ-calculus model checking over a KMTS (Bruns–Godefroid CONCUR
+> 2000; Godefroid–Jagadeesan TACAS 2003; Shoham–Grumberg LMCS 2007 for the
+> game/GKMTS extension and the alternating-fixpoint monotonicity).
+
+**Preservation theorem.** Let `A` be a KMTS abstraction of `M` such that
+- (over) `R_may ⊇ α(T)`: every concrete transition is covered by a may-edge;
+- (under) `R_must ⊆ α(T)`: every must-edge is realized by every concrete state of
+  its source cube;
+- (labels) each AP's 3-valued cube label is `KleeneT`/`KleeneF` only when the AP
+  is, respectively, definitely true / definitely false over **all** of `γ(c)`.
+
+Then for every closed μ-calculus formula `φ` and abstract state `c`:
+`⟦φ⟧_A(c) = KleeneT ⟹ ∀ s ∈ γ(c). M, s ⊨ φ`, and
+`⟦φ⟧_A(c) = KleeneF ⟹ ∀ s ∈ γ(c). M, s ⊭ φ`.
+`KleeneBot` carries no claim (refine, or report honest ⊥).
+
+> Source of truth: [`evaluate_tri`](../../crates/mununu-core/src/mu_calculus/evaluator.rs) + [`parity_game_3v`](../../crates/mununu-core/src/mu_calculus/parity_game_3v.rs) — surface: API (the 3-valued evaluator; verdict-equivalence to the 2-valued path on Sharp-only inputs is a shipped done-criterion).
+
+**The obligation this doc discharges.** The theorem is about the *evaluator*. Our
+job is to show our **construction** satisfies the three preconditions (over,
+under, labels). §4–§5 do that, per predicate kind.
+
+## 4. The predicate-image construction
+
+> Concept: implicit predicate abstraction — Cimatti–Griggio–Mover–Tonetta,
+> "IC3 modulo theories via implicit predicate abstraction", TACAS 2014; the
+> abstract image is a single SMT query, predicates over arbitrary terms.
+
+The **uniform** abstract may-relation is one satisfiability query over the SMT
+encoding of `T`:
+
+```
+(c, c') ∈ R_may   ⟺   ∃ s, i, i', s'.  T(s, i, s')  ∧  src@(s,i)  ∧  tgt@(s',i')
+```
+
+where `src@(s,i) = ⋀_k cube_bit(c,k)?  p_k(s,i)` and `tgt@(s',i')` is the
+**primed** form of each predicate: `p_k` over term `t_k(state, input)` becomes
+`t_k(s', i')` with `i'` a **fresh** next-cycle input. A pair is excluded only when
+the solver proves the query UNSAT — so timeouts / unresolved terms conservatively
+*keep* the edge (over-approximation preserved).
+
+> Source of truth: [`smt_per_target_may_check`](../../crates/mununu-core/src/adapter/btor2/smt_must_edge.rs) — surface: API.
+
+The must-relation is the dual ∀∃ obligation (UNSAT of its negation), so a pair is
+*included* only when proved — failure conservatively *drops* it (never fabricates
+a must-witness, preserving the under-approximation):
+
+```
+(c, c') ∈ R_must  ⟺   ∀ s ⊨ src.  ∃ i, i', s'.  T(s,i,s') ∧ tgt@(s',i')
+```
+
+> Source of truth: [`smt_per_target_must_check_standard`](../../crates/mununu-core/src/adapter/btor2/smt_must_edge.rs) + [`smt_hyper_must_check`](../../crates/mununu-core/src/adapter/btor2/smt_must_edge.rs) — surface: API.
+
+**Why uniformity is the soundness lever.** With one rule, the over/under
+preconditions of §3 hold for *every* predicate by the same argument — there is no
+per-atom-kind encoding to get wrong. Every special case below is a *projection* of
+this rule:
+- **latch** `t_k = state_q`: `tgt` uses `s'` (`state_next`); no `i'`.
+- **raw input** `t_k = in`: `src` pins `in`, `tgt` uses the *fresh* `i'` →
+  existential in may (both flavours reachable — correct, the environment is free).
+- **combinational** `t_k = g(state, input)`: `tgt` is `g(s', i')`.
+- **relational / arithmetic**: `t_k` is the comparison/arith term itself.
+
+The current code (pre-H.U) implements latch + raw-input directly and special-cases
+combinational; §5 records exactly which projections are shipped-sound vs awaiting
+H.U.
+
+> Source of truth: [`build_pred_constraint`](../../crates/mununu-core/src/adapter/btor2/smt_must_edge.rs) — surface: API (today: per-kind branches; H.U: the one uniform rule above).
+
+## 5. Per-case soundness ledger
+
+| Predicate term kind | `src` encoding | `tgt` (primed) encoding | Status | Sound? |
+|---|---|---|---|---|
+| **latch** `state_q ⋈ v` | `state_curr` | `state_next` (`s'`) | shipped | **Yes** — the textbook case; over/under hold by the SMT image. |
+| **free input** `in ⋈ v` (H.B) | pin `view.inputs[in]` | `true` (≡ fresh `i'` existential) | shipped | **Yes** — `tgt` free = "for all next-input flavours"; over-approx in may, and in must the next input is genuinely environment-free so both flavours are realizable. |
+| **combinational-of-state** `g(state) ⋈ v` (H.E) | derived per-cube 3-valued **label** | the same label at the target cube (value determined by that cube's own state) | shipped (foundation) | **Yes** — `g(state)` is determined by `γ(c)`'s latch dimensions, so the label meets the §3 label precondition at every cube incl. targets. *Caveat:* no anchor exercises it end-to-end (sysrst's are output-line, §7). |
+| **combinational-of-input** `g(state, input) ⋈ v` (H.E) | — | — | **deferred (SKIPPED)** | label is unsound (cube can't pin a free input → label not definite over `γ(c)`); `target-free` is unsound for must (`g(s',i')` is not freely both flavours → fabricates must-edges). The sound encoding is `tgt = g(s', i')` (§4) = **H.U.1**. Until then SKIP — never a misleading verdict. |
+| **relational** `t1 ⋈ t2` (REL / H.F) | both terms at `(s,i)` | both terms at `(s',i')` | partial (state↔state shipped via `CmpReg`; input/comb operands deferred) | state↔state **Yes**; an input/comb operand needs the §4 primed form = H.U. |
+| **arithmetic** `t == t' + k` (H.G) | term BV | primed term BV | deferred | a derived observer node (pure function of state, the `$past`-shadow regime) under H.U. |
+
+**The empty-cube subtlety.** A cube whose dimension constraints are jointly UNSAT
+(e.g. `state==0 ∧ state==1`) has `γ(c) = ∅`. A `KleeneT`/`KleeneF` label there is
+*vacuously* consistent with §3 (the ∀ over an empty set), and such cubes are
+unreachable from `I` so they cannot pollute the init verdict — but the may/must
+*edge* checks must treat them correctly (an empty source has no must-obligation;
+an empty target receives no must-edge). The SMT image handles this automatically
+(an UNSAT `src`/`tgt` makes the query UNSAT). The H.E `smt_combinational_label`
+guard against an empty cube was added under a *wrong* hypothesis (it was not the
+cause of the spurious VIOLATED) — it is sound but is retired with the
+derived-label machinery in H.U.2.
+
+## 6. The must relation, inputs, and controllability
+
+The ∀∃ must (§4) existentially chooses the input `i` and successor `s'` per source
+state. For a **closed** system or one where inputs are demonic-for-safety this is
+the standard KMTS must. For an **open** system the input partitions into
+*environment* (uncontrollable) and *controller* (controllable) — the must-edge
+quantifier alternation must respect that partition (∀ env ∃ ctrl for a controller
+obligation). That is the controllability-aware KMTS of de Alfaro–Godefroid–
+Jagadeesan (LICS 2004), tracked separately as the **R.6** arc; this doc's plain
+∀∃ must is sound for the safety + non-controllability fragment the H-track
+verify-auto path targets. A DEFINITE *controllability* verdict additionally
+depends on R.6.8 (the per-player preservation audit) and is out of scope here.
+
+> Source of truth: [`docs/design/kmts-theory.md`](kmts-theory.md) §7 — surface: (theory companion).
+
+## 7. What is argued vs verified vs gap
+
+- **Argued (this doc):** the over/under/label preconditions hold for the latch,
+  free-input, and combinational-of-state cases; therefore definite verdicts on
+  those transfer (Bruns–Godefroid).
+- **Verified (tests):** the 3-valued evaluator equals the 2-valued path on
+  Sharp-only inputs; the SMT may/must edge checks on small fixtures
+  (`smt_must_edge` + `sts_ir` seam tests); the cone classifier; the
+  combinational-label determinism on a state-cube. These check *components*, not
+  the end-to-end transfer on real RTL.
+- **Gap 1 — no end-to-end oracle.** No DEFINITE verify-auto verdict on real RTL
+  has been cross-checked against an independent model checker. A spurious
+  `HOLDS` (worse than a spurious `VIOLATED`) would be undetected. Closed by
+  **H.O** (oracle harness): H.O.0 = differential vs mununu's own *exact*
+  bit-blast path on small fixtures (catches spurious HOLDS on the shipped core);
+  H.O.1 = external BTOR2 model checker on the real anchors.
+- **Gap 2 — combinational-of-input not yet sound-and-bound.** Currently SKIPPED;
+  closed by **H.U.1** (the primed term `g(s',i')`).
+- **Gap 3 — the construction is argued, not mechanized.** The mapping in §5 is a
+  pen-and-paper argument; the mis-steps show pen-and-paper alone is fallible.
+  H.U makes the construction uniform so the argument reduces to inspecting one
+  rule; H.O provides empirical evidence the rule is implemented correctly.
+
+**Honest bottom line.** The state-predicate + free-input cases are on solid
+footing and PO-backed; combinational-of-input is correctly *deferred*, not
+wrongly bound; and "verify-auto produces a sound verdict on real RTL" is **not a
+publishable claim until H.O lands**.
+
+## 8. References
+
+- E. M. Clarke, O. Grumberg, S. Jha, Y. Lu, H. Veith. *Counterexample-guided
+  abstraction refinement.* CAV 2000.
+- S. Graf, H. Saïdi. *Construction of abstract state graphs with PVS.* CAV 1997.
+- G. Bruns, P. Godefroid. *Generalized model checking: reasoning about partial
+  state spaces.* CONCUR 2000.
+- P. Godefroid, R. Jagadeesan. *On the expressiveness of 3-valued models.*
+  VMCAI/TACAS 2003.
+- S. Shoham, O. Grumberg. *A game-based framework for CTL counterexamples and
+  3-valued abstraction-refinement.* LMCS 2007.
+- A. Cimatti, A. Griggio, S. Mover, S. Tonetta. *IC3 modulo theories via implicit
+  predicate abstraction.* TACAS 2014.
+- L. de Alfaro, P. Godefroid, R. Jagadeesan. *Three-valued abstractions of games.*
+  LICS / CONCUR 2004. (controllability axis; R.6.)
+- Cross-refs: [`kmts-theory.md`](kmts-theory.md),
+  [`predicate-abstraction-recipe.md`](predicate-abstraction-recipe.md),
+  [`abstraction-literature.md`](abstraction-literature.md).


### PR DESCRIPTION
## What

Two soundness-track deliverables from the 2026-06-29 review of the no-sidecar SVA-verification (`verify-auto`) path:

1. **H.U.3 — `docs/design/predicate-image-soundness.md`** (commit 1eb8af6). The soundness argument for the predicate-cube/edge construction: maps cube + may/must-edge construction to the Bruns–Godefroid 3-valued preservation preconditions and the IC3-IA (Cimatti et al. TACAS 2014) implicit-abstraction image; §5 is a per-atom-kind soundness ledger (latch / free-input = sound + shipped; combinational-of-state = sound foundation; combinational-of-input = deferred; relational / arithmetic = under the planned uniform-image work); §7 separates *argued* from *mechanically-verified* and names the two open gaps — **no independent oracle** for a spurious verdict, and the construction is hand-written per atom kind rather than one uniform image. Tagged `> Status: planning` with verified Source-of-truth anchors.

2. **H.O.0.1 — `adapter/btor2/concrete_oracle.rs`** (commit 3b8c18c). The first, cheapest closure of the "no oracle" gap. The review's key finding: a spurious `HOLDS` (silently claiming a property holds) is more dangerous than a spurious `VIOLATED`, and nothing catches it. This module computes a safety property's **concrete** truth by bounded reachability enumeration (mununu's own exact one-step semantics, `bit_blast::simulate_one_step`, no abstraction):
   - `reachable_register_states` — BFS the reachable concrete register valuations from the design's init over every 1-bit-input combination; bounded by `max_states` / wide inputs.
   - `ag_state_atom` — concrete `AG (state-register ⋈ value)` → `Holds` / `Violated(witness)` / `Inconclusive`.

   **Soundness:** sound for finding violations always; sound for concluding AG-true only on full (`!bounded`) enumeration — a bounded run never concludes true. Uses concrete enumeration rather than a second lift path, sidestepping the cube-vs-bit-blast atom-binding mismatch.

## Scope

This is the **oracle core** (increment 1): the `AG(state-register atom)` fragment — exactly where a spurious HOLDS on the merged H.A/H.B state-predicate cube path would surface. Not wired into the production path; it's a validation oracle.

**Next (separate PRs):** H.O.0.2 wires it as a differential vs the cube verdict (the actual spurious-HOLDS guard); H.O.0.3 widens to `|=>` (AX) + combinational/input atoms and gates the verify-auto e2e.

## Tests

5 unit tests on a 0→1→2→0 FSM fixture: reachability enumerates {0,1,2}; `AG state≠3` Holds; `AG state≠1` Violated with witness; `AG state≤2` Holds; non-state signal rejected. Workspace `make ci` green (pre-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)