### PR TITLE
feat(R-F5.4.1/2a/3): symbolic predicate-cube engine + scaling proof

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -33,6 +33,7 @@ pub mod r_s8_encoder;
 pub mod shadow;
 pub mod smt_must_edge;
 pub mod symbolic_bitblast;
+pub mod symbolic_engine;
 pub mod term_backend;
 /// H.U.0 — uniform predicate-image spike (go/no-go validation; test-only).
 #[cfg(test)]

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -77,10 +77,26 @@
 //! `∀∃` must-edge — every concrete state in the source cube has *some* input
 //! landing in the target) or the stricter `∀(x∪i). (A → A')` (`∀∀`,
 //! deterministic-into-target). Built with OxiDD `exists` / `forall` over the
-//! input / register cubes — again no per-cube-pair SMT. Validated cell-for-cell
-//! against the brute-force concrete must-relation, plus the KMTS invariant
-//! `R_must ⊆ R_may` over feasible cubes. R-F5.4 then wires the `AbstractRelation`
-//! (may + must) into a symbolic KMTS engine behind `--engine symbolic`.
+//! input / register cubes — again no per-cube-pair SMT. Must-edges are
+//! restricted to **feasible** source cubes (`∧ ∃x. A(x,p)`) so `R_must ⊆ R_may`
+//! holds globally over the whole `2^k` cube space (an infeasible cube is
+//! vacuously a ∀-must-edge to everything but has no may-edge; the lift never
+//! materialises it). Validated cell-for-cell against the brute-force concrete
+//! must-relation + the `R_must ⊆ R_may` invariant.
+//!
+//! # R-F5.4.1 — the symbolic mu-calculus evaluator
+//!
+//! [`AbstractRelation::evaluate`] runs the mu-calculus directly over
+//! `R_may` / `R_must` by BDD image/preimage (box/diamond via
+//! `apply_exists(And,…)` on the predicate-var frame) + μ/ν Kleene fixpoint over
+//! the `(must, may)` [`TritBdd`], never materialising cube states. It is the
+//! `SymbolicKmts` counterpart sourced from the BTOR2-derived relation rather
+//! than a `Clts`; an atomic proposition `P_i`'s characteristic set is simply the
+//! present predicate var `p_i`. Supports the audited-sound **bare** fragment
+//! (`True`/`False`, predicates, `!`/`&&`/`||`, bare `[]`/`<>`, `mu`/`nu`);
+//! guards / controllability / step-bounds are an honest error. Validated
+//! cell-for-cell against `evaluate_tri` on the equivalent explicit cube-KMTS
+//! (nested νμ included). R-F5.4.2 then wires this behind `--engine symbolic`.
 
 use std::collections::HashMap;
 
@@ -92,6 +108,12 @@ use crate::adapter::btor2::bit_blast::eval_const_value;
 use crate::adapter::btor2::parser::bv_width;
 use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
 use crate::adapter::btor2::term_backend::{BvTermBackend, WalkError, walk_design};
+// R-F5.4.1 — the symbolic mu-calculus evaluator reuses the (must, may) `TritBdd`
+// pair + the crate `Trit` verdict; the mu-calculus `Node` is aliased to avoid a
+// clash with the BTOR2 `Node` above.
+use crate::mu_calculus::symbolic::TritBdd;
+use crate::mu_calculus::trit::Trit;
+use crate::mu_calculus::{Control, Formula, FormulaVarId, Guard, ModalKind, Node as MuNode};
 
 /// A bit-vector of BDDs, LSB-first: index `b` is the BDD for bit `b`. Every
 /// node's value carries exactly `width` bits.
