### PR TITLE
feat(R-F5.4.2b): --engine symbolic opt-in on btor2/sv cegar (CLI + API)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -172,6 +172,29 @@ enum MayEdgeInferenceArg {
     SmtAllPairs,
 }
 
+/// R-F5.4.2b (2026-07-03) — which predicate-cube engine evaluates the
+/// property. Mirrors the two edge-construction strategies.
+#[derive(Clone, Debug, Copy, clap::ValueEnum, Default, PartialEq, Eq)]
+enum EngineArg {
+    /// Explicit predicate-cube lift + CEGAR refinement loop (default): the
+    /// may/must edges are built with SMT (`O(2^2|P|)` at `--may/must-edge-inference`
+    /// = smt), which is the scaling wall at large `|P|`. Supports the full
+    /// refinement loop, `--predicate-source`, sidecar compound predicates, etc.
+    #[default]
+    Explicit,
+    /// R-F5 symbolic engine: build the may/must transition relation as BDDs
+    /// directly from the BTOR2 (no per-cube-pair SMT) and evaluate the formula
+    /// by BDD image/preimage + μ/ν fixpoint. Orders of magnitude faster at large
+    /// `|P|` (≈10 ms at `|P|=12` where the explicit SMT path takes ~29 min).
+    ///
+    /// **Single-shot** (2026-07-03): evaluates at the given `--predicate` set
+    /// with no CEGAR refinement, and handles only simple `NAME:REG=VALUE`
+    /// (equality) predicates — sidecar compound / inequality predicates and
+    /// refinement-under-symbolic are follow-ups. The bare `[]`/`<>` fragment
+    /// only (guarded / controllability / step-bounded modalities error).
+    Symbolic,
+}
+
 /// R.2.5b session-1 follow-up (2026-06-06) — must-edge inference
 /// selector for `mununu btor2 cegar`. Mirrors the values of
 /// [`mununu_core::adapter::btor2::kmts_lift::MustEdgeInference`].
@@ -276,6 +299,12 @@ struct Btor2CegarArgs {
     /// human-readable format.
     #[arg(long)]
     json: bool,
+    /// R-F5.4.2b (2026-07-03) — predicate-cube engine: `explicit` (default,
+    /// SMT edges + CEGAR refinement) or `symbolic` (R-F5 BDD relation, no
+    /// per-cube-pair SMT; single-shot at the given predicate set). `symbolic`
+    /// is orders of magnitude faster at large `|P|`.
+    #[arg(long, value_enum, default_value_t = EngineArg::Explicit)]
+    engine: EngineArg,
     /// R.6.6 / V.6 (2026-06-09) — name of a BTOR2 input symbol the
     /// controller drives. Repeated to declare multiple controllable
     /// inputs. When non-empty, the predicate-cube lifter partitions
@@ -1139,6 +1168,11 @@ struct SvCegarArgs {
     /// CTXDSL to this path (stderr confirmation; stdout stays clean).
     #[arg(long = "emit-ctxdsl", value_name = "PATH")]
     emit_ctxdsl: Option<PathBuf>,
+    /// R-F5.4.2b (2026-07-03) — predicate-cube engine: `explicit` (default,
+    /// SMT edges + CEGAR refinement) or `symbolic` (R-F5 BDD relation,
+    /// single-shot, no per-cube-pair SMT). See `mununu btor2 cegar --help`.
+    #[arg(long, value_enum, default_value_t = EngineArg::Explicit)]
+    engine: EngineArg,
 }
 
 #[derive(Args, Debug)]
@@ -2010,6 +2044,7 @@ fn btor2_cegar(args: Btor2CegarArgs) -> Result<(), String> {
             sidecar: args.sidecar.as_deref(),
             emit_ctxdsl: args.emit_ctxdsl.as_deref(),
             json: args.json,
+            engine: args.engine,
         },
     )
 }
