### PR TITLE
feat(sva): reduction-OR inside a 1-bit comparison (translation widening)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/translate.rs
+++ b/crates/mununu-core/src/adapter/slang/translate.rs
@@ -742,11 +742,30 @@ fn compare(expr: &Value, op: &str) -> Result<String, String> {
             return Ok(format!("({inner} {flipped} {other})"));
         }
     }
+    // (6) 1-bit boolean equality/inequality where a plain-signal / literal form did
+    // not match — e.g. a reduction operand (`(|oh_i) != en_i`, prim_onehot_check's
+    // EnableCheck) or a boolean sub-expression. Both operands are 1-bit booleans, so
+    // `a != b ≡ a XOR b` and `a == b ≡ a XNOR b`, expanded into the propositional
+    // fragment via `bool_expr` (which handles the reduction `|x → (x != 0)`). Guarded
+    // to 1-bit both sides: for a multi-bit operand `bool_expr` reduction-ORs it,
+    // which would change an `==`'s meaning.
+    if matches!(op, "==" | "!=")
+        && signal_width(left) == 1
+        && signal_width(right) == 1
+        && let (Ok(a), Ok(b)) = (bool_expr(left), bool_expr(right))
+    {
+        return Ok(if op == "!=" {
+            format!("(({a} && (!({b}))) || ((!({a})) && {b}))") // a XOR b
+        } else {
+            format!("(({a} && {b}) || ((!({a})) && (!({b}))))") // a XNOR b
+        });
+    }
     Err(format!(
         "comparison must be `signal {op} literal`, `literal {op} signal`, a relational \
-         `signal {op} signal`, a 1-bit `!signal ==/!= …`, or a `boolean-expr ==/!= 0` \
-         form; got left={:?} right={:?} (an arithmetic operand like `== x + 1` needs \
-         predicate-arithmetic, not yet supported)",
+         `signal {op} signal`, a 1-bit `!signal ==/!= …`, a 1-bit boolean `==/!=` (incl. \
+         a reduction operand), or a `boolean-expr ==/!= 0` form; got left={:?} right={:?} \
+         (an arithmetic operand like `== x + 1` needs predicate-arithmetic, not yet \
+         supported)",
         left.get("kind").and_then(Value::as_str),
         right.get("kind").and_then(Value::as_str),
     ))
@@ -1506,17 +1525,27 @@ mod tests {
     }
 
     #[test]
