### PR TITLE
fix(R-F5.5d): symbolic verdict projection returned an unsound VIOLATED on infeasible cubes

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -1928,6 +1928,78 @@ mod tests {
         }
     }
 
+    /// Gated counter: `cnt` decrements only when the *untracked* register `tb`
+    /// is 1, else holds; `tb' = setb` (free input). Mirrors uart_tx's `bit_cnt_q`
+    /// gated by the `tick_baud_q` register. The predicate set is only `cnt == 0`
+    /// (so `tb` is untracked). With the state `(cnt=1, tb=1)` FORCED to `cnt=0`
+    /// regardless of input, the `∀∃` must-edge `{cnt≠0} → {cnt≠0}` must NOT hold
+    /// (that state escapes). This is the exact structure where the verify-auto
+    /// symbolic engine returned an (apparently unsound) definite verdict on
+    /// `AG AF (bit_cnt==0)` — the brute-force oracle is ground truth.
+    const GATED_COUNTER_BTOR2: &str = r#"
+1 sort bitvec 2
+2 sort bitvec 1
+3 state 1 cnt
+4 state 2 tb
+5 input 2 setb
+6 one 1
+7 zero 1
+8 eq 2 3 7
+9 not 2 8
+10 and 2 4 9
+11 sub 1 3 6
+12 ite 1 10 11 3
+13 next 1 3 12
+14 next 2 4 5
+"#;
+
+    #[test]
+    fn rf5_soundness_gated_counter_must_relation_matches_bruteforce() {
+        let predicates = [PredicateExpr::eq("cnt", 0)];
+        for sem in [MustSemantics::ForallExists, MustSemantics::ForallForall] {
+            assert_must_relation_matches_bruteforce(
+                GATED_COUNTER_BTOR2,
+                &predicates,
+                &[("cnt", 2), ("tb", 1)],
+                &[("setb", 1)],
+                sem,
+            );
+        }
+    }
+
+    /// Evaluate `AG AF (cnt==0)` over the gated counter and print the per-cube
+    /// verdict. `c1 = {cnt≠0}` has may-edges to both `c0` and `c1` but (per the
+    /// brute-force-verified relation) NO must-edge, so `AF (cnt==0)` at `c1` must
+    /// be ⊥ (`must=false`, `may=true`), hence `AG AF` is ⊥ — NOT a definite
+    /// VIOLATED. If this prints `False` at a feasible cube, the evaluation is the
+    /// unsoundness source; if `⊥`, the verify-auto VIOLATED comes from elsewhere
+    /// (pinning / shadow / compound / final-verdict projection).
+    #[test]
+    fn rf5_soundness_gated_counter_ag_af_is_bottom_not_violated() {
+        let predicates = [PredicateExpr::eq("cnt", 0)];
+        let file = parser::parse(GATED_COUNTER_BTOR2).expect("parse");
+        let bb = BddBitBlaster::build(&file).expect("build");
+        let rel = bb
+            .abstract_relation(&predicates, Some(MustSemantics::ForallExists))
+            .expect("rel");
+        let names = ["done".to_string()];
+        let formula = crate::mu_calculus::parser::parse("nu X. ((mu Y. (done or [] Y)) and [] X)")
+            .expect("formula");
+        let v = rel.evaluate(&formula, &names).expect("eval");
+        for c in rel.feasible_cubes() {
+            let verdict = rel.verdict_at(&v, c);
+            eprintln!("AG AF (cnt==0) @ cube {c}: {verdict:?}");
+            // No feasible cube may be definite-False: the concrete design can
+            // always eventually reach cnt==0 (or stay), so a definite VIOLATED
+            // would be unsound. ⊥ or True are acceptable.
+            assert_ne!(
+                verdict,
+                crate::mu_calculus::trit::Trit::False,
+                "cube {c}: AG AF (cnt==0) is definite-False — unsound over the gated counter"
+            );
+        }
+    }
+
     /// The KMTS invariant `R_must ⊆ R_may` over **feasible** source cubes: every
     /// must-edge out of a satisfiable cube is a may-edge (for both semantics).
     /// An infeasible (unsatisfiable) cube is excluded — it is vacuously a

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1131,7 +1131,13 @@ fn symbolic_final_verdict(
     let n = 1usize << k;
     let mut must = bitvec![usize, Lsb0; 0; n];
     let mut may = bitvec![usize, Lsb0; 0; n];
+    // `symbolic_cube_verdicts` tallies ONLY feasible cubes. Every other cube
+    // stays absent from `cube_verdicts`. Track which cubes were tallied so the
+    // untallied (infeasible) ones can be projected to ⊥ below — NOT left at
+    // `must=0, may=0`, which `TritSet::verdict_at` reads as a definite-False.
+    let mut tallied = bitvec![usize, Lsb0; 0; n];
     for (cube, trit) in &result.final_verdicts.cube_verdicts {
+        tallied.set(*cube, true);
         match trit {
             crate::mu_calculus::trit::Trit::True => {
                 must.set(*cube, true);
@@ -1141,6 +1147,18 @@ fn symbolic_final_verdict(
                 may.set(*cube, true);
             }
             crate::mu_calculus::trit::Trit::False => {}
+        }
+    }
+    // SOUNDNESS (R-F5.5d projection fix): an infeasible cube — one no concrete
+    // state inhabits, hence absent from the feasible-cube tally — is VACUOUS,
+    // not a definite violation. Projecting it to ⊥ (`may=1, must=0`) prevents an
+    // infeasible `init_cube` from reading as a spurious VIOLATED via
+    // `TritSet::verdict_at` (which maps `must=0, may=0` → `Trit::False`).
+    // Feasible cubes that genuinely evaluate to False stay `must=0, may=0` (a
+    // real violation is preserved) because they ARE tallied.
+    for c in 0..n {
+        if !tallied[c] {
+            may.set(c, true);
         }
     }
     crate::mu_calculus::trit::TritSet::from_parts(must, may)
@@ -1808,6 +1826,48 @@ module uart_tx(); endmodule"#;
 
         let plain = scan_annotation_properties(&src("module m(); endmodule"));
         assert!(annotation_note(&plain).is_none());
+    }
+
+    /// R-F5.5d projection SOUNDNESS fix — an infeasible cube (absent from the
+    /// symbolic feasible-cube tally) must project to ⊥, NOT a spurious
+    /// definite-False. Regression for the unsound VIOLATED verify-auto returned
+    /// on `AG AF` (the symbolic tally covers only feasible cubes; an infeasible
+    /// `init_cube` was reading as `must=0,may=0` → `Trit::False` → VIOLATED).
+    #[test]
+    fn rf5_5d_symbolic_final_verdict_infeasible_cube_is_bottom_not_false() {
+        use crate::adapter::btor2::symbolic_engine::{
+            SymbolicCegarResult, SymbolicCegarTermination, SymbolicCubeVerdicts,
+        };
+        use crate::mu_calculus::trit::Trit;
+        // 2 predicates → 4 cubes; only 0,1 are feasible + tallied. Cubes 2,3 are
+        // infeasible and absent from the tally.
+        let result = SymbolicCegarResult {
+            iterations: Vec::new(),
+            final_predicates: Vec::new(),
+            final_verdicts: SymbolicCubeVerdicts {
+                num_predicates: 2,
+                cube_verdicts: vec![(0, Trit::Unknown), (1, Trit::True)],
+                definite_true: 1,
+                definite_false: 0,
+                bottom: 1,
+            },
+            terminated_with: SymbolicCegarTermination::Converged,
+        };
+        let ts = symbolic_final_verdict(&result);
+        // Feasible cubes keep their verdict.
+        assert_eq!(ts.verdict_at(0), Trit::Unknown);
+        assert_eq!(ts.verdict_at(1), Trit::True);
+        // Infeasible (untallied) cubes are ⊥, never a spurious definite-False.
+        assert_eq!(
+            ts.verdict_at(2),
+            Trit::Unknown,
+            "infeasible cube 2 must project to ⊥, not False"
+        );
+        assert_eq!(
+            ts.verdict_at(3),
+            Trit::Unknown,
+            "infeasible cube 3 must project to ⊥, not False"
+        );
     }
 
     /// R-F5.5d — `symbolic_final_verdict` projects the symbolic engine's per-cube


### PR DESCRIPTION
## Summary

A **soundness bug** in the R-F5.5d symbolic verdict projection: `--engine symbolic` on `sv verify-auto` could report a spurious **VIOLATED** (a false counterexample) on a property with no real violation, whenever an `init_cube` was infeasible in the symbolic relation's feasibility set.

Found while investigating why `--engine symbolic` and `--engine explicit` disagreed on `AG AF (bit_cnt_q == 0)` over real OpenTitan `uart_tx` (explicit → ⊥, symbolic → VIOLATED).

## Root cause (clear, code-proven)

- `symbolic_cube_verdicts` tallies **only feasible cubes** (`for cube in rel.feasible_cubes()`). Infeasible cubes are absent from `cube_verdicts`.
- `symbolic_final_verdict` initialized `must`/`may` bitvecs over all `2^k` cubes to **zeros** and set bits only for tallied cubes — so every infeasible cube stayed `must=0, may=0`.
- `TritSet::verdict_at(must=0, may=0)` = **`Trit::False`**.

⇒ an infeasible `init_cube` was projected to a spurious definite-False → `any_false` → **VIOLATED**.

The core engine is **not** at fault — ruled out rigorously:
- The symbolic `∀∃`/`∀∀` **must-relation matches the brute-force concrete oracle** on a gated-counter repro (`cnt` decrements only when the *untracked* register `tb=1`, mirroring `bit_cnt` gated by `tick_baud_q`).
- The core **`evaluate`** yields ⊥/True at every feasible cube on that model — never a definite-False.

## Fix

An infeasible (untallied) cube is **vacuous** → project it to **⊥ (`may=1, must=0`)**, not False. Feasible cubes that genuinely evaluate to False stay `must=0, may=0` (a real violation is preserved) because they *are* tallied.

## Test plan (in `make ci`)

- `rf5_5d_symbolic_final_verdict_infeasible_cube_is_bottom_not_false` — deterministic: cubes absent from a 2-predicate (4-cube) tally read as ⊥, not False; tallied cubes keep their verdict.
- `rf5_soundness_gated_counter_must_relation_matches_bruteforce` — the symbolic must-relation matches the brute-force oracle (rules out a must-edge over-claim).
- `rf5_soundness_gated_counter_ag_af_is_bottom_not_violated` — `AG AF (cnt==0)` never produces a definite-False on the gated counter.
- **End-to-end (mununu-sva docker):** the uart_tx symbolic VIOLATED → ⊥, matching the explicit engine.

Full `make ci` green (pre-push hook passed on `3939453`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)