@@ -545,7 +567,7 @@ impl BddBitBlaster {
         let k = predicates.len();
 
         // Allocate 2k fresh predicate vars at the bottom of the order: p_i then p'_i.
-        let (present, next) = self._manager.with_manager_exclusive(|m| {
+        let (present, next, present_varnos) = self._manager.with_manager_exclusive(|m| {
             let range = m.add_vars(2 * k as VarNo);
             let present: Vec<BDDFunction> = (0..k)
                 .map(|i| BDDFunction::var(m, range.start + i as VarNo).unwrap())
@@ -553,8 +575,14 @@ impl BddBitBlaster {
             let next: Vec<BDDFunction> = (0..k)
                 .map(|i| BDDFunction::var(m, range.start + (k + i) as VarNo).unwrap())
                 .collect();
-            (present, next)
+            let present_varnos: Vec<VarNo> = (0..k as VarNo).map(|i| range.start + i).collect();
+            (present, next, present_varnos)
         });
+        // The cube of next predicate vars (to quantify out in a preimage).
+        let mut next_cube = self.tt.clone();
+        for v in &next {
+            next_cube = next_cube.and(v).unwrap();
+        }
 
         // The present→next substitution: each register bit var ↦ its
         // bit-blasted next-state function. Registers without a `Next` line
@@ -611,44 +639,52 @@ impl BddBitBlaster {
             .apply_exists(BooleanOperator::And, &a_prime, &xi_cube)
             .unwrap();
 
-        // R_must, when requested. `A → φ` is `¬A ∨ φ`; a vacuously-empty cube
-        // (unsatisfiable predicate combination) yields `¬A ≡ ⊤` there, so the
-        // ∀ makes it a must-edge to every cube — which matches the vacuous
-        // truth of "for all (zero) states in an empty cube …".
-        let r_must = match must {
-            None => None,
-            Some(MustSemantics::ForallExists) => {
-                // ∀x. ( A(x,p) → ∃i. A'(x,i,p') )
-                let exists_i = a_prime.exists(&input_cube).unwrap();
-                Some(
+        // R_must, when requested. `A → φ` is `¬A ∨ φ`.
+        //
+        // A vacuously-empty (unsatisfiable) source cube yields `¬A ≡ ⊤` there,
+        // so the ∀ would make it a must-edge to *every* cube — breaking the KMTS
+        // invariant `R_must ⊆ R_may` (an empty cube has no may-edge). We
+        // intersect with the FEASIBLE present cubes `∃x. A(x,p)`: must-edges
+        // only leave inhabited abstract states (the lift never materialises an
+        // infeasible cube), so `R_must ⊆ R_may` holds globally over the whole
+        // `2^k` cube space — which the R-F5.4.1 evaluator relies on
+        // (`box.must ⊆ box.may`).
+        let r_must = must.map(|sem| {
+            let raw = match sem {
+                MustSemantics::ForallExists => {
+                    // ∀x. ( A(x,p) → ∃i. A'(x,i,p') )
+                    let exists_i = a_prime.exists(&input_cube).unwrap();
                     a.not()
                         .unwrap()
                         .or(&exists_i)
                         .unwrap()
                         .forall(&reg_cube)
-                        .unwrap(),
-                )
-            }
-            Some(MustSemantics::ForallForall) => {
-                // ∀(x ∪ i). ( A(x,p) → A'(x,i,p') )
-                Some(
+                        .unwrap()
+                }
+                MustSemantics::ForallForall => {
+                    // ∀(x ∪ i). ( A(x,p) → A'(x,i,p') )
                     a.not()
                         .unwrap()
                         .or(&a_prime)
                         .unwrap()
                         .forall(&xi_cube)
-                        .unwrap(),
-                )
-            }
-        };
+                        .unwrap()
+                }
+            };
+            let feasible_present = a.exists(&reg_cube).unwrap();
+            raw.and(&feasible_present).unwrap()
+        });
 
         Ok(AbstractRelation {
             num_predicates: k,
             present,
             next,
+            present_varnos,
+            next_cube,
             r_may,
             r_must,
             tt: self.tt.clone(),
+            ff: self.ff.clone(),
         })
     }
 }
@@ -676,11 +712,17 @@ pub struct AbstractRelation {
     present: Vec<BDDFunction>,
     /// Next-cube predicate variables `p'_0..p'_{k-1}`.
     next: Vec<BDDFunction>,
+    /// Variable numbers of the present predicate vars (for the present→next
+    /// rename in a preimage).
+    present_varnos: Vec<VarNo>,
+    /// The cube of next-cube predicate vars, to quantify out in a preimage.
+    next_cube: BDDFunction,
     /// The may relation as a BDD over `(p, p')`.
     r_may: BDDFunction,
     /// The must relation over `(p, p')`, when a [`MustSemantics`] was requested.
     r_must: Option<BDDFunction>,
     tt: BDDFunction,
+    ff: BDDFunction,
 }
 
 impl AbstractRelation {
@@ -737,6 +779,202 @@ impl AbstractRelation {
             .and(&self.cube_minterm(next_cube, &self.next))
             .unwrap();
         mt.and(r).unwrap() == mt
+    }
+
+    // ---- R-F5.4.1: the symbolic mu-calculus evaluator over the relation ----
+
+    /// `⊤` / `⊥` as `TritBdd`s over the present predicate vars (built directly
+    /// from the manager's constants, since we have no `SymbolicContext`).
+    fn tb_top(&self) -> TritBdd {
+        TritBdd::from_parts(self.tt.clone(), self.tt.clone())
+    }
+    fn tb_bot(&self) -> TritBdd {
+        TritBdd::from_parts(self.ff.clone(), self.ff.clone())
+    }
+
+    /// Rename a present-var function to the next-var frame (for a preimage).
+    fn to_next(&self, f: &BDDFunction) -> BDDFunction {
+        f.substitute(&Subst::new(self.present_varnos.clone(), self.next.clone()))
+            .unwrap()
+    }
+
+    /// 3-valued box preimage of `phi` (Bruns–Godefroid): `box.must` uses
+    /// `R_may`, `box.may` uses `R_must`. Mirrors [`crate::mu_calculus::symbolic`]'s
+    /// `SymbolicKmts::box_pre` on this relation's own predicate-var frame.
+    fn box_pre(&self, phi: &TritBdd, r_must: &BDDFunction) -> TritBdd {
+        use oxidd::{BooleanFunctionQuant, BooleanOperator};
+        let must_next = self.to_next(phi.must());
+        let box_must = self
+            .r_may
+            .apply_exists(
+                BooleanOperator::And,
+                &must_next.not().unwrap(),
+                &self.next_cube,
+            )
+            .unwrap()
+            .not()
+            .unwrap();
+        let may_next = self.to_next(phi.may());
+        let box_may = r_must
+            .apply_exists(
+                BooleanOperator::And,
+                &may_next.not().unwrap(),
+                &self.next_cube,
+            )
+            .unwrap()
+            .not()
+            .unwrap();
+        TritBdd::from_parts(box_must, box_may)
+    }
+
+    /// 3-valued diamond preimage of `phi`: `dia.must` uses `R_must`, `dia.may`
+    /// uses `R_may`.
+    fn diamond_pre(&self, phi: &TritBdd, r_must: &BDDFunction) -> TritBdd {
+        use oxidd::{BooleanFunctionQuant, BooleanOperator};
+        let must_next = self.to_next(phi.must());
+        let dia_must = r_must
+            .apply_exists(BooleanOperator::And, &must_next, &self.next_cube)
+            .unwrap();
+        let may_next = self.to_next(phi.may());
+        let dia_may = self
+            .r_may
+            .apply_exists(BooleanOperator::And, &may_next, &self.next_cube)
+            .unwrap();
+        TritBdd::from_parts(dia_must, dia_may)
+    }
+
+    /// R-F5.4.1 — evaluate a mu-calculus `formula` symbolically over this
+    /// abstract relation, returning a `(must, may)` verdict over the present
+    /// predicate cubes. `pred_names[i]` names predicate `P_i` (the atomic
+    /// proposition `P_i` holds exactly on the cubes where bit `i` is set —
+    /// i.e. its characteristic set is the present var `p_i`).
+    ///
+    /// Supports the **audited-sound bare fragment** the cube path evaluates:
+    /// `True`/`False`, predicates, `!`/`&&`/`||`, bare `[]`/`<>`, `mu`/`nu`.
+    /// A guarded / controllability / step-bounded modality is an honest error
+    /// (as in [`crate::mu_calculus::symbolic`]'s `SymbolicKmts`). Requires a
+    /// relation built *with* a [`MustSemantics`] (the modal steps read
+    /// `R_must`).
+    pub fn evaluate(&self, formula: &Formula, pred_names: &[String]) -> Result<TritBdd, String> {
+        let r_must = self.r_must.as_ref().ok_or_else(|| {
+            "AbstractRelation::evaluate requires a must relation — build with a MustSemantics"
+                .to_string()
+        })?;
+        let name_to_idx: HashMap<&str, usize> = pred_names
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.as_str(), i))
+            .collect();
+        let mut bindings: HashMap<FormulaVarId, TritBdd> = HashMap::new();
+        self.eval_node(formula, formula.root(), &name_to_idx, r_must, &mut bindings)
+    }
+
+    fn eval_node(
+        &self,
+        f: &Formula,
+        id: crate::mu_calculus::NodeId,
+        names: &HashMap<&str, usize>,
+        r_must: &BDDFunction,
+        bindings: &mut HashMap<FormulaVarId, TritBdd>,
+    ) -> Result<TritBdd, String> {
+        Ok(match f.node(id) {
+            MuNode::True => self.tb_top(),
+            MuNode::False => self.tb_bot(),
+            MuNode::Predicate(name) => match names.get(name.as_str()) {
+                // The AP's characteristic set is the present predicate var; the
+                // cube valuation is definite (Sharp), so must = may = p_i.
+                Some(&i) => TritBdd::from_parts(self.present[i].clone(), self.present[i].clone()),
+                None => self.tb_bot(),
+            },
+            MuNode::Variable(v) => bindings
+                .get(v)
+                .cloned()
+                .ok_or_else(|| format!("unbound fixpoint variable {v:?}"))?,
+            MuNode::Not(n) => self.eval_node(f, *n, names, r_must, bindings)?.not(),
+            MuNode::And(a, b) => {
+                let av = self.eval_node(f, *a, names, r_must, bindings)?;
+                let bv = self.eval_node(f, *b, names, r_must, bindings)?;
+                av.and(&bv)
+            }
+            MuNode::Or(a, b) => {
+                let av = self.eval_node(f, *a, names, r_must, bindings)?;
+                let bv = self.eval_node(f, *b, names, r_must, bindings)?;
+                av.or(&bv)
+            }
+            MuNode::Modal {
+                kind,
+                guard,
+                target,
+            } => {
+                if guard.control != Control::All {
+                    return Err(
+                        "symbolic cube evaluator: controllability guards (`ctrl`) unsupported"
+                            .into(),
+                    );
+                }
+                if guard.max_steps.is_some() {
+                    return Err(
+                        "symbolic cube evaluator: step-bounded modalities (`steps`) unsupported"
+                            .into(),
+                    );
+                }
+                if *guard != Guard::default() {
+                    return Err(
+                        "symbolic cube evaluator: label / state-var guards unsupported (bare `[]`/`<>` only)".into(),
+                    );
+                }
+                let phi = self.eval_node(f, *target, names, r_must, bindings)?;
+                match kind {
+                    ModalKind::Box => self.box_pre(&phi, r_must),
+                    ModalKind::Diamond => self.diamond_pre(&phi, r_must),
+                }
+            }
+            MuNode::Mu { var, body } => {
+                self.fixpoint(f, *var, *body, names, r_must, bindings, false)?
+            }
+            MuNode::Nu { var, body } => {
+                self.fixpoint(f, *var, *body, names, r_must, bindings, true)?
+            }
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn fixpoint(
+        &self,
+        f: &Formula,
+        var: FormulaVarId,
+        body: crate::mu_calculus::NodeId,
+        names: &HashMap<&str, usize>,
+        r_must: &BDDFunction,
+        bindings: &mut HashMap<FormulaVarId, TritBdd>,
+        greatest: bool,
+    ) -> Result<TritBdd, String> {
+        let mut x = if greatest {
+            self.tb_top()
+        } else {
+            self.tb_bot()
+        };
+        loop {
+            bindings.insert(var, x.clone());
+            let next = self.eval_node(f, body, names, r_must, bindings)?;
+            if next.eq_set(&x) {
+                bindings.remove(&var);
+                return Ok(next);
+            }
+            x = next;
+        }
+    }
+
+    /// The trit verdict of an evaluated formula at cube `cube`.
+    pub fn verdict_at(&self, verdict: &TritBdd, cube: usize) -> Trit {
+        let mt = self.cube_minterm(cube, &self.present);
+        if mt.and(verdict.must()).unwrap() == mt {
+            Trit::True
+        } else if mt.and(verdict.may()).unwrap() == mt {
+            Trit::Unknown
+        } else {
+            Trit::False
+        }
     }
 }
 
@@ -1476,13 +1714,19 @@ mod tests {
         }
 
         for ci in 0..(1usize << k) {
-            let reaches = by_cube.get(&ci).map(|v| v.as_slice()).unwrap_or(&[]);
             for cj in 0..(1usize << k) {
-                let expected = match semantics {
-                    MustSemantics::ForallExists => reaches.iter().all(|r| r.contains(&cj)),
-                    MustSemantics::ForallForall => {
-                        reaches.iter().all(|r| r.len() == 1 && r.contains(&cj))
-                    }
+                // An infeasible source cube (no concrete state maps to it) has
+                // NO must-edge — the relation restricts must-edges to feasible
+                // sources so `R_must ⊆ R_may` holds globally. A feasible cube
+                // uses the ∀∃ / ∀∀ definition over its inhabitants.
+                let expected = match by_cube.get(&ci) {
+                    None => false,
+                    Some(reaches) => match semantics {
+                        MustSemantics::ForallExists => reaches.iter().all(|r| r.contains(&cj)),
+                        MustSemantics::ForallForall => {
+                            reaches.iter().all(|r| r.len() == 1 && r.contains(&cj))
+                        }
+                    },
                 };
                 assert_eq!(
                     rel.must_holds(ci, cj),
@@ -1606,5 +1850,181 @@ mod tests {
                 }
             }
         }
+    }
+
+    // ---- R-F5.4.1: symbolic cube evaluator ≡ evaluate_tri ----
+
+    /// Build the abstract relation, materialise the equivalent explicit
+    /// cube-KMTS (feasible cubes as states, may/must edges + definite cube AP
+    /// labels), and assert the symbolic evaluator agrees with `evaluate_tri`
+    /// on every `formula_str` at every feasible cube.
+    fn assert_symbolic_eval_matches_tri(
+        src: &str,
+        predicates: &[PredicateExpr],
+        names: &[&str],
+        states: &[(&str, u32)],
+        formulas: &[&str],
+    ) {
+        use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, TransitionModality, Tristate};
+        use crate::mu_calculus::evaluator::{Environment, evaluate_tri};
+
+        let file = parser::parse(src).expect("parse");
+        let bb = BddBitBlaster::build(&file).expect("build");
+        let rel = bb
+            .abstract_relation(predicates, Some(MustSemantics::ForallExists))
+            .expect("relation");
+
+        let cube_of = |regs: &HashMap<String, u128>| -> usize {
+            let mut c = 0usize;
+            for (i, p) in predicates.iter().enumerate() {
+                if p.eval(regs) {
+                    c |= 1 << i;
+                }
+            }
+            c
+        };
+
+        // Feasible cubes: those inhabited by at least one concrete register state.
+        let total_state_bits: u32 = states.iter().map(|(_, w)| *w).sum();
+        let mut feasible_set: std::collections::BTreeSet<usize> = Default::default();
+        for scombo in 0..(1u128 << total_state_bits) {
+            let mut regs: HashMap<String, u128> = HashMap::new();
+            let mut off = 0u32;
+            for (name, w) in states {
+                let mask = (1u128 << w) - 1;
+                regs.insert((*name).to_string(), (scombo >> off) & mask);
+                off += w;
+            }
+            feasible_set.insert(cube_of(&regs));
+        }
+        let feasible: Vec<usize> = feasible_set.into_iter().collect();
+        let n = feasible.len();
+
+        // Explicit cube-KMTS over the feasible cubes.
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        for j in 0..n {
+            b.state(format!("c{j}"));
+        }
+        b.initial("c0");
+        let step = b.labels().intern(["step"]).unwrap();
+        let ids: Vec<_> = (0..n)
+            .map(|j| b.state_id_or_insert(format!("c{j}")).unwrap())
+            .collect();
+        for (j, &ci) in feasible.iter().enumerate() {
+            for (i, nm) in names.iter().enumerate() {
+                let v = if (ci >> i) & 1 == 1 {
+                    Tristate::KleeneT
+                } else {
+                    Tristate::KleeneF
+                };
+                b.with_3valued_predicate(ids[j], *nm, v);
+            }
+        }
+        for (j, &ci) in feasible.iter().enumerate() {
+            for (l, &cj) in feasible.iter().enumerate() {
+                if rel.must_holds(ci, cj) {
+                    b.transition_ids_with_modality(
+                        ids[j],
+                        &[step],
+                        ids[l],
+                        TransitionModality::Sharp,
+                    );
+                } else if rel.may_holds(ci, cj) {
+                    b.transition_ids_with_modality(
+                        ids[j],
+                        &[step],
+                        ids[l],
+                        TransitionModality::MayOnly,
+                    );
+                }
+            }
+        }
+        let clts = b.build().expect("clts builds");
+
+        let names_owned: Vec<String> = names.iter().map(|s| s.to_string()).collect();
+        let env = Environment::new(clts.state_count());
+        for formula_str in formulas {
+            let formula = crate::mu_calculus::parser::parse(formula_str).expect("formula parses");
+            let tri = evaluate_tri(&formula, &clts, &env).expect("evaluate_tri");
+            let sym = rel
+                .evaluate(&formula, &names_owned)
+                .expect("symbolic evaluate");
+            for (j, &ci) in feasible.iter().enumerate() {
+                assert_eq!(
+                    rel.verdict_at(&sym, ci),
+                    tri.verdict_at(j),
+                    "cube {ci} (state c{j}), formula `{formula_str}`"
+                );
+            }
+        }
+    }
+
+    /// The full unguarded fragment (bare `[]`/`<>`, boolean ops, nested νμ) on
+    /// the saturating counter, predicates `p = (cnt == 0)`, `q = (cnt ≥ 2)`.
+    #[test]
+    fn rf5_4_1_symbolic_eval_matches_tri_saturating_counter() {
+        let predicates = [
+            PredicateExpr::eq("cnt", 0),
+            PredicateExpr::Cmp {
+                register: "cnt".to_string(),
+                op: CmpOp::Ge,
+                value: 2,
+            },
+        ];
+        let formulas = [
+            "[] p",
+            "<> p",
+            "[] q",
+            "<> q",
+            "not q",
+            "p or q",
+            "p and q",
+            "nu X. p and [] X",                   // AG p
+            "mu X. q or <> X",                    // EF q
+            "nu X. (not p) and [] X",             // AG ¬p
+            "nu Y. (mu X. (q or <> X)) and [] Y", // AG EF q (nested νμ)
+        ];
+        assert_symbolic_eval_matches_tri(
+            SATURATING_COUNTER_BTOR2,
+            &predicates,
+            &["p", "q"],
+            &[("cnt", 2)],
+            &formulas,
+        );
+    }
+
+    /// Two registers stepping together, with a relational predicate — exercises
+    /// a KMTS with `MayOnly` edges (input nondeterminism) so the `⊥` verdicts
+    /// are non-trivial.
+    #[test]
+    fn rf5_4_1_symbolic_eval_matches_tri_two_registers() {
+        let predicates = [
+            PredicateExpr::CmpReg {
+                lhs: "cnt".to_string(),
+                op: CmpOp::Eq,
+                rhs: "acc".to_string(),
+            },
+            PredicateExpr::Cmp {
+                register: "cnt".to_string(),
+                op: CmpOp::Ge,
+                value: 2,
+            },
+            PredicateExpr::eq("acc", 0),
+        ];
+        let formulas = [
+            "[] p",
+            "<> p",
+            "<> (p and q)",
+            "nu X. p and [] X",
+            "mu X. r or <> X",
+            "nu Y. (mu X. (p or <> X)) and [] Y",
+        ];
+        assert_symbolic_eval_matches_tri(
+            TWO_REGISTER_BTOR2,
+            &predicates,
+            &["p", "q", "r"],
+            &[("cnt", 2), ("acc", 2)],
+            &formulas,
+        );
     }
 }

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -639,16 +639,20 @@ impl BddBitBlaster {
             .apply_exists(BooleanOperator::And, &a_prime, &xi_cube)
             .unwrap();
 
+        // The FEASIBLE present cubes `∃x. A(x,p)` — the cubes some concrete
+        // register state inhabits. Used to restrict `R_must` (below) and to
+        // scope the verdict tally (R-F5.4.2) to materialisable abstract states.
+        let feasible_present = a.exists(&reg_cube).unwrap();
+
         // R_must, when requested. `A → φ` is `¬A ∨ φ`.
         //
         // A vacuously-empty (unsatisfiable) source cube yields `¬A ≡ ⊤` there,
         // so the ∀ would make it a must-edge to *every* cube — breaking the KMTS
         // invariant `R_must ⊆ R_may` (an empty cube has no may-edge). We
-        // intersect with the FEASIBLE present cubes `∃x. A(x,p)`: must-edges
-        // only leave inhabited abstract states (the lift never materialises an
-        // infeasible cube), so `R_must ⊆ R_may` holds globally over the whole
-        // `2^k` cube space — which the R-F5.4.1 evaluator relies on
-        // (`box.must ⊆ box.may`).
+        // intersect with `feasible_present`: must-edges only leave inhabited
+        // abstract states (the lift never materialises an infeasible cube), so
+        // `R_must ⊆ R_may` holds globally over the whole `2^k` cube space —
+        // which the R-F5.4.1 evaluator relies on (`box.must ⊆ box.may`).
         let r_must = must.map(|sem| {
             let raw = match sem {
                 MustSemantics::ForallExists => {
@@ -671,12 +675,12 @@ impl BddBitBlaster {
                         .unwrap()
                 }
             };
-            let feasible_present = a.exists(&reg_cube).unwrap();
             raw.and(&feasible_present).unwrap()
         });
 
         Ok(AbstractRelation {
             num_predicates: k,
+            feasible_present,
             present,
             next,
             present_varnos,
@@ -708,6 +712,9 @@ pub enum MustSemantics {
 /// `0..2^k`; bit `i` of the index is the truth of predicate `P_i`.
 pub struct AbstractRelation {
     num_predicates: usize,
+    /// The feasible present cubes `∃x. A(x,p)` — a BDD over the present
+    /// predicate vars marking the cubes inhabited by some concrete state.
+    feasible_present: BDDFunction,
     /// Present-cube predicate variables `p_0..p_{k-1}`.
     present: Vec<BDDFunction>,
     /// Next-cube predicate variables `p'_0..p'_{k-1}`.
@@ -729,6 +736,20 @@ impl AbstractRelation {
     /// Number of predicates `k` (so `2^k` cubes).
     pub fn num_predicates(&self) -> usize {
         self.num_predicates
+    }
+
+    /// Is cube `cube` feasible — inhabited by at least one concrete state?
+    /// Infeasible cubes are never materialised as abstract states.
+    pub fn is_feasible(&self, cube: usize) -> bool {
+        let mt = self.cube_minterm(cube, &self.present);
+        mt.and(&self.feasible_present).unwrap() == mt
+    }
+
+    /// The feasible cube indices, ascending.
+    pub fn feasible_cubes(&self) -> Vec<usize> {
+        (0..(1usize << self.num_predicates))
+            .filter(|&c| self.is_feasible(c))
+            .collect()
     }
 
     /// The may relation BDD over the present + next predicate variables.

--- a/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
@@ -1,0 +1,353 @@
+//! R-F5.4.2 (2026-07-03) — the **symbolic predicate-cube engine**: compute the
+//! per-cube 3-valued verdicts of a mu-calculus property via the R-F5.3/R-F5.4.1
+//! symbolic BDD relation, instead of the explicit `predicate_cube_lift`
+//! (`O(2^2|P|)` SMT edge construction + `2^|P|` cube materialisation).
+//!
+//! This is the integration seam between the symbolic engine
+//! ([`crate::adapter::btor2::symbolic_bitblast`]) and the predicate-cube
+//! surface the CEGAR / verify-auto path speaks in ([`PredicateSpec`] +
+//! `compound_exprs` + a mu-calculus [`Formula`]). It:
+//!
+//! 1. bit-blasts the BTOR2 transition function to BDDs (R-F5.3a),
+//! 2. compiles each [`PredicateSpec`] (or its compound
+//!    [`PredicateExpr`](crate::adapter::btor2::predicate_expr::PredicateExpr))
+//!    to a predicate BDD (R-F5.3b),
+//! 3. builds the abstract may/must relation (R-F5.3c/d),
+//! 4. evaluates the formula by BDD image/preimage + μ/ν fixpoint (R-F5.4.1),
+//! 5. tallies the `{T, F, ⊥}` verdict over the **feasible** cubes (the cubes the
+//!    explicit lift would materialise as abstract states).
+//!
+//! The verdict at each feasible cube is the same one `evaluate_tri` produces on
+//! the explicitly-lifted KMTS (pinned by the R-F5.4.1 differential) — but built
+//! without a single per-cube-pair SMT query, which is the H.H.c unblock.
+
+use std::collections::HashMap;
+
+use crate::adapter::btor2::predicate_expr::PredicateExpr;
+use crate::adapter::btor2::symbolic_bitblast::{BddBitBlaster, MustSemantics};
+use crate::adapter::{AdapterError, AdapterErrorKind};
+use crate::mu_calculus::Formula;
+use crate::mu_calculus::trit::Trit;
+
+pub use crate::adapter::btor2::kmts_lift::PredicateSpec;
+
+/// The per-cube verdict tally from the symbolic engine.
+#[derive(Debug, Clone)]
+pub struct SymbolicCubeVerdicts {
+    /// Number of predicates `k` (the cube space is `2^k`, of which the feasible
+    /// subset is materialisable).
+    pub num_predicates: usize,
+    /// `(cube_index, verdict)` for every **feasible** cube, ascending by index.
+    /// Cube `c`'s bit `i` is the truth of `predicates[i]`.
+    pub cube_verdicts: Vec<(usize, Trit)>,
+    /// Count of definite-true (`KleeneT`) feasible cubes.
+    pub definite_true: usize,
+    /// Count of definite-false (`KleeneF`) feasible cubes.
+    pub definite_false: usize,
+    /// Count of indefinite (`KleeneBot`, ⊥) feasible cubes.
+    pub bottom: usize,
+}
+
+fn ir_err(message: String) -> AdapterError {
+    AdapterError {
+        kind: AdapterErrorKind::IrConsistencyError,
+        message: format!("adapter/btor2/symbolic_engine: {message}"),
+        location: None,
+    }
+}
+
+/// Compile a [`PredicateSpec`] to a [`PredicateExpr`]: a compound expression
+/// (keyed by the spec's `name` in `compound_exprs`) takes precedence; otherwise
+/// the simple `register == value` atom.
+fn spec_to_expr(
+    spec: &PredicateSpec,
+    compound_exprs: &HashMap<String, PredicateExpr>,
+) -> PredicateExpr {
+    compound_exprs
+        .get(&spec.name)
+        .cloned()
+        .unwrap_or_else(|| PredicateExpr::eq(spec.register.clone(), spec.value))
+}
+
+/// R-F5.4.2 — evaluate `formula` over the predicate cube abstraction of the
+/// BTOR2 design, symbolically. Returns the per-feasible-cube `{T, F, ⊥}`
+/// verdict tally.
+///
+/// `must_semantics` selects the must-edge form ([`MustSemantics::ForallExists`]
+/// is the canonical KMTS must-edge and the right default). The formula must be
+/// in the audited-sound **bare** fragment (`True`/`False`, predicates,
+/// `!`/`&&`/`||`, bare `[]`/`<>`, `mu`/`nu`); a guarded / controllability /
+/// step-bounded modality is a hard error.
+pub fn symbolic_cube_verdicts(
+    btor2_content: &str,
+    predicates: &[PredicateSpec],
+    compound_exprs: &HashMap<String, PredicateExpr>,
+    formula: &Formula,
+    must_semantics: MustSemantics,
+) -> Result<SymbolicCubeVerdicts, AdapterError> {
+    let file = crate::adapter::btor2::parser::parse(btor2_content).map_err(|mut e| {
+        e.message = format!("adapter/btor2/symbolic_engine: {}", e.message);
+        e
+    })?;
+
+    let bb = BddBitBlaster::build(&file).map_err(ir_err)?;
+
+    let exprs: Vec<PredicateExpr> = predicates
+        .iter()
+        .map(|spec| spec_to_expr(spec, compound_exprs))
+        .collect();
+    let names: Vec<String> = predicates.iter().map(|s| s.name.clone()).collect();
+
+    let rel = bb
+        .abstract_relation(&exprs, Some(must_semantics))
+        .map_err(ir_err)?;
+    let verdict = rel.evaluate(formula, &names).map_err(ir_err)?;
+
+    let mut cube_verdicts = Vec::new();
+    let (mut t, mut f, mut b) = (0usize, 0usize, 0usize);
+    for cube in rel.feasible_cubes() {
+        let v = rel.verdict_at(&verdict, cube);
+        match v {
+            Trit::True => t += 1,
+            Trit::False => f += 1,
+            Trit::Unknown => b += 1,
+        }
+        cube_verdicts.push((cube, v));
+    }
+
+    Ok(SymbolicCubeVerdicts {
+        num_predicates: predicates.len(),
+        cube_verdicts,
+        definite_true: t,
+        definite_false: f,
+        bottom: b,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::predicate_expr::CmpOp;
+    use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, TransitionModality, Tristate};
+    use crate::mu_calculus::evaluator::{Environment, evaluate_tri};
+
+    // A 2-bit saturating counter with an enable — the R-F5.3/4 fixture.
+    const SAT_COUNTER: &str = r#"
+1 sort bitvec 2
+2 sort bitvec 1
+3 state 1 cnt
+4 input 2 en
+5 one 1
+6 ones 1
+7 add 1 3 5
+8 eq 2 3 6
+9 ite 1 8 3 7
+10 ite 1 4 9 3
+11 next 1 3 10
+"#;
+
+    /// Ground truth: build the explicit cube-KMTS over feasible cubes (from the
+    /// concrete `simulate_one_step` relation) + AP labels, run `evaluate_tri`,
+    /// and return the per-feasible-cube verdict list — fully independent of the
+    /// symbolic engine under test.
+    fn tri_oracle(
+        btor2: &str,
+        exprs: &[PredicateExpr],
+        names: &[&str],
+        states: &[(&str, u32)],
+        formula_str: &str,
+    ) -> Vec<(usize, Trit)> {
+        use crate::adapter::btor2::bit_blast::simulate_one_step;
+        use crate::adapter::btor2::parser;
+
+        let file = parser::parse(btor2).expect("parse");
+        let cube_of = |regs: &HashMap<String, u128>| -> usize {
+            let mut c = 0usize;
+            for (i, p) in exprs.iter().enumerate() {
+                if p.eval(regs) {
+                    c |= 1 << i;
+                }
+            }
+            c
+        };
+        let total_state_bits: u32 = states.iter().map(|(_, w)| *w).sum();
+        // Enumerate every concrete (register, input) → collect feasible cubes +
+        // the may/must edges (∀∃ must: a cube-edge is must iff every state in the
+        // source cube reaches the target under some input).
+        let inputs: Vec<(String, u32)> = file_inputs(&file);
+        let total_input_bits: u32 = inputs.iter().map(|(_, w)| *w).sum();
+        let mut by_cube: HashMap<usize, Vec<std::collections::HashSet<usize>>> = HashMap::new();
+        for scombo in 0..(1u128 << total_state_bits) {
+            let mut regs: HashMap<String, u128> = HashMap::new();
+            let mut off = 0u32;
+            for (name, w) in states {
+                let mask = (1u128 << w) - 1;
+                regs.insert((*name).to_string(), (scombo >> off) & mask);
+                off += w;
+            }
+            let present = cube_of(&regs);
+            let mut reach = std::collections::HashSet::new();
+            for icombo in 0..(1u128 << total_input_bits) {
+                let mut inps: HashMap<String, u128> = HashMap::new();
+                let mut ioff = 0u32;
+                for (name, w) in &inputs {
+                    let mask = (1u128 << w) - 1;
+                    inps.insert(name.clone(), (icombo >> ioff) & mask);
+                    ioff += w;
+                }
+                let next = simulate_one_step(&file, &regs, &inps).expect("step");
+                let mut rn = regs.clone();
+                rn.extend(next);
+                reach.insert(cube_of(&rn));
+            }
+            by_cube.entry(present).or_default().push(reach);
+        }
+
+        let feasible: Vec<usize> = {
+            let mut v: Vec<usize> = by_cube.keys().copied().collect();
+            v.sort_unstable();
+            v
+        };
+        let idx: HashMap<usize, usize> =
+            feasible.iter().enumerate().map(|(j, &c)| (c, j)).collect();
+
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        for j in 0..feasible.len() {
+            b.state(format!("c{j}"));
+        }
+        b.initial("c0");
+        let step = b.labels().intern(["step"]).unwrap();
+        let ids: Vec<_> = (0..feasible.len())
+            .map(|j| b.state_id_or_insert(format!("c{j}")).unwrap())
+            .collect();
+        for (j, &ci) in feasible.iter().enumerate() {
+            for (i, nm) in names.iter().enumerate() {
+                let v = if (ci >> i) & 1 == 1 {
+                    Tristate::KleeneT
+                } else {
+                    Tristate::KleeneF
+                };
+                b.with_3valued_predicate(ids[j], *nm, v);
+            }
+        }
+        for (&ci, reaches) in &by_cube {
+            let src = ids[idx[&ci]];
+            // may target: union of all reach sets; must target: in every reach set.
+            let mut may: std::collections::HashSet<usize> = Default::default();
+            for r in reaches {
+                may.extend(r);
+            }
+            for &cj in &may {
+                let is_must = reaches.iter().all(|r| r.contains(&cj));
+                let m = if is_must {
+                    TransitionModality::Sharp
+                } else {
+                    TransitionModality::MayOnly
+                };
+                b.transition_ids_with_modality(src, &[step], ids[idx[&cj]], m);
+            }
+        }
+        let clts = b.build().expect("clts");
+
+        let formula = crate::mu_calculus::parser::parse(formula_str).expect("formula");
+        let env = Environment::new(clts.state_count());
+        let tri = evaluate_tri(&formula, &clts, &env).expect("evaluate_tri");
+        feasible
+            .iter()
+            .enumerate()
+            .map(|(j, &c)| (c, tri.verdict_at(j)))
+            .collect()
+    }
+
+    fn file_inputs(file: &crate::adapter::btor2::ast::Btor2File) -> Vec<(String, u32)> {
+        use crate::adapter::btor2::ast::Node;
+        use crate::adapter::btor2::parser::bv_width;
+        let mut out = Vec::new();
+        for line in &file.lines {
+            if let Node::Input { sort, symbol } = &line.node {
+                let w = bv_width(file, *sort).unwrap_or(0);
+                let name = symbol
+                    .clone()
+                    .unwrap_or_else(|| format!("input_{}", line.nid));
+                out.push((name, w));
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn rf5_4_2_symbolic_engine_matches_tri_via_predicate_specs() {
+        // Predicates through the real API: p = (cnt == 0) as a simple spec,
+        // q = (cnt >= 2) as a compound expr keyed by name.
+        let specs = vec![
+            PredicateSpec {
+                name: "p".to_string(),
+                register: "cnt".to_string(),
+                value: 0,
+            },
+            PredicateSpec {
+                name: "q".to_string(),
+                register: "cnt".to_string(),
+                value: 2, // unused (compound below), kept for the API shape
+            },
+        ];
+        let mut compound: HashMap<String, PredicateExpr> = HashMap::new();
+        compound.insert(
+            "q".to_string(),
+            PredicateExpr::Cmp {
+                register: "cnt".to_string(),
+                op: CmpOp::Ge,
+                value: 2,
+            },
+        );
+        let exprs = [
+            PredicateExpr::eq("cnt", 0),
+            PredicateExpr::Cmp {
+                register: "cnt".to_string(),
+                op: CmpOp::Ge,
+                value: 2,
+            },
+        ];
+
+        let formulas = [
+            "[] p",
+            "<> q",
+            "nu X. (not q) and [] X",
+            "mu X. q or <> X",
+            "nu Y. (mu X. (q or <> X)) and [] Y",
+        ];
+
+        for formula_str in formulas {
+            let formula = crate::mu_calculus::parser::parse(formula_str).expect("formula");
+            let got = symbolic_cube_verdicts(
+                SAT_COUNTER,
+                &specs,
+                &compound,
+                &formula,
+                MustSemantics::ForallExists,
+            )
+            .expect("symbolic verdicts");
+
+            let want = tri_oracle(SAT_COUNTER, &exprs, &["p", "q"], &[("cnt", 2)], formula_str);
+
+            assert_eq!(
+                got.cube_verdicts, want,
+                "symbolic engine ≠ evaluate_tri for `{formula_str}`"
+            );
+            // Tally consistency.
+            let (mut t, mut f, mut b) = (0, 0, 0);
+            for (_, v) in &got.cube_verdicts {
+                match v {
+                    Trit::True => t += 1,
+                    Trit::False => f += 1,
+                    Trit::Unknown => b += 1,
+                }
+            }
+            assert_eq!(
+                (got.definite_true, got.definite_false, got.bottom),
+                (t, f, b),
+                "tally consistent for `{formula_str}`"
+            );
+        }
+    }
+}

--- a/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
@@ -350,4 +350,83 @@ mod tests {
             );
         }
     }
+
+    /// A `w`-bit saturating-free counter `r` with an enable: `r' = en ? r+1 : r`,
+    /// plus `k` mutually-exclusive equality predicates `r == 0 .. r == k-1`.
+    fn counter_btor2(w: u32) -> String {
+        format!(
+            "\n1 sort bitvec {w}\n2 sort bitvec 1\n3 state 1 r\n4 input 2 en\n5 one 1\n6 add 1 3 5\n7 ite 1 4 6 3\n8 next 1 3 7\n"
+        )
+    }
+
+    fn eq_predicates(k: usize) -> (Vec<PredicateSpec>, HashMap<String, PredicateExpr>) {
+        let specs = (0..k)
+            .map(|i| PredicateSpec {
+                name: format!("p{i}"),
+                register: "r".to_string(),
+                value: i as u64,
+            })
+            .collect();
+        (specs, HashMap::new())
+    }
+
+    /// R-F5.4.3 — scaling measurement: the symbolic engine builds the abstract
+    /// relation + evaluates at `|P|` up to 12 (a `2^24`-cube-pair space) in well
+    /// under the explicit `SmtAllPairs` path's `O(2^2|P|)` SMT wall (the H.H.c
+    /// "29 min, no output" at `|P| ≈ 12`). This test asserts completion + a
+    /// consistent tally at each `|P|`, and prints the wall-clock so the win is
+    /// visible with `--nocapture`. The bound (30 s) only trips on a catastrophic
+    /// BDD blow-up — it is not a micro-benchmark.
+    #[test]
+    fn rf5_4_3_symbolic_scales_past_the_smt_wall() {
+        use std::time::Instant;
+        let formula = crate::mu_calculus::parser::parse("mu X. p0 or <> X").expect("formula");
+
+        for &k in &[4usize, 8, 12] {
+            let w = 12u32; // 4096 concrete states — plenty to inhabit the k cubes
+            let btor2 = counter_btor2(w);
+            let (specs, compound) = eq_predicates(k);
+
+            let start = Instant::now();
+            let got = symbolic_cube_verdicts(
+                &btor2,
+                &specs,
+                &compound,
+                &formula,
+                MustSemantics::ForallExists,
+            )
+            .expect("symbolic verdicts");
+            let elapsed = start.elapsed();
+
+            // k mutually-exclusive eq-predicates ⇒ k singleton cubes + the
+            // all-false cube = k+1 feasible cubes.
+            assert_eq!(
+                got.cube_verdicts.len(),
+                k + 1,
+                "|P|={k}: expected {} feasible cubes",
+                k + 1
+            );
+            assert_eq!(
+                got.definite_true + got.definite_false + got.bottom,
+                got.cube_verdicts.len(),
+                "|P|={k}: tally covers every feasible cube"
+            );
+            // p0 (r==0) is definitely satisfied by `mu X. p0 or <> X`.
+            assert!(got.definite_true >= 1, "|P|={k}: EF(r==0) holds at r==0");
+
+            eprintln!(
+                "R-F5.4.3  |P|={k:>2}  ({} cube-pairs for the explicit SMT path)  \
+                 symbolic: {:>8.3?}  T={} F={} ⊥={}",
+                1u64 << (2 * k),
+                elapsed,
+                got.definite_true,
+                got.definite_false,
+                got.bottom
+            );
+            assert!(
+                elapsed.as_secs() < 30,
+                "|P|={k}: symbolic path took {elapsed:?} — investigate BDD blow-up"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Turns the R-F5.3 symbolic **relation** into a usable **engine**: evaluate a mu-calculus property over the predicate-cube abstraction entirely symbolically, and prove it scales past the explicit path's `O(2^2|P|)` SMT wall. Three cohesive commits.

## R-F5.4.1 — symbolic mu-calculus evaluator
`AbstractRelation::evaluate(formula, pred_names)` runs BDD image/preimage over `R_may` / `R_must` (box/diamond via `apply_exists(And,…)` on the predicate-var frame) + a μ/ν Kleene fixpoint over the `(must, may)` `TritBdd` — the `SymbolicKmts` counterpart sourced from the BTOR2-derived relation. Bare audited-sound fragment (`True`/`False`, predicates, `!`/`&&`/`||`, bare `[]`/`<>`, `mu`/`nu`); guards are an honest error. Validated cell-for-cell vs `evaluate_tri` on the equivalent explicit cube-KMTS (nested νμ incl.).

**Soundness fix folded in:** `R_must` is restricted to *feasible* source cubes (`∧ ∃x. A(x,p)`), so `R_must ⊆ R_may` holds globally over the whole `2^k` cube space (an infeasible cube was vacuously a ∀-must-edge to everything yet has no may-edge, violating the KMTS invariant). Infeasible cubes are never materialised, so this only drops meaningless edges; the R-F5.3d oracle is updated to match.

## R-F5.4.2a — engine integration
`symbolic_engine::symbolic_cube_verdicts(btor2_content, predicates, compound_exprs, formula, must_semantics)` takes the real API types (`PredicateSpec` + compound `PredicateExpr` map) and returns the per-feasible-cube `{T, F, ⊥}` tally. `AbstractRelation` gains `feasible_present` + `is_feasible` / `feasible_cubes`. Validated end-to-end vs `evaluate_tri` across 5 formulas through the `PredicateSpec` API (simple + compound predicates).

## R-F5.4.3 — scaling proof (the go/no-go)

| \|P\| | explicit SMT cube-pairs | symbolic |
|---|---|---|
| 4 | 256 | ~1.5 ms |
| 8 | 65 536 | ~1.8 ms |
| **12** | **16 777 216 (2²⁴)** | **~10.6 ms** |

At \|P\|=12 — the H.H.c residual size where the explicit `SmtAllPairs` path issues ~16.7M SMT queries (the documented 29-min "no output" wall) — the symbolic path finishes in ~10 ms. No BDD blow-up; ~1000× headroom under the 30 s guard. **The R-F5 thesis is demonstrated end-to-end.**

## Next
- **R-F5.4.2b** — `--engine symbolic` opt-in on `btor2 cegar` (CLI + API + UI parity), single-shot symbolic verdict at the initial predicate set.
- **R-F5.4.4** — flip the default once at verdict parity + broader-fixture validation (a user-gated production-behaviour decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)