### PR TITLE
H.U.1d: resolve combinational signals as uniform cube dimensions

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
+++ b/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
@@ -103,19 +103,34 @@ pub fn build_register_nid_map(view: &Btor2SmtView) -> HashMap<String, Nid> {
     map
 }
 
-/// H.B — like [`build_register_nid_map`] but also maps **input** symbols to
-/// their NID, so a predicate over a primary input can be admitted as a free
-/// cube dimension (see `docs/design/free-input-atoms.md`). A free-input
-/// predicate is constrained on the **source** cube (the current-cycle input,
-/// pinned) and left **free** on the **target** (the next-cycle input is not a
-/// variable of the one-step relation) — that source-pin / target-free shape is
-/// realized in [`build_pred_constraint`]. State symbols take precedence on a
-/// name collision. State-only callers keep using [`build_register_nid_map`], so
-/// their behaviour is unchanged.
+/// H.B / H.U.1d — like [`build_register_nid_map`] but also maps **input** and
+/// **combinational** signal symbols to their NID, so a predicate over a primary
+/// input (free cube dimension, `docs/design/free-input-atoms.md`) or over a
+/// combinational node (the uniform predicate-image term path) resolves.
+///
+/// - **Inputs** (H.B): source-pinned / target-free (the next-cycle input is not a
+///   one-step variable) — realized in [`build_pred_constraint_uniform`].
+/// - **Combinational** (H.U.1d): resolved to the combinational node's NID, whose
+///   current-/next-cycle BVs are [`Btor2SmtView::signal_bvs`] / the primed cache;
+///   the uniform rule then treats it as a determined-function-of-state cube
+///   dimension. Latent until the seeder routes a combinational atom as a cube
+///   dimension (H.U.2) — extending the map here is behaviour-preserving for
+///   state/input predicate sets (the extra entries go unused).
+///
+/// **State takes precedence**, then input, then combinational, on a name
+/// collision (`or_insert`). State-only callers use [`build_register_nid_map`],
+/// so their behaviour is unchanged.
 pub fn build_register_nid_map_with_inputs(view: &Btor2SmtView) -> HashMap<String, Nid> {
     let mut map = build_register_nid_map(view);
     for sig in &view.signals {
         if sig.kind == SignalKind::Input
+            && let Some(symbol) = &sig.symbol
+        {
+            map.entry(symbol.clone()).or_insert(sig.nid);
+        }
+    }
+    for sig in &view.signals {
+        if sig.kind == SignalKind::Combinational
             && let Some(symbol) = &sig.symbol
         {
             map.entry(symbol.clone()).or_insert(sig.nid);
@@ -1753,6 +1768,85 @@ mod tests {
                     );
                 }
             }
+        });
+    }
+
+    // ---- H.U.1d — combinational signal resolution + cube-dimension handling ----
+
+    // `reg` stuck at 0 (next = reg); `g = not(reg)` is a combinational-of-state
+    // op named `g` (so g ≡ 1 forever). A second combinational `h = not(reg)`
+    // carries NO own symbol but is named `h_out` on an `output` line.
+    const COMB_FIXTURE: &str = "\
+1 sort bitvec 1
+2 state 1 reg
+3 zero 1
+4 init 1 2 3
+5 next 1 2 2
+6 not 1 2 g
+7 not 1 2
+8 output 7 h_out
+";
+
+    #[test]
+    fn nid_map_resolves_combinational_op_and_output_symbols() {
+        let file = parse(COMB_FIXTURE).expect("parse comb fixture");
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = encode_design(&file).expect("encode");
+            let map = build_register_nid_map_with_inputs(&view);
+            // Op-symbol combinational (`g`, nid 6) resolves.
+            assert_eq!(
+                map.get("g"),
+                Some(&6),
+                "op-symbol combinational `g` resolves"
+            );
+            // Output-line-only combinational (`h_out`, the `not` at nid 7) resolves
+            // (H.U.1d output-line registration).
+            assert_eq!(
+                map.get("h_out"),
+                Some(&7),
+                "output-line combinational `h_out` resolves to its driving node"
+            );
+            // State still resolves + takes precedence (no regression).
+            assert_eq!(map.get("reg"), Some(&2));
+        });
+    }
+
+    #[test]
+    fn uniform_combinational_as_cube_dimension_may_and_must() {
+        // `g = not(reg)` with `reg` stuck → g ≡ 1. As a CUBE DIMENSION via the
+        // uniform image: {g==1}→{g==0} is NOT a may-edge (g never changes), and
+        // {g==1}→{g==1} IS a must-edge (g stays 1) — the new capability the
+        // per-kind path lacked (it returned conservative May / Unknown for a
+        // combinational register name absent from its nid-map).
+        let file = parse(COMB_FIXTURE).expect("parse");
+        let preds = vec![PredicateSpec {
+            name: "g".into(),
+            register: "g".into(),
+            value: 1,
+        }];
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = encode_design(&file).expect("encode");
+            let primed = encode_primed(&file, &view).expect("primed");
+            let nid_map = build_register_nid_map_with_inputs(&view);
+            // may {g}→{g}: g stays 1 ⇒ May.
+            assert_eq!(
+                smt_per_target_may_check_uniform(&view, &primed, 0b1, 0b1, &preds, &nid_map, 5_000),
+                SmtMayVerdict::May
+            );
+            // may {g}→{¬g}: g cannot become 0 ⇒ NotMay (precise).
+            assert_eq!(
+                smt_per_target_may_check_uniform(&view, &primed, 0b1, 0b0, &preds, &nid_map, 5_000),
+                SmtMayVerdict::NotMay
+            );
+            // must {g}→{g}: from every g==1 state, the (only) successor has g==1 ⇒ Must.
+            assert_eq!(
+                smt_per_target_must_check_uniform(
+                    &view, &primed, 0b1, 0b1, &preds, &nid_map, 5_000
+                ),
+                SmtMustVerdict::Must
+            );
         });
     }
 }

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
@@ -368,6 +368,35 @@ pub fn encode_design_with_theory(
             });
         }
     }