@@ -2066,6 +2101,7 @@ fn sv_cegar(args: SvCegarArgs) -> Result<(), String> {
             sidecar: args.sidecar.as_deref(),
             emit_ctxdsl: args.emit_ctxdsl.as_deref(),
             json: args.json,
+            engine: args.engine,
         },
     )
 }
@@ -2438,6 +2474,7 @@ struct CegarCliParams<'a> {
     sidecar: Option<&'a Path>,
     emit_ctxdsl: Option<&'a Path>,
     json: bool,
+    engine: EngineArg,
 }
 
 /// Run the predicate-abstraction refinement loop over a BTOR2 design
@@ -2461,6 +2498,76 @@ fn cegar_cells_json(
             })
             .collect(),
     )
+}
+
+/// R-F5.4.2b — the `--engine symbolic` path: evaluate the property over the
+/// predicate-cube abstraction via the R-F5 symbolic BDD relation (no
+/// per-cube-pair SMT), single-shot at the given predicate set. Prints the same
+/// `{T, F, ⊥}` verdict-cell tally + outcome shape as the explicit path (minus
+/// the refinement-iteration fields, which do not apply).
+fn run_symbolic_cegar_cli(
+    content: &str,
+    fixture_label: &str,
+    predicates: &[mununu_core::adapter::btor2::PredicateSpec],
+    formula: &mununu_core::mu_calculus::Formula,
+    json: bool,
+) -> Result<(), String> {
+    use mununu_core::adapter::btor2::symbolic_bitblast::MustSemantics;
+    use mununu_core::adapter::btor2::symbolic_engine::symbolic_cube_verdicts;
+    use std::collections::HashMap;
+
+    // CLI predicates are simple `NAME:REG=VALUE` equalities ⇒ empty compound map.
+    let compound = HashMap::new();
+    let verdicts = symbolic_cube_verdicts(
+        content,
+        predicates,
+        &compound,
+        formula,
+        MustSemantics::ForallExists,
+    )
+    .map_err(|e| format!("symbolic cube engine: {}", e.message))?;
+
+    let (t, f, b) = (
+        verdicts.definite_true,
+        verdicts.definite_false,
+        verdicts.bottom,
+    );
+    let outcome = if b > 0 {
+        format!("INDEFINITE — {b} cell(s) need a finer predicate set")
+    } else if f > 0 {
+        format!("PROPERTY VIOLATED — {f} cell(s) falsify the formula")
+    } else {
+        format!("PROPERTY HOLDS — all {t} cell(s) satisfy the formula")
+    };
+
+    if json {
+        let summary = serde_json::json!({
+            "fixture": fixture_label,
+            "engine": "symbolic",
+            "final_predicate_count": predicates.len(),
+            "feasible_cube_count": verdicts.cube_verdicts.len(),
+            "verdict": {
+                "true_cells": t,
+                "false_cells": f,
+                "unknown_cells": b,
+            },
+            "outcome": outcome,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&summary)
+                .map_err(|e| format!("serialize summary: {e}"))?
+        );
+    } else {
+        println!("Symbolic predicate-cube evaluation (R-F5, single-shot)");
+        println!("  fixture:           {fixture_label}");
+        println!("  engine:            symbolic (BDD relation, no per-cube-pair SMT)");
+        println!("  predicates:        {}", predicates.len());
+        println!("  feasible cubes:    {}", verdicts.cube_verdicts.len());
+        println!("  verdict cells:     T={t} F={f} ⊥={b}");
+        println!("  outcome:           {outcome}");
+    }
+    Ok(())
 }
 
 /// for `btor2 cegar`, the SV path for `sv cegar`). Shared by both CLI
