### PR TITLE
docs: propagate post-R-F5 architecture to README + wiki + design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,46 @@ context handshake {
 
 ## Architecture
 
+Mununu verifies by three orthogonal choices: **abstraction** (explicit-state vs
+predicate cubes), **engine** (explicit enumeration vs symbolic BDD), and **domain**
+(2-valued for exact models vs 3-valued Kleene may/must for sound abstraction). All
+paths flow through a frontend-agnostic transition-system seam (STS-IR) into one
+3-valued verdict vocabulary — `True` / `False` / `⊥` (abstraction too coarse to
+decide, never a false claim).
+
+```mermaid
+flowchart TD
+  subgraph FE["Frontends"]
+    SV["SystemVerilog + SVA"]
+    OTH["XState / TLSF / AIGER / Promela /<br/>CTXDSL / microcode / agentic"]
+  end
+
+  SV -->|"slang --ast-json"| TR["SVA translator<br/>→ mu-calculus formula + predicate atoms"]
+  SV -->|"sv2v + yosys (no flatten)"| B2["BTOR2 IR"]
+
+  B2 --> STS["STS-IR seam<br/>StsVar + StepEval + SmtEncode<br/>(hides BTOR2 / Z3)"]
+
+  STS -->|"StepEval::step"| ENUM["Explicit-Enumerate<br/>Sharp CLTS"]
+  STS -->|"SmtEncode::may_edges + must"| CUBE["Explicit predicate-cube lift"]
+  STS -->|"symbolic relation build (planned, R-F5)"| SYM["Symbolic predicate-cube (BDD)"]
+
+  ENUM --> CLTS["Clts (K)MTS<br/>states + may/must transitions + 3-valued labels"]
+  CUBE --> CLTS
+  OTH --> CLTS
+
+  CLTS --> EVX["Explicit evaluator<br/>(BoolDom / KleeneDom over BitVec)"]
+  SYM --> EVS["Symbolic evaluator (planned)<br/>BDD image/preimage fixpoint"]
+
+  EVX --> V["3-valued verdict:<br/>True / False / ⊥"]
+  EVS --> V
+```
+
+The full design — predicate abstraction, explicit & symbolic model checking, the IR
+layering, and how over/under/⊥ approximation and may/must edges operate — is in
+[`docs/design/post-rf5-architecture.md`](docs/design/post-rf5-architecture.md).
+
+Source layout:
+
 ```
 src/
 ├── adapter/        # Format adapters (TLSF, AIGER, Promela, XState, SystemVerilog, extraction)

--- a/docs/abstraction.md
+++ b/docs/abstraction.md
@@ -6,6 +6,8 @@
 
 Mununu's verdicts are correct **for the model**. Whether they transfer to the real system depends entirely on the abstraction the user (or adapter) picks. The [`Soundness Guarantees`](../CLAUDE.md#soundness-guarantees) section of CLAUDE.md states the soundness directions; this doc gives the **per-subsystem recipe** — *which* mununu primitive to reach for, *when*, and what each primitive preserves.
 
+For how the abstraction fits the wider engine picture — the frontend-agnostic STS-IR seam, the **explicit vs symbolic (BDD, R-F5)** engines, the IR layering, and how over/under/⊥ approximation and may/must edges operate end-to-end — see [`docs/design/post-rf5-architecture.md`](design/post-rf5-architecture.md).
+
 Use this doc when:
 
 - You are authoring an adapter and have to decide how to encode a multi-bit register, a memory region, or a wide-arithmetic operator.

--- a/docs/design/native-sv-abstraction.md
+++ b/docs/design/native-sv-abstraction.md
@@ -1,6 +1,6 @@
 # Native SV → KMTS Architecture
 
-> **Status: planning.** This document describes a unified replacement for mununu's SystemVerilog extraction pipeline. The current native-parser path (§2) is documented here for context and slated for removal (§9). The proposed pipeline (§3–§7) and the validation milestones (§10) are not yet implemented; planning sub-sections do not carry `> Source of truth:` anchors. Sections that document existing code (§2, §5.1 baseline, §9 removal inventory) do anchor live symbols. Companion docs once shipped: [`kmts-theory.md`](kmts-theory.md), [`predicate-abstraction-recipe.md`](predicate-abstraction-recipe.md), [`abstraction-literature.md`](abstraction-literature.md).
+> **Status: planning.** This document describes a unified replacement for mununu's SystemVerilog extraction pipeline. The current native-parser path (§2) is documented here for context and slated for removal (§9). The proposed pipeline (§3–§7) and the validation milestones (§10) are not yet implemented; planning sub-sections do not carry `> Source of truth:` anchors. Sections that document existing code (§2, §5.1 baseline, §9 removal inventory) do anchor live symbols. Companion docs once shipped: [`kmts-theory.md`](kmts-theory.md), [`predicate-abstraction-recipe.md`](predicate-abstraction-recipe.md), [`abstraction-literature.md`](abstraction-literature.md), [`post-rf5-architecture.md`](post-rf5-architecture.md) (the end-to-end engine picture: explicit vs symbolic, IR layering, may/must + over/under/⊥ approximation).
 
 ## §1 Context
 

--- a/docs/design/sts-ir.md
+++ b/docs/design/sts-ir.md
@@ -128,6 +128,19 @@ sampling representative inverse can't realise `a==0 && b==0`, and the lazy body
 never consults `compound_exprs`; `ensure_compound_lift_supported()` enforces this
 at the entry (and via thin defensive copies in each impl for direct callers).
 
+### 4.2 The third consumer — symbolic (BDD) engine (R-F5, planned)
+
+The seam admits a **third** strategy beyond `StepEval` (Enumerate) and `SmtEncode`
+(explicit predicate-cube): a **symbolic** engine that builds the may/must transition
+relation as BDDs and evaluates the mu-calculus by fixpoint image/preimage, never
+materialising the `2^|P|` cube states. It is the R-F5 track: R-F5.0 (the OxiDD spike,
+`mu_calculus/symbolic.rs`) is shipped and validated cell-for-cell against
+`evaluate_tri`; R-F5.1–.4 (BDD `TritSet`, symbolic modal step, symbolic relation
+construction from BTOR2, verify-auto wiring) are planned. It plugs into the *same*
+seam — the symbolic relation-builder consumes the transition-system view, not BTOR2
+directly. Full picture:
+[`docs/design/post-rf5-architecture.md`](post-rf5-architecture.md).
+
 ## 5. Z3 scope & batching (why `may_edges` is batched, not per-pair)
 
 Z3 calls must run inside a `z3::with_z3_config` scope, and the efficient pattern builds the

--- a/wiki/Predicate-Cube-CEGAR.md
+++ b/wiki/Predicate-Cube-CEGAR.md
@@ -40,6 +40,23 @@ SystemVerilog ──sv2v──► Verilog ──Yosys (no flatten)──► BTOR
 `mununu btor2 cegar` consumes a BTOR2 file directly; `mununu sv cegar` is the
 one-call variant that runs sv2v + Yosys for you.
 
+### Explicit vs symbolic engine (R-F5)
+
+The predicate-cube abstraction has two possible **engines** — the representation of the
+cube state space + transition relation, independent of the abstraction itself:
+
+- **Explicit (shipped)** — materialises `2^|P|` cube states in a `Clts` and builds the
+  may/must edges with SMT (`SmtEncode`). Fine at small `|P|`; the edge computation is
+  `O(2^2|P|)` SMT queries, which is the scaling wall.
+- **Symbolic / BDD (R-F5, planned)** — represents cube sets + the transition relation as
+  BDDs and runs the fixpoint by image/preimage (`∃x'. R(x,x') ∧ φ(x')`), never
+  enumerating cubes. The `evaluate_tri` verdict is the ground truth either way (the
+  symbolic path is validated cell-for-cell against it).
+
+Both engines share the same 3-valued semantics and soundness (below). See
+[the post-R-F5 architecture](https://github.com/vscorza/mununu/blob/main/docs/design/post-rf5-architecture.md)
+for the full picture (IR layering, may/must edges, over/under/⊥ approximation).
+
 ## CLI
 
 > **Source of truth:** the `btor2 cegar` / `sv cegar` subcommands in [`crates/mununu-cli/src/main.rs`](https://github.com/vscorza/mununu/blob/main/crates/mununu-cli/src/main.rs) — surface: CLI.
@@ -155,3 +172,4 @@ abstraction / CEGAR to convergence.
 - [Adapter Formats](Adapter-Formats) — BTOR2 + SystemVerilog import
 - [`docs/design/predicate-abstraction-recipe.md`](https://github.com/vscorza/mununu/blob/main/docs/design/predicate-abstraction-recipe.md) — the full operational recipe (predicate seeding, may/must image, CEGAR, §4.9 soundness)
 - [`docs/design/kmts-theory.md`](https://github.com/vscorza/mununu/blob/main/docs/design/kmts-theory.md) — KMTS + 3-valued mu-calculus theory
+- [`docs/design/post-rf5-architecture.md`](https://github.com/vscorza/mununu/blob/main/docs/design/post-rf5-architecture.md) — the whole picture: explicit vs symbolic engines, IR layering, may/must + over/under/⊥ approximation

--- a/wiki/RTL-Verification-Pipeline.md
+++ b/wiki/RTL-Verification-Pipeline.md
@@ -23,6 +23,15 @@ SV Source → sv2v → Yosys (hierarchy, no flatten) → BTOR2 (per module) → 
 
 Requires `yosys` (and `sv2v` for SV-2017 constructs) on `PATH`. Steps 2-4 are iterative — refine annotations and properties based on verification results.
 
+> **This page = the explicit bit-blast engine.** The BTOR2 IR also feeds the
+> **predicate-cube** abstraction (states = predicate cubes, not register bit-blast),
+> with automatic CEGAR refinement and 3-valued (`KleeneT`/`KleeneF`/`KleeneBot`)
+> verdicts — see [Predicate-Cube CEGAR](Predicate-Cube-CEGAR). Both the bit-blast and
+> predicate-cube paths flow through the same frontend-agnostic **STS-IR seam** and the
+> one 3-valued evaluator. For the whole architecture — explicit vs symbolic (BDD, R-F5)
+> engines, the IR layering, and how over/under/⊥ approximation + may/must edges operate —
+> see [`docs/design/post-rf5-architecture.md`](https://github.com/vscorza/mununu/blob/main/docs/design/post-rf5-architecture.md).
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
Propagates [`docs/design/post-rf5-architecture.md`](docs/design/post-rf5-architecture.md) (merged in #207) across the existing surfaces so the architecture is discoverable from the entry points.

- **README.md §Architecture** — adds the **end-to-end pipeline mermaid diagram** (frontends → STS-IR seam → {explicit-enumerate, explicit-predicate-cube, symbolic-BDD} → 3-valued verdict), the three-axes intro (abstraction / engine / domain), and a pointer to the full doc. Source-tree layout retained below.
- **wiki/Predicate-Cube-CEGAR.md** — new "Explicit vs symbolic engine (R-F5)" subsection + See Also link.
- **wiki/RTL-Verification-Pipeline.md** — note tying the bit-blast page to the predicate-cube path, the shared STS-IR seam, and the explicit/symbolic engines.
- **docs/design/sts-ir.md** — §4.2 documents the third seam consumer (the symbolic BDD engine; R-F5.0 shipped, .1–.4 planned).
- **docs/abstraction.md** + **docs/design/native-sv-abstraction.md** — cross-ref pointers.

Doc-only; no CTXDSL examples added; mermaid labels hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)