### PR TITLE
feat(R-F5.5b): refinement-under-symbolic — the symbolic CEGAR loop

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -186,12 +186,15 @@ enum EngineArg {
     /// directly from the BTOR2 (no per-cube-pair SMT) and evaluate the formula
     /// by BDD image/preimage + μ/ν fixpoint. Orders of magnitude faster at large
     /// `|P|` (≈10 ms at `|P|=12` where the explicit SMT path takes ~29 min).
+    /// Runs the CEGAR refinement loop (WP predicate discovery on ⊥, rebuilding
+    /// the relation each iteration; `--max-iterations 0` = single-shot).
     ///
-    /// **Single-shot** (2026-07-03): evaluates at the given `--predicate` set
-    /// with no CEGAR refinement, and handles only simple `NAME:REG=VALUE`
-    /// (equality) predicates — sidecar compound / inequality predicates and
-    /// refinement-under-symbolic are follow-ups. The bare `[]`/`<>` fragment
-    /// only (guarded / controllability / step-bounded modalities error).
+    /// **Scope:** simple `--predicate NAME:REG=VALUE` equalities + non-derived
+    /// `--sidecar` `compound_predicates` (`cnt >= 2`, relational); the bare
+    /// `[]`/`<>` fragment only (guarded / controllability / step-bounded
+    /// modalities error). Derived/combinational (per-cube SMT label) predicates
+    /// and the Clts-only optimisations (failure-subgame precision, approximant
+    /// reuse, CTXDSL emit) are still `--engine explicit` only.
     Symbolic,
 }
 