@@ -2514,6 +2621,21 @@ fn run_cegar_cli(
     // Parse the μ-calculus formula.
     let formula =
         mu_parser::parse(params.formula).map_err(|e| format!("formula parse error: {e:?}"))?;
+
+    // R-F5.4.2b — the symbolic engine short-circuits the explicit lift + CEGAR
+    // loop: it builds the may/must relation as BDDs directly from the BTOR2 and
+    // evaluates the formula by BDD image/preimage, avoiding the `O(2^2|P|)` SMT.
+    // Single-shot at the given predicate set (no refinement); simple equality
+    // predicates only (sidecar compound predicates are an explicit-path feature).
+    if params.engine == EngineArg::Symbolic {
+        return run_symbolic_cegar_cli(
+            content,
+            fixture_label,
+            &initial_predicates,
+            &formula,
+            params.json,
+        );
+    }
 
     // Build the environment with state_count = 2^|predicates|.
     let cube_count = 1usize << initial_predicates.len();

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -618,6 +618,7 @@ pub async fn btor2_cegar_handler(
         may_edge_inference: request.may_edge_inference.as_deref(),
         config_values: &request.config_values,
         emit_ctxdsl: request.emit_ctxdsl,
+        engine: request.engine.as_deref(),
     };
     Ok(Json(run_cegar_build_response(params)?))
 }
@@ -674,6 +675,7 @@ pub async fn sv_cegar_handler(
         may_edge_inference: request.may_edge_inference.as_deref(),
         config_values: &request.config_values,
         emit_ctxdsl: request.emit_ctxdsl,
+        engine: request.engine.as_deref(),
     };
     Ok(Json(run_cegar_build_response(params)?))
 }
@@ -892,6 +894,67 @@ struct CegarRunParams<'a> {
     may_edge_inference: Option<&'a str>,
     config_values: &'a [String],
     emit_ctxdsl: bool,
+    engine: Option<&'a str>,
+}
+
+/// R-F5.4.2b — the `engine=symbolic` path: evaluate the property over the
+/// predicate-cube abstraction via the R-F5 symbolic BDD relation (no
+/// per-cube-pair SMT), single-shot at the given predicate set. Returns the same
+/// [`Btor2CegarResponse`] shape as the explicit path (empty `iterations`,
+/// `terminated_with = "symbolic-single-shot"`, the `{T,F,⊥}` verdict summary).
+fn run_symbolic_cegar_response(
+    params: &CegarRunParams<'_>,
+    predicates: &[crate::adapter::btor2::kmts_lift::PredicateSpec],
+    formula: &crate::mu_calculus::Formula,
+) -> Result<Btor2CegarResponse, ApiError> {
+    use crate::adapter::btor2::symbolic_bitblast::MustSemantics;
+    use crate::adapter::btor2::symbolic_engine::symbolic_cube_verdicts;
+
+    // Simple equality predicates only (compound predicates are an explicit-path
+    // sidecar feature); empty compound map.
+    let compound = std::collections::HashMap::new();
+    let verdicts = symbolic_cube_verdicts(
+        params.btor2_content,
+        predicates,
+        &compound,
+        formula,
+        MustSemantics::ForallExists,
+    )
+    .map_err(|e| ApiError::BadRequest {
+        message: format!("symbolic cube engine: {}", e.message),
+        details: None,
+    })?;
+
+    Ok(Btor2CegarResponse {
+        success: true,
+        iterations: Vec::new(),
+        final_predicates: predicates
+            .iter()
+            .map(|p| PredicateView {
+                name: p.name.clone(),
+                register: p.register.clone(),
+                value: p.value,
+            })
+            .collect(),
+        terminated_with: "symbolic-single-shot".to_string(),
+        verdict: CegarVerdictSummary {
+            true_cells: verdicts.definite_true,
+            false_cells: verdicts.definite_false,
+            unknown_cells: verdicts.bottom,
+        },
+        lazy_lift_pending: false,
+        approximant_reuse_enabled: false,
+        warnings: vec![
+            "engine=symbolic (R-F5): single-shot, no CEGAR refinement; simple \
+             equality predicates + bare []/<> fragment only"
+                .to_string(),
+        ],
+        violating_cells: Vec::new(),
+        undecided_cells: Vec::new(),
+        counterexample: None,
+        refinement_candidates: Vec::new(),
+        ctxdsl: None,
+    })
 }
 
 /// Run the predicate-abstraction refinement loop over a BTOR2 design and
