### PR TITLE
feat(D1.8b): surface the exact-engine stall-lasso counterexample (CLI+API+UI)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2380,6 +2380,25 @@ fn render_verify_auto_text(report: &mununu_core::adapter::slang::verify_auto::Au
         if !p.seeded_predicates.is_empty() {
             println!("        predicates: {}", p.seeded_predicates.join(", "));
         }
+        // D1.8b — the exact engine's stall-lasso counterexample (reset → prefix →
+        // repeating ¬p cycle), present only for a Violated bare `AF p`.
+        if let Some(cex) = &p.counterexample {
+            println!("        counterexample (stall lasso):");
+            let render_state = |st: &[(String, u64)]| {
+                st.iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            for st in &cex.prefix {
+                println!("          -> {}", render_state(st));
+            }
+            for (i, st) in cex.cycle.iter().enumerate() {
+                let marker = if i == 0 { "(*)" } else { "   " };
+                println!("          {marker} {}", render_state(st));
+            }
+            println!("          (cycle repeats forever - the property is avoided)");
+        }
     }
     for (name, reason) in &report.unsupported {
         println!("  [unsupported] {name}: {reason}");
@@ -2441,6 +2460,22 @@ fn render_verify_auto_json(report: &mununu_core::adapter::slang::verify_auto::Au
                     ("skipped", serde_json::json!({ "reason": reason }))
                 }
             };
+            // D1.8b — stall-lasso counterexample; each state is an ordered list of
+            // [register, value] pairs so the register order is preserved in JSON.
+            let counterexample = p.counterexample.as_ref().map(|c| {
+                let states = |v: &[Vec<(String, u64)>]| -> Vec<serde_json::Value> {
+                    v.iter()
+                        .map(|st| {
+                            serde_json::Value::Array(
+                                st.iter()
+                                    .map(|(k, val)| serde_json::json!([k, val]))
+                                    .collect(),
+                            )
+                        })
+                        .collect()
+                };
+                serde_json::json!({ "prefix": states(&c.prefix), "cycle": states(&c.cycle) })
+            });
             serde_json::json!({
                 "name": p.name,
                 "kind": sva_kind_str(p.kind),
@@ -2448,6 +2483,7 @@ fn render_verify_auto_json(report: &mununu_core::adapter::slang::verify_auto::Au
                 "outcome": status,
                 "detail": detail,
                 "seeded_predicates": p.seeded_predicates,
+                "counterexample": counterexample,
             })
         })
         .collect();

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -1515,6 +1515,19 @@ impl ExactModel {
         self.eval_node(formula, formula.root(), atoms, &mut bindings)
     }
 
