### PR TITLE
H.O.0.3b: gate a real-OpenTitan verdict on the oracle (reset-pinned)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/concrete_oracle.rs
+++ b/crates/mununu-core/src/adapter/btor2/concrete_oracle.rs
@@ -194,18 +194,25 @@ fn cmp_holds(op: CmpOp, lhs: u128, rhs: u128) -> bool {
 /// state symbol resolves to itself; a `uext`/`sext`-by-0 or `output` rename of a
 /// state cell resolves to that cell; a combinational *function* of state does
 /// NOT resolve (binding it to a state's value would read the wrong value).
-/// Reset-mux aliases are NOT followed (`allow_reset_mux = false`): the oracle
-/// does not pin reset, so the register equals the state only when reset is
-/// inactive, which the free-input enumeration does not guarantee.
-fn resolve_signal_symbol(file: &Btor2File, signal: &str) -> Option<String> {
-    let nid = parser::resolve_state_alias(file, signal, false)?;
+///
+/// `allow_reset_mux` (H.O.0.3b) controls whether an async-reset register mux
+/// `ite(rst, state, resetval)` is followed to its state branch. Pass `true`
+/// **only when the design's reset input is pinned inactive** (e.g. the caller
+/// ran `pin_inputs_to_constants` to match verify_auto's reset-gating): then the
+/// mux always selects the state branch, so the register's value equals the
+/// state's and binding is sound — the same condition under which the verify-auto
+/// seeder follows it. Pass `false` when reset is a free input (the register only
+/// equals the state while reset is inactive, which free enumeration breaks).
+fn resolve_signal_symbol(file: &Btor2File, signal: &str, allow_reset_mux: bool) -> Option<String> {
+    let nid = parser::resolve_state_alias(file, signal, allow_reset_mux)?;
     parser::collect_symbols(file).get(&nid).cloned()
 }
 
 /// Concrete `AG (signal ⋈ value)` oracle over a **state-register** signal (or a
 /// value-alias of one — H.O.0.3 resolution). Reads each reachable state's
 /// register value directly — no abstraction. A signal that does not resolve to a
-/// state cell returns an error (out of the AG-state-atom fragment).
+/// state cell returns an error (out of the AG-state-atom fragment). See
+/// [`resolve_signal_symbol`] for `reset_pinned`.
 pub fn ag_state_atom(
     file: &Btor2File,
     signal: &str,
@@ -213,8 +220,9 @@ pub fn ag_state_atom(
     value: u128,
     max_states: usize,
     max_input_bits: usize,
+    reset_pinned: bool,
 ) -> Result<AgOracle, AdapterError> {
-    let cell = resolve_signal_symbol(file, signal).ok_or_else(|| AdapterError {
+    let cell = resolve_signal_symbol(file, signal, reset_pinned).ok_or_else(|| AdapterError {
         kind: crate::adapter::AdapterErrorKind::IrConsistencyError,
         location: None,
         message: format!(
@@ -273,13 +281,15 @@ impl OracleAtom {
 ///
 /// Out-of-fragment signals error: a consequent that is not a state cell, or an
 /// antecedent that is neither a state cell nor a 1-bit primary input (e.g. a
-/// combinational function of state, deferred to a later increment).
+/// combinational function of state, deferred to a later increment). See
+/// [`resolve_signal_symbol`] for `reset_pinned`.
 pub fn ag_implies_next(
     file: &Btor2File,
     ante: &OracleAtom,
     cons: &OracleAtom,
     max_states: usize,
     max_input_bits: usize,
+    reset_pinned: bool,
 ) -> Result<AgOracle, AdapterError> {
     let err = |m: String| AdapterError {
         kind: crate::adapter::AdapterErrorKind::IrConsistencyError,
@@ -287,7 +297,7 @@ pub fn ag_implies_next(
         message: m,
     };
     // Consequent: a state cell (checked at the next state).
-    let cons_cell = resolve_signal_symbol(file, &cons.signal).ok_or_else(|| {
+    let cons_cell = resolve_signal_symbol(file, &cons.signal, reset_pinned).ok_or_else(|| {
         err(format!(
             "concrete_oracle::ag_implies_next: consequent `{}` does not resolve to a state cell",
             cons.signal
@@ -295,7 +305,7 @@ pub fn ag_implies_next(
     })?;
     // Antecedent: a state cell OR a 1-bit primary input.
     let (bool_ins, _has_wide) = boolean_inputs(file);
-    let ante_cell = resolve_signal_symbol(file, &ante.signal);
+    let ante_cell = resolve_signal_symbol(file, &ante.signal, reset_pinned);
     let ante_is_input = bool_ins.iter().any(|n| n == &ante.signal);
     if ante_cell.is_none() && !ante_is_input {
         return Err(err(format!(
@@ -383,7 +393,7 @@ mod tests {
         let file = parse(CYCLE_FSM).expect("parse");
         // AG (state != 3) — 3 is unreachable → HOLDS (full enumeration).
         assert_eq!(
-            ag_state_atom(&file, "state", CmpOp::Ne, 3, 64, 8).unwrap(),
+            ag_state_atom(&file, "state", CmpOp::Ne, 3, 64, 8, false).unwrap(),
             AgOracle::Holds
         );
     }
@@ -392,7 +402,7 @@ mod tests {
     fn ag_violated_for_reachable_value() {
         let file = parse(CYCLE_FSM).expect("parse");
         // AG (state != 1) — 1 IS reachable → VIOLATED, with the witness.
-        match ag_state_atom(&file, "state", CmpOp::Ne, 1, 64, 8).unwrap() {
+        match ag_state_atom(&file, "state", CmpOp::Ne, 1, 64, 8, false).unwrap() {
             AgOracle::Violated(st) => assert_eq!(st["state"], 1),
             other => panic!("expected Violated(state=1), got {other:?}"),
         }
@@ -403,7 +413,7 @@ mod tests {
         let file = parse(CYCLE_FSM).expect("parse");
         // AG (state <= 2) — every reachable state ≤ 2 → HOLDS.
         assert_eq!(
-            ag_state_atom(&file, "state", CmpOp::Le, 2, 64, 8).unwrap(),
+            ag_state_atom(&file, "state", CmpOp::Le, 2, 64, 8, false).unwrap(),
             AgOracle::Holds
         );
     }
@@ -411,7 +421,7 @@ mod tests {
     #[test]
     fn non_state_signal_is_rejected() {
         let file = parse(CYCLE_FSM).expect("parse");
-        assert!(ag_state_atom(&file, "not_a_state", CmpOp::Eq, 0, 64, 8).is_err());
+        assert!(ag_state_atom(&file, "not_a_state", CmpOp::Eq, 0, 64, 8, false).is_err());
     }
 
     // ---- H.O.0.3 — `|=>` (AX) oracle + signal resolution -------------------
@@ -447,7 +457,7 @@ mod tests {
         let ante = OracleAtom::new("state", CmpOp::Eq, 0);
         let cons = OracleAtom::new("state", CmpOp::Eq, 1);
         assert_eq!(
-            ag_implies_next(&file, &ante, &cons, 64, 8).unwrap(),
+            ag_implies_next(&file, &ante, &cons, 64, 8, false).unwrap(),
             AgOracle::Holds
         );
     }
@@ -458,7 +468,7 @@ mod tests {
         // AG (state == 0 |=> state == 2) — from 0 the next is 1, not 2 → VIOLATED.
         let ante = OracleAtom::new("state", CmpOp::Eq, 0);
         let cons = OracleAtom::new("state", CmpOp::Eq, 2);
-        match ag_implies_next(&file, &ante, &cons, 64, 8).unwrap() {
+        match ag_implies_next(&file, &ante, &cons, 64, 8, false).unwrap() {
             AgOracle::Violated(st) => assert_eq!(st["state"], 0),
             other => panic!("expected Violated(state=0), got {other:?}"),
         }
@@ -471,7 +481,7 @@ mod tests {
         let ante = OracleAtom::new("en", CmpOp::Eq, 1);
         let cons = OracleAtom::new("q", CmpOp::Eq, 1);
         assert_eq!(
-            ag_implies_next(&file, &ante, &cons, 64, 8).unwrap(),
+            ag_implies_next(&file, &ante, &cons, 64, 8, false).unwrap(),
             AgOracle::Holds
         );
     }
@@ -483,7 +493,7 @@ mod tests {
         let ante = OracleAtom::new("en", CmpOp::Eq, 1);
         let cons = OracleAtom::new("q", CmpOp::Eq, 0);
         assert!(matches!(
-            ag_implies_next(&file, &ante, &cons, 64, 8).unwrap(),
+            ag_implies_next(&file, &ante, &cons, 64, 8, false).unwrap(),
             AgOracle::Violated(_)
         ));
     }
@@ -495,7 +505,7 @@ mod tests {
         // the |=> fragment (it has no "next state" value).
         let ante = OracleAtom::new("q", CmpOp::Eq, 0);
         let cons = OracleAtom::new("en", CmpOp::Eq, 1);
-        assert!(ag_implies_next(&file, &ante, &cons, 64, 8).is_err());
+        assert!(ag_implies_next(&file, &ante, &cons, 64, 8, false).is_err());
     }
 
     #[test]
@@ -504,11 +514,11 @@ mod tests {
         // `st_alias` is a uext-0 rename of the state `st_internal` (stuck at 0).
         // The oracle binds it to the underlying cell and reads its real value.
         assert_eq!(
-            resolve_signal_symbol(&file, "st_alias").as_deref(),
+            resolve_signal_symbol(&file, "st_alias", false).as_deref(),
             Some("st_internal")
         );
         assert_eq!(
-            ag_state_atom(&file, "st_alias", CmpOp::Eq, 0, 64, 8).unwrap(),
+            ag_state_atom(&file, "st_alias", CmpOp::Eq, 0, 64, 8, false).unwrap(),
             AgOracle::Holds
         );
     }

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1753,14 +1753,14 @@ mod tests {
 
         // `state != 3` — the oracle proves HOLDS on the lifted design; the
         // verify_auto verdict must agree.
-        let o_safe = ag_state_atom(&file, "state", CmpOp::Ne, 3, 1024, 8)
+        let o_safe = ag_state_atom(&file, "state", CmpOp::Ne, 3, 1024, 8, false)
             .expect("oracle binds lifted `state`");
         assert_eq!(o_safe, AgOracle::Holds, "oracle: encoding 3 unreachable");
         gate("state != 3", &o_safe);
 
         // `state == 1` — false at the reset state → the oracle finds the violation.
-        let o_bad =
-            ag_state_atom(&file, "state", CmpOp::Eq, 1, 1024, 8).expect("oracle ag(state==1)");
+        let o_bad = ag_state_atom(&file, "state", CmpOp::Eq, 1, 1024, 8, false)
+            .expect("oracle ag(state==1)");
         assert!(
             matches!(o_bad, AgOracle::Violated(_)),
             "oracle: state==1 violated at reset"
@@ -1771,10 +1771,140 @@ mod tests {
         // state is always 0. The oracle proves HOLDS; verify_auto must agree.
         let ante = OracleAtom::new("state", CmpOp::Eq, 2);
         let cons = OracleAtom::new("state", CmpOp::Eq, 0);
-        let o_imp =
-            ag_implies_next(&file, &ante, &cons, 1024, 8).expect("oracle ag(state==2 |=> 0)");
+        let o_imp = ag_implies_next(&file, &ante, &cons, 1024, 8, false)
+            .expect("oracle ag(state==2 |=> 0)");
         assert_eq!(o_imp, AgOracle::Holds, "oracle: 2 always steps to 0");
         gate("state == 2", &o_imp);
+    }
+
+    #[test]
+    #[ignore = "requires slang + sv2v + yosys — run in the mununu-sva image"]
+    fn e2e_oracle_gates_sysrst_real_rtl_verdict() {
+        // H.O.0.3b — gate the ONE definite REAL-OpenTitan verdict against the
+        // concrete oracle: sysrst_ctrl_detect sva_0, `cfg_enable_i |=> state_q
+        // == 0`, which verify_auto reports HOLDS (a config-INPUT antecedent + a
+        // state consequent — exactly `ag_implies_next`'s fragment).
+        //
+        // The oracle must answer verify_auto's GATED question, so we pin the SAME
+        // reset verify_auto pinned (`diagnostics.gated_resets`) before enumerating
+        // — otherwise the oracle would explore reset-active states verify_auto
+        // excluded and could "refute" a verdict that is correct under the gated
+        // semantics. Pinning happens at the BTOR2 level (`pin_inputs_to_constants`),
+        // so the oracle needs no reset awareness.
+        //
+        // Honest boundary: sysrst has WIDE config inputs (`cfg_detect_timer_i`)
+        // the oracle cannot exhaustively enumerate, so its reachability is
+        // BOUNDED → it can soundly REFUTE a (shallow) spurious HOLDS but cannot
+        // CONFIRM a real-RTL HOLDS. Confirming real-RTL verdicts is H.O.1's
+        // (external BTOR2 model checker) domain. This test proves the oracle
+        // BINDS real-RTL atoms (state_q via value-alias resolution; cfg_enable_i
+        // as a 1-bit input) and provides a sound refutation guard.
+        use crate::adapter::btor2::kmts_lift::MustEdgeInference;
+        use std::path::PathBuf;
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/verify");
+        let sysrst = root.join("r46_sysrst_detect_k5/source");
+        let prim = root.join("m0_opentitan_prim_arbiter/source");
+        let read = |p: PathBuf| {
+            std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+        };
+        let sources = vec![
+            (
+                "sysrst_ctrl_detect.sv".to_string(),
+                read(sysrst.join("sysrst_ctrl_detect.sv")),
+            ),
+            (
+                "sysrst_ctrl_pkg.sv".to_string(),
+                read(sysrst.join("sysrst_ctrl_pkg.sv")),
+            ),
+            (
+                "prim_assert.sv".to_string(),
+                read(prim.join("prim_assert.sv")),
+            ),
+            (
+                "prim_assert_standard_macros.svh".to_string(),
+                read(prim.join("prim_assert_standard_macros.svh")),
+            ),
+            (
+                "prim_assert_sec_cm.svh".to_string(),
+                read(prim.join("prim_assert_sec_cm.svh")),
+            ),
+            (
+                "prim_flop_macros.sv".to_string(),
+                read(prim.join("prim_flop_macros.sv")),
+            ),
+        ];
+        let yopts = YosysOptions {
+            top: Some("sysrst_ctrl_detect".to_string()),
+            use_sv2v: true,
+            additional_sources: sources[1..].to_vec(),
+            ..Default::default()
+        };
+        let report = verify_auto(
+            &sources,
+            &yopts,
+            &VerifyAutoOptions {
+                must_edge_inference: MustEdgeInference::SmtHyperMust,
+                ..Default::default()
+            },
+        )
+        .expect("verify_auto runs on sysrst_ctrl_detect");
+
+        let sva0 = report
+            .properties
+            .iter()
+            .find(|p| p.name == "sysrst_ctrl_detect_sva_0")
+            .expect("sva_0 present");
+        assert!(
+            matches!(sva0.outcome, VerifyOutcome::Holds),
+            "precondition: verify_auto reports sva_0 HOLDS; got {:?}",
+            sva0.outcome
+        );
+
+        // Lift the base BTOR2 + pin the SAME resets verify_auto pinned.
+        let (btor2, _bb) =
+            crate::adapter::yosys::sv_to_btor2_with_blackboxes(&sources[0].1, &yopts)
+                .expect("sv → btor2");
+        let pins: Vec<(String, u64)> = report
+            .diagnostics
+            .gated_resets
+            .iter()
+            .filter_map(|g| {
+                let (n, v) = g.split_once('=')?;
+                Some((n.to_string(), v.trim().parse::<u64>().ok()?))
+            })
+            .collect();
+        eprintln!("\n=== H.O.0.3b sysrst gate: pinning resets {pins:?} ===");
+        let (pinned, _) = crate::adapter::btor2::pin::pin_inputs_to_constants(&btor2, &pins);
+        let file = crate::adapter::btor2::parser::parse(&pinned).expect("parse pinned btor2");
+
+        // The oracle for sva_0's exact shape:
+        //   formula: nu X. (((!((!(cfg_enable_i))) || [] (state_q == 0))) && [] X)
+        //   = (!cfg_enable_i) |=> (state_q == 0)   — "while DISABLED, stay idle".
+        // The antecedent is `cfg_enable_i == 0` (the double-negation in the
+        // formula resolves to `!a = cfg_enable_i`, so the SVA antecedent
+        // `a = !cfg_enable_i`). Getting this polarity wrong checks a different
+        // property and yields a bogus contradiction.
+        let ante = OracleAtom::new("cfg_enable_i", CmpOp::Eq, 0);
+        let cons = OracleAtom::new("state_q", CmpOp::Eq, 0);
+        // reset_pinned = true: rst_ni is pinned to a constant above, so following
+        // the async-reset register mux to `state_q`'s state cell is sound (the mux
+        // always selects the state branch) — the same condition the verify-auto
+        // seeder resolves `state_q` under.
+        let oracle = ag_implies_next(&file, &ante, &cons, 100_000, 8, true)
+            .expect("oracle binds real-RTL state_q (resolution) + cfg_enable_i (input)");
+        eprintln!("sysrst sva_0 `!cfg_enable_i |=> state_q == 0` oracle: {oracle:?}");
+
+        // Soundness gate: verify_auto's HOLDS must not be contradicted. On a
+        // genuinely-holding property the oracle returns Holds (if the design fits
+        // the cap) or Inconclusive (bounded) — never Violated.
+        assert!(
+            spurious_verdict(Trit::True, &oracle).is_none(),
+            "verify_auto sva_0 HOLDS contradicted by the concrete oracle: {oracle:?}"
+        );
+        assert!(
+            matches!(oracle, AgOracle::Holds | AgOracle::Inconclusive),
+            "no reachable violation of a genuinely-holding property; got {oracle:?}"
+        );
     }
 
     // ---- H.O.0.2 — oracle differential vs the cube verdict --------------------
@@ -1945,7 +2075,8 @@ mod tests {
 
         // The oracle side (H.O.0.1) — concrete bounded reachability, no abstraction.
         let file = crate::adapter::btor2::parser::parse(btor2).expect("oracle parses btor2");
-        let oracle = ag_state_atom(&file, signal, op, value as u128, 1024, 8).expect("oracle runs");
+        let oracle =
+            ag_state_atom(&file, signal, op, value as u128, 1024, 8, false).expect("oracle runs");
 
         // The spurious-verdict guard.
         if let Some(reason) = spurious_verdict(cube, &oracle) {


### PR DESCRIPTION
## What

Gates the one **definite real-OpenTitan verdict** — `sysrst_ctrl_detect` sva_0, `(!cfg_enable_i) |=> (state_q == 0)` ("while disabled, stay idle"), which verify_auto reports HOLDS — against the concrete oracle on the real lifted + reset-pinned BTOR2. Docker-validated in the `mununu-sva` image.

## `reset_pinned` threading

`concrete_oracle.rs` gains a `reset_pinned` flag on `resolve_signal_symbol` / `ag_state_atom` / `ag_implies_next`. When the caller has pinned the design's reset inactive (via `pin_inputs_to_constants`, matching verify_auto's reset-gating), the resolver may follow an async-reset register mux `ite(rst, state, resetval)` to its state branch — **sound** because the pinned mux always selects the state, so the register's value equals the state's (the exact condition the verify-auto seeder resolves `state_q` under). Free-reset callers keep `false`.

This is what lets the oracle **bind real-OpenTitan `state_q`**, which sits behind that mux after sv2v+yosys; without it the state cell is unreachable to the oracle.

## E2E gate + the honest outcome

New slang-gated `e2e_oracle_gates_sysrst_real_rtl_verdict`: lifts sysrst, pins the **same** reset verify_auto pinned (`diagnostics.gated_resets` = `rst_ni=1`), runs `ag_implies_next` for sva_0.

**Outcome on this host:** the oracle **binds the real-RTL atoms** (state_q via reset-mux resolution; cfg_enable_i as a 1-bit input) and returns **`Inconclusive`** — sysrst has wide config inputs (`cfg_detect_timer_i`) the internal oracle cannot exhaustively enumerate, so it can soundly **refute** a shallow spurious verdict but cannot **confirm** a real-RTL HOLDS. This empirically establishes the boundary that **motivates H.O.1** (external BTOR2 model checker for real-RTL confirmation). The verdict is not contradicted.

## The differential is live (a real catch)

An intermediate run with the antecedent polarity wrong (`cfg_enable_i == 1` instead of `== 0`) made the oracle correctly report **Violated** against verify_auto's HOLDS. That was a **test-atom error, not a soundness bug** — reading the actual formula `nu X. (((!((!(cfg_enable_i))) || [] (state_q == 0))) && [] X)` showed the antecedent is `!cfg_enable_i`. Fixed; the test now quotes the formula and derives the polarity from it. (It does show the gate would catch a real contradiction.)

## Validation

`mununu-sva` docker image: the full `e2e_ --ignored` suite is green (**7 tests**) — the new sysrst gate + every real-OpenTitan anchor (csrng, sysrst, reset-handling) + the inline gate: **no regression**.

## Honest boundary / follow-up

Combinational-function-of-state atoms (csrng `main_sm_err_o`) remain out of the oracle fragment, and real-RTL **confirmation** (not just refutation) needs the external model checker — **H.O.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)