### PR TITLE
feat(R-F5.5a): compound/inequality predicates for --engine symbolic

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2505,23 +2505,33 @@ fn cegar_cells_json(
 /// per-cube-pair SMT), single-shot at the given predicate set. Prints the same
 /// `{T, F, ⊥}` verdict-cell tally + outcome shape as the explicit path (minus
 /// the refinement-iteration fields, which do not apply).
+#[allow(clippy::too_many_arguments)]
 fn run_symbolic_cegar_cli(
     content: &str,
     fixture_label: &str,
     predicates: &[mununu_core::adapter::btor2::PredicateSpec],
     formula: &mununu_core::mu_calculus::Formula,
+    sidecar: Option<&Path>,
+    config_values: &[String],
     json: bool,
 ) -> Result<(), String> {
     use mununu_core::adapter::btor2::symbolic_bitblast::MustSemantics;
-    use mununu_core::adapter::btor2::symbolic_engine::symbolic_cube_verdicts;
-    use std::collections::HashMap;
+    use mununu_core::adapter::btor2::symbolic_engine::symbolic_cube_verdicts_from_options;
 
-    // CLI predicates are simple `NAME:REG=VALUE` equalities ⇒ empty compound map.
-    let compound = HashMap::new();
-    let verdicts = symbolic_cube_verdicts(
+    // The simple `--predicate NAME:REG=VALUE` equalities plus any non-derived
+    // `compound_predicates` (e.g. `cnt >= 2`) declared in the `--sidecar`. The
+    // sidecar overrides the `--config-values` synthetic one (matches the
+    // explicit path). Derived/combinational compounds are rejected downstream.
+    let mut options = build_adapter_options_with_config_values(config_values)?;
+    if let Some(p) = sidecar {
+        let sidecar_content = std::fs::read_to_string(p)
+            .map_err(|e| format!("Failed to read sidecar '{}': {e}", p.display()))?;
+        options.sidecar_json = Some(sidecar_content);
+    }
+    let verdicts = symbolic_cube_verdicts_from_options(
         content,
         predicates,
-        &compound,
+        &options,
         formula,
         MustSemantics::ForallExists,
     )
@@ -2544,7 +2554,7 @@ fn run_symbolic_cegar_cli(
         let summary = serde_json::json!({
             "fixture": fixture_label,
             "engine": "symbolic",
-            "final_predicate_count": predicates.len(),
+            "final_predicate_count": verdicts.num_predicates,
             "feasible_cube_count": verdicts.cube_verdicts.len(),
             "verdict": {
                 "true_cells": t,
@@ -2562,7 +2572,7 @@ fn run_symbolic_cegar_cli(
         println!("Symbolic predicate-cube evaluation (R-F5, single-shot)");
         println!("  fixture:           {fixture_label}");
         println!("  engine:            symbolic (BDD relation, no per-cube-pair SMT)");
-        println!("  predicates:        {}", predicates.len());
+        println!("  predicates:        {}", verdicts.num_predicates);
         println!("  feasible cubes:    {}", verdicts.cube_verdicts.len());
         println!("  verdict cells:     T={t} F={f} ⊥={b}");
         println!("  outcome:           {outcome}");
@@ -2625,14 +2635,17 @@ fn run_cegar_cli(
     // R-F5.4.2b — the symbolic engine short-circuits the explicit lift + CEGAR
     // loop: it builds the may/must relation as BDDs directly from the BTOR2 and
     // evaluates the formula by BDD image/preimage, avoiding the `O(2^2|P|)` SMT.
-    // Single-shot at the given predicate set (no refinement); simple equality
-    // predicates only (sidecar compound predicates are an explicit-path feature).
+    // Single-shot at the given predicate set (no refinement). Simple equality
+    // `--predicate`s plus any non-derived `compound_predicates` (e.g. `cnt >= 2`)
+    // from the `--sidecar` (R-F5.5a).
     if params.engine == EngineArg::Symbolic {
         return run_symbolic_cegar_cli(
             content,
             fixture_label,
             &initial_predicates,
             &formula,
+            params.sidecar,
+            params.config_values,
             params.json,
         );
     }

--- a/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
@@ -124,6 +124,49 @@ pub fn symbolic_cube_verdicts(
     })
 }
 
+/// R-F5.5a (2026-07-03) — like [`symbolic_cube_verdicts`], but derives the
+/// compound cube-dimension predicates from an [`AdapterOptions`] sidecar (the
+/// `compound_predicates` block, e.g. `cnt >= 2`) rather than taking an explicit
+/// `compound_exprs` map. This is the surface entry point the CLI (`--sidecar`)
+/// and API use so `--engine symbolic` handles inequality / relational
+/// predicates — the real sysrst `cnt_clr` / H.H counter-bound residual.
+///
+/// **Derived / combinational** compound predicates (H.E.2/H.F — per-cube SMT
+/// labels, not cube dimensions) are a hard error: the symbolic path has no
+/// per-cube-label computation yet; those cases must use `--engine explicit`.
+pub fn symbolic_cube_verdicts_from_options(
+    btor2_content: &str,
+    initial_predicates: &[PredicateSpec],
+    options: &crate::adapter::AdapterOptions,
+    formula: &Formula,
+    must_semantics: MustSemantics,
+) -> Result<SymbolicCubeVerdicts, AdapterError> {
+    let mut predicates = initial_predicates.to_vec();
+    let mut compound: HashMap<String, PredicateExpr> = HashMap::new();
+    for (spec, expr, is_derived) in
+        crate::adapter::btor2::cegar::sidecar_compound_predicates(options)
+    {
+        if is_derived {
+            return Err(ir_err(format!(
+                "the derived/combinational predicate `{}` (a per-cube SMT label, not a cube \
+                 dimension) is not supported by the symbolic engine yet — use `--engine explicit`",
+                spec.name
+            )));
+        }
+        // A non-derived compound is a cube dimension whose truth the compound
+        // expr decides (not `register == value`); its name keys the expr map.
+        compound.insert(spec.name.clone(), expr);
+        predicates.push(spec);
+    }
+    symbolic_cube_verdicts(
+        btor2_content,
+        &predicates,
+        &compound,
+        formula,
+        must_semantics,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -428,5 +471,91 @@ mod tests {
                 "|P|={k}: symbolic path took {elapsed:?} — investigate BDD blow-up"
             );
         }
+    }
+
+    // ---- R-F5.5a: compound predicates from the sidecar ----
+
+    /// A sidecar `compound_predicates` inequality (`cnt >= 2`) becomes a cube
+    /// dimension under `symbolic_cube_verdicts_from_options`, and the verdicts
+    /// match `evaluate_tri` — the real inequality-predicate residual under
+    /// `--engine symbolic`.
+    #[test]
+    fn rf5_5a_symbolic_from_options_derives_sidecar_compound() {
+        use crate::adapter::AdapterOptions;
+        let sidecar =
+            r#"{"module":"m","compound_predicates":[{"name":"cnt_hi","expr":"cnt >= 2"}]}"#;
+        let options = AdapterOptions {
+            sidecar_json: Some(sidecar.to_string()),
+            ..Default::default()
+        };
+        let initial = vec![PredicateSpec {
+            name: "p".to_string(),
+            register: "cnt".to_string(),
+            value: 0,
+        }];
+        let formula_str = "mu X. cnt_hi or <> X"; // EF (cnt >= 2)
+        let formula = crate::mu_calculus::parser::parse(formula_str).expect("formula");
+        let got = symbolic_cube_verdicts_from_options(
+            SAT_COUNTER,
+            &initial,
+            &options,
+            &formula,
+            MustSemantics::ForallExists,
+        )
+        .expect("symbolic verdicts from sidecar");
+
+        // Oracle over the same predicate set [cnt==0, cnt>=2] in the same order.
+        let exprs = [
+            PredicateExpr::eq("cnt", 0),
+            PredicateExpr::Cmp {
+                register: "cnt".to_string(),
+                op: CmpOp::Ge,
+                value: 2,
+            },
+        ];
+        let want = tri_oracle(
+            SAT_COUNTER,
+            &exprs,
+            &["p", "cnt_hi"],
+            &[("cnt", 2)],
+            formula_str,
+        );
+        assert_eq!(
+            got.cube_verdicts, want,
+            "sidecar-compound path ≠ evaluate_tri"
+        );
+        // cnt ∈ {0,1,2,3} ⇒ 3 feasible cubes ({p}, {neither}, {cnt_hi}).
+        assert_eq!(got.cube_verdicts.len(), 3);
+    }
+
+    /// A **derived** compound predicate (per-cube SMT label) is rejected — the
+    /// symbolic engine has no per-cube-label path yet.
+    #[test]
+    fn rf5_5a_symbolic_from_options_rejects_derived_predicate() {
+        use crate::adapter::AdapterOptions;
+        let sidecar = r#"{"module":"m","compound_predicates":[{"name":"d","expr":"cnt >= 2","derived":true}]}"#;
+        let options = AdapterOptions {
+            sidecar_json: Some(sidecar.to_string()),
+            ..Default::default()
+        };
+        let initial = vec![PredicateSpec {
+            name: "p".to_string(),
+            register: "cnt".to_string(),
+            value: 0,
+        }];
+        let formula = crate::mu_calculus::parser::parse("[] p").expect("formula");
+        let err = symbolic_cube_verdicts_from_options(
+            SAT_COUNTER,
+            &initial,
+            &options,
+            &formula,
+            MustSemantics::ForallExists,
+        )
+        .expect_err("derived compound must be rejected");
+        assert!(
+            err.message.contains("derived"),
+            "expected a derived-predicate rejection, got: {}",
+            err.message
+        );
     }
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -907,16 +907,30 @@ fn run_symbolic_cegar_response(
     predicates: &[crate::adapter::btor2::kmts_lift::PredicateSpec],
     formula: &crate::mu_calculus::Formula,
 ) -> Result<Btor2CegarResponse, ApiError> {
+    use crate::adapter::AdapterOptions;
+    use crate::adapter::btor2::cegar::config_values_to_sidecar_json;
     use crate::adapter::btor2::symbolic_bitblast::MustSemantics;
-    use crate::adapter::btor2::symbolic_engine::symbolic_cube_verdicts;
+    use crate::adapter::btor2::symbolic_engine::symbolic_cube_verdicts_from_options;
 
-    // Simple equality predicates only (compound predicates are an explicit-path
-    // sidecar feature); empty compound map.
-    let compound = std::collections::HashMap::new();
-    let verdicts = symbolic_cube_verdicts(
+    // Build the same config-values synthetic sidecar the explicit path uses, so
+    // any non-derived `compound_predicates` become cube dimensions (R-F5.5a).
+    // The cegar request has no explicit sidecar field, so today this is
+    // equality-only unless config-values embed a compound — parity with the
+    // explicit API path.
+    let sidecar_json = config_values_to_sidecar_json(params.config_values).map_err(|message| {
+        ApiError::BadRequest {
+            message,
+            details: None,
+        }
+    })?;
+    let options = AdapterOptions {
+        sidecar_json,
+        ..AdapterOptions::default()
+    };
+    let verdicts = symbolic_cube_verdicts_from_options(
         params.btor2_content,
         predicates,
-        &compound,
+        &options,
         formula,
         MustSemantics::ForallExists,
     )


### PR DESCRIPTION
First slice toward **symbolic feature-parity** (the default-flip prerequisite): thread sidecar `compound_predicates` (`cnt >= 2`, relational forms) into the symbolic engine, so `--engine symbolic` handles the real sysrst `cnt_clr` / H.H counter-bound residual — not just equality predicates.

## What

`symbolic_engine::symbolic_cube_verdicts_from_options(btor2, initial, &AdapterOptions, formula, must)` derives the non-derived `sidecar_compound_predicates` (cube-dimension compounds + their `compound_exprs`) from the sidecar and feeds them to `symbolic_cube_verdicts`. The symbolic **engine** already compiled `PredicateExpr` compounds to BDDs (R-F5.3b) — this closes the **surface** gap that was passing an empty compound map. A **derived/combinational** compound (H.E.2/H.F per-cube SMT label, not a cube dimension) is a clean hard error pointing at `--engine explicit`.

Wired on both surfaces:
- **CLI** `run_symbolic_cegar_cli` builds `AdapterOptions` from `--config-values` + `--sidecar` (sidecar overrides, matching the explicit path).
- **API** `run_symbolic_cegar_response` builds the same config-values synthetic sidecar the explicit path uses.

## Tests

A sidecar `cnt >= 2` compound becomes a cube dimension and the symbolic verdicts match `evaluate_tri` cell-for-cell (EF(cnt≥2)); a `derived: true` compound is rejected. Existing symbolic tests + the API single-shot test (now routed through `_from_options`) stay green.

## Next (R-F5.5b)

Refinement-under-symbolic — a symbolic CEGAR loop that discovers + adds predicates on ⊥ (reusing the explicit path's WP discovery, which only needs a non-empty failure subgame) and re-evaluates (rebuild the relation, no SMT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)