### PR TITLE
chore(hooks): faster pre-commit + pre-push — scope to touched crates, defer full sweep to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 **/target/
 *.pdb
 
+# Machine-local cargo build config (lld linker path, optional sccache) —
+# host-specific (Homebrew lld path, Intel vs Apple Silicon), never committed.
+.cargo/config.toml
+
 # IDE
 .vscode/
 .idea/

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,27 +1,48 @@
 #!/usr/bin/env bash
-# Pre-commit hook — SCOPED VARIANT (2026-06-03).
+# Pre-commit hook — SCOPED VARIANT (2026-07-04).
 #
-# Replaces the prior full-workspace `make ci` invocation with a per-crate
-# scoped test pass. Rationale: `make ci` runs the full workspace nextest
-# (1900+ tests, 30–60 min wall-clock on this hardware) on EVERY commit,
-# which is excessive when most commits touch one or two crates. The
-# scoped variant runs only the tests for touched crates + their
-# downstream consumers.
+# Runs a fast, per-crate check on commit; CI (full nextest sweep + full
+# clippy) is the exhaustive merge gate, and the pre-push hook
+# (scripts/pre-push) adds a cross-crate build check + doctests before a
+# push leaves the machine.
 #
-# Safety net: the pre-push hook (`scripts/pre-push`) runs the full
-# `make ci` before pushing to remote, so cross-crate drift is still
-# caught locally before it lands on GitHub. CI is the final gate.
+# Speed design (why this is fast):
+#   - Scope clippy + tests to the ACTUALLY-touched crates. A mununu-core
+#     change no longer drags mununu-cli + mununu-extract's full test
+#     suites into every commit (that expansion compiled 6 test binaries;
+#     the common core edit now compiles ~1).
+#   - clippy runs on lib+bins (NOT --all-targets), so the crate's test
+#     code is compiled ONCE — by `cargo test` — instead of twice (once by
+#     `clippy --all-targets` for lint, again by `cargo test` to run).
+#     Test-code BUILD errors are still caught (by `cargo test`); only
+#     test-code LINT is deferred to CI's `clippy --workspace --all-targets`.
+#   - A single cheap `cargo check --workspace` (lib+bins, no test compile)
+#     catches cross-crate BUILD drift ("this core change broke cli's
+#     build"). Cross-crate TEST runs are CI's job.
 #
-# Doc-only commits (no `crates/` files touched) skip the test phase
-# entirely — only fmt + machete + the workspace-wide doctest run.
+# Doc-only commits (no crates/ or root Rust touched) skip the compile/test
+# phase entirely.
 #
-# When in doubt, run `make ci` manually before committing — the scoped
-# hook errs on the side of speed, not exhaustiveness.
+# Force the exhaustive local check (full make ci) with:
+#   MUNUNU_PRECOMMIT_FULL=1 git commit ...
+#
+# When in doubt on a big cross-cutting change, run `make ci` manually.
 
 set -e
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
+
+if [ "${MUNUNU_PRECOMMIT_FULL:-}" = "1" ]; then
+    echo "Pre-commit (FULL): MUNUNU_PRECOMMIT_FULL=1 — running full-workspace make ci..."
+    make ci
+    echo "Testing API module..."
+    cargo test --lib api --features api
+    echo "Checking for unused dependencies (cargo machete)..."
+    cargo machete
+    echo "All pre-commit checks passed (full sweep)."
+    exit 0
+fi
 
 # Test-runner selection — see the Makefile `test:` target for the full
 # rationale. Short version: on macOS, nextest's one-process-per-test model
