### PR TITLE
feat(H-track H.G): arithmetic-addend predicate — sysrst SVA translate 15→16/16

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/predicate_expr.rs
+++ b/crates/mununu-core/src/adapter/btor2/predicate_expr.rs
@@ -73,6 +73,34 @@ pub enum PredicateExpr {
         op: CmpOp,
         rhs: String,
     },
+    /// H.G — arithmetic relational `lhs <op> (rhs + addend)` over two registers
+    /// with a **constant** addend, in unsigned bit-vector arithmetic **mod
+    /// 2^width** (the register width — so it wraps exactly as the RTL's `+` does).
+    /// The one arithmetic form the translator needs (`cnt_q == $past(cnt_q) + 1`,
+    /// sysrst sva_15 `CntIncr_A`). No general arithmetic — a single `+const`
+    /// keeps the predicate layer inside the audited modal fragment.
+    ///
+    /// **SMT-primary.** Production routes this SMT-only (a derived relational
+    /// label, like [`PredicateExpr::CmpReg`]-with-an-input): [`build_constraint`]
+    /// does BV `bvadd` at the operand's real width (sound). [`eval`] is the
+    /// differential-test reference and computes `mod 2^width` from the embedded
+    /// `width`; a `width == 0` leaf must never be `eval`'d (production never does
+    /// — it uses `build_constraint`). The `predicate_expr_eval_matches_smt`
+    /// differential (the §4 PO) sets `width` explicitly and checks the two agree,
+    /// including at the wraparound boundary.
+    ///
+    /// [`build_constraint`]: PredicateExpr::build_constraint
+    /// [`eval`]: PredicateExpr::eval
+    CmpRegAddend {
+        lhs: String,
+        op: CmpOp,
+        rhs: String,
+        addend: u64,
+        /// Modulus width for `eval` (the register width). `0` ⇒ SMT-only
+        /// (`build_constraint` uses the operand's real BV width); `eval` on a
+        /// `width == 0` leaf is a caller error (production never evals it).
+        width: u32,
+    },
     And(Box<PredicateExpr>, Box<PredicateExpr>),
     Or(Box<PredicateExpr>, Box<PredicateExpr>),
     Not(Box<PredicateExpr>),
@@ -100,6 +128,38 @@ impl PredicateExpr {
         }
     }
 
+    /// H.G — an arithmetic relational `lhs <op> (rhs + addend)` (`width == 0` ⇒
+    /// SMT-only; `eval` requires a nonzero `width`). The `cnt == $past(cnt) + 1`
+    /// (`CntIncr_A`) translator form.
+    pub fn cmp_reg_addend(
+        lhs: impl Into<String>,
+        op: CmpOp,
+        rhs: impl Into<String>,
+        addend: u64,
+        width: u32,
+    ) -> Self {
+        PredicateExpr::CmpRegAddend {
+            lhs: lhs.into(),
+            op,
+            rhs: rhs.into(),
+            addend,
+            width,
+        }
+    }
+
+    /// True if the expression contains an arithmetic-addend leaf
+    /// ([`PredicateExpr::CmpRegAddend`]). The seeder routes such an expression
+    /// SMT-only (a derived relational label), since `eval` on a `width == 0`
+    /// production leaf is invalid.
+    pub fn has_addend(&self) -> bool {
+        match self {
+            PredicateExpr::CmpRegAddend { .. } => true,
+            PredicateExpr::Cmp { .. } | PredicateExpr::CmpReg { .. } => false,
+            PredicateExpr::And(a, b) | PredicateExpr::Or(a, b) => a.has_addend() || b.has_addend(),
+            PredicateExpr::Not(a) => a.has_addend(),
+        }
+    }
+
     /// Explicit evaluation over a concrete register valuation. Registers absent
     /// from `regs` default to `0` — matching the cube lifter's `.unwrap_or(0)`
     /// convention for next-state registers that no transition wrote.
