### PR TITLE
feat(R-F5.0): symbolic BDD spike — OxiDD image/preimage matches evaluate_tri

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +415,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dhat"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +446,15 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "either"
@@ -465,12 +491,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -653,6 +694,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hugealloc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542733215a252c27c674e5d875a910d7de509cb74123d0bdbaa050f871ec84c2"
+dependencies = [
+ "allocator-api2",
+ "libc",
+ "sptr",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +759,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_sorted"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357376465c37db3372ef6a00585d336ed3d0f11d4345eef77ebcb05865392b21"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,10 +814,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "linear-hashtbl"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11269ceb6867559e0fce487ff8148933040c7ac091ee4ecc904821f1db1e0fa"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -871,6 +941,7 @@ dependencies = [
  "criterion",
  "dhat",
  "itoa",
+ "oxidd",
  "proptest",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
@@ -904,6 +975,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "nanorand"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3d189da485332e96ba8a5ef646a311871abd7915bf06ac848a9117f19cf6e4"
 
 [[package]]
 name = "normalize-line-endings"
@@ -955,6 +1032,157 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "oxidd"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c984e2c820ff1306f7bd10ac166a542c69cce2d87331eb4caa1b78ca381e5c0b"
+dependencies = [
+ "cfg-if",
+ "derive-where",
+ "document-features",
+ "oxidd-cache",
+ "oxidd-core",
+ "oxidd-derive",
+ "oxidd-dump",
+ "oxidd-manager-index",
+ "oxidd-reorder",
+ "oxidd-rules-bdd",
+ "oxidd-rules-mtbdd",
+ "oxidd-rules-tdd",
+ "oxidd-rules-zbdd",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxidd-cache"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea87b04767bd71ec9a0f0f1b95b3e1be822365d611ae692734bf84dffdc1aae9"
+dependencies = [
+ "allocator-api2",
+ "document-features",
+ "hugealloc",
+ "oxidd-core",
+ "parking_lot",
+]
+
+[[package]]
+name = "oxidd-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ce8a17e276f5df5a9a2aabdc0fd1ccf2b3b73bc3b5ef7627f26f6ecc9afee3"
+dependencies = [
+ "nanorand",
+]
+
+[[package]]
+name = "oxidd-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96cb7e36aee287b5ad1921fb98050a1b9e5771bf5d34381f24b0548083aefeb3"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "oxidd-dump"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675fcc8144350309a3b94a4a3522d953472c29df06b783fe0dfafbc6b1d39b4b"
+dependencies = [
+ "document-features",
+ "fixedbitset",
+ "is_sorted",
+ "memchr",
+ "oxidd-core",
+ "oxidd-derive",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxidd-manager-index"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1339eb2952e23d62d3421f444fdf36d7f36b6a63707ae3d4fef1d1bfb007a47"
+dependencies = [
+ "crossbeam-utils",
+ "derive-where",
+ "fixedbitset",
+ "linear-hashtbl",
+ "oxidd-core",
+ "parking_lot",
+ "rayon",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxidd-reorder"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6863dd156fb2713ad1f6b7528d08da3cc675ae27e24b6e9a0df9d0fea8d9a839"
+dependencies = [
+ "flume",
+ "is_sorted",
+ "oxidd-core",
+ "rayon",
+ "smallvec",
+]
+
+[[package]]
+name = "oxidd-rules-bdd"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56b5465552bdc2c1f38c433f8751703d1561396f4be16315999cc47eed6e2ce"
+dependencies = [
+ "document-features",
+ "fixedbitset",
+ "oxidd-core",
+ "oxidd-derive",
+ "oxidd-dump",
+]
+
+[[package]]
+name = "oxidd-rules-mtbdd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49740035de417b58fad2fe420b5539081604e601c266841f3092ca8bb5db1da7"
+dependencies = [
+ "document-features",
+ "fixedbitset",
+ "oxidd-core",
+ "oxidd-derive",
+ "oxidd-dump",
+]
+
+[[package]]
+name = "oxidd-rules-tdd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb13c585037127f6066e3ca928e96bdc21df19a41b0242dfcb9e95faf723558c"
+dependencies = [
+ "document-features",
+ "oxidd-core",
+ "oxidd-derive",
+ "oxidd-dump",
+]
+
+[[package]]
+name = "oxidd-rules-zbdd"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917c941a721e884817a5b510ff818cb6d7033216817c0fd1e0b154f4cc7cfe5b"
+dependencies = [
+ "document-features",
+ "fixedbitset",
+ "oxidd-core",
+ "oxidd-derive",
+ "oxidd-dump",
+]
 
 [[package]]
 name = "page_size"
@@ -1088,6 +1316,29 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1476,6 +1727,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +2100,12 @@ name = "vcd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4505774fc84de82eb04caa74d859342b0daa376f4c6df45149593245dd62c004"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/mununu-core/Cargo.toml
+++ b/crates/mununu-core/Cargo.toml
@@ -20,6 +20,15 @@ bitvec = "1.0"
 smallvec = "1.15"
 regex = "1.12"
 
+# OxiDD — pure-Rust decision-diagram framework (BDD). Backs the R-F5 symbolic
+# abstraction path: predicate-cube state sets + the may/must transition relation as
+# BDDs, with fixpoint image/preimage via the native fused relational product
+# `apply_exists(And, …)` — the alternative to explicit-cube enumeration + the
+# O(2^2|P|) SMT edge computation. Pure-Rust (no new C build), permissive
+# (MIT OR Apache-2.0), `Send + Sync` manager. Not feature-gated — the symbolic path
+# is a first-class engine (R-F5).
+oxidd = "0.11"
+
 # CMSIS-SVD / IP-XACT importer for register-map sidecars (Document C
 # task C6). Small, zero-dep DOM parser well-suited to one-shot config
 # parsing. Pulled in unconditionally because `codesign::svd_import` is

--- a/crates/mununu-core/src/mu_calculus/mod.rs
+++ b/crates/mununu-core/src/mu_calculus/mod.rs
@@ -18,6 +18,7 @@ pub mod parity_game_3v_solve3v;
 pub mod parity_game_3v_subgame;
 pub mod parser;
 pub mod simplify;
+pub mod symbolic;
 pub mod trit;
 
 pub use evaluator::{

--- a/crates/mununu-core/src/mu_calculus/symbolic.rs
+++ b/crates/mununu-core/src/mu_calculus/symbolic.rs
@@ -1,0 +1,323 @@
+//! R-F5 — symbolic (BDD-backed) abstraction spike.
+//!
+//! The predicate-cube abstraction currently materializes 2^|P| explicit cube states
+//! and builds the may/must transition relation with O(2^2|P|) SMT queries (see
+//! `adapter/btor2/kmts_lift.rs`). This module is the de-risking spike for the
+//! symbolic alternative (R-F5): represent state sets and the transition relation as
+//! BDDs (via OxiDD) and evaluate the mu-calculus by fixpoint image/preimage, so the
+//! cube space is never enumerated.
+//!
+//! Spike scope (this file): validate the OxiDD dependency + the BDD encoding of a
+//! 3-valued (Kleene) state set as a `(must, may)` BDD pair, and the box preimage via
+//! the fused relational product `∃next. R ∧ φ` — checked **cell-for-cell against the
+//! explicit `evaluate_tri` evaluator** on hand-built KMTSes. This proves the
+//! semantics + encoding before the full port (R-F5.1: BDD-backed `TritSet`; R-F5.2:
+//! symbolic modal step in the evaluator; R-F5.3: symbolic edge construction from
+//! BTOR2, the actual O(2^2|P|)-SMT-avoidance win).
+//!
+//! 3-valued box semantics (Bruns–Godefroid; mirrors `evaluator::modal_trit_core`):
+//! for `[]φ`, `must = ∀ may-successors. φ.must` and `may = ∀ must-successors. φ.may`
+//! — as preimages, `box.must = ¬∃next. R_may ∧ ¬φ.must[next]` and
+//! `box.may = ¬∃next. R_must ∧ ¬φ.may[next]`.
+
+#[cfg(test)]
+mod tests {
+    use oxidd::bdd::{self, BDDFunction};
+    use oxidd::{
+        BooleanFunction, BooleanFunctionQuant, BooleanOperator, FunctionSubst, Manager, ManagerRef,
+        Subst, VarNo,
+    };
+
+    use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, TransitionModality, Tristate};
+    use crate::mu_calculus::evaluator::{Environment, evaluate_tri};
+    use crate::mu_calculus::parser;
+    use crate::mu_calculus::trit::Trit;
+
+    /// A 3-valued state set as a `(must, may)` BDD pair over the present-state vars,
+    /// with the KMTS invariant `must ⊑ may`.
+    struct TritBdd {
+        must: BDDFunction,
+        may: BDDFunction,
+    }
+
+    /// A minimal symbolic KMTS over `k` present- + `k` next-state boolean vars.
+    struct SymKmts {
+        _manager: bdd::BDDManagerRef,
+        present: Vec<BDDFunction>,
+        next: Vec<BDDFunction>,
+        present_varnos: Vec<VarNo>,
+        next_cube: BDDFunction,
+        tt: BDDFunction,
+        ff: BDDFunction,
+        r_may: BDDFunction,
+        r_must: BDDFunction,
+    }
+
+    impl SymKmts {
+        /// Build from `state_bits` and an edge list `(src, dst, is_must)`. `R_may` =
+        /// all edges; `R_must` = the `is_must` (Sharp) edges only (`must ⊆ may`).
+        fn new(state_bits: usize, edges: &[(usize, usize, bool)]) -> Self {
+            let manager = bdd::new_manager(1 << 16, 1 << 16, 1);
+            let (present, next, tt, ff) = manager.with_manager_exclusive(|m| {
+                let vars = m.add_vars(2 * state_bits as VarNo);
+                let mut present = Vec::with_capacity(state_bits);
+                let mut next = Vec::with_capacity(state_bits);
+                for i in 0..state_bits {
+                    present.push(BDDFunction::var(m, vars.start + i as VarNo).unwrap());
+                }
+                for i in 0..state_bits {
+                    next.push(BDDFunction::var(m, vars.start + (state_bits + i) as VarNo).unwrap());
+                }
+                (present, next, BDDFunction::t(m), BDDFunction::f(m))
+            });
+            let present_varnos: Vec<VarNo> = (0..state_bits as VarNo).collect();
+            // Cube of the next-state vars (to quantify them out in the preimage).
+            let mut next_cube = tt.clone();
+            for v in &next {
+                next_cube = next_cube.and(v).unwrap();
+            }
+
+            let minterm = |idx: usize, vars: &[BDDFunction], tt: &BDDFunction| -> BDDFunction {
+                let mut m = tt.clone();
+                for (b, v) in vars.iter().enumerate() {
+                    let lit = if (idx >> b) & 1 == 1 {
+                        v.clone()
+                    } else {
+                        v.not().unwrap()
+                    };
+                    m = m.and(&lit).unwrap();
+                }
+                m
+            };
+
+            // R(present, next) = ⋁ over edges of (src@present ∧ dst@next).
+            let mut r_may = ff.clone();
+            let mut r_must = ff.clone();
+            for &(src, dst, is_must) in edges {
+                let e = minterm(src, &present, &tt)
+                    .and(&minterm(dst, &next, &tt))
+                    .unwrap();
+                r_may = r_may.or(&e).unwrap();
+                if is_must {
+                    r_must = r_must.or(&e).unwrap();
+                }
+            }
+
+            SymKmts {
+                _manager: manager,
+                present,
+                next,
+                present_varnos,
+                next_cube,
+                tt,
+                ff,
+                r_may,
+                r_must,
+            }
+        }
+
+        fn present_minterm(&self, idx: usize) -> BDDFunction {
+            let mut m = self.tt.clone();
+            for (b, v) in self.present.iter().enumerate() {
+                let lit = if (idx >> b) & 1 == 1 {
+                    v.clone()
+                } else {
+                    v.not().unwrap()
+                };
+                m = m.and(&lit).unwrap();
+            }
+            m
+        }
+
+        /// Is state `idx` in the set `f`? (its present-minterm implies `f`.)
+        fn holds_at(&self, f: &BDDFunction, idx: usize) -> bool {
+            let mt = self.present_minterm(idx);
+            mt.and(f).unwrap() == mt
+        }
+
+        /// Rename a present-var function to the next-var frame.
+        fn to_next(&self, f: &BDDFunction) -> BDDFunction {
+            let subst = Subst::new(self.present_varnos.clone(), self.next.clone());
+            f.substitute(&subst).unwrap()
+        }
+
+        /// 3-valued box preimage of `phi` (over present vars).
+        fn box_pre(&self, phi: &TritBdd) -> TritBdd {
+            // box.must = ¬∃next. R_may ∧ ¬φ.must[next]
+            let must_next = self.to_next(&phi.must);
+            let ex_may = self
+                .r_may
+                .apply_exists(
+                    BooleanOperator::And,
+                    &must_next.not().unwrap(),
+                    &self.next_cube,
+                )
+                .unwrap();
+            let box_must = ex_may.not().unwrap();
+            // box.may = ¬∃next. R_must ∧ ¬φ.may[next]
+            let may_next = self.to_next(&phi.may);
+            let ex_must = self
+                .r_must
+                .apply_exists(
+                    BooleanOperator::And,
+                    &may_next.not().unwrap(),
+                    &self.next_cube,
+                )
+                .unwrap();
+            let box_may = ex_must.not().unwrap();
+            TritBdd {
+                must: box_must,
+                may: box_may,
+            }
+        }
+
+        /// Greatest fixpoint `νX. (p ∧ []X)` — the AGp safety verdict.
+        fn nu_p_and_box(&self, p: &TritBdd) -> TritBdd {
+            let mut x = TritBdd {
+                must: self.tt.clone(),
+                may: self.tt.clone(),
+            };
+            loop {
+                let bx = self.box_pre(&x);
+                // truth-meet `p ⊓ box` = (must∧must, may∧may).
+                let next = TritBdd {
+                    must: p.must.and(&bx.must).unwrap(),
+                    may: p.may.and(&bx.may).unwrap(),
+                };
+                if next.must == x.must && next.may == x.may {
+                    return next;
+                }
+                x = next;
+            }
+        }
+    }
+
+    /// Build the explicit KMTS twin, evaluate `nu X. p and [] X`, and return the
+    /// per-state trit verdicts (index 0..n).
+    fn explicit_verdicts(edges: &[(usize, usize, bool)], p: &[Tristate], n: usize) -> Vec<Trit> {
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        for i in 0..n {
+            b.state(format!("s{i}"));
+        }
+        b.initial("s0");
+        let step = b.labels().intern(["step"]).unwrap();
+        let ids: Vec<_> = (0..n)
+            .map(|i| b.state_id_or_insert(format!("s{i}")).unwrap())
+            .collect();
+        for (i, &verdict) in p.iter().enumerate() {
+            b.with_3valued_predicate(ids[i], "p", verdict);
+        }
+        for &(src, dst, is_must) in edges {
+            let modality = if is_must {
+                TransitionModality::Sharp
+            } else {
+                TransitionModality::MayOnly
+            };
+            b.transition_ids_with_modality(ids[src], &[step], ids[dst], modality);
+        }
+        let clts = b.build().expect("explicit KMTS builds");
+        let formula = parser::parse("nu X. p and [] X").expect("formula parses");
+        let env = Environment::new(clts.state_count());
+        let verdict = evaluate_tri(&formula, &clts, &env).expect("evaluate_tri");
+        (0..n).map(|i| verdict.verdict_at(i)).collect()
+    }
+
+    fn symbolic_verdicts(
+        state_bits: usize,
+        edges: &[(usize, usize, bool)],
+        p: &[Tristate],
+        n: usize,
+    ) -> Vec<Trit> {
+        let k = SymKmts::new(state_bits, edges);
+        // Atomic predicate `p` as a (must, may) BDD pair over present vars.
+        let mut p_must = k.ff.clone();
+        let mut p_may = k.ff.clone();
+        for (i, &verdict) in p.iter().enumerate() {
+            let mt = k.present_minterm(i);
+            match verdict {
+                Tristate::KleeneT => {
+                    p_must = p_must.or(&mt).unwrap();
+                    p_may = p_may.or(&mt).unwrap();
+                }
+                Tristate::KleeneBot => {
+                    p_may = p_may.or(&mt).unwrap();
+                }
+                Tristate::KleeneF => {}
+            }
+        }
+        let pbdd = TritBdd {
+            must: p_must,
+            may: p_may,
+        };
+        let x = k.nu_p_and_box(&pbdd);
+        (0..n)
+            .map(|i| {
+                if k.holds_at(&x.must, i) {
+                    Trit::True
+                } else if k.holds_at(&x.may, i) {
+                    Trit::Unknown
+                } else {
+                    Trit::False
+                }
+            })
+            .collect()
+    }
+
+    /// Sharp-only KMTS: a p-true 2-cycle {s0,s1} + a p-false self-loop s2.
+    /// `AGp` is definitely true on the cycle, false at s2.
+    #[test]
+    fn spike_sharp_only_matches_evaluate_tri() {
+        let edges = &[(0, 1, true), (1, 0, true), (2, 2, true)];
+        let p = &[Tristate::KleeneT, Tristate::KleeneT, Tristate::KleeneF];
+        let sym = symbolic_verdicts(2, edges, p, 3);
+        let exp = explicit_verdicts(edges, p, 3);
+        assert_eq!(
+            exp,
+            vec![Trit::True, Trit::True, Trit::False],
+            "explicit AGp"
+        );
+        assert_eq!(sym, exp, "symbolic == evaluate_tri (Sharp-only)");
+    }
+
+    /// Add a `MayOnly` edge s0→s2 (to a p-false state). The may-edge poisons the box:
+    /// s0 → ⊥, and via the s0↔s1 cycle s1 → ⊥ too; s2 stays False. This exercises the
+    /// may/must SPLIT (the whole point of the 3-valued domain).
+    #[test]
+    fn spike_may_edge_bottoms_match_evaluate_tri() {
+        let edges = &[(0, 1, true), (1, 0, true), (2, 2, true), (0, 2, false)];
+        let p = &[Tristate::KleeneT, Tristate::KleeneT, Tristate::KleeneF];
+        let sym = symbolic_verdicts(2, edges, p, 3);
+        let exp = explicit_verdicts(edges, p, 3);
+        assert_eq!(
+            exp,
+            vec![Trit::Unknown, Trit::Unknown, Trit::False],
+            "explicit AGp with the MayOnly edge"
+        );
+        assert_eq!(sym, exp, "symbolic == evaluate_tri (may/must split)");
+    }
+
+    #[test]
+    fn oxidd_smoke_boolean_algebra() {
+        let manager = bdd::new_manager(1 << 12, 1 << 12, 1);
+        let (x, y, tt, ff) = manager.with_manager_exclusive(|m| {
+            let vars = m.add_vars(2);
+            (
+                BDDFunction::var(m, vars.start).unwrap(),
+                BDDFunction::var(m, vars.start + 1).unwrap(),
+                BDDFunction::t(m),
+                BDDFunction::f(m),
+            )
+        });
+        let nx = x.not().unwrap();
+        assert!(x.and(&nx).unwrap() == ff, "x ∧ ¬x = ⊥");
+        assert!(x.or(&nx).unwrap() == tt, "x ∨ ¬x = ⊤");
+        let and = x.and(&y).unwrap();
+        let or = x.or(&y).unwrap();
+        assert!(and != or, "x ∧ y ≠ x ∨ y for distinct vars");
+        let ny = y.not().unwrap();
+        assert!(
+            and.not().unwrap() == nx.or(&ny).unwrap(),
+            "De Morgan: ¬(x ∧ y) = ¬x ∨ ¬y"
+        );
+    }
+}


### PR DESCRIPTION
## R-F5.0 — symbolic (BDD) de-risking spike

Start of the R-F5 symbolic-abstraction track. **Scoping finding:** R-F5 is bigger than the roadmap's "BDD-backed TritSet" — the dominant cost is the **O(2^2|P|) SMT edge computation** (`SmtAllPairs`, [kmts_lift.rs:2195](crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L2195); the H.H.c 29-min explosion), **not** the verdict repr (already a compact BitVec pair) or the evaluator (O(2^|P|) BitVec iteration). The real win is a **symbolic transition relation** (BDDs) + fixpoint image/preimage — a symbolic model checker. Full decomposition R-F5.0→.4 in [`.claude/plans/r-f5-symbolic-bdd-track.md`].

This PR is the de-risking spike (validate the machinery before the full port):
- Adds **`oxidd = "0.11"`** — pure-Rust decision-diagram framework, chosen over CUDD / biodivine-lib-bdd / rsdd for: pure-Rust (no new C build alongside z3-sys), MIT OR Apache-2.0, `Send + Sync` manager, and the decisive **native fused relational product `apply_exists(And, …)`** (the image/preimage primitive). Not feature-gated (per direction): the symbolic path is a first-class engine.
- New `mu_calculus/symbolic.rs`: a minimal symbolic KMTS (present/next boolean vars, a BDD transition relation split into `R_may` / `R_must`), the 3-valued **box preimage** (`box.must = ¬∃next. R_may ∧ ¬φ.must[next]`, `box.may = ¬∃next. R_must ∧ ¬φ.may` — the Bruns–Godefroid semantics mirroring `evaluator::modal_trit_core`), and a **νX fixpoint** over the `(must, may)` BDD pair.

### Validated CELL-FOR-CELL against `evaluate_tri`
- `spike_sharp_only_matches_evaluate_tri` — p-true 2-cycle + p-false self-loop; `νX.(p ∧ []X)` = AGp → **True/True/False**, symbolic == evaluate_tri.
- `spike_may_edge_bottoms_match_evaluate_tri` — add a `MayOnly` edge to a p-false state; the may-edge poisons the box → **⊥/⊥/False** (exercises the may/must **split** — the point of the 3-valued domain), symbolic == evaluate_tri.

So the OxiDD Kleene-pair encoding + fused-relational-product preimage + fixpoint reproduce the ground-truth evaluator, including the 3-valued split. **R-F5 is de-risked.** Next: R-F5.1 (BDD-backed `TritSet`) → R-F5.2 (symbolic modal step) → R-F5.3 (symbolic edge construction from BTOR2 — the O(2^2|P|)-SMT-avoidance win).

`cargo deny check licenses` ok, `cargo machete` clean, clippy + doctests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)