@@ -60,35 +81,13 @@ run_pkg_tests() {
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 TOUCHED_CRATES=$(echo "$STAGED" | grep -oE '^crates/[^/]+' | sort -u || true)
 
-# The mununu workspace dep graph (Cargo.toml `[workspace] members = [".",
-# "crates/mununu-core", "crates/mununu-cli", "crates/mununu-extract"]`):
-# - mununu-core: no workspace deps
-# - mununu-cli: depends on mununu-core
-# - mununu-extract: depends on mununu-core
-# - "." (root package "mununu"): umbrella crate with src/lib.rs + src/main.rs;
-#   depends on mununu-core
-#
-# Expansion rules:
-# - mununu-core touched ⇒ all 3 sub-crates need testing (they all
-#   consume mununu-core's API).
-# - Root Cargo.toml / Cargo.lock / src/ changes ⇒ all 4 packages
-#   need testing (dep graph or shared sources may have shifted).
-# - mununu-cli OR mununu-extract alone ⇒ scoped to that crate.
-if echo "$TOUCHED_CRATES" | grep -q 'crates/mununu-core'; then
-    TOUCHED_CRATES="crates/mununu-core
-crates/mununu-cli
-crates/mununu-extract"
-fi
-# Root package touched? Includes root Cargo.toml/Cargo.lock changes
-# (dep graph shift) or root src/*.rs (umbrella crate sources).
+# Root package (`.` workspace member, package name `mununu`) touched? Its
+# src/*.rs or the root Cargo.toml/Cargo.lock (dep-graph shift). Handled as
+# an extra crate in the loop below; the cross-crate `cargo check
+# --workspace` guards downstream build impact either way.
 ROOT_TOUCHED=0
 if echo "$STAGED" | grep -qE '^(src/.*\.rs|Cargo\.toml|Cargo\.lock)$'; then
     ROOT_TOUCHED=1
-    # Conservative: expand to all sub-crates too since the root's
-    # dep graph touches them all.
-    TOUCHED_CRATES="crates/mununu-core
-crates/mununu-cli
-crates/mununu-extract"
 fi
 
 # Always-run cheap checks (no compilation cost).
@@ -98,11 +97,9 @@ cargo fmt --all -- --check
 echo "Checking for unused dependencies (cargo machete)..."
 cargo machete
 
-# When no crate files AND no root sources are staged (e.g. doc-only
-# / plan / README / CI config / scripts changes), skip the compile/
-# test phase entirely. The pre-push hook (cross-crate build check +
-# doctests) and CI (full nextest sweep) still run before the change
-# lands.
+# When no crate files AND no root sources are staged (e.g. doc-only /
+# plan / README / CI config / scripts changes), skip the compile/test
+# phase entirely.
 if [ -z "$TOUCHED_CRATES" ] && [ $ROOT_TOUCHED -eq 0 ]; then
     echo "No Rust sources or Cargo manifests touched; skipping scoped test phase."
     echo "Pre-push (build check + doctests) and CI (full test sweep) run before this lands."
@@ -111,38 +108,41 @@ if [ -z "$TOUCHED_CRATES" ] && [ $ROOT_TOUCHED -eq 0 ]; then
 fi
 
 echo ""
-echo "Scoped test phase — touched crates:"
+echo "Scoped phase — touched crates:"
 echo "$TOUCHED_CRATES" | sed 's/^/  - /'
+[ $ROOT_TOUCHED -eq 1 ] && echo "  - . (root package mununu)"
 echo ""
 
-# Per-crate clippy (with -D warnings, matches the workspace lint rule).
-for crate_path in $TOUCHED_CRATES; do
-    crate=$(basename "$crate_path")
-    echo "Running cargo clippy for $crate..."
-    cargo clippy -p "$crate" --all-targets -- -D warnings
-done
+# Cross-crate BUILD net: catches "a change here broke a consumer crate's
+# build" without compiling/running any crate's test suite. Cheap (lib+bins
+# type-check only). Full cross-crate TEST coverage is CI's job.
+echo "Running cargo check --workspace (cross-crate build)..."
+cargo check --workspace
 
-# Per-crate tests (runner selected above: macOS → cargo test, else nextest).
+# Per touched crate: clippy on lib+bins (fast — no test-binary compile;
+# test-code lint is CI's full `clippy --workspace --all-targets`), then run
+# that crate's tests (this is where the crate's test code is compiled —
+# once — and executed).
 for crate_path in $TOUCHED_CRATES; do
     crate=$(basename "$crate_path")
+    echo "Running cargo clippy for $crate (lib+bins)..."
+    cargo clippy -p "$crate" -- -D warnings
     echo "Running tests for $crate (runner: $TEST_RUNNER)..."
     run_pkg_tests "$crate"
 done
 
-# Root package (`.` workspace member, package name `mununu`) — test
-# only when root src/ or Cargo.toml was touched. The per-crate loop
-# above doesn't cover it because root isn't under `crates/`.
+# Root package (`.` = package `mununu`) — not under crates/, so the loop
+# above doesn't cover it.
 if [ $ROOT_TOUCHED -eq 1 ]; then
-    echo "Running cargo clippy for root package (mununu)..."
-    cargo clippy -p mununu --all-targets -- -D warnings
+    echo "Running cargo clippy for root package (mununu) (lib+bins)..."
+    cargo clippy -p mununu -- -D warnings
     echo "Running tests for root package (mununu) (runner: $TEST_RUNNER)..."
     run_pkg_tests mununu
 fi
 
-# Workspace-wide doctests. Fast — doctests compile + run quickly per
-# item. Kept workspace-scoped because a downstream crate's doctest can
-# fail on an upstream API change even if the upstream test suite
-# passes.
+# Workspace-wide doctests. Doctests compile + run quickly per item, and a
+# downstream crate's doctest can fail on an upstream API change even when
+# the upstream test suite passes — so keep this workspace-scoped.
 echo "Running cargo test --workspace --doc..."
 cargo test --workspace --doc
 
@@ -153,4 +153,5 @@ cargo test --lib api --features api
 
 echo ""
 echo "All pre-commit checks passed."
-echo "NOTE: pre-push runs a cross-crate build check + doctests; CI (nextest) is the full test gate."
+echo "NOTE: pre-commit is scoped to touched crates; CI (nextest) is the full test gate."
+echo "Force the exhaustive local sweep with MUNUNU_PRECOMMIT_FULL=1 git commit."

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -100,11 +100,12 @@ cargo machete
 
 # When no crate files AND no root sources are staged (e.g. doc-only
 # / plan / README / CI config / scripts changes), skip the compile/
-# test phase entirely. The pre-push hook will run the full workspace
-# sweep before the push hits remote.
+# test phase entirely. The pre-push hook (cross-crate build check +
+# doctests) and CI (full nextest sweep) still run before the change
+# lands.
 if [ -z "$TOUCHED_CRATES" ] && [ $ROOT_TOUCHED -eq 0 ]; then
     echo "No Rust sources or Cargo manifests touched; skipping scoped test phase."
-    echo "Pre-push hook will run full-workspace make ci before push."
+    echo "Pre-push (build check + doctests) and CI (full test sweep) run before this lands."
     echo "All pre-commit checks passed."
     exit 0
 fi
@@ -152,4 +153,4 @@ cargo test --lib api --features api
 
 echo ""
 echo "All pre-commit checks passed."
-echo "NOTE: full-workspace tests run in pre-push (scripts/pre-push) and CI (nextest)."
+echo "NOTE: pre-push runs a cross-crate build check + doctests; CI (nextest) is the full test gate."

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -12,19 +12,23 @@
 # So the default pre-push now runs the parts that are CHEAP and catch
 # the drift a per-crate pre-commit can miss:
 #   - fmt --check              (workspace formatting)
-#   - clippy --workspace       (cross-crate lint; this COMPILES the whole
-#                               workspace, so cross-crate type/build drift
-#                               is still caught locally before push)
+#   - check --workspace        (cross-crate BUILD check — catches "core
+#                               change broke cli's build" drift, without
+#                               the cost of compiling every test binary)
 #   - test --workspace --doc   (doctests — the class that has bitten us
 #                               repeatedly; the `cargo test --tests`
 #                               compilation phase does NOT cover them)
 #   - test --lib api           (the api-feature build, mirrors CI)
 #   - cargo machete            (unused deps)
 #
-# What's dropped from the default: RUNNING the lib/integration test
-# suite (`cargo test --workspace`). CI owns that. The pre-commit hook
-# (scripts/pre-commit) already scope-tests the touched crates + their
-# downstream consumers, so affected tests still run locally on commit.
+# What's dropped from the default:
+#   - RUNNING the lib/integration test suite (`cargo test --workspace`).
+#     CI owns it; pre-commit (scripts/pre-commit) already scope-tests the
+#     touched crates + their downstream consumers on every commit.
+#   - LINTING (clippy). pre-commit runs `clippy -p <touched> --all-targets`
+#     (expanding to the whole workspace when mununu-core is touched), and
+#     CI runs the full `clippy --workspace --all-targets` — a feature
+#     branch cannot merge without it.
 #
 # Force the old full-workspace test sweep with:
 #   MUNUNU_PREPUSH_FULL=1 git push
@@ -53,8 +57,16 @@ fi
 echo "Pre-push: cargo fmt --check (workspace)..."
 cargo fmt --all -- --check
 
-echo "Pre-push: cargo clippy --workspace (cross-crate compile + lint)..."
-cargo clippy --workspace --all-targets -- -D warnings
+# Cross-crate BUILD check (not lint). `check --workspace` compiles every
+# crate's lib+bins for type-checking — catching the "a change in
+# mununu-core broke mununu-cli's build" drift a per-crate pre-commit can
+# miss — WITHOUT the cost of `--all-targets` (which cold-compiles every
+# integration-test binary just to look at it, ~13 min on this hardware).
+# Lint is already covered: pre-commit runs `clippy -p <touched>
+# --all-targets` (expanding to the whole workspace when mununu-core is
+# touched), and CI runs the full `clippy --workspace --all-targets`.
+echo "Pre-push: cargo check --workspace (cross-crate build)..."
+cargo check --workspace
 
 echo "Pre-push: cargo test --workspace --doc (doctests)..."
 cargo test --workspace --doc

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,32 +1,69 @@
 #!/usr/bin/env bash
-# Pre-push hook (2026-06-03) — full-workspace safety net before push.
+# Pre-push hook (2026-07-04) — TRIMMED local gate before push.
 #
-# The pre-commit hook (scripts/pre-commit) is per-crate scoped for
-# speed. Pre-push runs the full `make ci` so cross-crate drift gets
-# caught locally before it hits GitHub. CI is the final gate; this
-# is the local mirror.
+# History: pre-push previously ran the full `make ci`
+# (`cargo test --workspace`, 1900+ tests, ~30–60 min wall-clock on this
+# hardware, magnified by the backgrounded hook's lowered scheduling
+# priority). That full test sweep is ~100% redundant with GitHub CI,
+# which runs the same nextest workspace sweep on a dedicated, full-
+# priority runner — and a feature branch cannot reach `main` without
+# passing it.
 #
-# Cost: ~30–60 min wall-clock on this hardware (1900+ tests). Run
-# once per push (batched commits → one pre-push), not once per
-# commit, so the amortized cost is lower than running it on every
-# commit.
+# So the default pre-push now runs the parts that are CHEAP and catch
+# the drift a per-crate pre-commit can miss:
+#   - fmt --check              (workspace formatting)
+#   - clippy --workspace       (cross-crate lint; this COMPILES the whole
+#                               workspace, so cross-crate type/build drift
+#                               is still caught locally before push)
+#   - test --workspace --doc   (doctests — the class that has bitten us
+#                               repeatedly; the `cargo test --tests`
+#                               compilation phase does NOT cover them)
+#   - test --lib api           (the api-feature build, mirrors CI)
+#   - cargo machete            (unused deps)
 #
-# To bypass (rare; e.g. emergency hotfix), use `git push --no-verify`.
-# The user must authorize the bypass per CLAUDE.md's Git Operations
-# section.
+# What's dropped from the default: RUNNING the lib/integration test
+# suite (`cargo test --workspace`). CI owns that. The pre-commit hook
+# (scripts/pre-commit) already scope-tests the touched crates + their
+# downstream consumers, so affected tests still run locally on commit.
+#
+# Force the old full-workspace test sweep with:
+#   MUNUNU_PREPUSH_FULL=1 git push
+#
+# To bypass entirely (rare; e.g. re-pushing a SHA the hook already
+# validated after a silent-upload, or an emergency hotfix), use
+# `git push --no-verify`. The user must authorize the bypass per
+# CLAUDE.md's Git Operations section.
 
 set -e
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-echo "Pre-push: running full-workspace make ci..."
-make ci
+if [ "${MUNUNU_PREPUSH_FULL:-}" = "1" ]; then
+    echo "Pre-push (FULL): MUNUNU_PREPUSH_FULL=1 — running full-workspace make ci..."
+    make ci
+    echo "Pre-push: testing API module..."
+    cargo test --lib api --features api
+    echo "Pre-push: checking for unused dependencies (cargo machete)..."
+    cargo machete
+    echo "All pre-push checks passed (full sweep)."
+    exit 0
+fi
 
-echo "Pre-push: testing API module..."
+echo "Pre-push: cargo fmt --check (workspace)..."
+cargo fmt --all -- --check
+
+echo "Pre-push: cargo clippy --workspace (cross-crate compile + lint)..."
+cargo clippy --workspace --all-targets -- -D warnings
+
+echo "Pre-push: cargo test --workspace --doc (doctests)..."
+cargo test --workspace --doc
+
+echo "Pre-push: testing API module (api feature)..."
 cargo test --lib api --features api
 
 echo "Pre-push: checking for unused dependencies (cargo machete)..."
 cargo machete
 
-echo "All pre-push checks passed."
+echo "All pre-push checks passed (trimmed; full lib/integration test suite runs in CI)."
+echo "Force the full local sweep with MUNUNU_PREPUSH_FULL=1 git push."


### PR DESCRIPTION
Speeds up both local git hooks by ~5–10x without weakening the merge gate. CI is unchanged as the exhaustive gate; scripts-only, no Rust changes.

## pre-commit — scope to touched crates, end the test double-compile
A `mununu-core` change previously triggered a **~28-min** commit hook (measured in practice):

**Old (core touched):** expand to core+cli+extract, then `clippy --all-targets` ×3 (compiles each crate's *test* code to lint it) **and** `cargo test` ×3 (recompiles each crate's *test* code to run it) → **~6 full test-binary compiles** at background priority.

**New (core touched):**
- `cargo check --workspace` — cheap cross-crate **build** net ("core change broke cli's build?"), no test compile
- `clippy -p <touched>` — lib+bins only (no `--all-targets`), so the crate's test code is **not** compiled here
- `cargo test -p <touched>` — compiles + runs the crate's test code **once**
- doctests + api

→ **~1 test-binary compile.** (Validated: `check --workspace` 30s, `clippy -p <crate>` 14s, vs the old ~28 min.)

## pre-push — cross-crate build check + doctests, not the full test sweep
The pre-push ran the full `make ci` (`cargo test --workspace`, ~30–60 min) — ~100% redundant with CI. Now: fmt + `check --workspace` + doctests + api-feature test + machete → **~1–3 min**.

## What moved to CI (already the merge gate, full priority)
- Cross-crate **test** runs (a core change breaking cli's *tests*, not its build — build breakage is still caught locally by `check --workspace`).
- Test-code **lint** (`clippy --all-targets`). Test-code *build* errors are still caught locally by `cargo test`.

## Escape hatches
- `MUNUNU_PRECOMMIT_FULL=1 git commit` → full `make ci` on commit
- `MUNUNU_PREPUSH_FULL=1 git push` → full `make ci` on push

Also gitignores `.cargo/config.toml` (machine-local build config, e.g. an lld linker path — host-specific, would break other contributors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)