@@ -922,6 +985,14 @@ fn run_cegar_build_response(params: CegarRunParams<'_>) -> Result<Btor2CegarResp
         message: format!("formula parse error: {e:?}"),
         details: None,
     })?;
+
+    // R-F5.4.2b — the symbolic engine short-circuits the explicit lift + CEGAR
+    // loop: build the may/must relation as BDDs directly (no per-cube-pair SMT)
+    // and evaluate. Single-shot at the given predicate set; simple equality
+    // predicates + the bare `[]`/`<>` fragment only.
+    if matches!(params.engine, Some(e) if e.eq_ignore_ascii_case("symbolic")) {
+        return run_symbolic_cegar_response(&params, &predicates, &formula);
+    }
 
     // Environment is sized to the cube space (2^|predicates|), matching the
     // CLI `btor2 cegar` bootstrap.
@@ -3205,6 +3276,7 @@ members = ["x"]
             may_edge_inference: None,
             config_values: vec![],
             emit_ctxdsl: false,
+            engine: None,
         };
 
         let Json(out) = btor2_cegar_handler(Json(request))
@@ -3241,6 +3313,66 @@ members = ["x"]
         );
     }
 
+    /// R-F5.4.2b (2026-07-03) — `engine: "symbolic"` runs the R-F5 BDD engine
+    /// single-shot (no CEGAR refinement) and returns the same
+    /// [`Btor2CegarResponse`] shape: empty iterations, `terminated_with =
+    /// "symbolic-single-shot"`, and the `{T,F,⊥}` verdict over the feasible cubes.
+    #[tokio::test]
+    async fn btor2_cegar_handler_symbolic_engine_single_shot() {
+        use crate::api::models::PredicateSpecRequest;
+        // 2-bit saturating counter with an enable.
+        let btor2 = "\
+1 sort bitvec 2
+2 sort bitvec 1
+3 state 1 cnt
+4 input 2 en
+5 one 1
+6 ones 1
+7 add 1 3 5
+8 eq 2 3 6
+9 ite 1 8 3 7
+10 ite 1 4 9 3
+11 next 1 3 10
+";
+        let request = Btor2CegarRequest {
+            content: btor2.to_string(),
+            formula: "mu X. p or <> X".to_string(), // EF (cnt==0), bare diamond
+            predicates: vec![PredicateSpecRequest {
+                name: "p".to_string(),
+                register: "cnt".to_string(),
+                value: 0,
+            }],
+            controllable_inputs: vec![],
+            predicate_source: None,
+            max_iterations: None,
+            must_edge_inference: None,
+            may_edge_inference: None,
+            config_values: vec![],
+            emit_ctxdsl: false,
+            engine: Some("symbolic".to_string()),
+        };
+
+        let Json(out) = btor2_cegar_handler(Json(request))
+            .await
+            .expect("symbolic CEGAR endpoint should run");
+
+        assert!(out.success);
+        assert!(
+            out.iterations.is_empty(),
+            "symbolic single-shot performs no refinement iterations"
+        );
+        assert_eq!(out.terminated_with, "symbolic-single-shot");
+        // One predicate (cnt==0) ⇒ 2 feasible cubes ({cnt==0}, {cnt!=0}).
+        let total = out.verdict.true_cells + out.verdict.false_cells + out.verdict.unknown_cells;
+        assert_eq!(total, 2, "verdict covers both feasible cubes; got {total}");
+        // EF(cnt==0) holds at the cnt==0 cube ⇒ at least one definite-true cell.
+        assert!(out.verdict.true_cells >= 1);
+        assert!(
+            out.warnings.iter().any(|w| w.contains("symbolic")),
+            "symbolic path surfaces its single-shot caveat"
+        );
+    }
+
     /// CTXDSL Phase 2 (2026-06-22) — `emit_ctxdsl: true` returns the final
     /// refined cube model + the checked formula as a self-contained CTXDSL
     /// document in the response's `ctxdsl` field.
