### PR TITLE
fix(verify-auto): init reset-gated registers at their reset value, not 0

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -30,6 +30,7 @@ pub mod parser;
 pub mod pin;
 pub mod predicate_expr;
 pub mod r_s8_encoder;
+pub mod reset_init;
 pub mod shadow;
 pub mod smt_must_edge;
 pub mod symbolic_bitblast;

--- a/crates/mununu-core/src/adapter/btor2/reset_init.rs
+++ b/crates/mununu-core/src/adapter/btor2/reset_init.rs
@@ -1,0 +1,228 @@
+//! Reset-gated initial state — inject BTOR2 `init` lines at the post-reset state.
+//!
+//! An async-reset flop (`always_ff @(posedge clk or negedge rst_ni)
+//! if (!rst_ni) q <= ResetValue; else q <= d;`) lifts — via Yosys `async2sync` —
+//! to a next-state mux `next(q) = ite(rst, ResetValue, d)` with **no `init`
+//! line**: the *reset*, not a power-on value, establishes the start state.
+//! verify-auto then PINS the reset input to its inactive level (the "verified
+//! out of reset" discipline), so the mux never selects `ResetValue`, and both
+//! verify-auto engines default the init-less register to 0
+//! ([`crate::adapter::btor2::symbolic_bitblast`]'s `initial_state_bdd` and the
+//! predicate-cube path's `state_cell_init_values`, per the `setundef -zero`
+//! convention).
+//!
+//! For a design whose valid initial state is established BY reset — e.g. an
+//! OpenTitan sparse-FSM whose `ResetValue` is a non-zero sparse encoding
+//! (`MainSmIdle = 6'b110111`) — starting at 0 lands on an **illegal encoding**,
+//! which the FSM's `default` arm traps into its error state. Every
+//! reset-dependent verdict (recoverability `AG EF idle`, liveness-from-reset) is
+//! then computed from a state the real design never occupies.
+//!
+//! This transformation restores the intended semantics. BEFORE the reset is
+//! pinned inactive, it derives the post-reset state by simulating one cycle with
+//! the reset ASSERTED (the same 1-cycle hold as
+//! [`crate::adapter::btor2::bit_blast`]'s F1.1 `apply_auto_reset`, which does the
+//! equivalent for the enum/CTXDSL path) and appends an `init` line per state
+//! cell at that value. Working at the BTOR2 **text** level means both
+//! verify-auto engines — which each re-parse the text and read `init` lines —
+//! pick up the reset state with no per-engine change.
+//!
+//! Scope guard: only fires when reset-gating is on (`resets` non-empty — empty
+//! under `--no-gate-reset`, where the design chooses its own power-up, including
+//! the undefined-encoding scenarios CWE-1245 detection relies on) AND the design
+//! carries no `init` line already (the pure-async-reset shape; a design with an
+//! authoritative BTOR2 init is left untouched).
+
+use crate::adapter::AdapterError;
+use crate::adapter::btor2::ast::{Nid, Node};
+use crate::adapter::btor2::bit_blast::simulate_one_step;
+use crate::adapter::btor2::parser;
+use std::collections::HashMap;
+
+/// Inject `init` lines at the post-reset state for a reset-gated async-reset
+/// design that has none. `resets` is the set of `(name, inactive_value)` reset
+/// pins verify-auto detected — the same set it pins inactive.
+///
+/// No-op (returns `content` unchanged) when: `resets` is empty; the design has
+/// no state cells; or ANY state cell already carries an `init` line (then the
+/// BTOR2 init is authoritative and must not be advanced past — matching
+/// `apply_auto_reset`'s guard).
+///
+/// The post-reset state is `simulate_one_step` from the all-zero power-on cube
+/// with each reset input pinned to its ASSERTED level (the complement of its
+/// inactive level). A reset-register's next-state mux then selects its
+/// `ResetValue`; a register with no reset advances one cycle from 0 (its
+/// post-reset value is whatever a held-reset cycle yields — the faithful "one
+/// reset cycle then release" state).
+pub fn inject_reset_init(content: &str, resets: &[(String, u64)]) -> Result<String, AdapterError> {
+    if resets.is_empty() {
+        return Ok(content.to_string());
+    }
+
+    let file = parser::parse(content).map_err(|mut e| {
+        e.message = format!("adapter/btor2/reset_init: {}", e.message);
+        e
+    })?;
+
+    // Guard: only the pure-async-reset shape. Any existing `init` line means the
+    // BTOR2 init is authoritative — leave it untouched.
+    if file
+        .lines
+        .iter()
+        .any(|l| matches!(&l.node, Node::Init { .. }))
+    {
+        return Ok(content.to_string());
+    }
+
+    // State cells (nid, sort, key). Yosys leaves the async2sync FSM register
+    // unnamed; `simulate_one_step` keys those by `st_n<nid>`, so mirror that.
+    let symbols = parser::collect_symbols(&file);
+    let states: Vec<(Nid, Nid, String)> = file
+        .lines
+        .iter()
+        .filter_map(|l| match &l.node {
+            Node::State { sort, .. } => {
+                let key = symbols
+                    .get(&l.nid)
+                    .cloned()
+                    .unwrap_or_else(|| format!("st_n{}", l.nid));
+                Some((l.nid, *sort, key))
+            }
+            _ => None,
+        })
+        .collect();
+    if states.is_empty() {
+        return Ok(content.to_string());
+    }
+
+    // Reset ASSERTED = complement of the inactive level (resets are 1-bit).
+    // Registers default 0 (setundef -zero power-on); non-reset inputs default 0.
+    let reset_inputs: HashMap<String, u128> = resets
+        .iter()
+        .map(|(name, inactive)| {
+            let asserted: u128 = if *inactive == 0 { 1 } else { 0 };
+            (name.clone(), asserted)
+        })
+        .collect();
+    let post_reset = simulate_one_step(&file, &HashMap::new(), &reset_inputs)?;
+
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut appended: Vec<String> = Vec::new();
+    for (state_nid, sort_nid, key) in &states {
+        let value = post_reset.get(key).copied().unwrap_or(0);
+        let const_nid = next_nid;
+        next_nid += 1;
+        let init_nid = next_nid;
+        next_nid += 1;
+        appended.push(format!("{const_nid} constd {sort_nid} {value}"));
+        appended.push(format!(
+            "{init_nid} init {sort_nid} {state_nid} {const_nid}"
+        ));
+    }
+
+    Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Resolve a state cell's init value (mirrors how the exact engine's
+    /// `initial_state_bdd` reads the BTOR2 init), for assertions.
+    fn init_value(content: &str, state_symbol: &str) -> Option<u128> {
+        let file = parser::parse(content).ok()?;
+        let symbols = parser::collect_symbols(&file);
+        let state_nid = file.lines.iter().find_map(|l| match &l.node {
+            Node::State { .. } if symbols.get(&l.nid).map(String::as_str) == Some(state_symbol) => {
+                Some(l.nid)
+            }
+            _ => None,
+        })?;
+        let value_op = file.lines.iter().find_map(|l| match &l.node {
+            Node::Init { state, value, .. } if *state == state_nid => Some(*value),
+            _ => None,
+        })?;
+        // The init value operand references a const line; resolve its value.
+        file.lines.iter().find_map(|l| {
+            if l.nid != value_op.nid() {
+                return None;
+            }
+            match &l.node {
+                Node::Const {
+                    value: crate::adapter::btor2::ast::ConstValue::Dec(d),
+                    ..
+                } => Some(*d as u128),
+                _ => None,
+            }
+        })
+    }
+
+    // Async-reset FSM, active-HIGH reset: `next(fsm) = ite(rst, 1, 2)` — asserting
+    // rst forces the reset value 1. No `init` line (the async-reset shape). The
+    // injection must init fsm at its reset value 1, NOT the power-on default 0.
+    const ASYNC_RESET_HIGH: &str = r#"1 sort bitvec 1
+2 sort bitvec 2
+3 state 2 fsm
+4 constd 2 1
+5 constd 2 2
+6 input 1 rst
+7 ite 2 6 4 5
+8 next 2 3 7
+"#;
+
+    #[test]
+    fn injects_reset_value_as_init_active_high() {
+        // Active-high reset ⇒ inactive level 0 ⇒ asserted level 1.
+        let out = inject_reset_init(ASYNC_RESET_HIGH, &[("rst".to_string(), 0)]).unwrap();
+        assert_eq!(
+            init_value(&out, "fsm"),
+            Some(1),
+            "fsm must init at the reset value 1, not the power-on default 0; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn injects_reset_value_as_init_active_low() {
+        // Active-low reset shape: `next(fsm) = ite(rst_ni, 2, 1)` — rst_ni LOW
+        // (asserted) selects the reset value 1. Inactive level 1 ⇒ asserted 0.
+        let src = r#"1 sort bitvec 1
+2 sort bitvec 2
+3 state 2 fsm
+4 constd 2 1
+5 constd 2 2
+6 input 1 rst_ni
+7 ite 2 6 5 4
+8 next 2 3 7
+"#;
+        let out = inject_reset_init(src, &[("rst_ni".to_string(), 1)]).unwrap();
+        assert_eq!(
+            init_value(&out, "fsm"),
+            Some(1),
+            "fsm must init at the reset value 1 for an active-low reset; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn no_op_without_resets() {
+        let out = inject_reset_init(ASYNC_RESET_HIGH, &[]).unwrap();
+        assert_eq!(out, ASYNC_RESET_HIGH, "empty resets ⇒ unchanged");
+    }
+
+    #[test]
+    fn no_op_when_init_already_present() {
+        // A design with an authoritative BTOR2 init (fsm init = 2) must be left
+        // untouched — the reset injection never overrides an explicit init.
+        let src = r#"1 sort bitvec 1
+2 sort bitvec 2
+3 state 2 fsm
+4 constd 2 1
+5 constd 2 2
+6 input 1 rst
+7 ite 2 6 4 5
+8 next 2 3 7
+9 init 2 3 5
+"#;
+        let out = inject_reset_init(src, &[("rst".to_string(), 0)]).unwrap();
+        assert_eq!(out, src, "existing init is authoritative ⇒ unchanged");
+    }
+}

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1313,6 +1313,19 @@ pub fn verify_auto(
         }
     }
     report.diagnostics.blackboxed_modules = blackboxed_modules;
+
+    // Inject `init` lines at the post-reset state so a reset-gated async-reset
+    // FSM starts in its real reset state (e.g. an OpenTitan sparse-FSM's non-zero
+    // `MainSmIdle = 6'b110111`) rather than the init-less power-on default 0.
+    // Zero is an illegal sparse encoding: the FSM's `default` arm traps it into
+    // its error state, so without this the reset-gated model starts in a state
+    // the real design never occupies, silently corrupting every reset-dependent
+    // verdict (recoverability `AG EF idle`, liveness-from-reset). Runs on the
+    // reset-FREE BTOR2 (before the pin below) so it can assert the reset to
+    // derive the post-reset state; no-op unless reset-gating is on (`reset_pins`
+    // non-empty) and the design carries no authoritative `init` line.
+    btor2 = crate::adapter::btor2::reset_init::inject_reset_init(&btor2, &reset_pins)?;
+
     // Augment only the `__past` shadows whose base resolves to a BTOR2 state
     // cell. A base the lift renamed away (the SVA name not matching the lifted
     // register) would hard-error `augment_with_past_shadows`, aborting the whole
@@ -4745,6 +4758,83 @@ endmodule
             "AG AF (bit_cnt_q==0) must be decided Holds by the exact-symbolic route \
              through verify_auto; got {:?}",
             guarantee.outcome
+        );
+    }
+
+    #[test]
+    #[ignore = "requires slang + sv2v + yosys (mununu-sva image)"]
+    fn e2e_reset_gated_sparse_fsm_inits_at_reset_value() {
+        // Regression for the reset-gated async-reset init fix (reset_init.rs).
+        // OpenTitan csrng_main_sm's FSM resets — via prim_sparse_fsm_flop's
+        // ResetValue — to MainSmIdle = 6'b110111 = 55, a NON-ZERO sparse
+        // encoding. Yosys `async2sync` lifts the async reset to a next-state mux
+        // with no BTOR2 `init` line, and verify-auto pins the reset inactive.
+        // Without `inject_reset_init` the model would power up at 0 (an ILLEGAL
+        // sparse encoding → the FSM's `default` arm traps to MainSmError), so the
+        // init-state probe `(state_q == 55)` would be VIOLATED. With the fix the
+        // reset-gated model starts at MainSmIdle, so it HOLDS — the faithful
+        // post-reset state, decided exactly by the exact-symbolic engine (which
+        // reads the injected `init` line).
+        use std::path::PathBuf;
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/verify");
+        let csrng = root.join("m2_opentitan_csrng_main_sm/source");
+        let prim = root.join("m0_opentitan_prim_arbiter/source");
+        let read = |p: PathBuf| {
+            std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+        };
+        // The @mununu_guarantee carries the init-state probe; the standard
+        // prim_assert macros come from the M.0 fixture (the csrng dir's own
+        // prim_assert.sv is the dummy variant).
+        let annotated = format!(
+            "// @mununu_guarantee (state_q == 55)\n{}",
+            read(csrng.join("csrng_main_sm.sv"))
+        );
+        let sources = vec![
+            ("csrng_main_sm.sv".to_string(), annotated),
+            ("csrng_pkg.sv".to_string(), read(csrng.join("csrng_pkg.sv"))),
+            (
+                "prim_assert.sv".to_string(),
+                read(prim.join("prim_assert.sv")),
+            ),
+            (
+                "prim_assert_standard_macros.svh".to_string(),
+                read(prim.join("prim_assert_standard_macros.svh")),
+            ),
+            (
+                "prim_assert_sec_cm.svh".to_string(),
+                read(prim.join("prim_assert_sec_cm.svh")),
+            ),
+            (
+                "prim_flop_macros.sv".to_string(),
+                read(prim.join("prim_flop_macros.sv")),
+            ),
+        ];
+        let yopts = YosysOptions {
+            top: Some("csrng_main_sm".to_string()),
+            use_sv2v: true,
+            additional_sources: sources[1..].to_vec(),
+            ..Default::default()
+        };
+        let report = verify_auto(
+            &sources,
+            &yopts,
+            &VerifyAutoOptions {
+                exact_symbolic: true,
+                ..Default::default()
+            },
+        )
+        .expect("verify_auto runs exact-symbolic on csrng_main_sm");
+        let probe = report
+            .properties
+            .iter()
+            .find(|p| p.name.contains("ann_guarantee"))
+            .expect("the @mununu_guarantee init probe is present");
+        assert!(
+            matches!(probe.outcome, VerifyOutcome::Holds),
+            "reset-gated csrng must init at MainSmIdle (state_q==55), not the \
+             power-on default 0 — the reset-init fix; got {:?} for `{}`",
+            probe.outcome,
+            probe.formula
         );
     }
 }


