### PR TITLE
feat(D1.6): --engine exact-symbolic across CLI + API + UI + verify-auto

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -196,6 +196,15 @@ enum EngineArg {
     /// and the Clts-only optimisations (failure-subgame precision, approximant
     /// reuse, CTXDSL emit) are still `--engine explicit` only.
     Symbolic,
+    /// D1 exact symbolic MC: decide the μ-calculus EXACTLY over the full
+    /// bit-blasted state (no predicate abstraction), by ROBDD μ/ν fixpoint from the
+    /// reset init. The verdict is **definite** (2-valued Holds/Violated, never ⊥) —
+    /// it decides `AF`-liveness (and any μ-calculus property) where the abstraction
+    /// engines return Unknown: over the exact finite state the fixpoint IS the
+    /// ranking, so no ranking/fairness infra is needed. Bounded by BDD size (a
+    /// design too large to bit-blast ⇒ the property is `Skipped`). Verify-auto only
+    /// (the surface that supplies a reset-gated model).
+    ExactSymbolic,
 }
 
 /// R.2.5b session-1 follow-up (2026-06-06) — must-edge inference
@@ -1251,7 +1260,11 @@ struct SvVerifyAutoArgs {
     /// of magnitude faster at large `|P|`, the FSM-cone residual). Symbolic
     /// supports cube-dimension predicates (equality + non-derived compounds) +
     /// the bare `[]`/`<>` fragment; a derived predicate or guarded modality
-    /// `Skipped`s that property.
+    /// `Skipped`s that property. D1.6 (2026-07-04) — `exact-symbolic` decides
+    /// each property EXACTLY over the reset-gated design's full bit-blasted state
+    /// (no predicate abstraction, so a **definite** 2-valued verdict, never ⊥) —
+    /// it decides `AF`-liveness where both cube engines return Unknown; bounded by
+    /// BDD size (a design too large to bit-blast ⇒ the property is `Skipped`).
     #[arg(long, value_enum, default_value_t = EngineArg::Explicit)]
     engine: EngineArg,
 }
@@ -2295,6 +2308,9 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         // R-F5.5d — `--engine symbolic` routes every property through the R-F5
         // BDD CEGAR loop (no per-cube-pair SMT).
         symbolic_engine: args.engine == EngineArg::Symbolic,
+        // D1.6 — `--engine exact-symbolic` decides each property exactly over the
+        // full bit-blasted state (definite verdict, never ⊥).
+        exact_symbolic: args.engine == EngineArg::ExactSymbolic,
     };
 
     let report = verify_auto(&sources, &yopts, &opts)
@@ -2660,6 +2676,18 @@ fn run_cegar_cli(
     // Parse the μ-calculus formula.
     let formula =
         mu_parser::parse(params.formula).map_err(|e| format!("formula parse error: {e:?}"))?;
+
+    // D1.6 — exact symbolic MC is a verify-auto-only engine: it needs the
+    // reset-gated model + reset init that `sv verify-auto` builds. The raw
+    // `btor2 cegar` / `sv cegar` surfaces are cube-CEGAR (trace output).
+    if params.engine == EngineArg::ExactSymbolic {
+        return Err(
+            "--engine exact-symbolic is available on `sv verify-auto` only (it decides the \
+             property exactly over the reset-gated model verify-auto builds). Use `--engine \
+             explicit` or `symbolic` here."
+                .to_string(),
+        );
+    }
 
     // R-F5.4.2b — the symbolic engine short-circuits the explicit lift + CEGAR
     // loop: it builds the may/must relation as BDDs directly from the BTOR2 and

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -466,6 +466,14 @@ pub struct VerifyAutoOptions {
     /// derived/combinational predicate or a guarded modality errors → the
     /// property is `Skipped` with the reason. Mirrors the CLI/API `--engine`.
     pub symbolic_engine: bool,
+    /// D1.6 (2026-07-04) — run each property through **exact** full-state symbolic
+    /// MC (`--engine exact-symbolic`): the μ-calculus is decided EXACTLY over the
+    /// reset-gated btor2's bit-blasted state (no predicate abstraction), so the
+    /// verdict is a **definite** 2-valued Holds/Violated — never ⊥. Decides
+    /// `AF`-liveness (and any μ-calculus property) where the cube path returns
+    /// Unknown; bounded by BDD size (a design over the bit cap ⇒ `Skipped`). Takes
+    /// precedence over `symbolic_engine`. Mirrors the CLI/API `--engine`.
+    pub exact_symbolic: bool,
 }
 
 impl Default for VerifyAutoOptions {
@@ -478,6 +486,7 @@ impl Default for VerifyAutoOptions {
             config_values: std::collections::HashMap::new(),
             counter_bounds: std::collections::HashMap::new(),
             symbolic_engine: false,
+            exact_symbolic: false,
         }
     }
 }