@@ -3271,6 +3403,7 @@ members = ["x"]
             may_edge_inference: None,
             config_values: vec![],
             emit_ctxdsl: true,
+            engine: None,
         };
         let Json(out) = btor2_cegar_handler(Json(request))
             .await
@@ -3324,6 +3457,7 @@ members = ["x"]
             may_edge_inference: Some("smt-all-pairs".to_string()),
             config_values: vec!["burst=0,1,2,3".to_string()],
             emit_ctxdsl: false,
+            engine: None,
         };
         let Json(out) = btor2_cegar_handler(Json(request))
             .await
@@ -3352,6 +3486,7 @@ members = ["x"]
             may_edge_inference: None,
             config_values: vec!["this is not valid".to_string()],
             emit_ctxdsl: false,
+            engine: None,
         };
         let err = btor2_cegar_handler(Json(request))
             .await
@@ -3380,6 +3515,7 @@ members = ["x"]
             may_edge_inference: None,
             config_values: vec![],
             emit_ctxdsl: false,
+            engine: None,
         };
         let err = sv_cegar_handler(Json(request))
             .await
@@ -3434,6 +3570,7 @@ endmodule
             may_edge_inference: None,
             config_values: vec![],
             emit_ctxdsl: false,
+            engine: None,
         };
         let Json(out) = sv_cegar_handler(Json(request))
             .await

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -872,6 +872,14 @@ pub struct Btor2CegarRequest {
     /// `mu_formulas` block). Mirrors the CLI `--emit-ctxdsl`.
     #[serde(default)]
     pub emit_ctxdsl: bool,
+    /// R-F5.4.2b (2026-07-03) — predicate-cube engine: `"explicit"` (default,
+    /// SMT edges + CEGAR refinement) or `"symbolic"` (R-F5 BDD relation,
+    /// single-shot, no per-cube-pair SMT). Mirrors the CLI `--engine`. The
+    /// symbolic path handles only simple equality predicates + the bare
+    /// `[]`/`<>` fragment, and does not refine (`iterations` is empty,
+    /// `terminated_with` is `"symbolic-single-shot"`).
+    #[serde(default)]
+    pub engine: Option<String>,
 }
 
 /// cegar-extraction Stage 2 (2026-06-22) — request for the SV-direct
@@ -935,6 +943,10 @@ pub struct SvCegarRequest {
     /// CTXDSL Phase 2 — opt-in CTXDSL of the final refined model + formula.
     #[serde(default)]
     pub emit_ctxdsl: bool,
+    /// R-F5.4.2b (2026-07-03) — predicate-cube engine: `"explicit"` (default)
+    /// or `"symbolic"` (R-F5 BDD relation, single-shot). Mirrors `--engine`.
+    #[serde(default)]
+    pub engine: Option<String>,
 }
 
 /// XL.6a — SVA-extraction endpoint (`POST /api/v1/sv/extract-sva`). Mirrors the

--- a/wiki/Predicate-Cube-CEGAR.md
+++ b/wiki/Predicate-Cube-CEGAR.md
@@ -45,13 +45,20 @@ one-call variant that runs sv2v + Yosys for you.
 The predicate-cube abstraction has two possible **engines** — the representation of the
 cube state space + transition relation, independent of the abstraction itself:
 
-- **Explicit (shipped)** — materialises `2^|P|` cube states in a `Clts` and builds the
+- **Explicit (default)** — materialises `2^|P|` cube states in a `Clts` and builds the
   may/must edges with SMT (`SmtEncode`). Fine at small `|P|`; the edge computation is
