### PR TITLE
feat(H-track): combinational-of-input ⊥-label — binds real OpenTitan SVA (sound)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2803,6 +2803,7 @@ fn btor2_discover(args: Btor2DiscoverArgs) -> Result<(), String> {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         }
     };
 

--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -722,9 +722,15 @@ pub fn cegar_refine_loop(
         compound_exprs.insert(spec.name.clone(), expr);
         current_predicates.push(spec);
     }
-    // SmtAllPairs + Eager are forced when compound predicates are present (the
-    // SMT-seam-only path).
-    let smt_seam_required = !compound_exprs.is_empty();
+    // H.E.2 — derived combinational predicates (labeled per cube via SMT, NOT
+    // cube dimensions). They do NOT go into `current_predicates` (the cube index
+    // is unchanged); the lift writes their per-cube label into
+    // `state_3valued_predicates`. Like compounds, they require the eager
+    // SmtAllPairs lift (the labeling pass is SMT-based).
+    let derived_predicates = sidecar_combinational_predicates(adapter_options);
+    // SmtAllPairs + Eager are forced when EITHER compound OR derived predicates
+    // are present (both are SMT-seam-only paths).
+    let smt_seam_required = !compound_exprs.is_empty() || !derived_predicates.is_empty();
     let effective_may = if smt_seam_required {
         crate::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs
     } else {
@@ -851,6 +857,11 @@ pub fn cegar_refine_loop(
         // declared → preserves the simple-atom path). The lift honours these via
         // the SmtEncode seam's `PredicateLike::expr`.
         compound_exprs: compound_exprs.clone(),
+        // H.E.2 — derived combinational predicates parsed from the sidecar
+        // (empty when none declared). The lift labels each per cube via the
+        // SmtEncode seam's `combinational_labels` pass and writes the label into
+        // `state_3valued_predicates` (NOT a cube dimension).
+        derived_predicates: derived_predicates.clone(),
     };
 
     for iteration in 0..=cegar_opts.max_iterations {
@@ -1734,6 +1745,31 @@ pub fn sidecar_compound_predicates(
         ));
     }
     out
+}
+
+/// H.E.2 (2026-06-28) — read `combinational_predicates` from the SvAnnotation
+/// sidecar into derived-label [`PredicateSpec`]s (`name` = the formula atom,
+/// `register` = the combinational signal's symbol, `value`). The cube lift
+/// labels each per cube via the SMT `combinational_labels` pass — they are NOT
+/// cube dimensions, so they never enter `current_predicates` / the cube index.
+/// Empty when there is no sidecar or no `combinational_predicates` declared.
+pub fn sidecar_combinational_predicates(options: &AdapterOptions) -> Vec<PredicateSpec> {
+    let Some(json) = &options.sidecar_json else {
+        return Vec::new();
+    };
+    let Ok(ann) =
+        serde_json::from_str::<crate::adapter::systemverilog::annotation::SvAnnotation>(json)
+    else {
+        return Vec::new();
+    };
+    ann.combinational_predicates
+        .iter()
+        .map(|d| PredicateSpec {
+            name: d.name.clone(),
+            register: d.signal.clone(),
+            value: d.value,
+        })
+        .collect()
 }
 
 /// Parse `--config-values`-style `REG=v1,v2,...` entries into the synthetic

--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -436,6 +436,19 @@ pub struct PredicateCubeLiftOptions {
     /// Default empty preserves the pre-B.1 simple-atom behaviour exactly.
     pub compound_exprs:
         std::collections::HashMap<String, crate::adapter::btor2::predicate_expr::PredicateExpr>,
+    /// H.E.2 (combinational outputs, 2026-06-28) — **derived combinational
+    /// predicates**: `register == value` atoms whose `register` is a
+    /// *combinational node* (an `eq`/`or`/… output of state, e.g. csrng's
+    /// `main_sm_err_o`), NOT a cube dimension. Approach B
+    /// (free-input-atoms.md §4): rather than make a determined signal a free
+    /// dimension, the lift LABELS it per cube via
+    /// [`crate::adapter::sts_ir::SmtEncode::combinational_labels`] — KleeneT/F
+    /// where the cube pins it, KleeneBot where it doesn't — writing the label
+    /// into `state_3valued_predicates` (keyed by the predicate `name`, so the
+    /// evaluator binds the formula atom). These do NOT enlarge the cube space
+    /// (`2^|predicates|` is unchanged). Default empty preserves pre-H.E
+    /// behaviour.
+    pub derived_predicates: Vec<PredicateSpec>,
 }
 
 impl Default for PredicateCubeLiftOptions {
@@ -447,6 +460,7 @@ impl Default for PredicateCubeLiftOptions {
             may_edge_inference: MayEdgeInference::Off,
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         }
     }
 }
@@ -2074,6 +2088,32 @@ pub fn predicate_cube_lift(
         }
     }
 
+    // H.E.2 — derived combinational predicate labels (Approach B). A
+    // combinational atom is NOT a cube dimension; its per-cube KleeneT/F/Bot
+    // label is decided by SMT (`combinational_labels`) over the cube's dimension
+    // predicates + the signal's encoded BV, then written into
+    // `state_3valued_predicates` keyed by the predicate name (the evaluator binds
+    // the formula atom by name). Independent of the may/must edge policy; the
+    // cube space is unchanged (these are labels, not dimensions).
+    if !lift_opts.derived_predicates.is_empty() {
+        use crate::adapter::sts_ir::{BtorSts, SmtEncode};
+        let cube_preds = cube_predicates(&predicates, &lift_opts.compound_exprs);
+        let empty_exprs: std::collections::HashMap<
+            String,
+            crate::adapter::btor2::predicate_expr::PredicateExpr,
+        > = std::collections::HashMap::new();
+        let derived_cube = cube_predicates(&lift_opts.derived_predicates, &empty_exprs);
+        let labels = BtorSts::new(&file).combinational_labels(&cube_preds, &derived_cube, 5_000);
+        for (cube_idx, d_idx, label) in labels {
+            if let (Some(&sid), Some(d)) = (
+                state_ids.get(cube_idx),
+                lift_opts.derived_predicates.get(d_idx),
+            ) {
+                builder.with_3valued_predicate(sid, &d.name, label);
+            }
+        }
+    }
+
     // R.2.5 predicate-image MVP — emit MayOnly edges between cubes.
     //
     // For each cube_i, build a "canonical representative" concrete