@@ -2513,10 +2516,13 @@ fn run_symbolic_cegar_cli(
     formula: &mununu_core::mu_calculus::Formula,
     sidecar: Option<&Path>,
     config_values: &[String],
+    max_iterations: usize,
     json: bool,
 ) -> Result<(), String> {
     use mununu_core::adapter::btor2::symbolic_bitblast::MustSemantics;
-    use mununu_core::adapter::btor2::symbolic_engine::symbolic_cube_verdicts_from_options;
+    use mununu_core::adapter::btor2::symbolic_engine::{
+        SymbolicCegarTermination, symbolic_cegar_refine,
+    };
 
     // The simple `--predicate NAME:REG=VALUE` equalities plus any non-derived
     // `compound_predicates` (e.g. `cnt >= 2`) declared in the `--sidecar`. The
@@ -2528,20 +2534,28 @@ fn run_symbolic_cegar_cli(
             .map_err(|e| format!("Failed to read sidecar '{}': {e}", p.display()))?;
         options.sidecar_json = Some(sidecar_content);
     }
-    let verdicts = symbolic_cube_verdicts_from_options(
+    // R-F5.5b — the symbolic CEGAR loop (WP refinement on ⊥, rebuilding the BDD
+    // relation each iteration; no per-cube-pair SMT). `--max-iterations 0` gives
+    // the single-shot behaviour.
+    let result = symbolic_cegar_refine(
         content,
         predicates,
         &options,
         formula,
         MustSemantics::ForallExists,
+        max_iterations,
     )
     .map_err(|e| format!("symbolic cube engine: {}", e.message))?;
 
-    let (t, f, b) = (
-        verdicts.definite_true,
-        verdicts.definite_false,
-        verdicts.bottom,
-    );
+    let v = &result.final_verdicts;
+    let (t, f, b) = (v.definite_true, v.definite_false, v.bottom);
+    let terminated = match result.terminated_with {
+        SymbolicCegarTermination::Converged => "converged",
+        SymbolicCegarTermination::BoundedIterationsReached => "bounded-iterations-reached",
+        SymbolicCegarTermination::PredicateSourceExhausted => "predicate-source-exhausted",
+    };
+    // iteration 0 is the initial evaluation; the rest are refinements.
+    let refinements = result.iterations.len().saturating_sub(1);
     let outcome = if b > 0 {
         format!("INDEFINITE — {b} cell(s) need a finer predicate set")
     } else if f > 0 {
@@ -2554,8 +2568,10 @@ fn run_symbolic_cegar_cli(
         let summary = serde_json::json!({
             "fixture": fixture_label,
             "engine": "symbolic",
-            "final_predicate_count": verdicts.num_predicates,
-            "feasible_cube_count": verdicts.cube_verdicts.len(),
+            "refinement_iterations": refinements,
+            "terminated_with": terminated,
+            "final_predicate_count": v.num_predicates,
+            "feasible_cube_count": v.cube_verdicts.len(),
             "verdict": {
                 "true_cells": t,
                 "false_cells": f,
@@ -2569,13 +2585,15 @@ fn run_symbolic_cegar_cli(
                 .map_err(|e| format!("serialize summary: {e}"))?
         );
     } else {
-        println!("Symbolic predicate-cube evaluation (R-F5, single-shot)");
-        println!("  fixture:           {fixture_label}");
-        println!("  engine:            symbolic (BDD relation, no per-cube-pair SMT)");
-        println!("  predicates:        {}", verdicts.num_predicates);
-        println!("  feasible cubes:    {}", verdicts.cube_verdicts.len());
-        println!("  verdict cells:     T={t} F={f} ⊥={b}");
-        println!("  outcome:           {outcome}");
+        println!("Symbolic predicate-cube CEGAR (R-F5)");
+        println!("  fixture:              {fixture_label}");
+        println!("  engine:               symbolic (BDD relation, no per-cube-pair SMT)");
+        println!("  refinement iterations:{refinements}");
+        println!("  terminated_with:      {terminated}");
+        println!("  final predicates:     {}", v.num_predicates);
+        println!("  feasible cubes:       {}", v.cube_verdicts.len());
+        println!("  verdict cells:        T={t} F={f} ⊥={b}");
+        println!("  outcome:              {outcome}");
     }
     Ok(())
 }
@@ -2646,6 +2664,7 @@ fn run_cegar_cli(
             &formula,
             params.sidecar,
             params.config_values,
+            params.max_iterations,
             params.json,
         );
     }

--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -1513,6 +1513,31 @@ fn craig_interpolation_predicates(
 /// register is already covered, OR when the BTOR2 file fails to
 /// parse — the CEGAR loop then terminates with
 /// `CegarTermination::PredicateSourceExhausted`.
+/// R-F5.5b (2026-07-03) — the WP predicate-discovery step for the **symbolic**
+/// CEGAR loop. The symbolic path detects ⊥ cubes but does not build the explicit
+/// parity-game failure subgame; [`weakest_precondition_predicates`] only uses the
+/// subgame as a non-empty *trigger* (it proposes predicates from the current
+/// predicates' cone-of-influence + BTOR2 constants, not from the specific
+/// classifying transition), so a minimal placeholder subgame is sufficient.
+/// Returns the next batch of candidate predicates (capped, same as the explicit
+/// loop); empty ⇒ the predicate source is exhausted.
+pub fn wp_refine_predicates(
+    current_predicates: &[PredicateSpec],
+    btor2_content: &str,
+) -> Vec<PredicateSpec> {
+    let trigger = FailureSubgame {
+        positions: Vec::new(),
+        classifying_transitions: vec![(
+            0,
+            0,
+            crate::mu_calculus::parity_game_3v::OwningPlayer::Unknown,
+        )],
+        root: None,
+        subgame_extraction_complete: false,
+    };
+    weakest_precondition_predicates(&trigger, current_predicates, btor2_content)
+}
+
 fn weakest_precondition_predicates(
     subgame: &FailureSubgame,
     current_predicates: &[PredicateSpec],

--- a/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
@@ -141,6 +141,24 @@ pub fn symbolic_cube_verdicts_from_options(
     formula: &Formula,
     must_semantics: MustSemantics,
 ) -> Result<SymbolicCubeVerdicts, AdapterError> {
+    let (predicates, compound) = derive_sidecar_compounds(initial_predicates, options)?;
+    symbolic_cube_verdicts(
+        btor2_content,
+        &predicates,
+        &compound,
+        formula,
+        must_semantics,
+    )
+}
+
+/// Derive the full cube-dimension predicate set (initial + non-derived sidecar
+/// `compound_predicates`) + the compound-expr map. A derived/combinational
+/// compound (per-cube SMT label) is a hard error — the symbolic path has no
+/// per-cube-label computation yet.
+fn derive_sidecar_compounds(
+    initial_predicates: &[PredicateSpec],
+    options: &crate::adapter::AdapterOptions,
+) -> Result<(Vec<PredicateSpec>, HashMap<String, PredicateExpr>), AdapterError> {
     let mut predicates = initial_predicates.to_vec();
     let mut compound: HashMap<String, PredicateExpr> = HashMap::new();
     for (spec, expr, is_derived) in
@@ -153,18 +171,137 @@ pub fn symbolic_cube_verdicts_from_options(
                 spec.name
             )));
         }
-        // A non-derived compound is a cube dimension whose truth the compound
-        // expr decides (not `register == value`); its name keys the expr map.
         compound.insert(spec.name.clone(), expr);
         predicates.push(spec);
     }
-    symbolic_cube_verdicts(
-        btor2_content,
-        &predicates,
-        &compound,
-        formula,
-        must_semantics,
-    )
+    Ok((predicates, compound))
+}
+
+/// R-F5.5b — how a [`symbolic_cegar_refine`] run terminated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolicCegarTermination {
+    /// No ⊥ cube remains — every feasible cube has a definite verdict.
+    Converged,
+    /// The iteration / cube-count cap was reached with ⊥ cubes still present.
+    BoundedIterationsReached,
+    /// WP proposed no new predicate (cone-of-influence exhausted) with ⊥ present.
+    PredicateSourceExhausted,
+}
+
+/// R-F5.5b — one refinement-iteration record (verdict summary at the start of
+/// the iteration, before any predicate for it was added).
+#[derive(Debug, Clone)]
+pub struct SymbolicCegarIteration {
+    pub iteration: usize,
+    pub predicate_count: usize,
+    pub definite_true: usize,
+    pub definite_false: usize,
+    pub bottom: usize,
+}
+
+/// R-F5.5b — the result of a symbolic CEGAR refinement run.
+#[derive(Debug, Clone)]
+pub struct SymbolicCegarResult {
+    /// Per-iteration verdict records (iteration 0 = the initial evaluation).
+    pub iterations: Vec<SymbolicCegarIteration>,
+    /// Predicate set at termination (initial + sidecar compounds + WP-added).
+    pub final_predicates: Vec<PredicateSpec>,
+    /// The final 3-valued verdict tally.
+    pub final_verdicts: SymbolicCubeVerdicts,
+    pub terminated_with: SymbolicCegarTermination,
+}
+
+/// Cube-count cap for the symbolic refinement loop: the per-iteration verdict
+/// tally enumerates `2^|P|` cubes, so `|P|` is bounded to keep that tractable
+/// (`2^16 = 65 536`). The symbolic *relation* stays compact regardless; only the
+/// tally enumerates — a fully-symbolic feasible-cube count (BDD `SatCount`) is a
+/// later optimisation.
+const MAX_SYMBOLIC_CUBE_BITS: usize = 16;
+
+/// R-F5.5b — symbolic CEGAR refinement loop. Evaluates the property over the
+/// predicate-cube abstraction symbolically (no per-cube-pair SMT); on a ⊥
+/// verdict, discovers a separating predicate via WP
+/// ([`crate::adapter::btor2::cegar::wp_refine_predicates`]), adds it, and
+/// re-evaluates — rebuilding the `AbstractRelation` each iteration (cheap; still
+/// no SMT). Terminates on convergence (no ⊥), the iteration / cube-count cap, or
+/// WP exhaustion.
+///
+/// `max_iterations = 0` reproduces the single-shot behaviour (evaluate once, no
+/// refinement). Compound predicates are derived from the sidecar exactly as
+/// [`symbolic_cube_verdicts_from_options`].
+pub fn symbolic_cegar_refine(
+    btor2_content: &str,
+    initial_predicates: &[PredicateSpec],
+    options: &crate::adapter::AdapterOptions,
+    formula: &Formula,
+    must_semantics: MustSemantics,
+    max_iterations: usize,
+) -> Result<SymbolicCegarResult, AdapterError> {
+    let (mut predicates, compound) = derive_sidecar_compounds(initial_predicates, options)?;
+    let mut iterations: Vec<SymbolicCegarIteration> = Vec::new();
+    let mut iter = 0usize;
+
+    loop {
+        let verdicts = symbolic_cube_verdicts(
+            btor2_content,
+            &predicates,
+            &compound,
+            formula,
+            must_semantics,
+        )?;
+        iterations.push(SymbolicCegarIteration {
+            iteration: iter,
+            predicate_count: predicates.len(),
+            definite_true: verdicts.definite_true,
+            definite_false: verdicts.definite_false,
+            bottom: verdicts.bottom,
+        });
+
+        // Converged — every feasible cube is definite.
+        if verdicts.bottom == 0 {
+            return Ok(SymbolicCegarResult {
+                iterations,
+                final_predicates: predicates,
+                final_verdicts: verdicts,
+                terminated_with: SymbolicCegarTermination::Converged,
+            });
+        }
+        // Iteration cap.
+        if iter >= max_iterations {
+            return Ok(SymbolicCegarResult {
+                iterations,
+                final_predicates: predicates,
+                final_verdicts: verdicts,
+                terminated_with: SymbolicCegarTermination::BoundedIterationsReached,
+            });
+        }
+        // Discover a refining predicate (WP over the current predicate cone).
+        let proposed =
+            crate::adapter::btor2::cegar::wp_refine_predicates(&predicates, btor2_content);
+        let fresh: Vec<PredicateSpec> = proposed
+            .into_iter()
+            .filter(|p| !predicates.iter().any(|q| q.name == p.name))
+            .collect();
+        if fresh.is_empty() {
+            return Ok(SymbolicCegarResult {
+                iterations,
+                final_predicates: predicates,
+                final_verdicts: verdicts,
+                terminated_with: SymbolicCegarTermination::PredicateSourceExhausted,
+            });
+        }
+        // Cube-count cap — don't grow the predicate set past the tally bound.
+        if predicates.len() + fresh.len() > MAX_SYMBOLIC_CUBE_BITS {
+            return Ok(SymbolicCegarResult {
+                iterations,
+                final_predicates: predicates,
+                final_verdicts: verdicts,
+                terminated_with: SymbolicCegarTermination::BoundedIterationsReached,
+            });
+        }
+        predicates.extend(fresh);
+        iter += 1;
+    }
 }
 
 #[cfg(test)]
@@ -557,5 +694,89 @@ mod tests {
             "expected a derived-predicate rejection, got: {}",
             err.message
         );
+    }
+
+    // ---- R-F5.5b: symbolic CEGAR refinement loop ----
+
+    /// `EF(cnt == 3)` on the saturating counter: the `{cnt != 3}` cubes are ⊥
+    /// (they *may* reach cnt==3 via `en=1`, but not *must* — input
+    /// nondeterminism), so the initial verdict carries ⊥. The refinement loop
+    /// must record iterations, only ever grow the predicate set, and terminate
+    /// with a valid reason (this ⊥ is a genuine thoroughness gap, so it does not
+    /// converge — WP exhausts / caps).
+    #[test]
+    fn rf5_5b_symbolic_refine_terminates_and_grows_predicates() {
+        use crate::adapter::AdapterOptions;
+        let options = AdapterOptions::default();
+        let initial = vec![PredicateSpec {
+            name: "top".to_string(),
+            register: "cnt".to_string(),
+            value: 3,
+        }];
+        let formula = crate::mu_calculus::parser::parse("mu X. top or <> X").expect("formula");
+
+        let result = symbolic_cegar_refine(
+            SAT_COUNTER,
+            &initial,
+            &options,
+            &formula,
+            MustSemantics::ForallExists,
+            8,
+        )
+        .expect("symbolic refine");
+
+        assert!(!result.iterations.is_empty());
+        assert_eq!(result.iterations[0].iteration, 0);
+        assert!(
+            result.iterations[0].bottom >= 1,
+            "EF(cnt==3) starts with ⊥ cubes"
+        );
+        // Predicate count is non-decreasing (predicates are only ever added).
+        for w in result.iterations.windows(2) {
+            assert!(
+                w[1].predicate_count >= w[0].predicate_count,
+                "predicate set must not shrink"
+            );
+        }
+        // The final verdict summary matches the last iteration record.
+        assert_eq!(
+            result.final_verdicts.bottom,
+            result.iterations.last().unwrap().bottom
+        );
+        // Converged ⇒ no ⊥ remains; otherwise ⊥ persists (thoroughness gap).
+        match result.terminated_with {
+            SymbolicCegarTermination::Converged => {
+                assert_eq!(result.final_verdicts.bottom, 0)
+            }
+            SymbolicCegarTermination::BoundedIterationsReached
+            | SymbolicCegarTermination::PredicateSourceExhausted => {}
+        }
+    }
+
+    /// `max_iterations = 0` reproduces the single-shot behaviour: exactly one
+    /// evaluation, no refinement, the predicate set unchanged.
+    #[test]
+    fn rf5_5b_symbolic_refine_single_shot_when_max_zero() {
+        use crate::adapter::AdapterOptions;
+        let options = AdapterOptions::default();
+        let initial = vec![PredicateSpec {
+            name: "top".to_string(),
+            register: "cnt".to_string(),
+            value: 3,
+        }];
+        let formula = crate::mu_calculus::parser::parse("mu X. top or <> X").expect("formula");
+
+        let result = symbolic_cegar_refine(
+            SAT_COUNTER,
+            &initial,
+            &options,
+            &formula,
+            MustSemantics::ForallExists,
+            0,
+        )
+        .expect("symbolic refine single-shot");
+
+        assert_eq!(result.iterations.len(), 1, "single-shot = one evaluation");
+        assert_eq!(result.final_predicates.len(), 1, "no predicate added");
     }
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -910,7 +910,7 @@ fn run_symbolic_cegar_response(
     use crate::adapter::AdapterOptions;
     use crate::adapter::btor2::cegar::config_values_to_sidecar_json;
     use crate::adapter::btor2::symbolic_bitblast::MustSemantics;
-    use crate::adapter::btor2::symbolic_engine::symbolic_cube_verdicts_from_options;
+    use crate::adapter::btor2::symbolic_engine::{SymbolicCegarTermination, symbolic_cegar_refine};
 
     // Build the same config-values synthetic sidecar the explicit path uses, so
     // any non-derived `compound_predicates` become cube dimensions (R-F5.5a).
@@ -927,22 +927,51 @@ fn run_symbolic_cegar_response(
         sidecar_json,
         ..AdapterOptions::default()
     };
-    let verdicts = symbolic_cube_verdicts_from_options(
+    // R-F5.5b — the symbolic CEGAR loop (WP refinement on ⊥; no per-cube-pair SMT).
+    let max_iterations = params.max_iterations.unwrap_or(16);
+    let result = symbolic_cegar_refine(
         params.btor2_content,
         predicates,
         &options,
         formula,
         MustSemantics::ForallExists,
+        max_iterations,
     )
     .map_err(|e| ApiError::BadRequest {
         message: format!("symbolic cube engine: {}", e.message),
         details: None,
     })?;
 
+    let iterations = result
+        .iterations
+        .iter()
+        .map(|it| CegarIterationView {
+            iteration: it.iteration,
+            predicate_count: it.predicate_count,
+            had_failure_subgame: it.bottom > 0,
+            // The symbolic MVP does not track which predicate closed each ⊥.
+            predicates_added: Vec::new(),
+            game_position_evaluations: 0,
+            verdict: CegarVerdictSummary {
+                true_cells: it.definite_true,
+                false_cells: it.definite_false,
+                unknown_cells: it.bottom,
+            },
+        })
+        .collect();
+    let terminated_with = match result.terminated_with {
+        SymbolicCegarTermination::Converged => "converged",
+        SymbolicCegarTermination::BoundedIterationsReached => "bounded-iterations-reached",
+        SymbolicCegarTermination::PredicateSourceExhausted => "predicate-source-exhausted",
+    }
+    .to_string();
+    let v = &result.final_verdicts;
+
     Ok(Btor2CegarResponse {
         success: true,
-        iterations: Vec::new(),
-        final_predicates: predicates
+        iterations,
+        final_predicates: result
+            .final_predicates
             .iter()
             .map(|p| PredicateView {
                 name: p.name.clone(),
@@ -950,17 +979,17 @@ fn run_symbolic_cegar_response(
                 value: p.value,
             })
             .collect(),
-        terminated_with: "symbolic-single-shot".to_string(),
+        terminated_with,
         verdict: CegarVerdictSummary {
-            true_cells: verdicts.definite_true,
-            false_cells: verdicts.definite_false,
-            unknown_cells: verdicts.bottom,
+            true_cells: v.definite_true,
+            false_cells: v.definite_false,
+            unknown_cells: v.bottom,
         },
         lazy_lift_pending: false,
         approximant_reuse_enabled: false,
         warnings: vec![
-            "engine=symbolic (R-F5): single-shot, no CEGAR refinement; simple \
-             equality predicates + bare []/<> fragment only"
+            "engine=symbolic (R-F5): BDD relation + WP refinement, no per-cube-pair SMT; \
+             simple + non-derived-compound predicates + bare []/<> fragment only"
                 .to_string(),
         ],
         violating_cells: Vec::new(),
@@ -3327,12 +3356,14 @@ members = ["x"]
         );
     }
 
-    /// R-F5.4.2b (2026-07-03) — `engine: "symbolic"` runs the R-F5 BDD engine
-    /// single-shot (no CEGAR refinement) and returns the same
-    /// [`Btor2CegarResponse`] shape: empty iterations, `terminated_with =
-    /// "symbolic-single-shot"`, and the `{T,F,⊥}` verdict over the feasible cubes.
+    /// R-F5.4.2b + R-F5.5b — `engine: "symbolic"` runs the R-F5 BDD engine with
+    /// the symbolic CEGAR loop and returns the standard [`Btor2CegarResponse`]
+    /// shape: per-iteration records, a `terminated_with` reason, and the
+    /// `{T,F,⊥}` verdict over the feasible cubes. `EF(cnt==0)` on this
+    /// monotone counter is definite everywhere (T at cnt==0, F elsewhere), so
+    /// it converges at iteration 0.
     #[tokio::test]
-    async fn btor2_cegar_handler_symbolic_engine_single_shot() {
+    async fn btor2_cegar_handler_symbolic_engine_cegar() {
         use crate::api::models::PredicateSpecRequest;
         // 2-bit saturating counter with an enable.
         let btor2 = "\
@@ -3371,19 +3402,19 @@ members = ["x"]
             .expect("symbolic CEGAR endpoint should run");
 
         assert!(out.success);
-        assert!(
-            out.iterations.is_empty(),
-            "symbolic single-shot performs no refinement iterations"
-        );
-        assert_eq!(out.terminated_with, "symbolic-single-shot");
+        // The loop records at least the initial evaluation (iteration 0).
+        assert!(!out.iterations.is_empty(), "loop records iteration 0");
+        assert_eq!(out.iterations[0].iteration, 0);
+        // Definite everywhere ⇒ converged, no ⊥.
+        assert_eq!(out.terminated_with, "converged");
+        assert_eq!(out.verdict.unknown_cells, 0);
         // One predicate (cnt==0) ⇒ 2 feasible cubes ({cnt==0}, {cnt!=0}).
         let total = out.verdict.true_cells + out.verdict.false_cells + out.verdict.unknown_cells;
         assert_eq!(total, 2, "verdict covers both feasible cubes; got {total}");
-        // EF(cnt==0) holds at the cnt==0 cube ⇒ at least one definite-true cell.
         assert!(out.verdict.true_cells >= 1);
         assert!(
             out.warnings.iter().any(|w| w.contains("symbolic")),
-            "symbolic path surfaces its single-shot caveat"
+            "symbolic path surfaces its caveat"
         );
     }
 

--- a/wiki/Predicate-Cube-CEGAR.md
+++ b/wiki/Predicate-Cube-CEGAR.md
@@ -55,10 +55,14 @@ cube state space + transition relation, independent of the abstraction itself:
   enumerating cube pairs or issuing per-cube-pair SMT. Orders of magnitude faster at large
   `|P|` (≈10 ms at `|P|=12`, where the explicit SMT path issues ~16.7M queries / ~29 min).
   The `evaluate_tri` verdict is the ground truth either way — the symbolic path is
-  validated cell-for-cell against it. **Current scope (R-F5.4.2b):** *single-shot* (no
-  CEGAR refinement), simple `NAME:REG=VALUE` equality predicates, and the bare `[]`/`<>`
-  fragment only. Source of truth:
-  [`adapter::btor2::symbolic_engine::symbolic_cube_verdicts`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs).
+  validated cell-for-cell against it. Runs the **CEGAR refinement loop** (WP predicate
+  discovery on ⊥, rebuilding the BDD relation each iteration — still no per-cube-pair SMT;
+  `--max-iterations 0` = single-shot). **Current scope (R-F5.5a/b):** simple
+  `NAME:REG=VALUE` equalities + non-derived `--sidecar` `compound_predicates` (`cnt >= 2`,
+  relational), and the bare `[]`/`<>` fragment only. Derived/combinational predicates and
+  the Clts-only optimisations (failure-subgame precision, approximant reuse, CTXDSL emit)
+  remain `--engine explicit` only. Source of truth:
+  [`adapter::btor2::symbolic_engine::symbolic_cegar_refine`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs).
 
 Both engines share the same 3-valued semantics and soundness (below). See
 [the post-R-F5 architecture](https://github.com/vscorza/mununu/blob/main/docs/design/post-rf5-architecture.md)
@@ -90,7 +94,7 @@ Key flags:
 | `--max-iterations` | CEGAR refinement cap (default 16) |
 | `--controllable-input` | mark an input as controller-chosen (synthesis / controllability-aware lift) |
 | `--emit-ctxdsl <PATH>` | dump the refined cube model as CTXDSL |
-| `--engine` | `explicit` (default, SMT edges + CEGAR) \| `symbolic` (R-F5 BDD relation, single-shot, no per-cube-pair SMT — orders of magnitude faster at large `\|P\|`) |
+| `--engine` | `explicit` (default, SMT edges + CEGAR) \| `symbolic` (R-F5 BDD relation + CEGAR loop, no per-cube-pair SMT — orders of magnitude faster at large `\|P\|`; handles equality + non-derived sidecar compound predicates) |
 
 `mununu sv cegar <design.sv> --formula … --predicate …` accepts the same property
 flags and runs sv2v + Yosys internally.


### PR DESCRIPTION
`--engine symbolic` now runs the full **CEGAR refinement loop**, not a single-shot: on a ⊥ verdict it discovers a separating predicate, adds it, and re-evaluates — rebuilding the BDD relation each iteration (cheap; still no per-cube-pair SMT). The last big parity gap before the default-flip.

## What

`symbolic_engine::symbolic_cegar_refine(...)` → `SymbolicCegarResult` (per-iteration verdict records + final predicates + `SymbolicCegarTermination` {Converged, BoundedIterationsReached, PredicateSourceExhausted}).

The loop **reuses the explicit path's WP discovery**: `cegar::wp_refine_predicates` (new pub wrapper) hands `weakest_precondition_predicates` a minimal placeholder failure subgame — WP only uses the subgame as a non-empty *trigger* (it proposes predicates from the current predicates' COI + BTOR2 constants, not the specific transition), so no explicit Clts / parity-game subgame is needed. `max_iterations = 0` reproduces single-shot. A `MAX_SYMBOLIC_CUBE_BITS = 16` cap bounds the (still-enumerative) per-cube tally.

## Surfaces (via `--max-iterations`)

- **CLI** `run_symbolic_cegar_cli` reports `refinement iterations` + `terminated_with` alongside the T/F/⊥ tally.
- **API** `run_symbolic_cegar_response` returns the standard `Btor2CegarResponse` with per-iteration `CegarIterationView`s + `terminated_with`.

## Tests

The loop terminates with a valid reason + only ever grows the predicate set on a ⊥-inducing property (`EF(cnt==3)`, a genuine thoroughness gap that doesn't converge); `max_iterations=0` = one evaluation; the API cegar test asserts the loop shape (iteration 0 recorded; converges on a definite property). Wiki updated.

## Next (R-F5.5c/d — the default-flip gate)

Guarded modalities in the symbolic evaluator (R-F5.2c), then the dual-engine verdict-parity sweep + real sysrst measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)