-  `O(2^2|P|)` SMT queries, which is the scaling wall.
-- **Symbolic / BDD (R-F5, planned)** — represents cube sets + the transition relation as
-  BDDs and runs the fixpoint by image/preimage (`∃x'. R(x,x') ∧ φ(x')`), never
-  enumerating cubes. The `evaluate_tri` verdict is the ground truth either way (the
-  symbolic path is validated cell-for-cell against it).
+  `O(2^2|P|)` SMT queries, which is the scaling wall. Supports the full CEGAR refinement
+  loop, `--predicate-source`, sidecar compound predicates, etc.
+- **Symbolic / BDD (R-F5, shipped — opt-in via `--engine symbolic`)** — represents cube
+  sets + the transition relation as BDDs (bit-blasted straight from the BTOR2 transition
+  function) and runs the fixpoint by image/preimage (`∃x'. R(x,x') ∧ φ(x')`), never
+  enumerating cube pairs or issuing per-cube-pair SMT. Orders of magnitude faster at large
+  `|P|` (≈10 ms at `|P|=12`, where the explicit SMT path issues ~16.7M queries / ~29 min).
+  The `evaluate_tri` verdict is the ground truth either way — the symbolic path is
+  validated cell-for-cell against it. **Current scope (R-F5.4.2b):** *single-shot* (no
+  CEGAR refinement), simple `NAME:REG=VALUE` equality predicates, and the bare `[]`/`<>`
+  fragment only. Source of truth:
+  [`adapter::btor2::symbolic_engine::symbolic_cube_verdicts`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs).
 
 Both engines share the same 3-valued semantics and soundness (below). See
 [the post-R-F5 architecture](https://github.com/vscorza/mununu/blob/main/docs/design/post-rf5-architecture.md)
@@ -83,6 +90,7 @@ Key flags:
 | `--max-iterations` | CEGAR refinement cap (default 16) |
 | `--controllable-input` | mark an input as controller-chosen (synthesis / controllability-aware lift) |
 | `--emit-ctxdsl <PATH>` | dump the refined cube model as CTXDSL |
+| `--engine` | `explicit` (default, SMT edges + CEGAR) \| `symbolic` (R-F5 BDD relation, single-shot, no per-cube-pair SMT — orders of magnitude faster at large `\|P\|`) |
 
 `mununu sv cegar <design.sv> --formula … --predicate …` accepts the same property
 flags and runs sv2v + Yosys internally.


### PR DESCRIPTION
Exposes the **R-F5 symbolic predicate-cube engine** as an opt-in across the CLI + HTTP API. The UI half is [mununu-ui#35](https://github.com/vscorza/mununu-ui/pull/35) — same slice, surface parity.

## What

- **CLI** (`mununu btor2 cegar` / `mununu sv cegar`): `--engine {explicit,symbolic}` (`EngineArg`). `symbolic` short-circuits the explicit lift + CEGAR loop via `run_symbolic_cegar_cli` → `symbolic_cube_verdicts`, printing the same `T=… F=… ⊥=…` tally + outcome (text + `--json`).
- **API** (`POST /api/v1/btor2/cegar`, `/sv/cegar`): `engine: Option<String>` on both request models; `run_symbolic_cegar_response` returns the same `Btor2CegarResponse` shape with empty `iterations` and `terminated_with = "symbolic-single-shot"`.

The symbolic path builds the may/must relation as BDDs directly from the BTOR2 (no per-cube-pair SMT) — ≈10 ms at `|P|=12` where the explicit `SmtAllPairs` path issues ~16.7M queries (~29 min).

## Scope (single-shot MVP)

No CEGAR refinement; simple `NAME:REG=VALUE` equality predicates; bare `[]`/`<>` fragment only (a guarded / controllability / step modality or a compound sidecar predicate errors). Refinement-under-symbolic + compound predicates + the **default-flip** are follow-ups (the default stays `explicit`).

## Tests + docs

- API test: `engine="symbolic"` returns the T/F/⊥ verdict + single-shot termination on a 2-bit counter.
- Wiki (Predicate-Cube-CEGAR) updated: symbolic engine is now opt-in, with the `--engine` flag row + a source-of-truth anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)