@@ -117,6 +177,31 @@ impl PredicateExpr {
                 let l = regs.get(lhs).copied().unwrap_or(0);
                 let r = regs.get(rhs).copied().unwrap_or(0);
                 cmp_apply(*op, l, r)
+            }
+            PredicateExpr::CmpRegAddend {
+                lhs,
+                op,
+                rhs,
+                addend,
+                width,
+            } => {
+                let l = regs.get(lhs).copied().unwrap_or(0);
+                let r = regs.get(rhs).copied().unwrap_or(0);
+                // `mod 2^width` to match the BV `bvadd` in `build_constraint`
+                // (wraps exactly as the RTL). A `width == 0` leaf is SMT-only and
+                // must not be `eval`'d — debug-assert, and fall back to unmasked
+                // (correct away from the wrap boundary) in release.
+                debug_assert!(
+                    *width > 0,
+                    "eval on a width==0 CmpRegAddend (SMT-only leaf) — production must use build_constraint"
+                );
+                let sum = r.wrapping_add(*addend as u128);
+                let sum = if *width == 0 || *width >= 128 {
+                    sum
+                } else {
+                    sum & ((1u128 << *width) - 1)
+                };
+                cmp_apply(*op, l, sum)
             }
             PredicateExpr::And(a, b) => a.eval(regs) && b.eval(regs),
             PredicateExpr::Or(a, b) => a.eval(regs) || b.eval(regs),
@@ -138,7 +223,8 @@ impl PredicateExpr {
             PredicateExpr::Cmp { register, .. } => {
                 out.insert(register.clone());
             }
-            PredicateExpr::CmpReg { lhs, rhs, .. } => {
+            PredicateExpr::CmpReg { lhs, rhs, .. }
+            | PredicateExpr::CmpRegAddend { lhs, rhs, .. } => {
                 out.insert(lhs.clone());
                 out.insert(rhs.clone());
             }
@@ -174,6 +260,24 @@ impl PredicateExpr {
                 let lbv = lookup(lhs)?;
                 let rbv = lookup(rhs)?;
                 Some(cmp_constraint_bv(&lbv, *op, &rbv))
+            }
+            PredicateExpr::CmpRegAddend {
+                lhs,
+                op,
+                rhs,
+                addend,
+                ..
+            } => {
+                // `lhs <op> (rhs + addend)` in BV — `bvadd` wraps at `rhs`'s real
+                // width (the RTL semantics). `width` is the eval-side modulus
+                // only; here the operand BVs carry the authoritative width.
+                let lbv = lookup(lhs)?;
+                let rbv = lookup(rhs)?;
+                let w = rbv.get_size();
+                let mask: u64 = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
+                let addend_bv = z3::ast::BV::from_u64(*addend & mask, w);
+                let sum = rbv.bvadd(&addend_bv);
+                Some(cmp_constraint_bv(&lbv, *op, &sum))
             }
             PredicateExpr::And(a, b) => {
                 let ca = a.build_constraint(lookup)?;
@@ -291,6 +395,9 @@ enum Token {
     And,
     Or,
     Not,
+    /// H.G — `+` for the arithmetic-addend RHS (`rhs + const`), the sole
+    /// arithmetic form (`cnt == $past(cnt) + 1`).
+    Plus,
     LParen,
     RParen,
 }
@@ -332,6 +439,10 @@ fn tokenize(s: &str) -> Result<Vec<Token>, PredicateExprParseError> {
             }
             '!' => {
                 tokens.push(Token::Not);
+                i += 1;
+            }
+            '+' => {
+                tokens.push(Token::Plus);
                 i += 1;
             }
             '<' if chars.get(i + 1) == Some(&'=') => {
@@ -485,11 +596,32 @@ impl Parser<'_> {
                 op,
                 value,
             }),
-            Some(Token::Ident(rhs)) => Ok(PredicateExpr::CmpReg {
-                lhs: register,
-                op,
-                rhs,
-            }),
+            Some(Token::Ident(rhs)) => {
+                // H.G — `rhs + const` → CmpRegAddend (`cnt == $past(cnt) + 1`);
+                // bare `rhs` → CmpReg (REL). width=0 ⇒ SMT-only (resolved at
+                // build_constraint from the operand BV; see CmpRegAddend docs).
+                if matches!(self.peek(), Some(Token::Plus)) {
+                    self.pos += 1; // consume `+`
+                    match self.next() {
+                        Some(Token::Int(addend)) => Ok(PredicateExpr::CmpRegAddend {
+                            lhs: register,
+                            op,
+                            rhs,
+                            addend,
+                            width: 0,
+                        }),
+                        other => Err(perr(format!(
+                            "expected an integer addend after `{register} <op> {rhs} +`, found {other:?}"
+                        ))),
+                    }
+                } else {
+                    Ok(PredicateExpr::CmpReg {
+                        lhs: register,
+                        op,
+                        rhs,
+                    })
+                }
+            }
             other => Err(perr(format!(
                 "expected an integer value or a register after `{register} <op>`, found {other:?}"
             ))),
@@ -777,6 +909,102 @@ mod tests {
                 }
             }
         });
