### PR TITLE
feat(R-F5.3a): BDD bit-blaster for the BTOR2 transition function

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -32,6 +32,7 @@ pub mod predicate_expr;
 pub mod r_s8_encoder;
 pub mod shadow;
 pub mod smt_must_edge;
+pub mod symbolic_bitblast;
 pub mod term_backend;
 /// H.U.0 — uniform predicate-image spike (go/no-go validation; test-only).
 #[cfg(test)]

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -1,0 +1,683 @@
+//! R-F5.3a (2026-07-02) — a **BDD bit-blaster** for the BTOR2 transition
+//! function, the first concrete slice of R-F5.3 (symbolic edge construction).
+//!
+//! # Why this exists
+//!
+//! The predicate-cube CEGAR path builds its may/must transition relation with
+//! `O(2^2|P|)` Z3 queries (`kmts_lift` → `smt_must_edge`), which is the H.H.c
+//! "29 min, no output" wall at `|P| ≈ 12`. R-F5's thesis (see
+//! [`.claude/plans/r-f5-symbolic-bdd-track.md`]) is that the relation should be
+//! built **symbolically** — as a BDD over the register/input bits — by
+//! bit-blasting the BTOR2 transition function once, rather than sampled pair by
+//! pair with SMT.
+//!
+//! This module is the foundation for that: it lifts each BTOR2 node to a
+//! **bit-vector of BDDs** (`Vec<BDDFunction>`, LSB-first) over one BDD variable
+//! per register bit + per input bit, using the same generic
+//! [`BvTermBackend`] / [`walk_design`] seam the concrete evaluator and the Z3
+//! encoder already share. The per-op BDD gadgets (ripple-carry adder, unsigned
+//! comparator, mux, sign/zero extension, …) mirror the concrete
+//! [`eval_op`](super::bit_blast) semantics bit-for-bit.
+//!
+//! # Correctness gate
+//!
+//! The bit-blaster is validated **cell-for-cell against the concrete
+//! simulator** [`simulate_one_step`](super::bit_blast::simulate_one_step): for
+//! every reachable (register, input) assignment, restricting the symbolic
+//! next-state BDDs to that assignment must equal the concrete next state. The
+//! differential is exhaustive on the small hand-built fixtures below, so a
+//! semantic drift in any gadget is caught immediately — the oracle is the
+//! same one the explicit path trusts.
+//!
+//! # Scope (R-F5.3a)
+//!
+//! Covers the FSM + counter core op set: `not/and/or/xor/nand/nor/xnor`,
+//! `inc/dec/neg`, `add/sub`, `eq/neq/iff/implies`, unsigned compares
+//! (`ult/ulte/ugt/ugte`), reductions (`redor/redand/redxor`),
+//! `concat/slice/uext/sext`, and `ite`. Multiplication, division, variable
+//! shifts, signed compares, and array ops are rejected with a clear error —
+//! they are later R-F5.3 slices (the FSM+counter residual the H.H.c ceiling
+//! needs does not use them). R-F5.3b then lifts predicate BDDs over these
+//! register-bit functions; R-F5.3c builds the abstract relation by existential
+//! quantification.
+
+use std::collections::HashMap;
+
+use oxidd::bdd::{self, BDDFunction, BDDManagerRef};
+use oxidd::{BooleanFunction, Manager, ManagerRef, VarNo};
+
+use crate::adapter::btor2::ast::{Btor2File, ConstValue, Nid, Node, Op, Operand};
+use crate::adapter::btor2::bit_blast::eval_const_value;
+use crate::adapter::btor2::parser::bv_width;
+use crate::adapter::btor2::term_backend::{BvTermBackend, WalkError, walk_design};
+
+/// A bit-vector of BDDs, LSB-first: index `b` is the BDD for bit `b`. Every
+/// node's value carries exactly `width` bits.
+type BitVec = Vec<BDDFunction>;
+
+/// A register or input cell: its BTOR2 NID + symbol + the fresh BDD variables
+/// standing for its bits (LSB-first). The bit-blaster restricts these to
+/// concrete values for the differential.
+struct Cell {
+    symbol: String,
+    vars: BitVec,
+}
+
+/// A BDD bit-blaster over one BTOR2 file. Owns one OxiDD manager; every node's
+/// value is a `Vec<BDDFunction>` over the register-bit + input-bit variables.
+pub struct BddBitBlaster {
+    _manager: BDDManagerRef,
+    tt: BDDFunction,
+    ff: BDDFunction,
+    /// `Nid → value` binding store, filled by [`walk_design`].
+    env: HashMap<Nid, BitVec>,
+    /// Register + input cells, in file order (drives the restriction minterm).
+    cells: Vec<Cell>,
+    /// State symbol → its next-state BDD vector, from the `Node::Next` lines.
+    next_funcs: HashMap<String, BitVec>,
+}
+
+impl BddBitBlaster {
+    /// Bit-blast `file`: allocate one BDD variable per register/input bit,
+    /// bind the leaves, walk every `Const`/`Op` node into a BDD vector, and
+    /// collect the per-register next-state functions.
+    pub fn build(file: &Btor2File) -> Result<Self, String> {
+        // Pass 1 — collect register + input cells with their widths.
+        let mut leaf_specs: Vec<(Nid, String, u32)> = Vec::new();
+        for line in &file.lines {
+            let (sort, symbol, tag) = match &line.node {
+                Node::State { sort, symbol } => (*sort, symbol.clone(), "state"),
+                Node::Input { sort, symbol } => (*sort, symbol.clone(), "input"),
+                _ => continue,
+            };
+            let width = bv_width(file, sort)
+                .ok_or_else(|| format!("NID {}: {tag} has non-bitvec sort", line.nid))?;
+            let symbol = symbol.unwrap_or_else(|| format!("{tag}_{}", line.nid));
+            leaf_specs.push((line.nid, symbol, width));
+        }
+
+        let total_bits: u32 = leaf_specs.iter().map(|(_, _, w)| *w).sum();
+
+        // Allocate the manager + one BDD variable per leaf bit.
+        let manager = bdd::new_manager(1 << 16, 1 << 16, 1);
+        let (all_vars, tt, ff) = manager.with_manager_exclusive(|m| {
+            let range = m.add_vars(total_bits as VarNo);
+            let vars: Vec<BDDFunction> = (0..total_bits)
+                .map(|i| BDDFunction::var(m, range.start + i as VarNo).unwrap())
+                .collect();
+            (vars, BDDFunction::t(m), BDDFunction::f(m))
+        });
+
+        // Slice the flat variable pool out per cell, LSB-first.
+        let mut env: HashMap<Nid, BitVec> = HashMap::new();
+        let mut cells: Vec<Cell> = Vec::new();
+        let mut cursor = 0usize;
+        for (nid, symbol, width) in leaf_specs {
+            let vars: BitVec = all_vars[cursor..cursor + width as usize].to_vec();
+            cursor += width as usize;
+            env.insert(nid, vars.clone());
+            cells.push(Cell { symbol, vars });
+        }
+
+        let mut blaster = BddBitBlaster {
+            _manager: manager,
+            tt,
+            ff,
+            env,
+            cells,
+            next_funcs: HashMap::new(),
+        };
+
+        // Pass 2 — walk the node DAG, evaluating every Const/Op into a BitVec.
+        walk_design(file, &mut blaster).map_err(|e| match e {
+            WalkError::NonBitvecSort(nid) => {
+                format!("NID {nid}: non-bitvec sort in the transition cone")
+            }
+            WalkError::Unevaluated(nid) => format!("NID {nid}: operand unevaluated"),
+            WalkError::Backend(msg) => msg,
+        })?;
+
+        // Pass 3 — collect the per-register next-state functions. A state's
+        // symbol is looked up from its declaration.
+        let mut nid_symbol: HashMap<Nid, String> = HashMap::new();
+        for line in &file.lines {
+            if let Node::State { symbol, .. } = &line.node {
+                let sym = symbol
+                    .clone()
+                    .unwrap_or_else(|| format!("state_{}", line.nid));
+                nid_symbol.insert(line.nid, sym);
+            }
+        }
+        for line in &file.lines {
+            if let Node::Next { state, value, .. } = &line.node {
+                let Some(sym) = nid_symbol.get(state) else {
+                    continue;
+                };
+                let next = blaster.resolve(*value)?;
+                blaster.next_funcs.insert(sym.clone(), next);
+            }
+        }
+
+        Ok(blaster)
+    }
+
+    /// Symbolically compute one clock step and restrict it to a concrete
+    /// assignment: the BDD counterpart of
+    /// [`simulate_one_step`](super::bit_blast::simulate_one_step). Returns each
+    /// register symbol (that has a `Next` line) mapped to its next value.
+    ///
+    /// `assignment` maps every register + input symbol to its current value.
+    /// Symbols absent from the map default to `0` (the `setundef -zero`
+    /// discipline the concrete oracle also follows).
+    pub fn eval_step(&self, assignment: &HashMap<String, u128>) -> HashMap<String, u128> {
+        let minterm = self.minterm_for(assignment);
+        self.next_funcs
+            .iter()
+            .map(|(sym, bits)| (sym.clone(), self.value_of(bits, &minterm)))
+            .collect()
+    }
+
+    /// The full-assignment minterm over every register + input bit.
+    fn minterm_for(&self, assignment: &HashMap<String, u128>) -> BDDFunction {
+        let mut mt = self.tt.clone();
+        for cell in &self.cells {
+            let v = assignment.get(&cell.symbol).copied().unwrap_or(0);
+            for (b, var) in cell.vars.iter().enumerate() {
+                let lit = if (v >> b) & 1 == 1 {
+                    var.clone()
+                } else {
+                    var.not().unwrap()
+                };
+                mt = mt.and(&lit).unwrap();
+            }
+        }
+        mt
+    }
+
+    /// Read a bit-vector of BDDs at a full assignment: bit `b` is set iff the
+    /// minterm implies `bits[b]` (`mt ⊑ f ⟺ mt ∧ f == mt`).
+    fn value_of(&self, bits: &[BDDFunction], minterm: &BDDFunction) -> u128 {
+        let mut val = 0u128;
+        for (b, f) in bits.iter().enumerate() {
+            if minterm.and(f).unwrap() == *minterm {
+                val |= 1u128 << b;
+            }
+        }
+        val
+    }
+
+    /// Resolve an operand to its BDD vector, applying the BTOR2 negative-NID
+    /// bitwise-NOT shorthand (mirrors the concrete `read_operand`).
+    fn resolve(&self, op: Operand) -> Result<BitVec, String> {
+        let v = self
+            .env
+            .get(&op.nid())
+            .ok_or_else(|| format!("operand {} unevaluated", op.nid()))?;
+        if op.is_negated() {
+            Ok(v.iter().map(|b| b.not().unwrap()).collect())
+        } else {
+            Ok(v.clone())
+        }
+    }
+
+    // ---- Boolean gadgets (each mirrors a concrete `eval_op` arm) ----
+
+    fn xor(&self, a: &BDDFunction, b: &BDDFunction) -> BDDFunction {
+        // (a ∧ ¬b) ∨ (¬a ∧ b) — kept crate-portable (oxidd exposes `.and/.or/.not`).
+        let lhs = a.and(&b.not().unwrap()).unwrap();
+        let rhs = a.not().unwrap().and(b).unwrap();
+        lhs.or(&rhs).unwrap()
+    }
+
+    /// Ripple-carry adder over `width` bits: returns `(sum, carry_out)`.
+    /// Missing high bits of either operand read as `0`.
+    fn add_bits(
+        &self,
+        a: &[BDDFunction],
+        b: &[BDDFunction],
+        cin: BDDFunction,
+        width: u32,
+    ) -> (BitVec, BDDFunction) {
+        let mut carry = cin;
+        let mut sum = Vec::with_capacity(width as usize);
+        for i in 0..width as usize {
+            let ai = a.get(i).cloned().unwrap_or_else(|| self.ff.clone());
+            let bi = b.get(i).cloned().unwrap_or_else(|| self.ff.clone());
+            let axb = self.xor(&ai, &bi);
+            let s = self.xor(&axb, &carry);
+            // carry' = (ai ∧ bi) ∨ (carry ∧ (ai ⊕ bi))
+            let c = ai.and(&bi).unwrap().or(&carry.and(&axb).unwrap()).unwrap();
+            sum.push(s);
+            carry = c;
+        }
+        (sum, carry)
+    }
+
+    /// OR-reduce a bit-vector to a single BDD (`|x`).
+    fn or_reduce(&self, bits: &[BDDFunction]) -> BDDFunction {
+        let mut acc = self.ff.clone();
+        for b in bits {
+            acc = acc.or(b).unwrap();
+        }
+        acc
+    }
+
+    /// AND-reduce a bit-vector to a single BDD (`&x`).
+    fn and_reduce(&self, bits: &[BDDFunction]) -> BDDFunction {
+        let mut acc = self.tt.clone();
+        for b in bits {
+            acc = acc.and(b).unwrap();
+        }
+        acc
+    }
+
+    /// XOR-reduce a bit-vector to a single BDD (`^x`).
+    fn xor_reduce(&self, bits: &[BDDFunction]) -> BDDFunction {
+        let mut acc = self.ff.clone();
+        for b in bits {
+            acc = self.xor(&acc, b);
+        }
+        acc
+    }
+
+    /// Structural bit-equality: AND of per-bit XNOR. Returns a 1-bit vector.
+    fn eq_bits(&self, a: &[BDDFunction], b: &[BDDFunction]) -> BitVec {
+        let n = a.len().max(b.len());
+        let mut acc = self.tt.clone();
+        for i in 0..n {
+            let ai = a.get(i).cloned().unwrap_or_else(|| self.ff.clone());
+            let bi = b.get(i).cloned().unwrap_or_else(|| self.ff.clone());
+            let xnor = self.xor(&ai, &bi).not().unwrap();
+            acc = acc.and(&xnor).unwrap();
+        }
+        vec![acc]
+    }
+
+    /// Unsigned `a >= b`: the carry-out of `a + ¬b + 1` (borrow-free subtract).
+    fn uge(&self, a: &[BDDFunction], b: &[BDDFunction], width: u32) -> BDDFunction {
+        let not_b: BitVec = (0..width as usize)
+            .map(|i| {
+                b.get(i)
+                    .cloned()
+                    .unwrap_or_else(|| self.ff.clone())
+                    .not()
+                    .unwrap()
+            })
+            .collect();
+        let (_, cout) = self.add_bits(a, &not_b, self.tt.clone(), width);
+        cout
+    }
+}
+
+impl BvTermBackend for BddBitBlaster {
+    type Value = BitVec;
+    type Error = String;
+
+    fn eval_const(&mut self, value: &ConstValue, width: u32) -> Result<Self::Value, Self::Error> {
+        // Reuse the concrete constant semantics, then splat to per-bit BDDs.
+        let bv = eval_const_value(value, width)?;
+        Ok((0..width as usize)
+            .map(|b| {
+                if (bv.bits >> b) & 1 == 1 {
+                    self.tt.clone()
+                } else {
+                    self.ff.clone()
+                }
+            })
+            .collect())
+    }
+
+    fn eval_op(
+        &mut self,
+        _nid: Nid,
+        op: Op,
+        immediates: &[u32],
+        args: &[Operand],
+        width: u32,
+    ) -> Result<Self::Value, Self::Error> {
+        let read = |i: usize| -> Result<BitVec, String> { self.resolve(args[i]) };
+
+        let result: BitVec = match op {
+            // ---- Bitwise (result + operands all `width` bits) ----
+            Op::Not => {
+                let a = read(0)?;
+                (0..width as usize).map(|i| a[i].not().unwrap()).collect()
+            }
+            Op::And => {
+                let (a, b) = (read(0)?, read(1)?);
+                (0..width as usize)
+                    .map(|i| a[i].and(&b[i]).unwrap())
+                    .collect()
+            }
+            Op::Or => {
+                let (a, b) = (read(0)?, read(1)?);
+                (0..width as usize)
+                    .map(|i| a[i].or(&b[i]).unwrap())
+                    .collect()
+            }
+            Op::Xor => {
+                let (a, b) = (read(0)?, read(1)?);
+                (0..width as usize)
+                    .map(|i| self.xor(&a[i], &b[i]))
+                    .collect()
+            }
+            Op::Nand => {
+                let (a, b) = (read(0)?, read(1)?);
+                (0..width as usize)
+                    .map(|i| a[i].and(&b[i]).unwrap().not().unwrap())
+                    .collect()
+            }
+            Op::Nor => {
+                let (a, b) = (read(0)?, read(1)?);
+                (0..width as usize)
+                    .map(|i| a[i].or(&b[i]).unwrap().not().unwrap())
+                    .collect()
+            }
+            Op::Xnor => {
+                let (a, b) = (read(0)?, read(1)?);
+                (0..width as usize)
+                    .map(|i| self.xor(&a[i], &b[i]).not().unwrap())
+                    .collect()
+            }
+
+            // ---- Arithmetic (two's-complement, wrap to `width`) ----
+            Op::Add => {
+                let (a, b) = (read(0)?, read(1)?);
+                self.add_bits(&a, &b, self.ff.clone(), width).0
+            }
+            Op::Sub => {
+                // a − b = a + ¬b + 1
+                let (a, b) = (read(0)?, read(1)?);
+                let not_b: BitVec = (0..width as usize).map(|i| b[i].not().unwrap()).collect();
+                self.add_bits(&a, &not_b, self.tt.clone(), width).0
+            }
+            Op::Inc => {
+                let a = read(0)?;
+                self.add_bits(&a, &[], self.tt.clone(), width).0
+            }
+            Op::Dec => {
+                // a − 1 = a + (all ones) + 0
+                let a = read(0)?;
+                let ones: BitVec = (0..width as usize).map(|_| self.tt.clone()).collect();
+                self.add_bits(&a, &ones, self.ff.clone(), width).0
+            }
+            Op::Neg => {
+                // −a = ¬a + 1
+                let a = read(0)?;
+                let not_a: BitVec = (0..width as usize).map(|i| a[i].not().unwrap()).collect();
+                self.add_bits(&not_a, &[], self.tt.clone(), width).0
+            }
+
+            // ---- Equality / implication (1-bit result) ----
+            Op::Eq | Op::Iff => {
+                let (a, b) = (read(0)?, read(1)?);
+                self.eq_bits(&a, &b)
+            }
+            Op::Neq => {
+                let (a, b) = (read(0)?, read(1)?);
+                vec![self.eq_bits(&a, &b)[0].not().unwrap()]
+            }
+            Op::Implies => {
+                // ¬(|a) ∨ (|b)
+                let (a, b) = (read(0)?, read(1)?);
+                let a_bool = self.or_reduce(&a);
+                let b_bool = self.or_reduce(&b);
+                vec![a_bool.not().unwrap().or(&b_bool).unwrap()]
+            }
+
+            // ---- Unsigned comparisons (1-bit result) ----
+            Op::Ugte => {
+                let (a, b) = (read(0)?, read(1)?);
+                let w = a.len().max(b.len()) as u32;
+                vec![self.uge(&a, &b, w)]
+            }
+            Op::Ult => {
+                let (a, b) = (read(0)?, read(1)?);
+                let w = a.len().max(b.len()) as u32;
+                vec![self.uge(&a, &b, w).not().unwrap()]
+            }
+            Op::Ugt => {
+                // a > b ⟺ b < a ⟺ ¬(b ≥ a)
+                let (a, b) = (read(0)?, read(1)?);
+                let w = a.len().max(b.len()) as u32;
+                vec![self.uge(&b, &a, w).not().unwrap()]
+            }
+            Op::Ulte => {
+                // a ≤ b ⟺ b ≥ a
+                let (a, b) = (read(0)?, read(1)?);
+                let w = a.len().max(b.len()) as u32;
+                vec![self.uge(&b, &a, w)]
+            }
+
+            // ---- Reductions (1-bit result) ----
+            Op::Redor => vec![self.or_reduce(&read(0)?)],
+            Op::Redand => vec![self.and_reduce(&read(0)?)],
+            Op::Redxor => vec![self.xor_reduce(&read(0)?)],
+
+            // ---- Structural rearrangement ----
+            Op::Concat => {
+                // {a, b}: b occupies the low bits, a the high bits.
+                let (a, b) = (read(0)?, read(1)?);
+                let mut out = b;
+                out.extend(a);
+                out.truncate(width as usize);
+                out
+            }
+            Op::Slice => {
+                // immediates = [upper, lower]; out bit i = a[lower + i].
+                let a = read(0)?;
+                let lower = *immediates.get(1).ok_or("slice missing lower")? as usize;
+                (0..width as usize)
+                    .map(|i| a.get(lower + i).cloned().unwrap_or_else(|| self.ff.clone()))
+                    .collect()
+            }
+            Op::Uext => {
+                // zero-extend to `width`.
+                let a = read(0)?;
+                (0..width as usize)
+                    .map(|i| a.get(i).cloned().unwrap_or_else(|| self.ff.clone()))
+                    .collect()
+            }
+            Op::Sext => {
+                // sign-extend to `width` (replicate the MSB of `a`).
+                let a = read(0)?;
+                let msb = a.last().cloned().unwrap_or_else(|| self.ff.clone());
+                (0..width as usize)
+                    .map(|i| a.get(i).cloned().unwrap_or_else(|| msb.clone()))
+                    .collect()
+            }
+
+            // ---- Conditional ----
+            Op::Ite => {
+                // c ? t : e — c is 1-bit.
+                let c = read(0)?;
+                let (t, e) = (read(1)?, read(2)?);
+                let cond = c[0].clone();
+                let ncond = cond.not().unwrap();
+                (0..width as usize)
+                    .map(|i| {
+                        cond.and(&t[i])
+                            .unwrap()
+                            .or(&ncond.and(&e[i]).unwrap())
+                            .unwrap()
+                    })
+                    .collect()
+            }
+
+            // Out of R-F5.3a scope — later slices / never in the FSM+counter core.
+            other => {
+                return Err(format!(
+                    "operator {other:?} not yet supported in the R-F5.3a BDD bit-blaster"
+                ));
+            }
+        };
+        Ok(result)
+    }
+
+    fn bind(&mut self, nid: Nid, value: Self::Value) {
+        self.env.insert(nid, value);
+    }
+
+    fn honor_init(&self) -> bool {
+        // Register bits stand for their present-state variables, not init
+        // values — the walk computes the transition function symbolically.
+        false
+    }
+
+    fn read_operand(&self, op: Operand) -> Option<Self::Value> {
+        self.resolve(op).ok()
+    }
+
+    fn uf_substitute(&mut self, _nid: Nid, _width: u32) -> Option<Self::Value> {
+        // No uninterpreted-function abstraction in R-F5.3a.
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::bit_blast::simulate_one_step;
+    use crate::adapter::btor2::parser;
+
+    /// Run the BDD bit-blaster against the concrete simulator over an
+    /// exhaustive enumeration of the given (symbol, bit-width) leaves.
+    fn assert_matches_simulator(
+        src: &str,
+        leaves: &[(&str, u32)],
+        states: &[&str],
+        inputs: &[&str],
+    ) {
+        let file = parser::parse(src).expect("parse fixture");
+        let bb = BddBitBlaster::build(&file).expect("build bit-blaster");
+
+        let total_bits: u32 = leaves.iter().map(|(_, w)| *w).sum();
+        assert!(total_bits <= 16, "keep the exhaustive sweep small");
+
+        for combo in 0..(1u128 << total_bits) {
+            // Decode `combo` into a per-symbol value assignment.
+            let mut assignment: HashMap<String, u128> = HashMap::new();
+            let mut offset = 0u32;
+            for (sym, w) in leaves {
+                let mask = (1u128 << w) - 1;
+                assignment.insert((*sym).to_string(), (combo >> offset) & mask);
+                offset += w;
+            }
+
+            // Symbolic step.
+            let symbolic = bb.eval_step(&assignment);
+
+            // Concrete oracle.
+            let regs: HashMap<String, u128> = states
+                .iter()
+                .map(|s| ((*s).to_string(), assignment[*s]))
+                .collect();
+            let inps: HashMap<String, u128> = inputs
+                .iter()
+                .map(|s| ((*s).to_string(), assignment[*s]))
+                .collect();
+            let concrete = simulate_one_step(&file, &regs, &inps).expect("concrete step");
+
+            for st in states {
+                assert_eq!(
+                    symbolic.get(*st).copied(),
+                    concrete.get(*st).copied(),
+                    "next-state mismatch for `{st}` at assignment {assignment:?}"
+                );
+            }
+        }
+    }
+
+    /// Saturating counter + companion register: exercises `state`, `one`,
+    /// `ones`, `add`, `sub`, `eq`, `ult`, `and`, `ite`.
+    #[test]
+    fn rf5_3a_matches_simulator_saturating_counter() {
+        let src = r#"
+1 sort bitvec 3
+2 sort bitvec 1
+3 state 1 cnt
+4 state 1 acc
+5 input 2 en
+6 one 1
+7 ones 1
+8 add 1 3 6
+9 eq 2 3 7
+10 ite 1 9 3 8
+11 ite 1 5 10 3
+12 next 1 3 11
+13 sub 1 4 6
+14 and 1 4 3
+15 ult 2 4 3
+16 ite 1 15 13 14
+17 next 1 4 16
+"#;
+        assert_matches_simulator(
+            src,
+            &[("cnt", 3), ("acc", 3), ("en", 1)],
+            &["cnt", "acc"],
+            &["en"],
+        );
+    }
+
+    /// Bit-manipulation heavy: exercises `not`, `inc`, `dec`, `neg`, `slice`,
+    /// `uext`, `sext`, `concat`, `xor`, `or`, `redor`, `ite`. The next-state
+    /// funnels every wide intermediate back to a 4-bit register, so the
+    /// exhaustive check on `r'` transitively validates the whole cone.
+    #[test]
+    fn rf5_3a_matches_simulator_bit_manipulation() {
+        let src = r#"
+1 sort bitvec 4
+2 sort bitvec 1
+3 sort bitvec 2
+4 sort bitvec 8
+5 state 1 r
+6 input 2 sel
+7 not 1 5
+8 inc 1 5
+9 dec 1 5
+10 neg 1 5
+11 slice 3 5 3 2
+12 uext 4 5 4
+13 sext 4 5 4
+14 concat 4 5 5
+15 slice 1 14 7 4
+16 xor 1 7 8
+17 or 1 9 10
+18 redor 2 5
+19 ite 1 6 16 17
+20 ite 1 18 15 19
+21 next 1 5 20
+"#;
+        assert_matches_simulator(src, &[("r", 4), ("sel", 1)], &["r"], &["sel"]);
+    }
+
+    /// Unsigned comparator family + reductions on their own: `ult`, `ulte`,
+    /// `ugt`, `ugte`, `neq`, `redand`, `redxor`. The seven 1-bit results are
+    /// packed (via correctly-sized `concat`s) into two 3-bit words that an
+    /// `ite` funnels back into the register, so the exhaustive check on `x'`
+    /// validates every comparator.
+    #[test]
+    fn rf5_3a_matches_simulator_comparators() {
+        let src = r#"
+1 sort bitvec 3
+2 sort bitvec 1
+3 sort bitvec 2
+4 state 1 x
+5 input 1 y
+6 ult 2 4 5
+7 ulte 2 4 5
+8 ugt 2 4 5
+9 ugte 2 4 5
+10 neq 2 4 5
+11 redand 2 4
+12 redxor 2 4
+13 concat 3 6 7
+14 concat 1 13 8
+15 concat 3 9 10
+16 concat 1 15 11
+17 ite 1 12 14 16
+18 next 1 4 17
+"#;
+        assert_matches_simulator(src, &[("x", 3), ("y", 3)], &["x"], &["y"]);
+    }
+}


### PR DESCRIPTION
First concrete slice of **R-F5.3** (symbolic edge construction) — the foundation for building the predicate-cube may/must relation *symbolically* instead of with `O(2^2|P|)` Z3 queries (the H.H.c "29 min, no output" wall).

## What

`adapter/btor2/symbolic_bitblast.rs` lifts each BTOR2 node to a **bit-vector of BDDs** (`Vec<BDDFunction>`, LSB-first) over one BDD var per register/input bit, plugging into the shared `term_backend::BvTermBackend` / `walk_design` seam the concrete evaluator and Z3 encoder already share. The per-op gadgets — ripple-carry `add_bits`, unsigned comparator `uge`, mux, reductions, `concat`/`slice`/`uext`/`sext` — mirror the concrete `eval_op` bit-for-bit; constants reuse `eval_const_value` directly.

## Correctness gate

Validated by an **exhaustive differential against the concrete oracle** `simulate_one_step`: for every reachable (register, input) assignment, restricting the symbolic next-state BDDs equals the concrete next state. Three hand-built fixtures cover the FSM+counter core op set:
- saturating counter (`state`, `one`, `ones`, `add`, `sub`, `eq`, `ult`, `and`, `ite`),
- bit-manipulation cone (`not`, `inc`, `dec`, `neg`, `slice`, `uext`, `sext`, `concat`, `xor`, `or`, `redor`),
- unsigned comparator family (`ult`, `ulte`, `ugt`, `ugte`, `neq`, `redand`, `redxor`).

## Scope

The FSM+counter core op set. `mul`/`div`/variable-shift/signed-compare/array ops are rejected with a clear error — later R-F5.3 slices; not in the H.H.c residual cone.

## Next

- **R-F5.3b** — predicate BDDs over these register-bit functions (`PredicateExpr` -> BDD over the leaf vars), so a predicate cube becomes a BDD over the present-state vars.
- **R-F5.3c** — build `R_may`/`R_must` as the abstract relation by conjoining the bit-blasted next-state functions with the predicate BDDs and existentially quantifying the register bits (the actual SMT-edge-avoidance win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)