@@ -2765,6 +2805,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, SMALL_BTOR2, &AdapterOptions::default(), &opts);
         assert!(result.is_err());
@@ -3332,6 +3373,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
 
         // Baseline: SmtAllPairs may, no must → MayOnly only, zero promotions.
@@ -3395,6 +3437,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let lifted = predicate_cube_lift(preds, toggle, &AdapterOptions::default(), &opts)
             .expect("SmtAllPairs + SmtHyperMust lift");
@@ -3453,6 +3496,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
             compound_exprs,
+            derived_predicates: Vec::new(),
         };
         let preds = vec![PredicateSpec {
             name: "idle".into(),
@@ -3491,6 +3535,7 @@ mod tests {
             // Sampling (Off) — disallowed when compounds are present.
             may_edge_inference: MayEdgeInference::Off,
             compound_exprs,
+            derived_predicates: Vec::new(),
             ..Default::default()
         };
         let preds = vec![PredicateSpec {
@@ -3529,6 +3574,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             config_values: std::collections::HashMap::new(),
             compound_exprs,
+            derived_predicates: Vec::new(),
         };
         let preds = vec![PredicateSpec {
             name: "stable".into(),
@@ -3677,6 +3723,7 @@ mod tests {
                     may_edge_inference: MayEdgeInference::Off,
                     config_values: std::collections::HashMap::new(),
                     compound_exprs: std::collections::HashMap::new(),
+                    derived_predicates: Vec::new(),
                 };
                 let eager = predicate_cube_lift(
                     preds.clone(),
@@ -3734,6 +3781,7 @@ mod tests {
             may_edge_inference: MayEdgeInference::Off,
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let eager = lift_predicate_cube(
             preds.clone(),
@@ -3774,6 +3822,7 @@ mod tests {
             // Even with SmtAllPairs, Lazy can't honour compounds.
             may_edge_inference: MayEdgeInference::SmtAllPairs,
             compound_exprs,
+            derived_predicates: Vec::new(),
             ..Default::default()
         };
         let preds = vec![PredicateSpec {
@@ -3815,6 +3864,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("ok");
@@ -3883,6 +3933,7 @@ mod tests {
 
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -3925,6 +3976,7 @@ mod tests {
 
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -3968,6 +4020,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4026,6 +4079,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4057,6 +4111,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let mut lazy =
             LazyLift::from_btor2(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
@@ -4116,6 +4171,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(
             preds.clone(),
@@ -4152,6 +4208,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let mvp_result =
             predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &mvp_opts)
@@ -4192,6 +4249,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("lift succeeds");
@@ -4230,6 +4288,7 @@ mod tests {
                 may_edge_inference: Default::default(),
                 config_values: std::collections::HashMap::new(),
                 compound_exprs: std::collections::HashMap::new(),
+                derived_predicates: Vec::new(),
             };
             let result = predicate_cube_lift(
                 preds.clone(),
@@ -4270,6 +4329,7 @@ mod tests {
                 may_edge_inference: Default::default(),
                 config_values: std::collections::HashMap::new(),
                 compound_exprs: std::collections::HashMap::new(),
+                derived_predicates: Vec::new(),
             };
             let mut lazy = LazyLift::from_btor2(
                 preds.clone(),
@@ -4424,6 +4484,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &adapter_opts, &lift_opts)
             .expect("lift succeeds");
@@ -4501,6 +4562,7 @@ mod tests {
 
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4535,6 +4597,7 @@ mod tests {
 
             config_values: std::collections::HashMap::new(),
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let mut lazy =
             LazyLift::from_btor2(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
@@ -4622,6 +4685,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values,
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");
@@ -4657,6 +4721,7 @@ mod tests {
             may_edge_inference: Default::default(),
             config_values,
             compound_exprs: std::collections::HashMap::new(),
+            derived_predicates: Vec::new(),
         };
         let result = predicate_cube_lift(preds, COUNTER_BTOR2, &AdapterOptions::default(), &opts)
             .expect("predicate_cube_lift succeeds");

--- a/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
+++ b/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
@@ -928,6 +928,91 @@ where
     }
 }
 
+/// H.E.2 — the per-cube label of a **derived combinational predicate**
+/// (`signal == value`, where `signal` is a combinational node, NOT a cube
+/// dimension). Approach B (free-input-atoms.md §4): a combinational signal's
+/// value is a *determined function* of (state, inputs), so rather than make it a
+/// free cube dimension we LABEL it per cube — KleeneT/F where the cube pins it,
+/// KleeneBot where it doesn't.
+///
+/// `cube_bits` + `cube_predicates` define the cube C (its *dimension*
+/// predicates, over state + free inputs); `signal_nid` is the combinational
+/// node's NID (its current-cycle BV is `view.curr_signal(signal_nid)`).
+///
+/// Decides, over all concrete states ⊨ C (current cycle):
+/// - `UNSAT(C ∧ signal != value)` → `KleeneT` (always `value` in C);
+/// - `UNSAT(C ∧ signal == value)` → `KleeneF` (never `value` in C);
+/// - else → `KleeneBot` (the cube doesn't pin it — honest).
+///
+/// **Soundness:** a definite KleeneT/F is a sound label (standard 3-valued
+/// preservation); a dimension predicate whose constraint can't be built is
+/// *omitted*, which only widens C (a superset) — KleeneT/F over a superset still
+/// hold on the cube (subset), and the widening can only push toward KleeneBot,
+/// never toward a false-definite. Timeout → conservative `KleeneBot`.
+///
+/// **Caller must hold a [`z3::with_z3_config`] scope.**
+pub fn smt_combinational_label<P: PredicateLike>(
+    view: &Btor2SmtView,
+    cube_bits: u64,
+    cube_predicates: &[P],
+    nid_map: &HashMap<String, Nid>,
+    signal_nid: Nid,
+    value: u64,
+    timeout_ms: u32,
+) -> crate::clts::Tristate {
+    use crate::clts::Tristate;
+    let Some(sig) = view.curr_signal(signal_nid) else {
+        return Tristate::KleeneBot;
+    };
+    // Cube C = conjunction of the dimension predicates at this cube's polarities,
+    // over the current cycle. A predicate whose constraint can't be built is
+    // omitted (sound — only widens C; see the doc note).
+    let mut cube: Vec<z3::ast::Bool> = Vec::new();
+    for (b, pred) in cube_predicates.iter().enumerate() {
+        let polarity = (cube_bits >> b) & 1 == 1;
+        if let Some(c) = build_pred_constraint(view, nid_map, pred, false, polarity) {
+            cube.push(c);
+        }
+    }
+    let val_bv = z3::ast::BV::from_u64(value, sig.get_size());
+    let eq = sig.eq(&val_bv);
+
+    let check = |extra: &z3::ast::Bool| -> z3::SatResult {
+        let solver = z3::Solver::new();
+        let mut params = z3::Params::new();
+        params.set_u32("timeout", timeout_ms);
+        solver.set_params(&params);
+        for c in &cube {
+            solver.assert(c);
+        }
+        solver.assert(extra);
+        solver.check()
+    };
+
+    // SOUNDNESS GUARD (H.E.2, 2026-06-28) — empty/unreachable cube. If the cube's
+    // own dimension constraints are UNSAT (no concrete state satisfies them), then
+    // BOTH `C ∧ signal == value` and `C ∧ signal != value` are trivially UNSAT, and
+    // the `KleeneF` check below would fire SPURIOUSLY — a definite label on an empty
+    // cube. That spurious definite is what fabricated the VIOLATED on shipped
+    // OpenTitan SVA (the `!trigger_active` antecedents). An empty cube has no
+    // states, so its label is meaningless: return KleeneBot (honest "undetermined").
+    // A definite KleeneT/F is only emitted for a NON-empty cube below, where it is
+    // a sound fact over that cube's concrete states.
+    if matches!(check(&z3::ast::Bool::from_bool(true)), z3::SatResult::Unsat) {
+        return Tristate::KleeneBot;
+    }
+    // never == value?  UNSAT(C ∧ signal == value) → KleeneF.
+    if matches!(check(&eq), z3::SatResult::Unsat) {
+        return Tristate::KleeneF;
+    }
+    // always == value?  UNSAT(C ∧ signal != value) → KleeneT.
+    if matches!(check(&eq.not()), z3::SatResult::Unsat) {
+        return Tristate::KleeneT;
+    }
+    // Both satisfiable (mixed), or undecided → honest KleeneBot.
+    Tristate::KleeneBot
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mununu-core/src/adapter/sidecar/btor2_resolver.rs
+++ b/crates/mununu-core/src/adapter/sidecar/btor2_resolver.rs
@@ -120,6 +120,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         }
     }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -286,13 +286,27 @@ fn seed_from_formula(
                         value,
                     });
                 }
-                // DEFERRED (sound SKIP): a combinational function of a FREE INPUT
-                // (`trigger_active = !trigger_i`). Its next-cycle value is
-                // `f(state_next, next_input)`, so as a cube TARGET it needs the
-                // nested `∀ i'` the uniform must does not yet build (H.U.0 finding);
-                // a free cube dimension would fabricate must-edges. SKIP until that
-                // lands, never a misleading verdict.
-                Some(CombKind::InputDependent) | None => out.unseedable.push(atom.to_string()),
+                // H.E.r2 (combinational-input-atoms.md §6.1) — a combinational
+                // function of a FREE INPUT (`trigger_active = !trigger_i`,
+                // `main_sm_err_o = f(state, enable_i)`). It is NOT a sound cube
+                // dimension (target-free fabricates must-edges; §5.1 / H.U.0), so
+                // route it to a DERIVED 3-valued label: per cube the labeller
+                // (`smt_combinational_label`) decides KleeneT/F where the cube pins
+                // the signal, KleeneBot where the free input swings it (the generic
+                // case for combinational-of-input). SOUND — a pure observation, no
+                // edge change (§6.1 Prop 3) — and a `⊥` atom can never produce a
+                // spurious VIOLATED (in Kleene `⊥ ∨ []C` is `T` or `⊥`, never `F`);
+                // for the `AG(A→AX C)` safety shape with the atom in the antecedent
+                // it yields a DEFINITE HOLDS via `⊥ ∨ []C = T` when the consequent
+                // carries the property.
+                Some(CombKind::InputDependent) => out.derived.push(PredicateSpec {
+                    name: atom.to_string(),
+                    register: register.to_string(),
+                    value,
+                }),
+                // Unresolvable combinational (no nid in the lifted design): cannot
+                // label what we cannot resolve — honest SKIP.
+                None => out.unseedable.push(atom.to_string()),
             }
         }
     };
@@ -756,7 +770,23 @@ pub fn verify_auto(
             enable_approximant_reuse: false,
             smart_uf_cap: true,
             lift_strategy: LiftStrategy::Eager,
-            must_edge_inference: opts.must_edge_inference,
+            // SOUNDNESS (H.E.r2, combinational-input-atoms.md §6.1): a property
+            // carrying a derived ⊥-label combinational-of-input atom is a SAFETY
+            // property whose verdict rides on `[]C` over the MAY relation (Kleene
+            // `⊥ ∨ []C = T` when the consequent holds). The MUST relation is not
+            // needed for it, and an under-approximating must-edge is the unsound
+            // direction here: with `must=Off` the box is only KleeneT / KleeneBot
+            // (never KleeneF), so no spurious VIOLATED is possible — exactly the
+            // sound "safety + over-approximation" recipe (CLAUDE.md §Soundness).
+            // (An empirical spurious VIOLATED under `SmtHyperMust` — btormc proves
+            // sysrst sva_6 SAFE on the lifted model — exposed a separate must-edge
+            // imprecision tracked for the must path; it does not affect the
+            // may-only verdict this forces here.)
+            must_edge_inference: if has_derived {
+                MustEdgeInference::Off
+            } else {
+                opts.must_edge_inference
+            },
             may_edge_inference: if has_compounds || has_inputs || has_derived || has_combinational {
                 MayEdgeInference::SmtAllPairs
             } else {
@@ -1135,12 +1165,12 @@ mod tests {
     }
 
     #[test]
-    fn h_e_input_dependent_combinational_is_skipped_soundly() {
-        // `trigger_active = !trigger_i` — combinational of a FREE INPUT. DEFERRED:
-        // neither a derived state-cube label nor a free dimension is sound for the
-        // MUST relation (the next-cycle value f(state_next, next_input) isn't
-        // freely both flavours → target-free fabricates must-edges). So it is
-        // SKIPPED (never a misleading verdict) until the next-cycle-cache fix.
+    fn h_e_r2_input_dependent_combinational_routed_to_derived_label() {
+        // `trigger_active = !trigger_i` — combinational of a FREE INPUT. H.E.r2
+        // routes it to a DERIVED 3-valued label, NOT a cube dimension and NOT a
+        // free dimension (both unsound for the must relation). The per-cube
+        // labeller decides KleeneT/F where the cube pins it, KleeneBot where the
+        // free input swings it — sound, and never a spurious VIOLATED.
         let f = mu_parser::parse("nu X. ((trigger_active && (state == 2)) && [] X)").unwrap();
         let s = seed_from_formula(
             &f,
@@ -1161,9 +1191,14 @@ mod tests {
             "not a cube dimension"
         );
         assert!(
-            s.unseedable.contains(&"trigger_active".to_string()),
-            "input-dependent combinational is soundly SKIPPED: {:?}",
+            !s.unseedable.contains(&"trigger_active".to_string()),
+            "no longer skipped: {:?}",
             s.unseedable
+        );
+        assert!(
+            s.derived.iter().any(|p| p.register == "trigger_active"),
+            "input-dependent combinational is routed to the derived ⊥-label: {:?}",
+            s.derived
         );
     }
 
@@ -1432,8 +1467,7 @@ mod tests {
         );
         // H.A — `state_q` (a `uext`-0 alias of the async-reset register mux)
         // now binds, so the pure-state `$stable` property reaches a verdict
-        // instead of SKIP. (Here ⊥: the auto-seeded predicate set is too coarse
-        // to decide `state_q==Error |=> $stable(state_q)`.)
+        // instead of SKIP.
         assert!(
             report.properties.iter().any(|p| {
                 p.formula.contains("state_q == state_q__past")
@@ -1446,10 +1480,12 @@ mod tests {
                 .map(|p| &p.outcome)
                 .collect::<Vec<_>>()
         );
-        // SOUNDNESS — no spurious counterexample. A combinational output like
-        // `main_sm_err_o` must NOT be mis-bound to the state register (which
-        // would wrongly report VIOLATED); the strict alias resolver excludes it,
-        // so it is honestly SKIPPED instead.
+        // SOUNDNESS — no spurious counterexample. H.E.r2: the combinational-of-
+        // input output `main_sm_err_o` now BINDS as a derived 3-valued ⊥-label
+        // (NOT mis-bound to the state register); at the `state_q==41` error cube
+        // the label is a sound definite-true, so `state_q==41 |=> main_sm_err_o`
+        // reaches HOLDS via Kleene `F ∨ T = T`. Never a spurious VIOLATED (the
+        // must relation is forced Off for derived-label properties).
         assert!(
             !report
                 .properties
@@ -1605,10 +1641,13 @@ mod tests {
              free-input dimension; got {:?}",
             sva0.outcome
         );
-        // The only remaining SKIPs are pure combinational signals (case 4 of the
-        // design doc — `event_detected_*`, `trigger_*`, `cnt_clr`), never a
-        // primary input: H.B closed the free-input antecedents; combinational
-        // outputs await the signal-node mapping follow-up.
+        // After H.E.r2, the simple combinational-of-input antecedents
+        // (`trigger_active`, `event_detected_*`, `cnt_clr`) BIND as derived
+        // ⊥-labels (HOLDS-or-honest-⊥). The only remaining SKIPs are the
+        // RELATIONAL-with-input compounds (`cnt_q >= cfg_*_timer_i`, sva_5/7/10/11)
+        // — an input operand inside a compound, which the compound SMT path does
+        // not yet admit (H.F). Never a free-input *simple* antecedent: H.B closed
+        // those (`cfg_enable_i`).
         for p in &report.properties {
             if let VerifyOutcome::Skipped { reason } = &p.outcome {
                 assert!(
@@ -1657,23 +1696,26 @@ mod tests {
                 .any(|p| p.formula.contains("cnt_q >= cfg_")),
             "H.D translated a `signal >= signal` (cnt_q >= cfg_*_timer_i)"
         );
-        // SOUNDNESS — no spurious counterexample. This is the H.E soundness
-        // anchor: an INPUT-DEPENDENT combinational antecedent (`trigger_active =
-        // !trigger_i`, etc.) is SKIPPED (its register reaches a free input via
-        // `cone_reaches_input`, so it is deferred to the next-cycle-cache
-        // must-edge fix), NEVER bound as a state-cube label or free dimension —
-        // both of which fabricated a VIOLATED on these shipped OpenTitan
-        // assertions. `sva_6` (`DetectStDropOut`: `state==DetectSt && !trigger_active
-        // && cfg |=> state==IdleSt`) is the canonical case it must not VIOLATE.
+        // SOUNDNESS — no spurious counterexample. H.E.r2 (combinational-input-
+        // atoms.md §6.1): an INPUT-DEPENDENT combinational antecedent
+        // (`trigger_active = !trigger_i`, etc.) now BINDS as a derived 3-valued
+        // ⊥-label and the property reaches an honest `⊥` (Unknown) — NOT a SKIP,
+        // and NEVER a VIOLATED. `sva_6` (`DetectStDropOut`: `state==DetectSt &&
+        // !trigger_active && cfg |=> state==IdleSt`) is the canonical case: btormc
+        // proves it SAFE on the lifted model, so the `⊥` is honest (the may-only
+        // abstraction is too coarse to prove it), not a missed violation. The
+        // must relation is forced Off for derived-label properties (the sound
+        // "safety + over-approximation" recipe), so the box is only KleeneT /
+        // KleeneBot — a spurious VIOLATED is impossible here.
         let sva6 = report
             .properties
             .iter()
             .find(|p| p.name == "sysrst_ctrl_detect_sva_6")
             .expect("sva_6 present");
         assert!(
-            matches!(sva6.outcome, VerifyOutcome::Skipped { .. }),
-            "sva_6's input-dependent combinational `trigger_active` is soundly \
-             SKIPPED (deferred), not a spurious VIOLATED; got {:?}",
+            matches!(sva6.outcome, VerifyOutcome::Unknown { .. }),
+            "sva_6's input-dependent combinational `trigger_active` BINDS as a ⊥-label \
+             and reaches an honest ⊥ (not a SKIP, not a spurious VIOLATED); got {:?}",
             sva6.outcome
         );
         assert!(

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -205,6 +205,12 @@ struct Seeded {
     /// across **all** of its initial polarities. See
     /// `docs/design/free-input-atoms.md`. Empty ⇒ the pre-H.B state-only shape.
     input_registers: HashSet<String>,
+    /// H.E (combinational outputs) — **derived** combinational predicates: a
+    /// simple atom whose register is a combinational node (e.g. csrng's
+    /// `main_sm_err_o`), NOT a cube dimension. The lift labels each per cube via
+    /// SMT (Approach B). Threaded to `cegar_refine_loop` through the synthesised
+    /// sidecar's `combinational_predicates`. Empty ⇒ the pre-H.E shape.
+    derived: Vec<PredicateSpec>,
 }
 
 /// The minimal H.1 (+ H.B) — derive cube predicates from a formula's
@@ -333,6 +339,7 @@ fn seed_from_formula(
 /// fictitious init. Returns `None` when there is nothing to emit.
 fn synth_sidecar_json(
     compounds: &[(String, PredicateExpr)],
+    derived: &[PredicateSpec],
     referenced: &std::collections::BTreeSet<String>,
     init_values: &std::collections::HashMap<String, u64>,
 ) -> Option<String> {
@@ -342,6 +349,13 @@ fn synth_sidecar_json(
         // re-parses via `parse_predicate_expr` (REL handles `reg == reg`).
         .map(|(name, _)| serde_json::json!({ "name": name, "expr": name }))
         .collect();
+    // H.E — derived combinational predicates: `cegar_refine_loop` reads these
+    // into `lift_opts.derived_predicates`; the lift labels each per cube via the
+    // SMT `combinational_labels` pass (NOT a cube dimension).
+    let combinational_decls: Vec<serde_json::Value> = derived
+        .iter()
+        .map(|d| serde_json::json!({ "name": d.name, "signal": d.register, "value": d.value }))
+        .collect();
     let signals: Vec<serde_json::Value> = referenced
         .iter()
         .filter_map(|r| {
@@ -350,13 +364,14 @@ fn synth_sidecar_json(
                 .map(|v| serde_json::json!({ "name": r, "config_values": [v] }))
         })
         .collect();
-    if compound_decls.is_empty() && signals.is_empty() {
+    if compound_decls.is_empty() && combinational_decls.is_empty() && signals.is_empty() {
         return None;
     }
     serde_json::to_string(&serde_json::json!({
         "module": "cegar",
         "source": "verify_auto.btor2",
         "compound_predicates": compound_decls,
+        "combinational_predicates": combinational_decls,
         "signals": signals,
     }))
     .ok()
@@ -692,7 +707,7 @@ pub fn verify_auto(
             continue;
         }
         let predicate_count = seeded.specs.len() + seeded.compounds.len();
-        if predicate_count == 0 {
+        if predicate_count == 0 && seeded.derived.is_empty() {
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
                 kind: t.kind,
@@ -708,6 +723,7 @@ pub fn verify_auto(
 
         let mut seeded_names: Vec<String> = seeded.specs.iter().map(|s| s.name.clone()).collect();
         seeded_names.extend(seeded.compounds.iter().map(|(n, _)| n.clone()));
+        seeded_names.extend(seeded.derived.iter().map(|d| d.name.clone()));
 
         // Compounds OR free inputs ⇒ force the SmtAllPairs eager lift.
         // Compounds: the only compound-aware may path. Free inputs (H.B): the
@@ -718,6 +734,10 @@ pub fn verify_auto(
         // `cegar_refine_loop` re-checks the compound gate.
         let has_compounds = !seeded.compounds.is_empty();
         let has_inputs = !seeded.input_registers.is_empty();
+        // H.E — derived combinational predicates are labeled per cube by the
+        // SMT `combinational_labels` pass, which also requires the SmtAllPairs
+        // eager lift (precise state edges + the encoded view).
+        let has_derived = !seeded.derived.is_empty();
         // H.U.2 — a combinational-of-state spec (register present in
         // `combinational_nid`, not a state cell) is a cube dimension over a
         // *determined function of state*. The sampling may-path is state-register
@@ -737,7 +757,7 @@ pub fn verify_auto(
             smart_uf_cap: true,
             lift_strategy: LiftStrategy::Eager,
             must_edge_inference: opts.must_edge_inference,
-            may_edge_inference: if has_compounds || has_inputs || has_combinational {
+            may_edge_inference: if has_compounds || has_inputs || has_derived || has_combinational {
                 MayEdgeInference::SmtAllPairs
             } else {
                 MayEdgeInference::Off
@@ -756,7 +776,12 @@ pub fn verify_auto(
             }
         }
         let adapter_options = AdapterOptions {
-            sidecar_json: synth_sidecar_json(&seeded.compounds, &referenced, &init_values),
+            sidecar_json: synth_sidecar_json(
+                &seeded.compounds,
+                &seeded.derived,
+                &referenced,
+                &init_values,
+            ),
             ..Default::default()
         };
         // Env sized to the cube space: simple specs + the sidecar compounds
@@ -925,7 +950,8 @@ mod tests {
             [("state".to_string(), 0), ("state__past".to_string(), 0)]
                 .into_iter()
                 .collect();
-        let json = synth_sidecar_json(&s.compounds, &referenced, &inits).expect("sidecar json");
+        let json =
+            synth_sidecar_json(&s.compounds, &[], &referenced, &inits).expect("sidecar json");
         assert!(json.contains("compound_predicates"));
         assert!(json.contains("state == state__past"));
         assert!(json.contains("config_values"), "init pins present: {json}");
@@ -1196,7 +1222,7 @@ mod tests {
     fn no_sidecar_when_nothing_to_emit() {
         let empty_refs = std::collections::BTreeSet::new();
         let empty_inits = std::collections::HashMap::new();
-        assert!(synth_sidecar_json(&[], &empty_refs, &empty_inits).is_none());
+        assert!(synth_sidecar_json(&[], &[], &empty_refs, &empty_inits).is_none());
     }
 
     #[test]
@@ -2014,8 +2040,10 @@ mod tests {
         let seeded = seed_from_formula(&formula, |r| r == signal, |_| false, |_| None);
 
         // Mirror verify_auto's default cegar_opts (must Off; may = SmtAllPairs
-        // iff a compound / input predicate is present).
-        let has_smt_seam = !seeded.compounds.is_empty() || !seeded.input_registers.is_empty();
+        // iff a compound / input / derived predicate is present).
+        let has_smt_seam = !seeded.compounds.is_empty()
+            || !seeded.input_registers.is_empty()
+            || !seeded.derived.is_empty();
         let cegar_opts = CegarOptions {
             max_iterations: 16,
             predicate_source: PredicateSource::WeakestPrecondition,
@@ -2047,7 +2075,12 @@ mod tests {
             }
         }
         let adapter_options = AdapterOptions {
-            sidecar_json: synth_sidecar_json(&seeded.compounds, &referenced, &init_u64),
+            sidecar_json: synth_sidecar_json(
+                &seeded.compounds,
+                &seeded.derived,
+                &referenced,
+                &init_u64,
+            ),
             ..Default::default()
         };
 

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -209,6 +209,22 @@ pub trait SmtEncode: SymbolicTransitionSystem {
         may_edges: &[(usize, usize)],
         timeout_ms: u32,
     ) -> Vec<(usize, Vec<usize>)>;
+
+    /// H.E.2 — per-cube labels for **derived combinational predicates** (Approach
+    /// B). `cube_predicates` are the cube *dimensions* (state + free inputs,
+    /// indices `0..2^|cube_predicates|`); `derived` are the combinational
+    /// predicates to label (their `register()` names a combinational node, NOT a
+    /// dimension). Returns `(cube_index, derived_index, label)` for every (cube,
+    /// derived) pair: KleeneT/F where the cube pins the signal, KleeneBot where it
+    /// doesn't (or on encoder failure / timeout — the conservative, honest
+    /// label). The lift writes these into `state_3valued_predicates` so the
+    /// evaluator binds the formula atom by name.
+    fn combinational_labels<P: PredicateLike + Sync>(
+        &self,
+        cube_predicates: &[P],
+        derived: &[P],
+        timeout_ms: u32,
+    ) -> Vec<(usize, usize, crate::clts::Tristate)>;
 }
 
 /// The BTOR2 implementation of the STS-IR seam — a thin borrow over a
@@ -466,6 +482,76 @@ impl SmtEncode for BtorSts<'_> {
             edges
         })
     }
+
+    fn combinational_labels<P: PredicateLike + Sync>(
+        &self,
+        cube_predicates: &[P],
+        derived: &[P],
+        timeout_ms: u32,
+    ) -> Vec<(usize, usize, crate::clts::Tristate)> {
+        use crate::adapter::btor2::kmts_lift::encode_design_for_lift;
+        use crate::adapter::btor2::smt_must_edge::{
+            build_register_nid_map_with_inputs, smt_combinational_label,
+        };
+        use crate::adapter::sidecar::predicate_image::btor2_encode::SignalKind;
+        use crate::clts::Tristate;
+
+        if derived.is_empty() {
+            return Vec::new();
+        }
+        let n_cubes = 1usize << cube_predicates.len();
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            let view = match encode_design_for_lift(self.file) {
+                Ok(v) => v,
+                // Encoder failure → every derived predicate is conservatively
+                // KleeneBot in every cube (honest "couldn't determine").
+                Err(_) => {
+                    let mut out = Vec::with_capacity(n_cubes * derived.len());
+                    for i in 0..n_cubes {
+                        for d in 0..derived.len() {
+                            out.push((i, d, Tristate::KleeneBot));
+                        }
+                    }
+                    return out;
+                }
+            };
+            let nid_map = build_register_nid_map_with_inputs(&view);
+            // Resolve each derived predicate's signal name → its combinational
+            // node NID (own-symbol match in the view's Combinational signals).
+            let derived_nids: Vec<Option<_>> = derived
+                .iter()
+                .map(|d| {
+                    view.signals
+                        .iter()
+                        .find(|s| {
+                            s.kind == SignalKind::Combinational
+                                && s.symbol.as_deref() == Some(d.register())
+                        })
+                        .map(|s| s.nid)
+                })
+                .collect();
+            let mut out = Vec::with_capacity(n_cubes * derived.len());
+            for i in 0..n_cubes {
+                for (d_idx, d) in derived.iter().enumerate() {
+                    let label = match derived_nids[d_idx] {
+                        Some(nid) => smt_combinational_label(
+                            &view,
+                            i as u64,
+                            cube_predicates,
+                            &nid_map,
+                            nid,
+                            d.value(),
+                            timeout_ms,
+                        ),
+                        None => Tristate::KleeneBot,
+                    };
+                    out.push((i, d_idx, label));
+                }
+            }
+            out
+        })
+    }
 }
 
 #[cfg(test)]
@@ -710,6 +796,46 @@ mod tests {
         assert!(
             !edges.contains(&(0, 1)) && !edges.contains(&(0, 3)),
             "source in_a=1 must NOT reach reg_a'==0 — the source input pin is load-bearing"
+        );
+    }
+
+    // H.E.2 — a state-only combinational signal `g = !q` (NID 3). With cube
+    // dimension `q == 1`, the derived label `g == 1` is DETERMINED per cube:
+    // q==1 ⇒ g==0 (KleeneF for g==1); q==0 ⇒ g==1 (KleeneT).
+    const COMB_LABEL_BTOR2: &str =
+        "1 sort bitvec 1\n2 state 1 q\n3 not 1 2 g\n4 zero 1\n5 init 1 2 4\n6 next 1 2 2\n";
+
+    #[test]
+    fn btor_sts_combinational_labels_determined_by_state_cube() {
+        use crate::clts::Tristate;
+        let file = parser::parse(COMB_LABEL_BTOR2).expect("parse combinational-label fixture");
+        let sts = BtorSts::new(&file);
+        let cube_preds = vec![PredicateSpec {
+            name: "q == 1".into(),
+            register: "q".into(),
+            value: 1,
+        }];
+        let derived = vec![PredicateSpec {
+            name: "g == 1".into(),
+            register: "g".into(), // the combinational node's own symbol
+            value: 1,
+        }];
+        let labels: std::collections::HashMap<(usize, usize), Tristate> = sts
+            .combinational_labels(&cube_preds, &derived, 5_000)
+            .into_iter()
+            .map(|(c, d, t)| ((c, d), t))
+            .collect();
+        // cube 0 = (q==1 false ⇒ q==0) ⇒ g = !0 = 1 ⇒ g==1 is KleeneT.
+        assert_eq!(
+            labels.get(&(0, 0)),
+            Some(&Tristate::KleeneT),
+            "q==0 ⇒ g==1 true"
+        );
+        // cube 1 = (q==1 true) ⇒ g = !1 = 0 ⇒ g==1 is KleeneF.
+        assert_eq!(
+            labels.get(&(1, 0)),
+            Some(&Tristate::KleeneF),
+            "q==1 ⇒ g==1 false"
         );
     }
 }

--- a/crates/mununu-core/src/adapter/systemverilog/annotation.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/annotation.rs
@@ -260,6 +260,35 @@ pub struct SvAnnotation {
     /// Default empty — preserves behaviour for every existing fixture.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub compound_predicates: Vec<CompoundPredicateDecl>,
+
+    /// H.E.2 (combinational outputs, 2026-06-28) — **derived combinational
+    /// predicates**: `signal == value` atoms whose `signal` is a *combinational
+    /// node* (an `eq`/`or`/… output of state, e.g. csrng's `main_sm_err_o`), NOT
+    /// a cube dimension. The cube lift labels each per cube via SMT (Approach B,
+    /// free-input-atoms.md §4) — KleeneT/F where the cube pins the signal,
+    /// KleeneBot where it doesn't — writing the label into
+    /// `state_3valued_predicates` so the evaluator binds the formula atom by
+    /// name. These do NOT enlarge the cube space. Like compounds, they require
+    /// the eager SmtAllPairs lift (the labeling pass is SMT-based).
+    ///
+    /// Default empty — preserves behaviour for every existing fixture.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub combinational_predicates: Vec<CombinationalPredicateDecl>,
+}
+
+/// H.E.2 (2026-06-28) — one derived combinational predicate declaration for the
+/// predicate-cube path. [`crate::adapter::btor2::sidecar_combinational_predicates`]
+/// reads these into [`crate::adapter::btor2::kmts_lift::PredicateCubeLiftOptions::derived_predicates`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CombinationalPredicateDecl {
+    /// Predicate name = the formula atom string (the `state_3valued_predicates`
+    /// key the evaluator binds by name), e.g. `"main_sm_err_o"`.
+    pub name: String,
+    /// The combinational node's symbol in the lifted BTOR2 (its own `Op` symbol).
+    pub signal: String,
+    /// Value the predicate checks: it holds iff `signal == value` (bare boolean
+    /// atom ⇒ `value = 1`).
+    pub value: u64,
 }
 
 /// IR-track P3.2 (2026-06-22) — one register-value equality predicate
@@ -1817,6 +1846,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         }
     }
 
@@ -2457,6 +2487,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2526,6 +2557,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2670,6 +2702,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2823,6 +2856,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(
@@ -2923,6 +2957,7 @@ mod tests {
             uf_unwrap: Vec::new(),
             predicates: Vec::new(),
             compound_predicates: Vec::new(),
+            combinational_predicates: Vec::new(),
         };
         let json = serde_json::to_string(&ann).expect("serialize");
         assert!(

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -523,6 +523,7 @@ fn run_controllability_aware_lift(
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
 
     let lift_result =

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -1071,6 +1071,7 @@ fn dispatch_sv_predicate_cube(
         may_edge_inference: MayEdgeInference::SmtAllPairs,
         config_values: crate::adapter::btor2::r_s8_encoder::sidecar_config_values(opts),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
     // U.4 — route the verify-path lift through the single gated entry
     // (always Eager for this non-CEGAR path; the entry runs the compound

--- a/crates/mununu-core/tests/v6_controllability_kmts.rs
+++ b/crates/mununu-core/tests/v6_controllability_kmts.rs
@@ -88,6 +88,7 @@ fn v6_amba_arbiter_lifts_with_controllability_aware_dual_labels() {
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)
@@ -163,6 +164,7 @@ fn v6_amba_arbiter_lifts_with_mayonly_transitions_present() {
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)
@@ -247,6 +249,7 @@ fn v6_amba_arbiter_controllability_aware_skips_smt_post_pass() {
         may_edge_inference: Default::default(),
         config_values: std::collections::HashMap::new(),
         compound_exprs: std::collections::HashMap::new(),
+        derived_predicates: Vec::new(),
     };
 
     let result = predicate_cube_lift(predicates, AMBA_ARBITER_BTOR2, &adapter_options, &lift_opts)


### PR DESCRIPTION
Implements the **combinational-of-input ⊥-label** ([docs/design/combinational-input-atoms.md](docs/design/combinational-input-atoms.md) §6.1) — the chosen treatment for the dominant blocker on both real-RTL anchors (15/16 SKIPs were combinational-of-input atoms). Two commits:

## H.E.r1 — revive the derived-label infrastructure (dormant)
A faithful `git revert` of #189 re-adds the per-cube 3-valued combinational labeller (`smt_combinational_label`, with its sound empty-cube guard), the `combinational_labels` seam, the `predicate_cube_lift` derived-label pass, the `combinational_predicates` sidecar + cegar threading, and `Seeded::derived`. #189 deleted these as *dead* (after H.U.2a routed combinational-of-**state** to cube dims); the 2026-06-30 cone investigation showed every SVA-referenced combinational signal is combinational-of-**input** — a genuine consumer. Behaviour-preserving (dormant).

## H.E.r2 — activate + soundness-fix
The seeder routes `CombKind::InputDependent => out.derived` (a per-cube ⊥-label); `None` stays unseedable.

**Found + fixed a spurious VIOLATED via the H.O oracle.** The raw activation, under the breakdown e2e's opt-in `SmtHyperMust`, reported VIOLATED on sysrst sva_6/9/13. A hand-built `btormc` `bad` monitor on the **same lifted model** proved sva_6 **SAFE** → those VIOLATEDs are spurious: the definite ⊥-labels (sound per-cube) activated antecedents that exposed a latent `SmtHyperMust` must-edge imprecision.

**Sound fix:** force `must_edge_inference = Off` for any property carrying a derived ⊥-label. These are SAFETY properties (`AG(A→AX C)`) whose verdict rides on `[]C` over the MAY relation (Kleene `⊥ ∨ []C = T`); may-only is the textbook **safety + over-approximation = sound** recipe (the box is only KleeneT/KleeneBot, never a spurious KleeneF). Principled, not bug-hiding — the must (under-approximation) is the unsound direction here and is not needed.

## Result (validated in `mununu-sva` docker)
- **csrng: HOLDS 1→2** — sva_1 `state_q==41 |=> main_sm_err_o` binds (the label is a sound definite-true at the error cube → HOLDS via `F ∨ T`).
- **sysrst: HOLDS 1→6** (sva_1/4/8/12/14), **VIOLATED 0**, 3 honest ⊥ (sva_6/9/13 — btormc confirms sva_6 SAFE, so the ⊥ is honest + refinement-closable), 6 SKIP (the H.F relational-with-input residue).
- Full `e2e_` suite **9/9 green**; clippy `-D warnings` 0; fmt clean.

## Separate finding (filed)
`SmtHyperMust` produces a spurious must-edge on certain cube structures (sysrst sva_6's dimension set) → a spurious box `KleeneF`. Structure-specific (H.O.1c proved `SmtHyperMust` SOUND for sva_0); the ⊥-label sidesteps it via must=Off, but the must path needs a root-cause fix before `SmtHyperMust` is trusted for VIOLATED on arbitrary cube structures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)