+    }
+
+    #[test]
+    fn arithmetic_addend_eval_matches_smt() {
+        // H.G — the §4 PO for the arithmetic leaf: `a <op> (b + k) mod 2^width`
+        // must agree between `eval` (embedded width) and `build_constraint` (BV
+        // `bvadd`) across ALL 2-bit assignments, INCLUDING the wraparound
+        // boundary (width=2 → `b=3, +1` wraps to `0`). This is the guard that
+        // makes the arithmetic predicate sound.
+        const W: u32 = 2; // 2-bit → wraps at 4
+        let exprs: Vec<PredicateExpr> = vec![
+            PredicateExpr::cmp_reg_addend("a", CmpOp::Eq, "b", 1, W),
+            PredicateExpr::cmp_reg_addend("a", CmpOp::Ne, "b", 1, W),
+            PredicateExpr::cmp_reg_addend("a", CmpOp::Ge, "b", 1, W),
+            PredicateExpr::cmp_reg_addend("a", CmpOp::Lt, "b", 2, W),
+            PredicateExpr::And(
+                Box::new(PredicateExpr::eq("a", 0)),
+                Box::new(PredicateExpr::cmp_reg_addend("a", CmpOp::Eq, "b", 1, W)),
+            ),
+            PredicateExpr::Not(Box::new(PredicateExpr::cmp_reg_addend(
+                "a",
+                CmpOp::Eq,
+                "b",
+                1,
+                W,
+            ))),
+        ];
+        let cfg = z3::Config::new();
+        z3::with_z3_config(&cfg, || {
+            for e in &exprs {
+                for a in 0u64..4 {
+                    for b in 0u64..4 {
+                        let want = e.eval(&regs(&[("a", a as u128), ("b", b as u128)]));
+                        let a_bv = z3::ast::BV::new_const("a", W);
+                        let b_bv = z3::ast::BV::new_const("b", W);
+                        let lookup = |name: &str| -> Option<z3::ast::BV> {
+                            match name {
+                                "a" => Some(a_bv.clone()),
+                                "b" => Some(b_bv.clone()),
+                                _ => None,
+                            }
+                        };
+                        let constraint = e.build_constraint(&lookup).expect("all regs present");
+                        let solver = z3::Solver::new();
+                        let a_val = z3::ast::BV::from_u64(a, W);
+                        let b_val = z3::ast::BV::from_u64(b, W);
+                        let a_pin = a_bv.eq(&a_val);
+                        let b_pin = b_bv.eq(&b_val);
+                        solver.assert(&a_pin);
+                        solver.assert(&b_pin);
+                        solver.assert(&constraint);
+                        let got = matches!(solver.check(), z3::SatResult::Sat);
+                        assert_eq!(
+                            want, got,
+                            "eval/SMT disagree for {e:?} at a={a}, b={b}: eval={want}, smt={got}"
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn parse_arithmetic_addend() {
+        // H.G — `cnt == cnt_past + 1` parses to a `CmpRegAddend` (width=0, filled
+        // by build_constraint from the operand BV in production).
+        let e = parse_predicate_expr("cnt == cnt_past + 1").expect("parse arithmetic addend");
+        assert_eq!(
+            e,
+            PredicateExpr::cmp_reg_addend("cnt", CmpOp::Eq, "cnt_past", 1, 0)
+        );
+        assert!(e.has_addend());
+        // a bare relational is still CmpReg (no addend)
+        let rel = parse_predicate_expr("cnt >= cnt_past").expect("parse rel");
+        assert!(!rel.has_addend());
+        assert_eq!(
+            rel,
+            PredicateExpr::CmpReg {
+                lhs: "cnt".into(),
+                op: CmpOp::Ge,
+                rhs: "cnt_past".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn eval_addend_wraps_at_width() {
+        // width=2: `3 + 1 = 0 (mod 4)`, so `cnt == cnt_past + 1` is TRUE at
+        // cnt=0, cnt_past=3 (the wrap) — matching the RTL BV `+`.
+        let e = PredicateExpr::cmp_reg_addend("cnt", CmpOp::Eq, "cnt_past", 1, 2);
+        assert!(
+            e.eval(&regs(&[("cnt", 0), ("cnt_past", 3)])),
+            "3+1 wraps to 0 at width 2"
+        );
+        assert!(!e.eval(&regs(&[("cnt", 0), ("cnt_past", 2)])), "2+1=3 != 0");
+        assert!(e.eval(&regs(&[("cnt", 3), ("cnt_past", 2)])), "2+1=3");
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/slang/translate.rs
+++ b/crates/mununu-core/src/adapter/slang/translate.rs
@@ -677,6 +677,18 @@ fn compare(expr: &Value, op: &str) -> Result<String, String> {
     if let (Some(l), Some(r)) = (cmp_signal_atom(left), cmp_signal_atom(right)) {
         return Ok(format!("({l} {op} {r})"));
     }
+    // (4b) H.G — arithmetic relational `signal OP (signal + literal)` — the sole
+    // arithmetic form (`cnt_q == $past(cnt_q) + 1`, sysrst `CntIncr_A`). Lowers to
+    // `PredicateExpr::CmpRegAddend`, whose SMT encoding is BV `bvadd` at the
+    // register width (wraps exactly as the RTL `+`). The addend base may be a
+    // `$past` shadow; the addend itself is a non-negative literal. Binding is the
+    // cube path's job (routed SMT-only there); the translation is sound
+    // regardless of what the operands resolve to.
+    if let Some(l) = cmp_signal_atom(left)
+        && let Some((r, addend)) = add_signal_literal(right)
+    {
+        return Ok(format!("({l} {op} {r} + {addend})"));
+    }
     // (5) H.D — negation-peel for 1-bit boolean eq/ne: `(!x) == y` ≡ `x != y`,
     // `(!x) != y` ≡ `x == y` (and the `(!x) ==/!= literal` forms). Peel a 1-bit
     // `!signal` on either side and flip the eq/ne operator, then re-resolve the
@@ -770,6 +782,33 @@ fn cmp_signal_atom(expr: &Value) -> Option<String> {
             .map(|(sig, _)| past_shadow_name(sig));
     }
     signal_name(expr).ok().map(|s| s.to_string())
+}
+
+/// H.G — if `expr` is `signal + literal` (or `literal + signal`), return the
+/// signal atom (a plain name or a `$past` shadow) and the non-negative literal
+/// addend. The base of the `CmpRegAddend` arithmetic relational (the sole
+/// arithmetic form the translator accepts, `== $past(cnt) + 1`). Slang names the
+/// `+` binary operator `"Add"`.
+fn add_signal_literal(expr: &Value) -> Option<(String, u64)> {
+    let expr = unwrap(expr);
+    if expr.get("kind").and_then(Value::as_str) != Some("BinaryOp")
+        || expr.get("op").and_then(Value::as_str) != Some("Add")
+    {
+        return None;
+    }
+    let l = unwrap(expr.get("left")?);
+    let r = unwrap(expr.get("right")?);
+    if let (Some(sig), Some(lit)) = (cmp_signal_atom(l), sv_integer(r))
+        && lit >= 0
+    {
+        return Some((sig, lit as u64));
+    }
+    if let (Some(lit), Some(sig)) = (sv_integer(l), cmp_signal_atom(r))
+        && lit >= 0
+    {
+        return Some((sig, lit as u64));
+    }
+    None
 }
 
 /// A Tier-2 history call (`$past`/`$stable`/`$changed`/`$rose`/`$fell`) takes
@@ -1367,6 +1406,38 @@ mod tests {
     }
 
     #[test]
+    fn hg_arithmetic_addend_translates() {
+        // H.G — `cnt_q == $past(cnt_q) + 1` (sysrst `CntIncr_A`), previously
+        // rejected as "arithmetic operand not supported". Now translates to the
+        // arithmetic relational atom (→ `PredicateExpr::CmpRegAddend`, BV `+`).
+        let cmp = serde_json::json!({
+            "kind": "BinaryOp", "op": "Equality",
+            "left":  {"kind": "NamedValue", "symbol": "1 cnt_q", "type": "logic[31:0]"},
+            "right": {
+                "kind": "BinaryOp", "op": "Add",
+                "left":  history_call("$past", "cnt_q", "logic[31:0]"),
+                "right": {"kind": "IntegerLiteral", "value": "1", "constant": "1"}
+            }
+        });
+        assert_eq!(bool_expr(&cmp).unwrap(), "(cnt_q == cnt_q__past + 1)");
+    }
+
+    #[test]
+    fn hg_arithmetic_addend_plain_register_base() {
+        // H.G — the base need not be `$past`: `x == y + 2` also translates.
+        let cmp = serde_json::json!({
+            "kind": "BinaryOp", "op": "Equality",
+            "left":  {"kind": "NamedValue", "symbol": "1 x", "type": "logic[7:0]"},
+            "right": {
+                "kind": "BinaryOp", "op": "Add",
+                "left":  {"kind": "NamedValue", "symbol": "2 y", "type": "logic[7:0]"},
+                "right": {"kind": "IntegerLiteral", "value": "2", "constant": "2"}
+            }
+        });
+        assert_eq!(bool_expr(&cmp).unwrap(), "(x == y + 2)");
+    }
+
+    #[test]
     fn hd_relational_signal_eq_signal_translates() {
         // H.D — general dataflow equality `data_o == data_i` (no `$past` side).
         let cmp = serde_json::json!({
@@ -1416,17 +1487,30 @@ mod tests {
     }
 
     #[test]
-    fn hd_arithmetic_rhs_still_unsupported_with_clear_reason() {
-        // H.D — `cnt == cnt + 1` (arithmetic RHS) stays unsupported: the
-        // predicate layer is arithmetic-free; the error must say so.
-        let cmp = serde_json::json!({
+    fn hg_nonlinear_arithmetic_still_unsupported_with_clear_reason() {
+        // H.G supports the `reg + const` addend (`hg_arithmetic_addend_translates`).
+        // NON-linear / non-constant arithmetic stays unsupported: a `reg * const`
+        // (Multiply, not Add) and a `reg + reg` (two-register addend, no literal)
+        // both fall through to the honest reject — the predicate layer carries
+        // only a constant addend, not general arithmetic.
+        let mul = serde_json::json!({
+            "kind": "BinaryOp", "op": "Equality",
+            "left":  {"kind": "NamedValue", "symbol": "1 cnt", "type": "logic[3:0]"},
+            "right": {"kind": "BinaryOp", "op": "Multiply",
+                      "left":  {"kind": "NamedValue", "symbol": "1 cnt", "type": "logic[3:0]"},
+                      "right": {"kind": "IntegerLiteral", "value": "2", "constant": "2"}}
+        });
+        let err = bool_expr(&mul).expect_err("multiply RHS must reject");
+        assert!(err.contains("arithmetic"), "got: {err}");
+
+        let two_reg = serde_json::json!({
             "kind": "BinaryOp", "op": "Equality",
             "left":  {"kind": "NamedValue", "symbol": "1 cnt", "type": "logic[3:0]"},
             "right": {"kind": "BinaryOp", "op": "Add",
-                      "left":  {"kind": "NamedValue", "symbol": "1 cnt", "type": "logic[3:0]"},
-                      "right": {"kind": "IntegerLiteral", "value": "1", "constant": "1"}}
+                      "left":  {"kind": "NamedValue", "symbol": "1 a", "type": "logic[3:0]"},
+                      "right": {"kind": "NamedValue", "symbol": "2 b", "type": "logic[3:0]"}}
         });
-        let err = bool_expr(&cmp).expect_err("arithmetic RHS must reject");
+        let err = bool_expr(&two_reg).expect_err("two-register addend must reject");
         assert!(err.contains("arithmetic"), "got: {err}");
     }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -393,14 +393,27 @@ fn seed_from_formula(
                 // Relational / `!=` / boolean combination.
                 _ => {
                     let regs = expr.registers();
-                    if regs.iter().all(|r| is_state(r)) {
+                    let resolvable = regs
+                        .iter()
+                        .all(|r| is_state(r) || is_input(r) || combinational_kind(r).is_some());
+                    if expr.has_addend() {
+                        // H.G — an arithmetic relational (`cnt_q == cnt_q__past + 1`,
+                        // sva_15). Its `CmpRegAddend` leaf is SMT-only (a `width==0`
+                        // production leaf must NOT be `eval`'d, and the all-state
+                        // compound path evals dimensions at the init cube). Route it
+                        // to the DERIVED relational label path (`build_constraint`
+                        // only, BV `bvadd` at the real register width). Sound — a
+                        // pure per-cube observation, like any derived relational.
+                        if resolvable {
+                            out.derived_relational.push((atom.clone(), expr));
+                        } else {
+                            out.unseedable.push(atom.clone());
+                        }
+                    } else if regs.iter().all(|r| is_state(r)) {
                         // All-state → a cube DIMENSION (B.1 compound). The SMT
                         // dimension path reads state BVs.
                         out.compounds.push((atom.clone(), expr));
-                    } else if regs
-                        .iter()
-                        .all(|r| is_state(r) || is_input(r) || combinational_kind(r).is_some())
-                    {
+                    } else if resolvable {
                         // H.F — a relational with an input / combinational operand
                         // (`cnt_q >= cfg_detect_timer_i`, `trigger_i !=
                         // trigger_active`). Its value depends on the demonic input,
@@ -2034,27 +2047,40 @@ mod tests {
                 p.outcome
             );
         }
-        // H.D (translation widening) — `signal >= signal` and 1-bit `!x === y`
-        // now translate (pre-H.D: 7 unsupported; now only the arithmetic-RHS
-        // `cnt == cnt + 1` form remains, which needs predicate-arithmetic).
-        // sva_15 is the lone arithmetic holdout.
-        assert!(
-            report.properties.len() >= 15,
-            "H.D translates ≥15 of 16 (was 9); got {} translated",
+        // H.D translation widening (`signal >= signal`, 1-bit `!x === y`) + H.G
+        // arithmetic-addend predicate (`cnt_q == $past(cnt_q) + 1`, CntIncr_A):
+        // ALL 16 sysrst SVA now translate — 0 unsupported (pre-H.D: 7 unsupported;
+        // pre-H.G: sva_15 was the lone arithmetic holdout).
+        assert_eq!(
+            report.properties.len(),
+            16,
+            "H.D + H.G translate all 16 sysrst SVA; got {} translated",
             report.properties.len()
         );
         assert!(
-            report.unsupported.len() <= 2,
-            "only the arithmetic-RHS form(s) remain unsupported after H.D; got {:?}",
+            report.unsupported.is_empty(),
+            "H.G closes the last arithmetic holdout — 0 unsupported; got {:?}",
             report.unsupported
         );
+        // H.G — sva_15 (`cnt_en && !cnt_clr |=> cnt_q == cnt_q__past + 1`) now
+        // BINDS (was unsupported): its arithmetic relational lowers to a
+        // `CmpRegAddend` derived label (BV `bvadd`), so it reaches a verdict — an
+        // honest ⊥ here (config-timer-entangled, like sva_5/7/10/11/13/14), never
+        // unsupported and never a spurious verdict.
+        let sva15 = report
+            .properties
+            .iter()
+            .find(|p| p.name == "sysrst_ctrl_detect_sva_15")
+            .expect("sva_15 present (translated)");
         assert!(
-            report
-                .unsupported
-                .iter()
-                .all(|(_, r)| r.contains("arithmetic")),
-            "every remaining unsupported is the arithmetic-operand case; got {:?}",
-            report.unsupported
+            sva15.formula.contains("cnt_q__past + 1"),
+            "sva_15 carries the arithmetic-addend atom; got {}",
+            sva15.formula
+        );
+        assert!(
+            !matches!(sva15.outcome, VerifyOutcome::Skipped { .. }),
+            "sva_15 binds to a verdict (not SKIP/unsupported); got {:?}",
+            sva15.outcome
         );
         // The negation-peel (`!trigger_i === trigger_active` → `trigger_i !=
         // trigger_active`) and the relational `signal >= signal` both reach the
@@ -2083,7 +2109,12 @@ mod tests {
         // so the consequent box `[](state==k')` becomes definite at the cube
         // pinning trigger_i, and Kleene `⊥ ∨ [] = T`. sva_4/6/8/9 are this class.
         // Pre-Slice-3 they were honest ⊥ (a bare ⊥-label did not refine the box).
-        // btormc confirms all four SAFE; NEVER a spurious VIOLATED.
+        // Soundness rests on the safety + may-over-approximation argument (a
+        // definite HOLDS on the KMTS may-relation transfers to the concrete);
+        // NEVER a spurious VIOLATED. Independent external confirmation is partial:
+        // sva_6 (DetectStDropOut) was checked SAFE by the btormc oracle (H.E/H.O
+        // work); sva_4/8/9 are not yet per-property oracle-confirmed — a btormc
+        // (H.O.1) sweep is the pending confirmation step.
         for name in [
             "sysrst_ctrl_detect_sva_4",
             "sysrst_ctrl_detect_sva_6",

--- a/crates/mununu-core/src/mu_calculus/parser.rs
+++ b/crates/mununu-core/src/mu_calculus/parser.rs
@@ -256,6 +256,16 @@ impl<'a> Parser<'a> {
                 if let Some(rhs) = self.parse_comparison_rhs() {
                     full.push(' ');
                     full.push_str(&rhs);
+                    // H.G — an arithmetic-addend RHS `<reg> + <int>`
+                    // (`cnt_q == cnt_q__past + 1`, sysrst `CntIncr_A`). Only when
+                    // the RHS is a register (identifier), consume an optional
+                    // ` + <int>` so the atom string carries the full arithmetic
+                    // relational for `parse_predicate_expr` (→ `CmpRegAddend`).
+                    if rhs.starts_with(is_ident_start)
+                        && let Some(addend) = self.try_consume_addend()
+                    {
+                        full.push_str(&addend);
+                    }
                     return Ok(self.builder.push_node(Node::Predicate(full)));
                 }
                 // No valid RHS — fall back to predicate-only. The leading
@@ -331,6 +341,35 @@ impl<'a> Parser<'a> {
             return Some("false".to_string());
         }
         self.parse_identifier()
+    }
+
+    /// H.G — after a comparison RHS register, optionally consume ` + <int>` (the
+    /// arithmetic addend of `cnt_q == cnt_q__past + 1`). Returns the canonical
+    /// ` + <digits>` suffix to append to the predicate atom string (so
+    /// `parse_predicate_expr` reads a `CmpRegAddend`), or `None` if no `+ <int>`
+    /// follows (position restored). Only `+` (a single constant addend) — no
+    /// general arithmetic.
+    fn try_consume_addend(&mut self) -> Option<String> {
+        let save = self.pos;
+        self.skip_whitespace();
+        if self.peek_char() != Some('+') {
+            self.pos = save;
+            return None;
+        }
+        self.consume_char(); // '+'
+        self.skip_whitespace();
+        let dstart = self.pos;
+        let mut has_digit = false;
+        while matches!(self.peek_char(), Some(c) if c.is_ascii_digit()) {
+            self.consume_char();
+            has_digit = true;
+        }
+        if !has_digit {
+            self.pos = save;
+            return None;
+        }
+        let digits = self.input[dstart..self.pos].to_string();
+        Some(format!(" + {digits}"))
     }
 
     /// Parses a modal guard up to the provided closing delimiter.
@@ -910,6 +949,25 @@ mod tests {
         let formula = parse("p").unwrap();
         assert!(matches!(formula.node(formula.root()), Node::Predicate(_)));
         assert_eq!(predicate_name(&formula, formula.root()), "p");
+    }
+
+    #[test]
+    fn parses_arithmetic_addend_predicate() {
+        // H.G — `cnt_q == cnt_q__past + 1` must parse as ONE predicate atom
+        // carrying the arithmetic addend (previously the `+ 1` was left dangling,
+        // so `[] (cnt_q == cnt_q__past + 1)` failed with "expected `)`").
+        let formula = parse("cnt_q == cnt_q__past + 1").unwrap();
+        assert_eq!(
+            predicate_name(&formula, formula.root()),
+            "cnt_q == cnt_q__past + 1"
+        );
+        // Inside a box + fixpoint (sva_15's exact shape) it parses end-to-end.
+        parse("nu X. (((!((cnt_en && (!(cnt_clr)))) || [] (cnt_q == cnt_q__past + 1))) && [] X)")
+            .expect("sva_15-shaped formula parses");
+        // A literal RHS keeps its own `+`-free form; a `+` after a literal is NOT
+        // consumed as an addend (only after an identifier RHS).
+        let lit = parse("cnt_q == 3").unwrap();
+        assert_eq!(predicate_name(&lit, lit.root()), "cnt_q == 3");
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes the last unsupported OpenTitan SVA — `cnt_q == $past(cnt_q) + 1` (sysrst `CntIncr_A`). The predicate layer was deliberately arithmetic-free; this adds a single, sound `+const` arithmetic relational (the H.G roadmap item, and the direct answer to "can we expand the grammar for sva_15?").

## Changes

- **`PredicateExpr::CmpRegAddend { lhs, op, rhs, addend, width }`** — `lhs <op> (rhs + addend)` in unsigned BV **mod 2^width** (wraps exactly as the RTL `+`). `build_constraint` does Z3 `bvadd` at the operand's real width (the sound production path); `eval` is the differential reference and masks by the embedded `width`. **SMT-primary:** `has_addend()` routes it to the derived-relational (SMT-only) path, so a `width==0` production leaf is never `eval`'d (no reset-cube width-plumbing).
- **Tokenizer/parser** (`predicate_expr.rs`): `+` token + an `ident + int` addend RHS.
- **mu-calculus atom lexer** (`mu_calculus/parser.rs`): an optional `+ <int>` suffix after an identifier RHS — `[] (cnt_q == cnt_q__past + 1)` previously failed with `expected ')'`.
- **Translator `compare()`** (`slang/translate.rs`): an arithmetic-RHS case via `add_signal_literal` (slang names `+` `"Add"`); the base may be a `$past` shadow.
- **Seeder** (`verify_auto.rs`): an `has_addend()` expr → `derived_relational`.

## Soundness

The load-bearing guard is `arithmetic_addend_eval_matches_smt` — `eval ≡ build_constraint` across **all** 2-bit assignments **including the wraparound boundary** (width=2 → `3+1=0`). Plus parser round-trip, eval-wrap, mu-parser, and translator unit tests. The overturned `hd_arithmetic_rhs_still_unsupported` test is rewritten to assert **non-linear** arithmetic (`* const`, two-register addend) still rejects — the grammar carries only a constant addend, not general arithmetic.

## Validation (mununu-sva docker, real OpenTitan RTL)

| anchor | before | after |
|---|---|---|
| sysrst translate | 15/16 | **16/16** (0 unsupported) |
| sysrst sva_15 | unsupported | **binds → honest ⊥** (config-timer/counter-entangled) |
| sysrst HOLDS / VIOLATED / SKIP | 9 / 0 / 0 | 9 / 0 / 0 (no regression) |
| csrng | HOLDS 2 | HOLDS 2 (no arithmetic SVA — clean anchor) |

Also corrects an earlier claims-integrity slip in the csrng e2e comment ("btormc confirms all four SAFE" — only sva_6 was checked).

Lib 2113 → 2121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)