### PR DESCRIPTION
## What

Fixes a model-faithfulness bug in `sv verify-auto`: reset-gated async-reset FSMs were initialized to `0` instead of their reset value, silently corrupting every reset-dependent verdict (recoverability `AG EF idle`, liveness-from-reset).

## Root cause

An async-reset flop lifts — via Yosys `async2sync` — to a next-state mux `next(q) = ite(rst, ResetValue, d)` with **no BTOR2 `init` line**: the reset, not a power-on value, establishes the start state. verify-auto then pins the reset inactive (the "verified out of reset" discipline), so the mux never selects `ResetValue`, and both engines default the init-less register to `0`:
- exact-symbolic `initial_state_bdd`
- predicate-cube `state_cell_init_values`

For a design whose valid initial state comes from reset — e.g. an OpenTitan sparse-FSM whose `ResetValue` is a non-zero sparse encoding (`csrng_main_sm`'s `MainSmIdle = 6'b110111 = 55`) — starting at `0` lands on an **illegal encoding** that the FSM's `default` arm traps into its error state. The model then starts in a state the real design never occupies. Latent for error-state-conditional SVA (they don't depend on the reset value), so it hid in exactly the properties people usually check.

## Fix

`adapter/btor2/reset_init::inject_reset_init` — before the reset is pinned inactive, simulate one cycle with the reset asserted to derive the post-reset state (the same 1-cycle hold as `bit_blast`'s F1.1 `apply_auto_reset`, which does the equivalent for the enum/CTXDSL path) and append an `init` line per state cell. Works at the BTOR2 text level so both engines pick it up.

No-op unless reset-gating is on (empty under `--no-gate-reset`, preserving the undefined-power-up model CWE-1245 detection relies on) and the design carries no authoritative `init` line.

## Validation (mununu-sva image)

| Check | Result |
|---|---|
| 5 real-OpenTitan e2e breakdowns | unchanged — sysrst HOLDS=9, csrng HOLDS=2, config-concretized HOLDS=12, D1 uart_tx `AG AF` Holds, btormc oracle Safe (**no regression**) |
| `e2e_reset_gated_sparse_fsm_inits_at_reset_value` (new) | reset-gated csrng inits at `MainSmIdle` (`state_q==55` HOLDS) — was VIOLATED at the illegal `0` |
| `reset_init` unit tests | 4 pass (active-high, active-low, no-op-without-reset, no-op-when-init-present) |
| fmt / clippy / lib tests / doctests | clean; 2187 lib + 57 doctests pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