@@ -1473,6 +1482,43 @@ pub fn verify_auto(
             }
         };
 
+        // D1.6 — exact full-state symbolic MC (`--engine exact-symbolic`): decide
+        // the property EXACTLY over the reset-gated btor2's bit-blasted state — no
+        // predicate abstraction, so a **definite** 2-valued verdict (never ⊥). Runs
+        // BEFORE cube seeding: the exact engine binds the formula's atoms directly
+        // (register-name resolution), so it needs no cube and must NOT be gated
+        // behind cube-seeding success — deciding a property the cube path cannot
+        // seed is exactly this engine's purpose. The btor2 here is reset-gated
+        // (reset input pinned inactive) and `$past`-shadow-augmented; the init is
+        // the modelled reset state (`initial_state_bdd`: every register pinned to
+        // its `init` value or 0). Decides `AF`-liveness (and any μ-calculus
+        // property) where the cube path returns Unknown; bounded by BDD size
+        // (build errors above the bit cap ⇒ Skipped).
+        if opts.exact_symbolic {
+            let outcome = match crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict(
+                &btor2, &formula,
+            ) {
+                Ok(crate::adapter::btor2::symbolic_bitblast::ExactVerdict::Holds) => {
+                    VerifyOutcome::Holds
+                }
+                Ok(crate::adapter::btor2::symbolic_bitblast::ExactVerdict::Violated) => {
+                    // A definite full-state counterexample (not a cube tally).
+                    VerifyOutcome::Violated { false_cells: 1 }
+                }
+                Err(e) => VerifyOutcome::Skipped {
+                    reason: format!("exact symbolic MC: {e}"),
+                },
+            };
+            report.properties.push(PropertyVerdict {
+                name: t.name.clone(),
+                kind: t.kind,
+                formula: formula_str.clone(),
+                outcome,
+                seeded_predicates: Vec::new(),
+            });
+            continue;
+        }
+
         let mut seeded = seed_from_formula(
             &formula,
             resolves_to_state,
@@ -1680,7 +1726,8 @@ pub fn verify_auto(
         // selected engine. The explicit path runs `cegar_refine_loop`; the
         // symbolic path runs the R-F5 BDD CEGAR loop and projects its per-cube
         // verdicts into the same `TritSet` shape (over `2^|final P|`, same cube
-        // indexing), so the init-cube read below is identical.
+        // indexing), so the init-cube read below is identical. (The
+        // `--engine exact-symbolic` path returned early above, before seeding.)
         let final_verdict_res: Result<
             crate::mu_calculus::trit::TritSet,
             crate::adapter::AdapterError,
@@ -4576,6 +4623,78 @@ endmodule
             "the full sysrst design exceeds the symbolic bit-blast cap → every property \
              degrades to a Skipped (bit-cap) verdict GRACEFULLY (no OoM panic); the R-F5.6 \
              COI restriction is what lets the symbolic engine scale to real designs"
+        );
+    }
+
+    /// D1.6 — the `--engine exact-symbolic` **surface route**, end-to-end through
+    /// `verify_auto` on real OpenTitan RTL. A `@mununu_guarantee` annotation carries
+    /// the headline `AG AF (bit_cnt_q == 0)` liveness property; `verify_auto` with
+    /// `exact_symbolic: true` must route it through the exact full-state ROBDD MC
+    /// (`exact_symbolic_verdict`) — the same engine `e2e_d1_uart_tx_exact_liveness_verdict`
+    /// exercises directly — and return a **definite Holds**, where the predicate-cube
+    /// path answers this ⊥ (no ranking for `AF`).
+    ///
+    /// This validates the CLI/API `--engine exact-symbolic` wiring, not the D1 thesis
+    /// itself (that is the direct test's job): the annotation guarantee flows through
+    /// scan → merge → the hoisted exact branch (which runs BEFORE cube seeding, so it
+    /// is never gated behind a seeding skip). The btor2 here is reset-gated +
+    /// `$past`-shadow-augmented (unlike the direct test's raw btor2); reset-gating
+    /// pins the reset input inactive, so a genuinely-holding liveness property stays
+    /// Holds.
+    #[test]
+    #[ignore = "requires slang + sv2v + Yosys (use the mununu-sva docker image); run with --ignored"]
+    fn e2e_d1_6_verify_auto_exact_symbolic_route_uart_tx() {
+        use std::path::PathBuf;
+        let src_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../examples/verify/m1_opentitan_uart_tx/source/uart_tx.sv");
+        let uart_tx = std::fs::read_to_string(&src_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", src_path.display()));
+        // Carry the AG AF liveness property as a source annotation — verify_auto's
+        // scan_annotation_properties reads the ORIGINAL source (not the elaborated
+        // output), parses the body via the mu-calculus parser, and merges it as
+        // `ann_guarantee_0`.
+        let annotated = format!(
+            "// @mununu_guarantee nu X. ((mu Y. ((bit_cnt_q == 0) or [] Y)) and [] X)\n{uart_tx}"
+        );
+        let sources = vec![("uart_tx.sv".to_string(), annotated)];
+        let yopts = YosysOptions {
+            top: Some("uart_tx".to_string()),
+            use_sv2v: true,
+            ..Default::default()
+        };
+        let report = verify_auto(
+            &sources,
+            &yopts,
+            &VerifyAutoOptions {
+                exact_symbolic: true,
+                ..Default::default()
+            },
+        )
+        .expect("verify_auto runs with --engine exact-symbolic");
+
+        let guarantee = report
+            .properties
+            .iter()
+            .find(|p| p.name.contains("ann_guarantee"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "the @mununu_guarantee property must appear in the report; got: {:?}",
+                    report
+                        .properties
+                        .iter()
+                        .map(|p| &p.name)
+                        .collect::<Vec<_>>()
+                )
+            });
+        eprintln!(
+            "\n=== D1.6 verify_auto --engine exact-symbolic on uart_tx ===\n  {} ({}): {:?}",
+            guarantee.name, guarantee.formula, guarantee.outcome
+        );
+        assert!(
+            matches!(guarantee.outcome, VerifyOutcome::Holds),
+            "AG AF (bit_cnt_q==0) must be decided Holds by the exact-symbolic route \
+             through verify_auto; got {:?}",
+            guarantee.outcome
         );
     }
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -805,6 +805,12 @@ pub async fn sv_verify_auto_handler(
             .engine
             .as_deref()
             .is_some_and(|e| e.eq_ignore_ascii_case("symbolic")),
+        // D1.6 — `engine: "exact-symbolic"` decides each property exactly over the
+        // full bit-blasted state (definite verdict, never ⊥).
+        exact_symbolic: request
+            .engine
+            .as_deref()
+            .is_some_and(|e| e.eq_ignore_ascii_case("exact-symbolic")),
     };
 
     let report = verify_auto(&sources, &yopts, &opts).map_err(|e| ApiError::BadRequest {

--- a/wiki/Predicate-Cube-CEGAR.md
+++ b/wiki/Predicate-Cube-CEGAR.md
@@ -67,8 +67,20 @@ cube state space + transition relation, independent of the abstraction itself:
   precision, approximant reuse, CTXDSL emit) remain `--engine explicit` only. Source of
   truth:
   [`adapter::btor2::symbolic_engine::symbolic_cegar_refine`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs).
+- **Exact symbolic MC (D1, shipped — `sv verify-auto --engine exact-symbolic` only)** — *not*
+  a predicate-cube engine: it drops the abstraction entirely and decides the μ-calculus
+  **exactly** over the full bit-blasted state by ROBDD μ/ν fixpoint from the reset init.
+  Because the state is exact (no may/must split), every verdict is **definite** — 2-valued
+  `Holds` / `Violated`, never ⊥. This decides `AF`-liveness (and any μ-calculus property)
+  where *both* cube engines return Unknown: over the exact finite state the least-fixpoint
+  iteration **is** the ranking, so no ranking/fairness infrastructure is needed. Bounded by
+  BDD size — a design too large to bit-blast makes the property `Skipped` (graceful, no OoM).
+  Exposed only on `sv verify-auto` (the surface that supplies a reset-gated model). Source of
+  truth:
+  [`adapter::btor2::symbolic_bitblast::exact_symbolic_verdict`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs)
+  — surface: CLI+API+UI.
 
-Both engines share the same 3-valued semantics and soundness (below). See
+The two cube engines share the same 3-valued semantics and soundness (below). See
 [the post-R-F5 architecture](https://github.com/vscorza/mununu/blob/main/docs/design/post-rf5-architecture.md)
 for the full picture (IR layering, may/must edges, over/under/⊥ approximation).
 


### PR DESCRIPTION
## D1.6 — `--engine exact-symbolic` surface integration

Completes the **D1 exact full-state symbolic MC** arc (D1.1–D1.5, #224–#228) by wiring the engine onto the user-facing surfaces with full CLI + HTTP API + UI parity.

### What it does

The exact engine (`exact_symbolic_verdict`) drops predicate abstraction entirely and decides the μ-calculus **exactly** over the reset-gated design's full bit-blasted state, by ROBDD μ/ν fixpoint from the reset init. Because the state is exact (no may/must split), every verdict is **definite** — 2-valued `Holds`/`Violated`, never ⊥. Over the exact finite state the least-fixpoint iteration *is* the ranking, so it decides `AF`-liveness (and any μ-calculus property) where both predicate-cube engines return Unknown. Bounded by BDD size: a design too large to bit-blast makes the property `Skipped` (graceful, no OoM).

### Surfaces

| Surface | Change |
|---|---|
| **CLI** | `EngineArg::ExactSymbolic` → `mununu sv verify-auto --engine exact-symbolic`. The `btor2 cegar` / `sv cegar` subcommands reject it with an actionable error (it is verify-auto-only — that's the surface that supplies a reset-gated model). |
| **API** | `engine: "exact-symbolic"` → `VerifyAutoOptions { exact_symbolic: true }`. |
| **UI** | Engine `<select>` gains an exact-symbolic option (endpoints already carry `engine?: string`). *(mununu-ui companion PR.)* |
| **core** | `VerifyAutoOptions.exact_symbolic: bool`. The exact branch runs **before** cube seeding and `continue`s — the exact engine binds the formula's atoms directly (register-name resolution), so it needs no cube and must not be gated behind cube-seeding success. |

### Tests & docs

- **Docker-gated e2e** (`e2e_d1_6_verify_auto_exact_symbolic_route_uart_tx`): a `@mununu_guarantee` carries `AG AF (bit_cnt_q==0)` through `verify_auto` with `exact_symbolic:true` on OpenTitan `uart_tx`, asserting a definite **Holds** — the surface route for the D1 thesis that the direct `e2e_d1_uart_tx_exact_liveness_verdict` proves on the raw btor2.
- Non-ignored: 38 `verify_auto` unit tests green; `cargo fmt --check` + `clippy -D warnings` clean.
- `wiki/Predicate-Cube-CEGAR.md` gains the exact-symbolic engine bullet with a `Source of truth:` anchor (surface: CLI+API+UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
