### PR TITLE
H.U.2a: route combinational-of-state to the uniform cube-dim path

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -2034,6 +2034,58 @@ mod tests {
         assert!(trace.final_clts.is_none());
     }
 
+    // H.U.2 — `reg` stuck at 0; `g = not(reg)` is a combinational-of-state signal
+    // (always 1). `AG (g == 1)` over this combinational CUBE DIMENSION must HOLD —
+    // the end-to-end exercise of the uniform combinational path through CEGAR
+    // (no slang, so no combinational-signal inlining; the predicate genuinely
+    // targets the combinational node `g`).
+    const COMB_CUBE_BTOR2: &str = "\
+1 sort bitvec 1
+2 state 1 reg
+3 zero 1
+4 init 1 2 3
+5 next 1 2 2
+6 not 1 2 g
+";
+
+    #[test]
+    fn cegar_combinational_of_state_cube_dimension_holds() {
+        let formula = parser::parse("nu X. ((g == 1) && [] X)").expect("formula parses");
+        let initial = vec![PredicateSpec {
+            name: "g == 1".into(),
+            register: "g".into(),
+            value: 1,
+        }];
+        let env = Environment::new(2);
+        let cegar_opts = CegarOptions {
+            max_iterations: 16,
+            // A combinational cube dimension requires the SmtAllPairs may relation
+            // (the sampling representative is state-register oriented).
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs,
+            ..Default::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            COMB_CUBE_BTOR2,
+            initial,
+            &env,
+            &AdapterOptions::default(),
+            &cegar_opts,
+        )
+        .expect("cegar succeeds");
+        // `g` at the reset state (reg = 0) is `not(0) = 1`, so the reset cube is
+        // {g == 1} = cube index 1 (the predicate-true cube). `g` never changes
+        // (reg stuck), so AG(g==1) HOLDS there.
+        assert_eq!(
+            trace.final_verdict.verdict_at(1),
+            Trit::True,
+            "AG(g==1) holds at the reset cube {{g==1}} (g is the constant-1 \
+             combinational-of-state output of a stuck reg)"
+        );
+        // The opposite cube {g==0} is unreachable / vacuously false for the body.
+        assert_eq!(trace.final_verdict.verdict_at(0), Trit::False);
+    }
+
     /// CTXDSL Phase 2 (2026-06-22) — `emit_ctxdsl: true` captures the final
     /// refined cube `Clts` into the trace; it serializes to a model +
     /// formula CTXDSL document via `clts_to_ctxdsl_with_formula`.

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -272,24 +272,26 @@ fn seed_from_formula(
         } else {
             match combinational_kind(register) {
                 Some(CombKind::StateOnly) => {
-                    // Sound: a combinational function of STATE only. Its value at
-                    // every cube (including must/may targets) is determined by
-                    // that cube's own state dimensions, so a derived per-cube
-                    // 3-valued label (NOT a cube dimension) is sound.
-                    out.derived.push(PredicateSpec {
+                    // H.U.2 — a combinational function of STATE only is a
+                    // determined function of state, so the uniform predicate-image
+                    // handles it as a CUBE DIMENSION (resolved to the combinational
+                    // node via the H.U.1d nid-map; its value over `(s,i)` /
+                    // `(s',i')` from the signal cache + primed cache). This
+                    // subsumes the retired H.E derived-label pass. The init-cube
+                    // bit for this dimension is computed by observing the signal at
+                    // the reset state (see the init-cube section below).
+                    out.specs.push(PredicateSpec {
                         name: atom.to_string(),
                         register: register.to_string(),
                         value,
                     });
                 }
                 // DEFERRED (sound SKIP): a combinational function of a FREE INPUT
-                // (`trigger_active = !trigger_i`). Neither the static label nor a
-                // free cube dimension is sound for the MUST relation here — the
-                // next-cycle value is `f(state_next, next_input)`, not freely both
-                // flavours, so `target-free` fabricates must-edges (the sysrst
-                // sva_6/sva_9 spurious VIOLATED). The sound fix needs the
-                // next-cycle combinational cache (compute the value at source AND
-                // target); until then SKIP, never a misleading verdict.
+                // (`trigger_active = !trigger_i`). Its next-cycle value is
+                // `f(state_next, next_input)`, so as a cube TARGET it needs the
+                // nested `∀ i'` the uniform must does not yet build (H.U.0 finding);
+                // a free cube dimension would fabricate must-edges. SKIP until that
+                // lands, never a misleading verdict.
                 Some(CombKind::InputDependent) | None => out.unseedable.push(atom.to_string()),
             }
         }
@@ -635,7 +637,7 @@ pub fn verify_auto(
     //   3-valued label (Approach B).
     // `is_state` is consulted first in the seeder, so a state value-alias (also
     // an Op with a symbol) binds as state, not combinational.
-    let combinational_nid: std::collections::HashMap<String, crate::adapter::btor2::ast::Nid> =
+    let mut combinational_nid: std::collections::HashMap<String, crate::adapter::btor2::ast::Nid> =
         file.lines
             .iter()
             .filter_map(|l| match &l.node {
@@ -647,6 +649,23 @@ pub fn verify_auto(
                 _ => None,
             })
             .collect();
+    // H.U.1d/H.U.2 — also map a combinational signal named only on an `output`
+    // line (a top-level combinational output port whose driving Op carries no own
+    // symbol — e.g. `assign bad = (state == 3)`). Mirrors the SMT view's
+    // output-line registration so the seeder classifier + the cegar nid-map agree.
+    // `resolves_to_state` / `is_input` are consulted first in the seeder, so an
+    // output that aliases a state cell still binds as state.
+    for l in &file.lines {
+        if let crate::adapter::btor2::ast::Node::Output {
+            symbol: Some(s),
+            signal,
+        } = &l.node
+            && !state_cells.contains(s)
+            && !input_symbols.contains(s)
+        {
+            combinational_nid.entry(s.clone()).or_insert(signal.nid());
+        }
+    }
     let combinational_kind = |name: &str| -> Option<CombKind> {
         combinational_nid.get(name).map(|&nid| {
             if crate::adapter::btor2::parser::cone_reaches_input(&file, nid) {
@@ -719,6 +738,16 @@ pub fn verify_auto(
         // SMT `combinational_labels` pass, which also requires the SmtAllPairs
         // eager lift (precise state edges + the encoded view).
         let has_derived = !seeded.derived.is_empty();
+        // H.U.2 — a combinational-of-state spec (register present in
+        // `combinational_nid`, not a state cell) is a cube dimension over a
+        // *determined function of state*. The sampling may-path is state-register
+        // oriented (its canonical representative cannot realise a combinational
+        // node's value), so it MUST use the SmtAllPairs seam — exactly like
+        // compounds and free inputs.
+        let has_combinational = seeded
+            .specs
+            .iter()
+            .any(|s| combinational_nid.contains_key(&s.register));
         let cegar_opts = CegarOptions {
             max_iterations: opts.max_iterations,
             predicate_source: PredicateSource::WeakestPrecondition,
@@ -728,7 +757,7 @@ pub fn verify_auto(
             smart_uf_cap: true,
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: opts.must_edge_inference,
-            may_edge_inference: if has_compounds || has_inputs || has_derived {
+            may_edge_inference: if has_compounds || has_inputs || has_derived || has_combinational {
                 MayEdgeInference::SmtAllPairs
             } else {
                 MayEdgeInference::Off
@@ -775,6 +804,35 @@ pub fn verify_auto(
             .iter()
             .map(|(k, v)| (k.clone(), *v as u128))
             .collect();
+        // H.U.2 — a combinational-of-state spec's register is neither a state cell
+        // (present in `init_values`) nor a free input, so its reset-cube value is
+        // not in `init_values`. OBSERVE the signal's value at the reset register
+        // state (combinational-of-state has no input dependence → empty inputs)
+        // and augment a local map, so the init-cube bit below is correct.
+        let mut init_for_cube = init_values.clone();
+        let comb_names: Vec<String> = seeded
+            .specs
+            .iter()
+            .filter(|s| {
+                !init_for_cube.contains_key(&s.register)
+                    && !seeded.input_registers.contains(&s.register)
+            })
+            .map(|s| s.register.clone())
+            .collect();
+        if !comb_names.is_empty()
+            && let Ok(outcome) = crate::adapter::btor2::bit_blast::simulate_one_step_observe(
+                &file,
+                &init_val_u128,
+                &std::collections::HashMap::new(),
+                &comb_names,
+            )
+        {
+            for n in &comb_names {
+                if let Some(&v) = outcome.observed.get(n) {
+                    init_for_cube.insert(n.clone(), v as u64);
+                }
+            }
+        }
         let mut base_init_cube = 0usize;
         let mut free_input_bits: Vec<u32> = Vec::new();
         let mut bit = 0u32;
@@ -782,7 +840,7 @@ pub fn verify_auto(
             if seeded.input_registers.contains(&s.register) {
                 // Free input dimension — left unset in the base; enumerated below.
                 free_input_bits.push(bit);
-            } else if init_values.get(&s.register).copied().unwrap_or(0) == s.value {
+            } else if init_for_cube.get(&s.register).copied().unwrap_or(0) == s.value {
                 base_init_cube |= 1 << bit;
             }
             bit += 1;
@@ -1016,31 +1074,35 @@ mod tests {
     }
 
     #[test]
-    fn h_e_admits_combinational_bare_atom_as_derived() {
-        // csrng `main_sm_err_o` — a combinational output, neither state nor input
-        // — is admitted as a DERIVED per-cube label (Approach B), not a spec.
+    fn h_u_admits_combinational_bare_atom_as_cube_dim() {
+        // csrng `main_sm_err_o` — a combinational-of-state output — is admitted as
+        // a CUBE DIMENSION (H.U.2: the uniform image resolves it via the
+        // combinational nid-map + reads its term over `(s,i)` / `(s',i')`), NOT a
+        // derived per-cube label.
         let f = mu_parser::parse("nu X. (main_sm_err_o && [] X)").unwrap();
         let s = seed_from_formula(
             &f,
             |_| false,
             |_| false,
-            // state-only combinational → derived label
             |n| {
                 cells(&["main_sm_err_o"])
                     .contains(n)
                     .then_some(CombKind::StateOnly)
             },
         );
-        assert!(s.specs.is_empty(), "combinational is not a cube dimension");
+        assert_eq!(
+            s.specs.len(),
+            1,
+            "combinational-of-state is a cube dimension"
+        );
+        assert_eq!(s.specs[0].name, "main_sm_err_o");
+        assert_eq!(s.specs[0].value, 1, "bare boolean ≡ == 1");
         assert!(s.compounds.is_empty());
         assert!(s.unseedable.is_empty(), "not skipped: {:?}", s.unseedable);
-        assert_eq!(s.derived.len(), 1, "one derived combinational predicate");
-        assert_eq!(s.derived[0].name, "main_sm_err_o");
-        assert_eq!(s.derived[0].value, 1, "bare boolean ≡ == 1");
     }
 
     #[test]
-    fn h_e_admits_combinational_eq_value_as_derived() {
+    fn h_u_admits_combinational_eq_value_as_cube_dim() {
         let f = mu_parser::parse("nu X. ((err_code == 3) && [] X)").unwrap();
         let s = seed_from_formula(
             &f,
@@ -1052,17 +1114,16 @@ mod tests {
                     .then_some(CombKind::StateOnly)
             },
         );
-        assert_eq!(s.derived.len(), 1);
-        assert_eq!(s.derived[0].register, "err_code");
-        assert_eq!(s.derived[0].value, 3);
-        assert!(s.specs.is_empty() && s.unseedable.is_empty());
+        assert_eq!(s.specs.len(), 1);
+        assert_eq!(s.specs[0].register, "err_code");
+        assert_eq!(s.specs[0].value, 3);
+        assert!(s.compounds.is_empty() && s.unseedable.is_empty());
     }
 
     #[test]
-    fn h_e_state_takes_precedence_over_combinational() {
-        // A name classified as BOTH state and combinational binds as STATE (a
-        // value-alias of state is also an Op-with-symbol; `is_state` is checked
-        // first), so it stays a cube dimension, never a derived label.
+    fn h_u_state_takes_precedence_over_combinational() {
+        // A name classified as BOTH state and combinational binds as STATE
+        // (`is_state` is checked first) — still a cube dimension either way.
         let f = mu_parser::parse("nu X. (sig && [] X)").unwrap();
         let s = seed_from_formula(
             &f,
@@ -1070,8 +1131,7 @@ mod tests {
             |_| false,
             |n| cells(&["sig"]).contains(n).then_some(CombKind::StateOnly),
         );
-        assert_eq!(s.specs.len(), 1, "state precedence → a cube dimension");
-        assert!(s.derived.is_empty());
+        assert_eq!(s.specs.len(), 1, "a cube dimension");
     }
 
     #[test]
@@ -1092,7 +1152,6 @@ mod tests {
                     .then_some(CombKind::InputDependent)
             },
         );
-        assert!(s.derived.is_empty(), "not a derived label");
         assert!(
             !s.input_registers.contains("trigger_active"),
             "NOT routed as a free dimension (unsound for must)"


### PR DESCRIPTION
The behaviour half of retiring the H.E derived-label machinery (deletion is H.U.2b). A combinational-of-state atom is now a **cube dimension** handled by the uniform predicate-image (H.U.1d), not a per-cube derived label.

## What

- `seed_from_formula`: `CombKind::StateOnly` → `out.specs` (cube dimension) instead of `out.derived`.
- **init-cube eval**: a combinational spec's register isn't in `init_values` (register reset values), so its reset-cube bit is computed by **observing** the signal at the reset state (`simulate_one_step_observe`; combinational-of-state has no input dependence → empty inputs).
- **`has_combinational` gate**: a combinational spec forces `MayEdgeInference::SmtAllPairs` (the sampling representative is state-register-oriented), like compounds + free inputs.

## Deep-debug finding

The "deep-debug the ⊥" investigation revealed **slang inlines combinational signals** (`bad = state==3` is folded into the SVA), so a combinational-of-state *output* produces a **state-based** atom, never a combinational-node atom. So combinational-of-state cube dimensions arise only from non-slang paths (hand-built BTOR2, a sidecar), never from real slang SVA. The misconceived slang e2e (which tested a state predicate and returned a sound-but-confusing ⊥) is removed; the path is validated by a **cegar-level** test on a hand-built combinational node instead.

## Validation

- `cegar::cegar_combinational_of_state_cube_dimension_holds` — `AG(g==1)` over a genuine combinational-node cube dimension (a stuck reg's `g=not(reg)`) **HOLDS** through `cegar_refine_loop` (SmtAllPairs);
- migrated seeder tests (`h_u_admits_combinational_*_as_cube_dim`) assert StateOnly → `specs`;
- full `mununu-core` lib suite green (**2090 passed**);
- `mununu-sva` docker `e2e_` green (**7/7**) — every real-OpenTitan anchor unchanged.

After this, `seeded.derived` is always empty + the H.E derived-label path is unreachable from verify_auto → **H.U.2b** deletes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)