### PR TITLE
feat(H-track H.F): relational SVA with an input operand binds to a verdict

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -718,16 +718,22 @@ pub fn cegar_refine_loop(
     // `ensure_compound_lift_supported` re-checks this at the lift entry.
     let mut compound_exprs: HashMap<String, crate::adapter::btor2::predicate_expr::PredicateExpr> =
         HashMap::new();
-    for (spec, expr) in sidecar_compound_predicates(adapter_options) {
+    // H.E.2 — derived predicates (labeled per cube via SMT, NOT cube dimensions):
+    // the simple combinational-of-input atoms (`combinational_predicates`) PLUS
+    // (H.F) the relational/compound ones whose operands include an input or
+    // combinational signal (`compound_predicates` with `derived = true`). They do
+    // NOT enter `current_predicates` (the cube index is unchanged); the lift writes
+    // their per-cube label into `state_3valued_predicates`, resolving any relational
+    // expr through `compound_exprs`.
+    let mut derived_predicates = sidecar_combinational_predicates(adapter_options);
+    for (spec, expr, is_derived) in sidecar_compound_predicates(adapter_options) {
         compound_exprs.insert(spec.name.clone(), expr);
-        current_predicates.push(spec);
+        if is_derived {
+            derived_predicates.push(spec); // H.F — a derived label, not a dimension
+        } else {
+            current_predicates.push(spec); // B.1 — a cube dimension
+        }
     }
-    // H.E.2 — derived combinational predicates (labeled per cube via SMT, NOT
-    // cube dimensions). They do NOT go into `current_predicates` (the cube index
-    // is unchanged); the lift writes their per-cube label into
-    // `state_3valued_predicates`. Like compounds, they require the eager
-    // SmtAllPairs lift (the labeling pass is SMT-based).
-    let derived_predicates = sidecar_combinational_predicates(adapter_options);
     // SmtAllPairs + Eager are forced when EITHER compound OR derived predicates
     // are present (both are SMT-seam-only paths).
     let smt_seam_required = !compound_exprs.is_empty() || !derived_predicates.is_empty();
@@ -1707,6 +1713,7 @@ pub fn sidecar_compound_predicates(
 ) -> Vec<(
     PredicateSpec,
     crate::adapter::btor2::predicate_expr::PredicateExpr,
+    bool, // H.F — `derived`: true ⇒ a per-cube label (not a cube dimension).
 )> {
     let Some(json) = &options.sidecar_json else {
         return Vec::new();
@@ -1742,6 +1749,7 @@ pub fn sidecar_compound_predicates(
                 value: 0,
             },
             expr,
+            decl.derived,
         ));
     }
     out

--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -1823,8 +1823,14 @@ fn ensure_compound_lift_supported(
     if lift_opts.compound_exprs.is_empty() {
         return Ok(());
     }
-    let names: std::collections::HashSet<&str> =
-        predicates.iter().map(|p| p.name.as_str()).collect();
+    // A compound_exprs key may name either a cube DIMENSION (`predicates`) or —
+    // H.F — a relational DERIVED label (`derived_predicates`, labelled per cube,
+    // not a cube index bit). Both legitimately carry a `PredicateExpr`.
+    let names: std::collections::HashSet<&str> = predicates
+        .iter()
+        .chain(lift_opts.derived_predicates.iter())
+        .map(|p| p.name.as_str())
+        .collect();
     for key in lift_opts.compound_exprs.keys() {
         if !names.contains(key.as_str()) {
             return Err(AdapterError {
@@ -2098,11 +2104,13 @@ pub fn predicate_cube_lift(
     if !lift_opts.derived_predicates.is_empty() {
         use crate::adapter::sts_ir::{BtorSts, SmtEncode};
         let cube_preds = cube_predicates(&predicates, &lift_opts.compound_exprs);
-        let empty_exprs: std::collections::HashMap<
-            String,
-            crate::adapter::btor2::predicate_expr::PredicateExpr,
-        > = std::collections::HashMap::new();
-        let derived_cube = cube_predicates(&lift_opts.derived_predicates, &empty_exprs);
+        // H.F — a derived predicate may be relational (`cnt_q >= cfg_*`); its
+        // `PredicateExpr` lives in `compound_exprs` (keyed by name, disjoint from
+        // the dimension keys), so the labeller resolves it. Simple
+        // combinational-of-input atoms have no entry → `expr() == None` (the
+        // signal⋈value labeller branch).
+        let derived_cube =
+            cube_predicates(&lift_opts.derived_predicates, &lift_opts.compound_exprs);
         let labels = BtorSts::new(&file).combinational_labels(&cube_preds, &derived_cube, 5_000);
         for (cube_idx, d_idx, label) in labels {
             if let (Some(&sid), Some(d)) = (

--- a/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
+++ b/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
@@ -928,41 +928,85 @@ where
     }
 }
 
-/// H.E.2 — the per-cube label of a **derived combinational predicate**
-/// (`signal == value`, where `signal` is a combinational node, NOT a cube
-/// dimension). Approach B (free-input-atoms.md §4): a combinational signal's
-/// value is a *determined function* of (state, inputs), so rather than make it a
-/// free cube dimension we LABEL it per cube — KleeneT/F where the cube pins it,
-/// KleeneBot where it doesn't.
+/// H.E.2 / H.F — the per-cube 3-valued label of a **derived predicate**: a
+/// combinational-of-input atom (`signal == value`, `signal` a combinational node)
+/// OR (H.F) a *relational* whose operands include an input / combinational signal
+/// (`cnt_q >= cfg_detect_timer_i`, `trigger_i != trigger_active`). Neither is a
+/// sound cube *dimension* (its next-cycle value depends on the demonic next
+/// input), so it is LABELLED per cube — KleeneT/F where the cube + the design's
+/// combinational logic pin it, KleeneBot where the free input swings it.
 ///
-/// `cube_bits` + `cube_predicates` define the cube C (its *dimension*
-/// predicates, over state + free inputs); `signal_nid` is the combinational
-/// node's NID (its current-cycle BV is `view.curr_signal(signal_nid)`).
+/// `cube_bits` + `cube_predicates` define the cube C (its dimension predicates,
+/// over state + free inputs); `derived` is the predicate to label, evaluated at
+/// the **current cycle** via the uniform source lookup ([`term_source_bv`]:
+/// state_curr ∪ inputs ∪ combinational signal cache) — so a relational with an
+/// input or combinational operand resolves (the legacy `build_pred_constraint`
+/// compound lookup reads `curr_state` only and could not).
 ///
 /// Decides, over all concrete states ⊨ C (current cycle):
-/// - `UNSAT(C ∧ signal != value)` → `KleeneT` (always `value` in C);
-/// - `UNSAT(C ∧ signal == value)` → `KleeneF` (never `value` in C);
-/// - else → `KleeneBot` (the cube doesn't pin it — honest).
+/// - `UNSAT(C ∧ ¬derived)` → `KleeneT` (derived always holds in C — e.g.
+///   `trigger_i != trigger_active` when `trigger_active = ~trigger_i`);
+/// - `UNSAT(C ∧ derived)` → `KleeneF` (never holds in C);
+/// - else → `KleeneBot` (the cube doesn't pin it — honest; e.g. `cnt_q >= cfg_*`
+///   with both operands free).
 ///
 /// **Soundness:** a definite KleeneT/F is a sound label (standard 3-valued
-/// preservation); a dimension predicate whose constraint can't be built is
-/// *omitted*, which only widens C (a superset) — KleeneT/F over a superset still
-/// hold on the cube (subset), and the widening can only push toward KleeneBot,
-/// never toward a false-definite. Timeout → conservative `KleeneBot`.
+/// preservation); the empty-cube guard prevents a vacuous definite. Timeout or an
+/// unresolvable operand → conservative `KleeneBot`.
 ///
 /// **Caller must hold a [`z3::with_z3_config`] scope.**
+///
+/// Resolve a derived predicate's operand NAME to its current-cycle source BV:
+/// state / input via `nid_map` (→ `state_curr` / `inputs`), or a combinational
+/// signal via the encoder's `view.signals` symbol table (→ `curr_signal`). The
+/// combinational case MUST go through `view.signals` (not `nid_map` +
+/// `term_source_bv`): an `output`-line symbol's NID differs from its driving
+/// node's NID, and only `view.signals` maps the symbol to the node that owns a
+/// `signal_bvs` entry — `nid_map` alone misses it, which would drop a definite
+/// combinational label to KleeneBot.
+fn derived_source_bv<'a>(
+    view: &'a Btor2SmtView,
+    nid_map: &HashMap<String, Nid>,
+    name: &str,
+) -> Option<&'a z3::ast::BV> {
+    if let Some(&nid) = nid_map.get(name)
+        && let Some(bv) = view.state_curr.get(&nid).or_else(|| view.inputs.get(&nid))
+    {
+        return Some(bv);
+    }
+    view.signals
+        .iter()
+        .find(|s| s.symbol.as_deref() == Some(name))
+        .and_then(|s| view.curr_signal(s.nid))
+}
+
 pub fn smt_combinational_label<P: PredicateLike>(
     view: &Btor2SmtView,
     cube_bits: u64,
     cube_predicates: &[P],
     nid_map: &HashMap<String, Nid>,
-    signal_nid: Nid,
-    value: u64,
+    derived: &P,
     timeout_ms: u32,
 ) -> crate::clts::Tristate {
     use crate::clts::Tristate;
-    let Some(sig) = view.curr_signal(signal_nid) else {
-        return Tristate::KleeneBot;
+    // The derived predicate's CURRENT-cycle constraint. `None` (an operand absent
+    // from the design) → honest KleeneBot.
+    let pred_bool = match derived.expr() {
+        Some(e) => {
+            let lookup = |reg: &str| -> Option<z3::ast::BV> {
+                derived_source_bv(view, nid_map, reg).cloned()
+            };
+            match e.build_constraint(&lookup) {
+                Some(b) => b,
+                None => return Tristate::KleeneBot,
+            }
+        }
+        None => {
+            let Some(bv) = derived_source_bv(view, nid_map, derived.register()) else {
+                return Tristate::KleeneBot;
+            };
+            build_predicate_constraint(bv, derived.value(), true)
+        }
     };
     // Cube C = conjunction of the dimension predicates at this cube's polarities,
     // over the current cycle. A predicate whose constraint can't be built is
@@ -974,8 +1018,7 @@ pub fn smt_combinational_label<P: PredicateLike>(
             cube.push(c);
         }
     }
-    let val_bv = z3::ast::BV::from_u64(value, sig.get_size());
-    let eq = sig.eq(&val_bv);
+    let eq = pred_bool;
 
     let check = |extra: &z3::ast::Bool| -> z3::SatResult {
         let solver = z3::Solver::new();

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -26,13 +26,19 @@
 //! verdict is read across every initial environment value — the "for all input
 //! sequences" over-approximation (see `docs/design/free-input-atoms.md`).
 //!
+//! A relational compound carrying an **input** operand (sysrst's
+//! `cnt_q >= cfg_*_timer_i`) BINDS as a derived RELATIONAL label (H.F): the
+//! per-cube 3-valued labeller resolves each operand over the uniform source
+//! image (state ∪ inputs ∪ combinational), so the property reaches an honest ⊥
+//! rather than skipping. Combinational-of-input *antecedents*
+//! (`trigger_active = !trigger_i`) likewise bind as derived ⊥-labels (H.E).
+//!
 //! What is still **Skipped** (never given a misleading verdict): an atom over a
-//! pure **combinational output** (an `eq`/`or` function of state like csrng's
-//! `main_sm_err_o` — case 4 of the design doc; needs the signal-node mapping a
-//! follow-up adds), and an input inside a *compound* (the compound SMT branch
-//! reads state BVs, not `view.inputs`). Those properties are reported Skipped
-//! with a reason — binding them would fall through to the evaluator's
-//! "unknown ⇒ false" under-approx and silently produce a vacuous verdict.
+//! pure **combinational output** that is a function of state (an `eq`/`or` of
+//! state like csrng's `main_sm_err_o` — case 4 of the design doc; needs the
+//! signal-node mapping a follow-up adds). Such an atom is reported Skipped with
+//! a reason — binding it would fall through to the evaluator's "unknown ⇒ false"
+//! under-approx and silently produce a vacuous verdict.
 
 use std::collections::HashSet;
 
@@ -211,6 +217,13 @@ struct Seeded {
     /// SMT (Approach B). Threaded to `cegar_refine_loop` through the synthesised
     /// sidecar's `combinational_predicates`. Empty ⇒ the pre-H.E shape.
     derived: Vec<PredicateSpec>,
+    /// H.F — **relational** derived predicates: a `PredicateExpr` (`cnt_q >=
+    /// cfg_detect_timer_i`, `trigger_i != trigger_active`) whose operands include
+    /// an input or combinational signal, so it is NOT a sound cube dimension. Like
+    /// [`Seeded::derived`] it is labelled per cube via SMT, but it carries a full
+    /// expr (not `register == value`). Threaded through the synthesised sidecar's
+    /// `compound_predicates` with `derived = true`. Empty ⇒ the pre-H.F shape.
+    derived_relational: Vec<(String, PredicateExpr)>,
 }
 
 /// The minimal H.1 (+ H.B) — derive cube predicates from a formula's
@@ -325,13 +338,31 @@ fn seed_from_formula(
                     op: CmpOp::Eq,
                     value,
                 } => seed_simple(&mut out, atom, register, *value),
-                // Relational / `!=` / boolean combination → compound predicate.
-                // The compound SMT branch reads state BVs only, so every
-                // referenced register must be a state cell.
+                // Relational / `!=` / boolean combination.
                 _ => {
-                    if expr.registers().iter().all(|r| is_state(r)) {
+                    let regs = expr.registers();
+                    if regs.iter().all(|r| is_state(r)) {
+                        // All-state → a cube DIMENSION (B.1 compound). The SMT
+                        // dimension path reads state BVs.
                         out.compounds.push((atom.clone(), expr));
+                    } else if regs
+                        .iter()
+                        .all(|r| is_state(r) || is_input(r) || combinational_kind(r).is_some())
+                    {
+                        // H.F — a relational with an input / combinational operand
+                        // (`cnt_q >= cfg_detect_timer_i`, `trigger_i !=
+                        // trigger_active`). Its value depends on the demonic input,
+                        // so it is NOT a sound cube dimension (the same reason a
+                        // combinational-of-input atom isn't). Route it to a DERIVED
+                        // per-cube 3-valued label: the SMT labeller decides
+                        // KleeneT/F where the design's logic pins it (e.g.
+                        // `trigger_i != ~trigger_i` ≡ true → HOLDS), KleeneBot where
+                        // a free operand swings it. Sound (a pure observation; a
+                        // KleeneBot atom is ⊥, never a spurious verdict).
+                        out.derived_relational.push((atom.clone(), expr));
                     } else {
+                        // An operand resolves to nothing in the lifted design —
+                        // cannot label it. Honest SKIP.
                         out.unseedable.push(atom.clone());
                     }
                 }
@@ -354,15 +385,24 @@ fn seed_from_formula(
 fn synth_sidecar_json(
     compounds: &[(String, PredicateExpr)],
     derived: &[PredicateSpec],
+    derived_relational: &[(String, PredicateExpr)],
     referenced: &std::collections::BTreeSet<String>,
     init_values: &std::collections::HashMap<String, u64>,
 ) -> Option<String> {
-    let compound_decls: Vec<serde_json::Value> = compounds
+    let mut compound_decls: Vec<serde_json::Value> = compounds
         .iter()
         // `expr` == `name` == the atom string, which `sidecar_compound_predicates`
         // re-parses via `parse_predicate_expr` (REL handles `reg == reg`).
         .map(|(name, _)| serde_json::json!({ "name": name, "expr": name }))
         .collect();
+    // H.F — relational derived predicates ride the SAME `compound_predicates`
+    // field tagged `derived: true`, so `cegar_refine_loop` routes them to the
+    // per-cube label path (not the cube index). `expr` == `name` as above.
+    compound_decls.extend(
+        derived_relational
+            .iter()
+            .map(|(name, _)| serde_json::json!({ "name": name, "expr": name, "derived": true })),
+    );
     // H.E — derived combinational predicates: `cegar_refine_loop` reads these
     // into `lift_opts.derived_predicates`; the lift labels each per cube via the
     // SMT `combinational_labels` pass (NOT a cube dimension).
@@ -721,7 +761,8 @@ pub fn verify_auto(
             continue;
         }
         let predicate_count = seeded.specs.len() + seeded.compounds.len();
-        if predicate_count == 0 && seeded.derived.is_empty() {
+        if predicate_count == 0 && seeded.derived.is_empty() && seeded.derived_relational.is_empty()
+        {
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
                 kind: t.kind,
@@ -738,6 +779,7 @@ pub fn verify_auto(
         let mut seeded_names: Vec<String> = seeded.specs.iter().map(|s| s.name.clone()).collect();
         seeded_names.extend(seeded.compounds.iter().map(|(n, _)| n.clone()));
         seeded_names.extend(seeded.derived.iter().map(|d| d.name.clone()));
+        seeded_names.extend(seeded.derived_relational.iter().map(|(n, _)| n.clone()));
 
         // Compounds OR free inputs ⇒ force the SmtAllPairs eager lift.
         // Compounds: the only compound-aware may path. Free inputs (H.B): the
@@ -748,10 +790,10 @@ pub fn verify_auto(
         // `cegar_refine_loop` re-checks the compound gate.
         let has_compounds = !seeded.compounds.is_empty();
         let has_inputs = !seeded.input_registers.is_empty();
-        // H.E — derived combinational predicates are labeled per cube by the
-        // SMT `combinational_labels` pass, which also requires the SmtAllPairs
-        // eager lift (precise state edges + the encoded view).
-        let has_derived = !seeded.derived.is_empty();
+        // H.E / H.F — derived predicates (simple combinational-of-input atoms +
+        // relational ones) are labeled per cube by the SMT `combinational_labels`
+        // pass, which requires the SmtAllPairs eager lift.
+        let has_derived = !seeded.derived.is_empty() || !seeded.derived_relational.is_empty();
         // H.U.2 — a combinational-of-state spec (register present in
         // `combinational_nid`, not a state cell) is a cube dimension over a
         // *determined function of state*. The sampling may-path is state-register
@@ -799,10 +841,19 @@ pub fn verify_auto(
                 referenced.insert(r);
             }
         }
+        // H.F — pin the state operands of relational derived predicates too (the
+        // input operands have no `init_values` entry, so they are silently skipped
+        // for config_values — correct, a free input has no reset value).
+        for (_, e) in &seeded.derived_relational {
+            for r in e.registers() {
+                referenced.insert(r);
+            }
+        }
         let adapter_options = AdapterOptions {
             sidecar_json: synth_sidecar_json(
                 &seeded.compounds,
                 &seeded.derived,
+                &seeded.derived_relational,
                 &referenced,
                 &init_values,
             ),
@@ -975,7 +1026,7 @@ mod tests {
                 .into_iter()
                 .collect();
         let json =
-            synth_sidecar_json(&s.compounds, &[], &referenced, &inits).expect("sidecar json");
+            synth_sidecar_json(&s.compounds, &[], &[], &referenced, &inits).expect("sidecar json");
         assert!(json.contains("compound_predicates"));
         assert!(json.contains("state == state__past"));
         assert!(json.contains("config_values"), "init pins present: {json}");
@@ -1076,11 +1127,11 @@ mod tests {
     }
 
     #[test]
-    fn h_b_input_inside_compound_is_unseedable() {
-        // An input inside a compound (`!=`, relational, boolean) is NOT admitted
-        // — the compound SMT branch reads state BVs only, not `view.inputs`. So
-        // `cfg_enable_i != 0` (a Ne, routed to the compound branch) over an
-        // input is unseedable even though the same atom as `== 0` would seed.
+    fn h_f_input_inside_compound_binds_as_derived_relational() {
+        // H.F supersedes the H.B deferral: an input inside a compound (`!=`,
+        // relational, boolean) is NO LONGER unseedable. `cfg_enable_i != 0` (a Ne
+        // over an input, routed to the compound branch) now binds as a derived
+        // per-cube 3-valued label (sound; ⊥ where the input swings it).
         let f = mu_parser::parse("nu X. ((cfg_enable_i != 0) && [] X)").unwrap();
         let s = seed_from_formula(
             &f,
@@ -1089,10 +1140,20 @@ mod tests {
             |_| None,
         );
         assert!(s.specs.is_empty());
-        assert!(s.compounds.is_empty());
         assert!(
-            s.unseedable.contains(&"cfg_enable_i != 0".to_string()),
-            "input inside a compound is unseedable: {:?}",
+            s.compounds.is_empty(),
+            "not a cube dimension (input operand)"
+        );
+        assert!(
+            s.derived_relational
+                .iter()
+                .any(|(n, _)| n == "cfg_enable_i != 0"),
+            "input inside a compound now binds as a derived relational label: {:?}",
+            s.derived_relational
+        );
+        assert!(
+            !s.unseedable.iter().any(|a| a.contains("cfg_enable_i")),
+            "no longer unseedable: {:?}",
             s.unseedable
         );
     }
@@ -1197,6 +1258,56 @@ mod tests {
     }
 
     #[test]
+    fn h_f_relational_with_input_operand_routed_to_derived_relational() {
+        // `cnt_q >= cfg_detect_timer_i` — `cnt_q` state, `cfg_detect_timer_i` a
+        // free input. The relational's value depends on the demonic input, so it
+        // is NOT a sound cube dimension; H.F routes it to a derived per-cube
+        // 3-valued label (carrying its PredicateExpr), not unseedable.
+        let f = mu_parser::parse("nu X. ((cnt_q >= cfg_detect_timer_i) && [] X)").unwrap();
+        let s = seed_from_formula(
+            &f,
+            |n| cells(&["cnt_q"]).contains(n),
+            |n| n == "cfg_detect_timer_i",
+            |_| None,
+        );
+        assert!(
+            s.compounds.is_empty(),
+            "not a cube dimension (has a non-state operand): {:?}",
+            s.compounds
+        );
+        assert!(
+            s.derived_relational
+                .iter()
+                .any(|(n, _)| n == "cnt_q >= cfg_detect_timer_i"),
+            "relational-with-input routed to derived_relational: {:?}",
+            s.derived_relational
+        );
+        assert!(
+            !s.unseedable.iter().any(|a| a.contains("cnt_q")),
+            "no longer skipped: {:?}",
+            s.unseedable
+        );
+    }
+
+    #[test]
+    fn h_f_relational_with_unresolvable_operand_is_skipped() {
+        // An operand that resolves to nothing in the design (not state / input /
+        // combinational) → cannot label it → honest SKIP, not a derived label.
+        let f = mu_parser::parse("nu X. ((cnt_q >= mystery_signal) && [] X)").unwrap();
+        let s = seed_from_formula(&f, |n| cells(&["cnt_q"]).contains(n), |_| false, |_| None);
+        assert!(
+            s.derived_relational.is_empty(),
+            "{:?}",
+            s.derived_relational
+        );
+        assert!(
+            s.unseedable.iter().any(|a| a.contains("mystery_signal")),
+            "unresolvable operand ⇒ SKIP: {:?}",
+            s.unseedable
+        );
+    }
+
+    #[test]
     fn skip_reason_enriched_with_blackboxed_module_root_cause() {
         // A cut FSM (e.g. csrng's prim_sparse_fsm_flop) → the bare "non-state
         // signal" symptom is augmented with the actionable root cause.
@@ -1251,7 +1362,7 @@ mod tests {
     fn no_sidecar_when_nothing_to_emit() {
         let empty_refs = std::collections::BTreeSet::new();
         let empty_inits = std::collections::HashMap::new();
-        assert!(synth_sidecar_json(&[], &[], &empty_refs, &empty_inits).is_none());
+        assert!(synth_sidecar_json(&[], &[], &[], &empty_refs, &empty_inits).is_none());
     }
 
     #[test]
@@ -1637,19 +1748,63 @@ mod tests {
         );
         // After H.E.r2, the simple combinational-of-input antecedents
         // (`trigger_active`, `event_detected_*`, `cnt_clr`) BIND as derived
-        // ⊥-labels (HOLDS-or-honest-⊥). The only remaining SKIPs are the
-        // RELATIONAL-with-input compounds (`cnt_q >= cfg_*_timer_i`, sva_5/7/10/11)
-        // — an input operand inside a compound, which the compound SMT path does
-        // not yet admit (H.F). Never a free-input *simple* antecedent: H.B closed
-        // those (`cfg_enable_i`).
+        // ⊥-labels (HOLDS-or-honest-⊥). H.F then closed the last residual: the
+        // RELATIONAL-with-input compounds (`cnt_q >= cfg_*_timer_i`, sva_5/7/10/11
+        // — an input operand inside a compound) are now admitted as derived
+        // RELATIONAL labels, so they reach an honest ⊥ instead of SKIPPING. Net
+        // effect: every translated property binds — SKIPPED is 0.
+        assert_eq!(
+            skipped, 0,
+            "H.F: every translated property binds (relational-with-input compounds \
+             now reach a verdict instead of SKIPPING); got SKIPPED={skipped}"
+        );
+        // No free-input antecedent (H.B) and no relational-with-input compound
+        // (H.F) remains skipped.
         for p in &report.properties {
             if let VerifyOutcome::Skipped { reason } = &p.outcome {
                 assert!(
-                    !reason.contains("cfg_enable_i"),
-                    "no free-input antecedent should remain skipped after H.B; got: {reason}"
+                    !reason.contains("cfg_enable_i") && !reason.contains("cnt_q >= cfg_"),
+                    "no free-input / relational-with-input atom should remain skipped \
+                     after H.B + H.F; got: {reason}"
                 );
             }
         }
+        // H.F — sva_5/7/10/11 are the relational-with-input compounds
+        // (`cnt_q >= cfg_*_timer_i`). Pre-H.F they SKIPPED ("input operand inside
+        // a compound"); now they bind as derived relational labels and reach an
+        // honest ⊥ (Unknown) — never a spurious verdict.
+        for name in [
+            "sysrst_ctrl_detect_sva_5",
+            "sysrst_ctrl_detect_sva_7",
+            "sysrst_ctrl_detect_sva_10",
+            "sysrst_ctrl_detect_sva_11",
+        ] {
+            let p = report
+                .properties
+                .iter()
+                .find(|p| p.name == name)
+                .unwrap_or_else(|| panic!("{name} present"));
+            assert!(
+                matches!(p.outcome, VerifyOutcome::Unknown { .. }),
+                "{name} (relational-with-input compound) binds and reaches an honest \
+                 ⊥, not a SKIP; got {:?}",
+                p.outcome
+            );
+        }
+        // H.F — sva_2/3 are `trigger_i != trigger_active` where
+        // `trigger_active = !trigger_i` (1-bit). `b != !b` is a tautology over the
+        // combinational relation, so the derived relational label is definite-True
+        // at every cube and the property reaches a sound HOLDS.
+        let sva2 = report
+            .properties
+            .iter()
+            .find(|p| p.name == "gen_low_level_sva_sva_2")
+            .expect("sva_2 present");
+        assert!(
+            matches!(sva2.outcome, VerifyOutcome::Holds),
+            "sva_2 (`trigger_i != !trigger_i` tautology) reaches a sound HOLDS; got {:?}",
+            sva2.outcome
+        );
         // H.D (translation widening) — `signal >= signal` and 1-bit `!x === y`
         // now translate (pre-H.D: 7 unsupported; now only the arithmetic-RHS
         // `cnt == cnt + 1` form remains, which needs predicate-arithmetic).
@@ -2114,6 +2269,7 @@ mod tests {
             sidecar_json: synth_sidecar_json(
                 &seeded.compounds,
                 &seeded.derived,
+                &seeded.derived_relational,
                 &referenced,
                 &init_u64,
             ),

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -493,7 +493,6 @@ impl SmtEncode for BtorSts<'_> {
         use crate::adapter::btor2::smt_must_edge::{
             build_register_nid_map_with_inputs, smt_combinational_label,
         };
-        use crate::adapter::sidecar::predicate_image::btor2_encode::SignalKind;
         use crate::clts::Tristate;
 
         if derived.is_empty() {
@@ -517,35 +516,22 @@ impl SmtEncode for BtorSts<'_> {
                 }
             };
             let nid_map = build_register_nid_map_with_inputs(&view);
-            // Resolve each derived predicate's signal name → its combinational
-            // node NID (own-symbol match in the view's Combinational signals).
-            let derived_nids: Vec<Option<_>> = derived
-                .iter()
-                .map(|d| {
-                    view.signals
-                        .iter()
-                        .find(|s| {
-                            s.kind == SignalKind::Combinational
-                                && s.symbol.as_deref() == Some(d.register())
-                        })
-                        .map(|s| s.nid)
-                })
-                .collect();
+            // Each derived predicate (a combinational-of-input atom OR an H.F
+            // relational over input/combinational operands) is labelled per cube
+            // by `smt_combinational_label`, which resolves its operands through
+            // `nid_map` (state ∪ inputs ∪ combinational) + the uniform source
+            // lookup. No separate combinational-NID resolution is needed.
             let mut out = Vec::with_capacity(n_cubes * derived.len());
             for i in 0..n_cubes {
                 for (d_idx, d) in derived.iter().enumerate() {
-                    let label = match derived_nids[d_idx] {
-                        Some(nid) => smt_combinational_label(
-                            &view,
-                            i as u64,
-                            cube_predicates,
-                            &nid_map,
-                            nid,
-                            d.value(),
-                            timeout_ms,
-                        ),
-                        None => Tristate::KleeneBot,
-                    };
+                    let label = smt_combinational_label(
+                        &view,
+                        i as u64,
+                        cube_predicates,
+                        &nid_map,
+                        d,
+                        timeout_ms,
+                    );
                     out.push((i, d_idx, label));
                 }
             }

--- a/crates/mununu-core/src/adapter/systemverilog/annotation.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/annotation.rs
@@ -322,6 +322,12 @@ pub struct CompoundPredicateDecl {
     /// Boolean-expression source, e.g. `"cnt == 0 && en == 1"`. Parsed by
     /// `parse_predicate_expr`; a malformed expr is skipped with a warning.
     pub expr: String,
+    /// H.F — when `true`, this compound is a DERIVED 3-valued LABEL (its operands
+    /// include an input/combinational signal, so it is not a sound cube dimension;
+    /// the lift labels it per cube via the SMT seam), NOT a cube dimension.
+    /// `false` (the default, the all-state B.1 case) → a cube dimension.
+    #[serde(default)]
+    pub derived: bool,
 }
 
 /// §Phase 10 §10.2 stage 2 — Memory-cell annotation.


### PR DESCRIPTION
## What

A relational compound carrying an **input** operand — sysrst_ctrl's `cnt_q >= cfg_*_timer_i` (state register vs config input) — was SKIPPED: the compound SMT branch resolved operands only over state/next BVs, so an input operand had nowhere to bind. **H.F** admits it as a derived RELATIONAL label, so the property reaches an honest verdict (⊥ or definite) instead of skipping.

## Changes

- **Seeder** (`verify_auto.rs`): an all-(state|input|combinational) relational atom routes to `Seeded::derived_relational` (state-only → compound; otherwise unseedable, unchanged). The no-atoms gate now counts `derived_relational`.
- **Labeller** (`smt_must_edge.rs`): the per-cube 3-valued labeller resolves each operand over the uniform source image (state ∪ inputs ∪ combinational) via a new `derived_source_bv` helper — state/input through `nid_map`, a combinational signal through `view.signals` (an output-line symbol's NID differs from its driving node's, so `nid_map` alone would miss it and drop a definite label to ⊥).
- **Lift validation** (`kmts_lift.rs`): `compound_exprs`-key validation accepts keys naming `derived_predicates` (relational labels), not only cube dimensions.
- **Schema** (`annotation.rs` / `cegar.rs` / `sts_ir.rs`): `CompoundPredicateDecl` gains `derived: bool`; `sidecar_compound_predicates` partitions dimension predicates from derived labels.

## Soundness

Inherited from the H.E derived-label path: a derived label is a pure per-cube 3-valued observation (definite only when 2-sided UNSAT pins it), never fabricates an edge, never yields a spurious verdict.

## Validation (mununu-sva image, real OpenTitan RTL)

| anchor | before | after |
|---|---|---|
| sysrst_ctrl_detect HOLDS | 3 | **5** (sva_2/3 `trigger_i != !trigger_i` tautology) |
| sysrst_ctrl_detect SKIPPED | 6 | **0** (sva_5/7/10/11 `cnt_q >= cfg_*_timer_i` bind → ⊥) |
| sysrst_ctrl_detect VIOLATED | 0 | 0 |
| csrng_main_sm HOLDS | 2 | 2 (clean no-regression anchor) |

sva_4/8/14 unchanged (Unknown — **verified against `main`** in an isolated worktree, no regression). Breakdown e2e updated to assert SKIPPED=0, sva_5/7/10/11 ⊥, sva_2 HOLDS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)