-    fn hd_negation_peel_requires_one_bit_operand() {
-        // A multi-bit `!bus` means `bus == 0`, NOT a simple operator flip — so
-        // the negation-peel must NOT fire on it. The comparison stays rejected
-        // (honest) rather than silently becoming the unsound `(bus != y)`.
+    fn hd_negation_peel_multibit_lowers_via_boolexpr_not_unsound_flip() {
+        // A multi-bit `!bus` means `bus == 0`, NOT a simple operator flip. The 1-bit
+        // negation-peel (case 5) does NOT fire on it; instead the 1-bit boolean
+        // comparison (case 6) handles `(!bus) == y` via `bool_expr`, which correctly
+        // lowers `!bus → !(bus != 0)` (i.e. `bus == 0`). Crucially it must NOT become
+        // the unsound `(bus != y)` peel-flip. (`!bus` is a 1-bit LogicalNot result.)
         let cmp = serde_json::json!({
             "kind": "BinaryOp", "op": "CaseEquality",
-            "left":  {"kind": "UnaryOp", "op": "LogicalNot",
+            "left":  {"kind": "UnaryOp", "op": "LogicalNot", "type": "logic",
                       "operand": {"kind": "NamedValue", "symbol": "1 bus", "type": "logic[7:0]"}},
             "right": {"kind": "NamedValue", "symbol": "2 y", "type": "logic"}
         });
-        bool_expr(&cmp).expect_err("multi-bit !bus must not peel-and-flip");
+        let s = bool_expr(&cmp).expect("(!bus) == y lowers via the boolean-comparison case");
+        assert!(
+            s.contains("bus != 0"),
+            "multi-bit !bus lowered as bus==0 (`!(bus != 0)`): {s}"
+        );
+        assert!(
+            !s.contains("bus != y") && !s.contains("bus == y"),
+            "no unsound peel-flip to a direct bus↔y comparison: {s}"
+        );
     }
 
     #[test]
@@ -1598,6 +1627,33 @@ mod tests {
             err.contains("$isunknown") || err.contains("not in the"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn reduction_operand_in_1bit_comparison_expands_to_xor() {
+        // prim_onehot_check EnableCheck shape: `(|oh_i) != en_i`. A reduction operand
+        // in a 1-bit `!=` expands to XOR over the propositional fragment (the
+        // reduction itself lowers `|oh_i → (oh_i != 0)`).
+        let ne = serde_json::json!({
+            "left": {
+                "kind": "UnaryOp", "op": "BitwiseOr", "type": "logic",
+                "operand": {"kind": "NamedValue", "symbol": "1 oh_i", "type": "logic[3:0]"}
+            },
+            "right": {"kind": "NamedValue", "symbol": "2 en_i", "type": "logic"}
+        });
+        let xor = compare(&ne, "!=").expect("(|oh_i) != en_i translates");
+        assert!(xor.contains("oh_i != 0"), "reduction lowered: {xor}");
+        assert!(
+            xor.contains("&&") && xor.contains("||"),
+            "!= is an XOR expansion: {xor}"
+        );
+        // `==` is the XNOR (same terms, opposite polarity structure).
+        let xnor = compare(&ne, "==").expect("(|oh_i) == en_i translates");
+        assert!(
+            xnor.contains("oh_i != 0") && xnor.contains("&&") && xnor.contains("||"),
+            "== is an XNOR expansion: {xnor}"
+        );
+        assert_ne!(xor, xnor, "XOR and XNOR expansions differ");
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -2850,6 +2850,64 @@ endmodule
 
     #[test]
     #[ignore = "requires slang + sv2v + Yosys + z3 (use the mununu-sva docker image); run with --ignored"]
+    fn e2e_reduction_or_in_comparison_translates() {
+        // Reduction-OR-in-comparison: `(|v_i) == nonzero` — a reduction operand
+        // inside a 1-bit comparison — now TRANSLATES (→ an XNOR over `v_i != 0` and
+        // `nonzero`) instead of being rejected as unsupported. It reaches the
+        // abstraction and a modeled verdict (not SKIPPED). The verdict here is an
+        // honest ⊥: the XNOR splits into two independent derived labels (`v_i != 0`
+        // and `nonzero`, both the same function of the input `v_i`) and the per-label
+        // abstraction doesn't see they are correlated — the SAME cone-completeness /
+        // correlation limit as the sysrst cnt_clr residual, which the R-F5 BDD track
+        // (joint symbolic evaluation) addresses. This test guards the TRANSLATION
+        // (never regress to unsupported) and will tighten to HOLDS once the engine
+        // resolves the correlation.
+        use crate::adapter::btor2::kmts_lift::MustEdgeInference;
+        const SV: &str = r#"module redor_demo (input logic clk, input logic rst_ni, input logic [1:0] v_i);
+  logic nonzero;
+  assign nonzero = |v_i;
+  RedOr_A: assert property (@(posedge clk) disable iff (!rst_ni) (|v_i) == nonzero);
+endmodule
+"#;
+        let sources = vec![("redor_demo.sv".to_string(), SV.to_string())];
+        let yopts = YosysOptions {
+            top: Some("redor_demo".to_string()),
+            use_sv2v: true,
+            ..Default::default()
+        };
+        let report = verify_auto(
+            &sources,
+            &yopts,
+            &VerifyAutoOptions {
+                must_edge_inference: MustEdgeInference::SmtHyperMust,
+                ..Default::default()
+            },
+        )
+        .expect("verify_auto runs on redor_demo");
+        assert!(
+            report.unsupported.is_empty(),
+            "reduction-in-comparison translates (nothing unsupported): {:?}",
+            report.unsupported
+        );
+        let p = report
+            .properties
+            .iter()
+            .find(|p| p.formula.contains("v_i != 0"))
+            .expect("the reduction `(|v_i)` lowered to `v_i != 0`");
+        // Reaches a MODELED verdict (definite or honest ⊥), never SKIPPED/unsupported.
+        assert!(
+            matches!(
+                p.outcome,
+                VerifyOutcome::Holds | VerifyOutcome::Unknown { .. }
+            ),
+            "reduction-in-comparison reaches the abstraction (not SKIPPED); got {:?}\n  {}",
+            p.outcome,
+            p.formula
+        );
+    }
+
+    #[test]
+    #[ignore = "requires slang + sv2v + Yosys + z3 (use the mununu-sva docker image); run with --ignored"]
     fn e2e_counter_bound_flips_saturating_monotonicity() {
         // H.H demonstrator — the bound-seeding mechanism isolated from any
         // antecedent co-blocker. A counter rises to K then HOLDS at K

--- a/examples/verify/opentitan_prim_onehot_check/source/prim_onehot_check_wrapper.sv
+++ b/examples/verify/opentitan_prim_onehot_check/source/prim_onehot_check_wrapper.sv
@@ -5,9 +5,13 @@
 //
 // OneHotWidth = 4 (AddrWidth = 2). Only the onehot0 check is enabled
 // (EnableCheck = AddrCheck = 0): its assertion `Onehot0Check_A, !$onehot0(oh_i) |->
-// err_o` is the one that exercises the new `$onehot0` translator support. The other
-// two checks use reduction-OR (`|oh_i`) and a variable bit-select (`oh_i[addr_i]`),
-// which are separate unsupported idioms. The upstream `prim_onehot_check.sv` is used
+// err_o` is the one that exercises the `$onehot0` translator support and reaches a
+// clean HOLDS. EnableCheck (`(|oh_i) != en_i |-> err_o`) DOES translate now
+// (reduction-OR in a 1-bit comparison → XOR), but reaches ⊥: with it on, `err_o`'s
+// combinational cone spans BOTH `onehot0(oh_i)` and the enable-mismatch, and the
+// property's own atoms don't pin all of it (an abstraction-completeness limit, the
+// cnt_clr-cone class). The reduction-OR translation is validated by the redor
+// demonstrator + unit test instead. The upstream `prim_onehot_check.sv` is used
 // UNCHANGED via parameter binding — this wrapper is test scaffolding.
 
 module prim_onehot_check_wrapper (


### PR DESCRIPTION
## Reduction-OR in a 1-bit comparison

Reduction operators already translated in **boolean position** (`|x → (x != 0)`; prim_arbiter's `|req_i |-> ready_i` HOLDS). This adds the **comparison form** — a reduction operand inside a 1-bit `==`/`!=` (prim_onehot_check's `EnableCheck_A, (|oh_i) != en_i |-> err_o`). For two 1-bit operands, `a != b ≡ a XOR b` and `a == b ≡ a XNOR b`, expanded into the propositional fragment via `bool_expr`. Guarded to 1-bit both sides; plain `signal ==/!= signal` still takes the CmpReg path.

**Bonus soundness improvement:** a multi-bit `(!bus) == y` (1-bit LogicalNot result) now lowers *soundly* via `bool_expr` (`!bus → bus == 0`) instead of rejecting — and still never becomes the unsound `(bus != y)` peel-flip.

### Honest scope — a translation widening, not a verdict win
- The reduction-in-comparison now **translates** (reaches the abstraction + a modeled verdict) instead of erroring as unsupported.
- On the natural **input-vector** targets it reaches **⊥, not HOLDS**: the XOR/XNOR splits into two independent derived labels (e.g. `v_i != 0` and `nonzero`, both the same function of the input) and the per-label abstraction can't see they're correlated — the **same cone-completeness / correlation limit as the sysrst cnt_clr residual**. Closing it needs the R-F5 BDD track (joint symbolic evaluation), not a translator change. So prim_onehot_check's EnableCheck stays OFF in the wrapper (its `err_o` two-input cone → ⊥); the onehot0 check remains a clean HOLDS.

### Validated (mununu-sva docker)
- `e2e_reduction_or_in_comparison_translates` — `(|v_i) == nonzero` translates to the XNOR and reaches a modeled verdict (currently ⊥; guards against regressing to unsupported, tightens to HOLDS when the engine resolves the correlation).
- `e2e_opentitan_prim_onehot_check_holds` — unchanged, still HOLDS.

New unit test `reduction_operand_in_1bit_comparison_expands_to_xor`; `hd_negation_peel_*` test updated (premise overturned — soundly translates now). fmt + workspace clippy + doctests green. No new user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)