+    // H.U.1d — also register a combinational node named only on an `output` line
+    // (a top-level combinational output port whose driving Op carries no symbol
+    // of its own). The output's symbol aliases the driven signal node; if that
+    // node is combinational (in the cache, neither a state cell nor an input),
+    // expose it as a `Combinational` signal under the output-port name so a
+    // predicate can reference it. An Op that already carries its own symbol is
+    // registered above; this adds the output alias (a nid may have multiple
+    // names — every entry resolves through the nid-map).
+    for line in &file.lines {
+        let Node::Output {
+            symbol: Some(name),
+            signal,
+        } = &line.node
+        else {
+            continue;
+        };
+        let nid = signal.nid();
+        if view.state_curr.contains_key(&nid) || view.inputs.contains_key(&nid) {
+            continue;
+        }
+        if let Some(bv) = cache.get(&nid) {
+            view.signals.push(EncodedSignal {
+                nid,
+                width: bv.get_size(),
+                symbol: Some(name.clone()),
+                kind: SignalKind::Combinational,
+            });
+        }
+    }
     view.signal_bvs = cache;
     Ok(view)
 }


### PR DESCRIPTION
The prerequisite for retiring the H.E derived-label machinery (H.U.2): make the uniform predicate-image resolve a combinational signal by name and treat it as a cube dimension (current value `signal_bvs`, next value the primed cache), exactly like a state predicate.

## What

- **`smt_must_edge::build_register_nid_map_with_inputs`** now also maps `SignalKind::Combinational` symbols → their NID (state > input > combinational precedence). A combinational predicate's register name then resolves, and `build_pred_constraint_uniform` reads its `(s,i)` / `(s',i')` term — the capability the per-kind path lacked (a combinational name was absent from its nid-map → conservative `May` / `Unknown`).
- **`btor2_encode`**: also register a combinational node named only on a BTOR2 `output` line (a top-level combinational output port whose driving Op carries no own symbol) — the "output-line term resolution" piece.

## Additive + behaviour-preserving

The extended map's combinational entries go unused until the seeder routes a combinational atom as a cube dimension (H.U.2); state/input predicate sets get the identical map. Validated: full `mununu-core` lib suite green (**2089 passed**) + `mununu-sva` docker `e2e_` green (**7/7**, every real-OpenTitan anchor unchanged).

## Tests

- `nid_map_resolves_combinational_op_and_output_symbols` — op-symbol `g` + output-line `h_out` resolve; state precedence preserved.
- `uniform_combinational_as_cube_dimension_may_and_must` — a combinational-of-state predicate as a cube dim: `{g}→{¬g}` NotMay (precise), `{g}→{g}` Must — via the production uniform may/must.

## Key finding (data-flow audit)

The H.E derived-label machinery is **dead in e2e** — every real combinational output is input-dependent → SKIP, so `seeded.derived` is always empty on real RTL; only synthetic unit tests exercise it. So **H.U.2's deletion is low-risk** (no real-RTL verdict to preserve). H.U.2 routes combinational-of-state atoms to this path and deletes the subsumed machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)