+    /// Evaluate a specific sub-node `id` of `formula` to its state-set BDD (fresh
+    /// bindings). D1.8b uses it to get the target-predicate BDD of a detected `AF p`.
+    /// Sound only when `id` has no free fixpoint variables (the `AF` target doesn't).
+    pub fn eval_at(
+        &self,
+        formula: &Formula,
+        id: crate::mu_calculus::NodeId,
+        atoms: &HashMap<&str, BDDFunction>,
+    ) -> Result<BDDFunction, String> {
+        let mut bindings: HashMap<FormulaVarId, BDDFunction> = HashMap::new();
+        self.eval_node(formula, id, atoms, &mut bindings)
+    }
+
     fn eval_node(
         &self,
         f: &Formula,
@@ -1669,6 +1682,20 @@ pub fn exact_symbolic_verdict(
     btor2_content: &str,
     formula: &Formula,
 ) -> Result<ExactVerdict, String> {
+    exact_symbolic_verdict_with_witness(btor2_content, formula).map(|(v, _)| v)
+}
+
+/// D1.8b — like [`exact_symbolic_verdict`], but on a `Violated` verdict for a bare
+/// `AF p`-shaped property (`μX. (p ∨ [] X)`) it also returns a concrete
+/// [`StallLasso`] counterexample: the reachable `¬p` stall witnessing that liveness
+/// fails from the reset state. The witness is `None` when the verdict is `Holds`,
+/// when `formula` is not that shape, or when the stall is not reachable *at* the
+/// initial state (a reachable-but-not-initial stall — the `AG AF` case — is a future
+/// extension of [`BddBitBlaster::exact_stall_lasso`]).
+pub fn exact_symbolic_verdict_with_witness(
+    btor2_content: &str,
+    formula: &Formula,
+) -> Result<(ExactVerdict, Option<StallLasso>), String> {
     use crate::adapter::sts_ir::SymbolicTransitionSystem;
     let file = crate::adapter::btor2::parser::parse(btor2_content)
         .map_err(|e| format!("adapter/btor2/exact MC: {}", e.message))?;
@@ -1708,11 +1735,50 @@ pub fn exact_symbolic_verdict(
     let init = bb.initial_state_bdd(&file);
     // Holds iff init ⊆ sat, i.e. no initial state violates φ.
     let violating = init.and(&sat.not().unwrap()).unwrap();
-    Ok(if violating == *exact.ff() {
-        ExactVerdict::Holds
+    if violating == *exact.ff() {
+        return Ok((ExactVerdict::Holds, None));
+    }
+    // Violated — attach a stall lasso when the property is a bare `AF p`. The target
+    // `p` is evaluated from the same atom set; `exact_stall_lasso` returns None if the
+    // stall is not reachable at the initial state (so the witness is best-effort).
+    let witness = detect_af_target(formula)
+        .and_then(|p_id| exact.eval_at(formula, p_id, &atoms).ok())
+        .and_then(|p_bdd| bb.exact_stall_lasso(&file, &p_bdd));
+    Ok((ExactVerdict::Violated, witness))
+}
+
+/// D1.8b — detect the bare `AF p` shape `μX. (p ∨ [] X)` and return the node id of
+/// its target `p` (the non-recursive disjunct), or `None` when the root is not that
+/// shape. Both disjunct orders are accepted; the modality must be a bare `[]` (no
+/// guard) over the fixpoint variable.
+fn detect_af_target(formula: &Formula) -> Option<crate::mu_calculus::NodeId> {
+    use crate::mu_calculus::NodeId;
+    let MuNode::Mu { var, body } = formula.node(formula.root()) else {
+        return None;
+    };
+    let MuNode::Or(a, b) = formula.node(*body) else {
+        return None;
+    };
+    let is_box_var = |id: NodeId| -> bool {
+        match formula.node(id) {
+            MuNode::Modal {
+                kind: ModalKind::Box,
+                guard,
+                target,
+            } => {
+                *guard == Guard::default()
+                    && matches!(formula.node(*target), MuNode::Variable(v) if v == var)
+            }
+            _ => false,
+        }
+    };
+    if is_box_var(*a) {
+        Some(*b)
+    } else if is_box_var(*b) {
+        Some(*a)
     } else {
-        ExactVerdict::Violated
-    })
+        None
+    }
 }
 
 /// D1.8 — a **stall lasso**: the concrete counterexample witness for a `Violated`
@@ -2973,6 +3039,28 @@ mod tests {
             .expect("predicate cnt==0");
         // cnt==0 holds at the initial state, so AF(cnt==0) holds ⇒ no stall witness.
         assert!(bb.exact_stall_lasso(&file, &p).is_none());
+    }
+
+    /// D1.8b — the verdict entry point also yields the stall lasso for a Violated
+    /// bare `AF p`, and `None` when it holds.
+    #[test]
+    fn d1_8b_verdict_with_witness_af_violated() {
+        let af = crate::mu_calculus::parser::parse("mu X. ((cnt == 3) or [] X)").expect("parse");
+        let (v, w) =
+            exact_symbolic_verdict_with_witness(RESET_COUNTER_BTOR2, &af).expect("verdict");
+        assert_eq!(v, ExactVerdict::Violated);
+        let lasso = w.expect("Violated AF ⇒ a stall lasso witness");
+        assert!(!lasso.cycle.is_empty());
+        for st in lasso.prefix.iter().chain(lasso.cycle.iter()) {
+            assert_ne!(st.get("cnt"), Some(&3), "every stall state is ¬(cnt==3)");
+        }
+
+        // `AF (cnt==0)` holds at reset (cnt is already 0) ⇒ no witness.
+        let holds = crate::mu_calculus::parser::parse("mu X. ((cnt == 0) or [] X)").expect("parse");
+        let (v2, w2) =
+            exact_symbolic_verdict_with_witness(RESET_COUNTER_BTOR2, &holds).expect("verdict");
+        assert_eq!(v2, ExactVerdict::Holds);
+        assert!(w2.is_none());
     }
 
     /// D1.4 — `resolve_predicate_expr_registers` rewrites every register name in a

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -92,6 +92,41 @@ pub struct PropertyVerdict {
     /// The cube predicates auto-seeded for this property (atom strings) — the
     /// diagnostic "what was tracked".
     pub seeded_predicates: Vec<String>,
+    /// D1.8b — a concrete stall-lasso counterexample, present only when the exact
+    /// engine (`--engine exact-symbolic`) reports a bare `AF p` property `Violated`
+    /// and the stall is reachable at the reset state. `None` otherwise.
+    pub counterexample: Option<ExactCounterexample>,
+}
+
+/// D1.8b — a concrete stall-lasso counterexample for a `Violated` liveness property
+/// from the exact engine: a `prefix` from the reset state into a repeating `cycle`,
+/// each state a list of `(register, value)` pairs in register order. The cycle
+/// witnesses that the property is avoided forever (the "stall").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExactCounterexample {
+    /// States from the reset state up to (excluding) the cycle entry.
+    pub prefix: Vec<Vec<(String, u64)>>,
+    /// The repeating stall cycle; the last state steps back to `cycle[0]`.
+    pub cycle: Vec<Vec<(String, u64)>>,
+}
+
+/// Convert an engine [`StallLasso`](crate::adapter::btor2::symbolic_bitblast::StallLasso)
+/// (register→value maps, `u128`) into the surface [`ExactCounterexample`] (ordered
+/// `(name, u64)` pairs; state-register values fit in `u64` under the exact engine's
+/// bit-blast cap).
+fn exact_counterexample_from_lasso(
+    lasso: crate::adapter::btor2::symbolic_bitblast::StallLasso,
+) -> ExactCounterexample {
+    let conv = |states: Vec<std::collections::BTreeMap<String, u128>>| {
+        states
+            .into_iter()
+            .map(|st| st.into_iter().map(|(k, v)| (k, v as u64)).collect())
+            .collect()
+    };
+    ExactCounterexample {
+        prefix: conv(lasso.prefix),
+        cycle: conv(lasso.cycle),
+    }
 }
 
 /// Model-level diagnostics for an automated verification run — what the lift
@@ -1477,6 +1512,7 @@ pub fn verify_auto(
                         reason: format!("formula failed to parse: {e:?}"),
                     },
                     seeded_predicates: Vec::new(),
+                    counterexample: None,
                 });
                 continue;
             }
@@ -1495,26 +1531,35 @@ pub fn verify_auto(
         // property) where the cube path returns Unknown; bounded by BDD size
         // (build errors above the bit cap ⇒ Skipped).
         if opts.exact_symbolic {
-            let outcome = match crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict(
-                &btor2, &formula,
-            ) {
-                Ok(crate::adapter::btor2::symbolic_bitblast::ExactVerdict::Holds) => {
-                    VerifyOutcome::Holds
-                }
-                Ok(crate::adapter::btor2::symbolic_bitblast::ExactVerdict::Violated) => {
-                    // A definite full-state counterexample (not a cube tally).
-                    VerifyOutcome::Violated { false_cells: 1 }
-                }
-                Err(e) => VerifyOutcome::Skipped {
-                    reason: format!("exact symbolic MC: {e}"),
-                },
+            use crate::adapter::btor2::symbolic_bitblast::{
+                ExactVerdict, exact_symbolic_verdict_with_witness,
             };
+            let (outcome, counterexample) =
+                match exact_symbolic_verdict_with_witness(&btor2, &formula) {
+                    Ok((ExactVerdict::Holds, _)) => (VerifyOutcome::Holds, None),
+                    Ok((ExactVerdict::Violated, witness)) => {
+                        // A definite full-state counterexample (not a cube tally); for
+                        // a bare `AF p` the witness carries the concrete stall lasso
+                        // (D1.8b) — reset → prefix → ¬p cycle.
+                        (
+                            VerifyOutcome::Violated { false_cells: 1 },
+                            witness.map(exact_counterexample_from_lasso),
+                        )
+                    }
+                    Err(e) => (
+                        VerifyOutcome::Skipped {
+                            reason: format!("exact symbolic MC: {e}"),
+                        },
+                        None,
+                    ),
+                };
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
                 kind: t.kind,
                 formula: formula_str.clone(),
                 outcome,
                 seeded_predicates: Vec::new(),
+                counterexample,
             });
             continue;
         }
@@ -1549,6 +1594,7 @@ pub fn verify_auto(
                 formula: formula_str.clone(),
                 outcome: VerifyOutcome::Skipped { reason },
                 seeded_predicates: Vec::new(),
+                counterexample: None,
             });
             continue;
         }
@@ -1564,6 +1610,7 @@ pub fn verify_auto(
                         .to_string(),
                 },
                 seeded_predicates: Vec::new(),
+                counterexample: None,
             });
             continue;
         }
@@ -1788,6 +1835,7 @@ pub fn verify_auto(
             formula: formula_str.clone(),
             outcome,
             seeded_predicates: seeded_names,
+            counterexample: None,
         });
     }
 
@@ -2131,6 +2179,7 @@ module uart_tx(); endmodule"#;
                     formula: "nu X. (a && [] X)".into(),
                     outcome: VerifyOutcome::Holds,
                     seeded_predicates: vec!["a".into()],
+                    counterexample: None,
                 },
                 PropertyVerdict {
                     name: "p_unknown".into(),
@@ -2138,6 +2187,7 @@ module uart_tx(); endmodule"#;
                     formula: "nu X. (b && [] X)".into(),
                     outcome: VerifyOutcome::Unknown { unknown_cells: 2 },
                     seeded_predicates: vec!["b".into()],
+                    counterexample: None,
                 },
             ],
             unsupported: vec![("u".into(), "reason".into())],

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -842,6 +842,25 @@ pub async fn sv_verify_auto_handler(
                 ),
                 VerifyOutcome::Skipped { reason } => ("skipped".to_string(), Some(reason.clone())),
             };
+            // D1.8b — carry the exact engine's stall-lasso counterexample.
+            let counterexample = p.counterexample.as_ref().map(|c| {
+                let states = |v: &[Vec<(String, u64)>]| -> Vec<Vec<CexCellView>> {
+                    v.iter()
+                        .map(|st| {
+                            st.iter()
+                                .map(|(register, value)| CexCellView {
+                                    register: register.clone(),
+                                    value: *value,
+                                })
+                                .collect()
+                        })
+                        .collect()
+                };
+                CounterexampleView {
+                    prefix: states(&c.prefix),
+                    cycle: states(&c.cycle),
+                }
+            });
             PropertyVerdictView {
                 name: p.name.clone(),
                 kind: kind_str(p.kind),
@@ -849,6 +868,7 @@ pub async fn sv_verify_auto_handler(
                 outcome,
                 detail,
                 seeded_predicates: p.seeded_predicates.clone(),
+                counterexample,
             }
         })
         .collect();

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1122,6 +1122,27 @@ pub struct PropertyVerdictView {
     pub detail: Option<String>,
     /// The cube predicates auto-seeded for this property (atom strings).
     pub seeded_predicates: Vec<String>,
+    /// D1.8b — a concrete stall-lasso counterexample, present only for a Violated
+    /// bare `AF p` decided by the exact engine (`engine: "exact-symbolic"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub counterexample: Option<CounterexampleView>,
+}
+
+/// D1.8b — a stall-lasso counterexample for the API (mirrors `ExactCounterexample`):
+/// reset → `prefix` → repeating `cycle`, each state an ordered list of register cells.
+#[derive(Debug, Serialize)]
+pub struct CounterexampleView {
+    /// States from the reset state up to (excluding) the cycle entry.
+    pub prefix: Vec<Vec<CexCellView>>,
+    /// The repeating stall cycle; the last state steps back to `cycle[0]`.
+    pub cycle: Vec<Vec<CexCellView>>,
+}
+
+/// One register's concrete value in a counterexample state.
+#[derive(Debug, Serialize)]
+pub struct CexCellView {
+    pub register: String,
+    pub value: u64,
 }
 
 /// U.0 — CEGAR refinement trace, JSON-shaped for the refinement-trace


### PR DESCRIPTION
## D1.8b — surface the exact-engine stall-lasso counterexample

Makes D1.8a's engine capability (#233) **user-visible**: when `sv verify-auto --engine exact-symbolic` reports a bare `AF p` property **Violated**, it now shows the concrete counterexample trace — a stall lasso (reset → prefix → repeating `¬p` cycle) — across **CLI + API + UI**.

### Engine
`exact_symbolic_verdict_with_witness(btor2, formula)` — on a `Violated` verdict for the `AF p` shape (`μX. (p ∨ [] X)`), detects the shape (`detect_af_target`), evaluates the target `p` sub-formula (`eval_at`), and returns the concrete `StallLasso` from `exact_stall_lasso`. `exact_symbolic_verdict` now delegates to it. Witness is `None` when the verdict holds, the formula isn't that shape, or the stall isn't reachable at the reset state (`AG AF` — reachable-but-not-initial stall — is a documented follow-up).

### Surfaces
| surface | change |
|---|---|
| **verify-auto** | `PropertyVerdict.counterexample: Option<ExactCounterexample>` (prefix/cycle of `(register, value)` states); the exact branch populates it. |
| **CLI** | text renderer prints the lasso (`-> prefix`, `(*) cycle`, "cycle repeats forever"); JSON renderer emits ordered `[register, value]` cells. |
| **API** | `CounterexampleView` / `CexCellView` on `PropertyVerdictView` (`skip_serializing_if none`); handler maps the lasso. |
| **UI** | `CounterexampleView`/`CexCellView` types + `SvVerifyAutoRunner` renders the trace under a Violated property. |

### Tests
- `d1_8b_verdict_with_witness_af_violated`: Violated `AF(cnt==3)` yields a lasso (every state `¬(cnt==3)`); `AF(cnt==0)` holds ⇒ no witness.
- Engine self-validation from D1.8a still holds; UI type-check + lint + `SvVerifyAutoRunner` tests (4) pass.

Completes the D1.8 witness arc for the bare-`AF` case. Builds on #229 (D1.6), #233 (D1.8a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
