### PR TITLE
fix(recoverability): re-found the v7 showcase on the sound exact engine

### DIFF
--- a/docs/design/recoverability-vs-sva.md
+++ b/docs/design/recoverability-vs-sva.md
@@ -90,6 +90,17 @@ inference rather than sampling:
 
 > Source of truth: [`MustEdgeInference::SmtHyperMust`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs#L547) — surface: CLI (`--must-edge-inference smt-hyper-must`)
 
+Symmetrically, the outer `AG` box quantifies over *may*-edges (an
+over-approximation), so a sound `AG EF` also requires the may-relation to
+over-approximate the concrete transitions. The default sampling may-edges
+(`MayEdgeInference::Off`) record only sampled transitions and therefore
+**under**-approximate — unsound for the box. The sound may-relation is
+`--may-edge-inference smt-all-pairs`, or the exact-symbolic engine, which drops the
+abstraction entirely and is the recommended path for recoverability (§3.2).
+verify-auto selects the SMT may-relation automatically when a property references
+inputs or combinational atoms; a hand-run `btor2 cegar` on pure-state atoms must
+request it explicitly.
+
 The verdict, soundness, and the audited modal fragment it holds over
 (`Control::All`, bare `<>`/`[]`, unbounded) are developed in
 [`kmts-theory.md`](kmts-theory.md) §7.
@@ -99,26 +110,35 @@ The verdict, soundness, and the audited modal fragment it holds over
 > Source of truth: [`examples/verify/v7_csrng_recoverability/validate.sh`](../../examples/verify/v7_csrng_recoverability/) — surface: CLI
 
 V.7-c runs `always_recoverable` with `good = (state_q == MainSmIdle)` on the real
-OpenTitan `csrng_main_sm` FSM (vendored under the M.2 fixture), via
-`sv2v → yosys → btor2 cegar … --must-edge-inference smt-hyper-must`. The verdict
-is *definite both ways and depends on reset*, which is the honest and interesting
-result:
+OpenTitan `csrng_main_sm` FSM (vendored under the M.2 fixture), decided by the
+**exact-symbolic engine** — the full bit-blasted state, no abstraction, so a
+definite two-valued verdict with no `⊥`. The verdict is definite both ways and
+depends on reset, which is the honest and interesting result:
 
-- **Reset available** (`rst_ni` a free input): `AG EF idle` is **definite-TRUE**
-  — asserting reset returns the FSM to `MainSmIdle` from any state.
-- **Reset held inactive** (`connect -set rst_ni 1'b1`): `AG EF idle` is
-  **definite-FALSE** (`T=0 / F=4`) — `MainSmError` and the unreachable sparse
-  encodings become permanent traps once reset is withheld.
+- **Normal operation** (init = `MainSmIdle`, verified out of reset): `AG EF idle`
+  is **HOLDS** — the running FSM always returns to idle; it never wedges.
+- **Fault premise** (FSM forced into `MainSmError`, reset withheld): `AG EF idle`
+  is **VIOLATED** — from the hardened error state, idle is unreachable without
+  reset; the error state is a permanent trap.
 
-This is a branching question SVA cannot phrase, answered with sound definite
-verdicts on production RTL. The Track-I countertrace surfaces the trap directly:
-the reset-held run reports `counterexample trace (1 step, ends in trap):
-{idle=false, err=false}` — the initial cube is itself the trap.
+Recovery from a fault therefore depends on reset — exactly the SEC_CM design intent
+(the flop's `state_q_next = rst_ni ? state_d : MainSmIdle` mux). This is a branching
+question SVA cannot phrase, answered with sound definite verdicts on production RTL.
+
+> Soundness note (2026-07-05). An earlier version decided this over the
+> predicate-cube path with the default sampling may-edges (`may=off`), which
+> under-approximate the may-relation and are unsound for the outer `AG` box — that
+> produced a spurious reset-dependent flip (`T=0 F=244 ⊥=12`) not matching the RTL.
+> The exact-symbolic engine has no such abstraction and is the authoritative sound
+> path here; on the predicate-cube path a sound may-relation
+> (`--may-edge-inference smt-all-pairs`) is required and must be verified per
+> property.
 
 > Claims-integrity: V.7-c is a *design-pattern demonstration* on real RTL, not a
-> vulnerability finding — the reset-dependence it surfaces is intended SEC_CM
-> behaviour. The only finding-grade anchor mununu has is the Caliptra
-> `soc_ifc_boot_fsm` CWE-1245 pair.
+> vulnerability finding — the reset-dependence is intended SEC_CM behaviour. The
+> fault premise forces the flop's reset value to `MainSmError` to model a
+> fault-injected error state; the error self-loop under test is unchanged. The only
+> finding-grade anchor mununu has is the Caliptra `soc_ifc_boot_fsm` CWE-1245 pair.
 
 ## 4. A second finding: extracting existing SVA is itself blocked (open toolchain)
 

--- a/examples/verify/v7_csrng_recoverability/README.md
+++ b/examples/verify/v7_csrng_recoverability/README.md
@@ -1,18 +1,17 @@
 # `v7_csrng_recoverability` — recoverability of a real OpenTitan FSM (AG EF idle)
 
-> **Status: PASS.** Asks whether OpenTitan's `csrng_main_sm` can always return to
-> its `MainSmIdle` state — a recoverability (branching-time `AG EF`) question — over
-> a predicate abstraction of the real RTL, and gets a definite answer that depends
-> on whether reset is available. §Phase 7 V-track / Track-B recoverability showcase.
+> **Status: PASS.** Asks whether OpenTitan's `csrng_main_sm` can return to its
+> `MainSmIdle` state — a recoverability (branching-time `AG EF`) question — and
+> gets a definite, sound answer from the exact-symbolic engine. §Phase 7 V-track /
+> Track-B recoverability showcase.
 
 > **Claims integrity.** `csrng_main_sm.sv` is real OpenTitan RTL (Apache-2.0),
-> vendored and pinned under [`../m2_opentitan_csrng_main_sm/source/`](../m2_opentitan_csrng_main_sm/source/)
-> (this fixture reuses that source rather than re-vendoring it). What follows is a
-> **demonstration of a property class on real silicon, not a vulnerability finding**:
-> the reset-dependence it surfaces is the design's *intended* recovery behaviour
-> (the SEC_CM sparse-FSM-plus-alert pattern relies on reset to leave the error
-> state). The value here is being able to *state and soundly decide* that branching
-> property at all.
+> vendored and pinned under [`../m2_opentitan_csrng_main_sm/source/`](../m2_opentitan_csrng_main_sm/source/).
+> What follows is a **demonstration of a property class on real silicon, not a
+> vulnerability finding**: the reset-dependence it surfaces is the design's
+> *intended* behaviour — the SEC_CM sparse-FSM-plus-alert pattern relies on reset
+> to leave the error state. The value here is being able to *state and soundly
+> decide* that branching property at all.
 
 ## The question
 
@@ -26,28 +25,43 @@ recoverable        = mu X. (idle || <> X)            # EF idle  — idle reachab
 always_recoverable = nu Y. (recoverable && [] Y)     # AG EF idle — ...from every reachable state
 ```
 
-with `idle = (state_q == MainSmIdle)` and `err = (state_q == MainSmError)`
-(`MainSmIdle = 6'b110111 = 55`, `MainSmError = 6'b101001 = 41`). It is evaluated
-over a predicate-cube abstraction of the BTOR2 the standard sv2v + Yosys flow
-produces, through the CEGAR path with SMT-proved (hyper-)must edges
-(`--must-edge-inference smt-hyper-must`).
+with `idle = (state_q == MainSmIdle)` (`MainSmIdle = 6'b110111 = 55`,
+`MainSmError = 6'b101001 = 41`). It is decided by the **exact-symbolic engine**
+over the full bit-blasted state of the standard sv2v + Yosys lift — no abstraction,
+so a **definite** two-valued verdict, never `⊥`.
 
-## What the verdict depends on
+## What the verdict says
 
-The answer turns on whether reset is in play, and that turns out to be the whole
-point:
+Recovery depends on whether reset is in play, and that is the whole point:
 
-| Setup | `always_recoverable` | Reading |
+| Setup | `AG EF idle` | Reading |
 |---|---|---|
-| reset available (`rst_ni` free) | **definite-TRUE** (`T=4`) | asserting reset returns the FSM to `MainSmIdle` from any state, so idle is always reachable again |
-| reset held inactive (`rst_ni` tied `1'b1`) | **definite-FALSE** (`T=0, F=4`) | once reset is withheld, `MainSmError` and the unreachable sparse encodings become permanent traps |
+| normal operation (init = `MainSmIdle`, verified out of reset) | **HOLDS** | the running FSM always returns to idle — it never wedges in normal operation |
+| fault premise (FSM in `MainSmError`, reset withheld) | **VIOLATED** | from the hardened error state, idle is unreachable without reset — the error state is a permanent trap |
 
-Both verdicts are **definite** (no `KleeneBot`) and sound for the model — they
-sit inside the audited `Control::All` / bare-modality / unbounded fragment, where
-the Bruns–Godefroid preservation result carries a definite abstract verdict back
-to the concrete design. Read together they say something precise and honest about
-the RTL: csrng's ability to return to idle rests on reset, which is exactly what
-its security-hardened state machine is built to do.
+Both verdicts are **definite** (exact, no abstraction) and sound. Read together
+they say something precise and honest about the RTL: csrng recovers on its own in
+normal operation, but its security-hardened error state can only be left through
+reset (the flop's `state_q_next = rst_ni ? state_d : MainSmIdle` mux). Recovery from
+a fault therefore depends on reset — exactly what the SEC_CM design intends.
+
+The fault premise forces the FSM's reset value to `MainSmError` to *model* a fault
+that has driven the FSM into its error state; the error self-loop (the behaviour
+under test) is unchanged, so the VIOLATED verdict reflects the real design's
+error-trap behaviour.
+
+## A soundness note (why exact, not predicate-cube)
+
+An earlier version of this example evaluated the property over the predicate-cube
+CEGAR path (`btor2 cegar`) with the default sampling-based may-edges (`may=off`).
+Sampling under-approximates the may-relation (one representative per cube plus a
+capped input set), which violates the KMTS `concrete ⊆ may` precondition and is
+**unsound for this branching property** — it produced a spurious reset-dependent
+"flip" (`T=0 F=244 ⊥=12`) that does not match the RTL. The exact-symbolic engine
+has no such abstraction, so it decides `AG EF idle` definitely and soundly. For the
+recoverability class, prefer the exact engine (or, on the predicate-cube path,
+`--may-edge-inference smt-all-pairs`, with the soundness of the may-relation
+verified for the property at hand).
 
 ## Why this is worth showing
 
@@ -55,22 +69,23 @@ its security-hardened state machine is built to do.
 ("from *every* state, idle is *still* reachable"), not over individual execution
 traces. SystemVerilog Assertions are linear-time, so this question cannot be
 written directly in SVA — the usual route is an auxiliary monitor FSM or a
-tool-specific deadlock check. Here it is one fixpoint, decided over an abstraction
-of the real module, with the three-valued machinery reporting `⊥` ("not enough
-abstraction to decide") rather than guessing when it cannot.
+tool-specific deadlock check. Here it is one fixpoint, decided exactly over the
+real module.
 
 ## Reproduce
 
 ```bash
-LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli
-LIBRARY_PATH=/usr/local/opt/z3/lib bash examples/verify/v7_csrng_recoverability/validate.sh
+# In the mununu-sva image (slang + sv2v + yosys):
+cargo build -p mununu-cli
+MUNUNU=/path/to/mununu bash examples/verify/v7_csrng_recoverability/validate.sh
 ```
 
-Expected: `always_recoverable` HOLDS with reset available and is VIOLATED with
-reset held → `V.7-c VALIDATION PASSED`. Requires `sv2v` and `yosys` on `PATH`.
+Expected: `AG EF idle` HOLDS in normal operation and is VIOLATED under the fault
+premise → `V.7-c VALIDATION PASSED`. Requires `slang`, `sv2v`, and `yosys` on
+`PATH` (the exact-symbolic engine consumes the SVA-extraction front-end).
 
 ## See also
 
 - [`m2_opentitan_csrng_main_sm`](../m2_opentitan_csrng_main_sm/) — the source of the vendored RTL (M.2 milestone)
-- [`sv_yosys_caliptra_rtl_150`](../sv_yosys_caliptra_rtl_150/) — M.4, the predicate-cube CEGAR safety verdict on Caliptra (the depth-1 companion to this branching property)
+- [`sv_yosys_caliptra_rtl_150`](../sv_yosys_caliptra_rtl_150/) — M.4, the predicate-cube CEGAR safety verdict on Caliptra
 - [`v1_noc_mesh_4router`](../v1_noc_mesh_4router/) — the same νμ liveness shape on an exact CTXDSL model

--- a/examples/verify/v7_csrng_recoverability/validate.sh
+++ b/examples/verify/v7_csrng_recoverability/validate.sh
@@ -1,90 +1,92 @@
 #!/usr/bin/env bash
-# validate.sh — V.7-c recoverability showcase on OpenTitan csrng_main_sm.
+# validate.sh — V.7-c recoverability of OpenTitan csrng_main_sm (AG EF idle),
+# decided SOUNDLY by the exact-symbolic engine.
 #
-# Asks a branching-time question SVA cannot state: "from every reachable state,
-# can the FSM still get back to MainSmIdle?" — i.e. recoverability,
+# The branching-time question SVA cannot state: "from every reachable state, can
+# the FSM still get back to MainSmIdle?" — recoverability,
 #     always_recoverable = nu Y. ((mu X. (idle || <> X)) && [] Y)   (AG EF idle)
-# over a predicate abstraction of the real RTL, with idle = (state_q == MainSmIdle)
-# and err = (state_q == MainSmError), via the predicate-cube CEGAR path with
-# SMT-proved (hyper-)must edges.
+# with idle = (state_q == MainSmIdle = 6'b110111 = 55).
 #
-# The verdict depends entirely on whether reset is available, and that is the
-# honest, interesting result — NOT a bug. csrng's recovery story rests on reset,
-# exactly as its SEC_CM sparse-FSM-plus-alert design intends:
+# SOUNDNESS NOTE (2026-07-05). An earlier version of this example evaluated the
+# property over the PREDICATE-CUBE path (`btor2 cegar`) with the DEFAULT
+# `may=off` (sampling) may-edges. Sampling under-approximates the may-relation
+# (one representative per cube + a capped input set), which violates the KMTS
+# `concrete ⊆ may` precondition and is UNSOUND for this branching property: it
+# produced a spurious reset-dependent "flip" that does not match the RTL (where
+# MainSmError self-loops and is a permanent trap without reset). See
+# `mununu-private/.../recoverability-soundness-findings.md`. This script now uses
+# the EXACT-SYMBOLIC engine (full bit-blasted state, no abstraction, no ⊥), which
+# decides the property definitely and soundly.
 #
-#   * reset available (rst_ni free)      -> always_recoverable HOLDS (definite-TRUE):
-#       asserting reset returns the FSM to MainSmIdle from any state.
-#   * reset held inactive (rst_ni tied)  -> always_recoverable VIOLATED (definite-FALSE):
-#       the MainSmError state and the unreachable sparse encodings become
-#       permanent traps once reset is taken away.
+# The sound result — recovery depends on reset, exactly as the SEC_CM
+# sparse-FSM-plus-alert design intends:
+#   * Normal operation (init = MainSmIdle): AG EF idle HOLDS — verified out of
+#     reset, the running FSM always returns to idle; it never wedges.
+#   * Fault premise (FSM forced into MainSmError, reset withheld): AG EF idle
+#     VIOLATED — from the hardened error state, idle is UNREACHABLE without reset;
+#     the error state is a permanent trap. Recovery is possible only through
+#     reset (the flop's `state_q_next = rst_ni ? state_d : MainSmIdle` mux).
 #
-# Both verdicts are definite (no KleeneBot) and sound for the model (Bruns-Godefroid
-# preservation over the audited Control::All / bare-modality / unbounded fragment).
+# Pedigree / claims integrity: csrng_main_sm.sv is real OpenTitan RTL (Apache-2.0)
+# vendored under ../m2_opentitan_csrng_main_sm/source/. The fault premise forces
+# the flop's reset value to MainSmError to MODEL a fault that has driven the FSM
+# into its error state; the FSM's error self-loop (the behaviour under test) is
+# unchanged, so the VIOLATED verdict reflects the real design's error-trap
+# behaviour. This is a demonstration of the recoverability property class on real
+# silicon, not a vulnerability finding.
 #
-# Pedigree: csrng_main_sm.sv is real OpenTitan RTL (Apache-2.0), vendored + pinned
-# under ../m2_opentitan_csrng_main_sm/source/ (M.2). This fixture reuses that
-# source rather than re-vendoring it. The recoverability property is a
-# design-pattern demonstration of the property class on real silicon, not a
-# vulnerability finding — the reset-dependence it surfaces is intended behaviour.
+# Requires the mununu-sva toolchain (slang + sv2v + yosys) — run in the
+# `mununu-sva` Docker image. The standard prim_assert macros come from the M.0
+# prim_arbiter fixture (the csrng dir's own prim_assert.sv is the dummy variant).
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
-SRC="examples/verify/m2_opentitan_csrng_main_sm/source"
+CS="examples/verify/m2_opentitan_csrng_main_sm/source"
+PR="examples/verify/m0_opentitan_prim_arbiter/source"
 MUNUNU="${MUNUNU:-./target/debug/mununu}"
-export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
 
 if [[ ! -x "${MUNUNU}" ]]; then
-  echo "validate.sh: mununu not found at ${MUNUNU} — build with: LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli" >&2
+  echo "validate.sh: mununu not found at ${MUNUNU} — build with: cargo build -p mununu-cli" >&2
   exit 2
 fi
-for tool in sv2v yosys; do
-  command -v "${tool}" >/dev/null 2>&1 || { echo "validate.sh: required tool '${tool}' not on PATH" >&2; exit 2; }
+for tool in slang sv2v yosys; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "validate.sh: required tool '${tool}' not on PATH (run in the mununu-sva image)" >&2; exit 2; }
 done
 
 OUT="$(mktemp -d -t mununu-v7c-XXXXXX)"
-FORMULA='nu Y. ((mu X. (idle || <> X)) && [] Y)'
-PREDS=(--predicate idle:state_q=55 --predicate err:state_q=41 --must-edge-inference smt-hyper-must)
+trap 'rm -rf "${OUT}"' EXIT
+AGEF='// @mununu_guarantee nu Y. ((mu X. ((state_q == 55) or <> X)) and [] Y)'
 
-# MainSmIdle = 6'b110111 = 55 ; MainSmError = 6'b101001 = 41 (csrng_pkg.sv).
-sv2v -I"${SRC}" "${SRC}/csrng_pkg.sv" "${SRC}/csrng_main_sm.sv" > "${OUT}/csrng.v" 2>"${OUT}/sv2v.err"
+cp "${CS}/csrng_pkg.sv" "${PR}/prim_assert.sv" "${PR}/prim_assert_standard_macros.svh" \
+   "${PR}/prim_assert_sec_cm.svh" "${PR}/prim_flop_macros.sv" "${OUT}/"
+SRCS=(--source "${OUT}/csrng_pkg.sv" --source "${OUT}/prim_assert.sv"
+      --source "${OUT}/prim_assert_standard_macros.svh" --source "${OUT}/prim_assert_sec_cm.svh"
+      --source "${OUT}/prim_flop_macros.sv")
 
-# Lift one variant to BTOR2 (reset free, or reset tied inactive) and run CEGAR.
-run_variant() {
-  local variant="$1" tie=""
-  [[ "${variant}" == "held" ]] && tie="connect -set rst_ni 1'b1;"
-  yosys -q -p "read_verilog -sv ${OUT}/csrng.v; hierarchy -check -top csrng_main_sm; proc; \
-               flatten; ${tie} async2sync; dffunmap; setundef -anyconst; write_btor ${OUT}/${variant}.btor2" \
-    2>"${OUT}/${variant}.yosys.err"
-  "${MUNUNU}" btor2 cegar "${OUT}/${variant}.btor2" --formula "${FORMULA}" "${PREDS[@]}" \
-    > "${OUT}/${variant}.out" 2>&1 || true
-  grep -iE "verdict cells|outcome" "${OUT}/${variant}.out" || true
-}
+# Normal: FSM reset value is MainSmIdle (unchanged).
+{ echo "${AGEF}"; cat "${CS}/csrng_main_sm.sv"; } > "${OUT}/normal.sv"
+# Fault premise: force the FSM reset value to MainSmError (models a fault-injected
+# error state); the error self-loop logic is untouched.
+{ echo "${AGEF}"; sed 's/main_sm_state_e, MainSmIdle)/main_sm_state_e, MainSmError)/' "${CS}/csrng_main_sm.sv"; } > "${OUT}/fault.sv"
 
-cell() { grep "verdict cells" "${OUT}/$1.out" | sed -E "s/.*$2=([0-9]+).*/\1/"; }
+run() { "${MUNUNU}" sv verify-auto "$1" "${SRCS[@]}" --top csrng_main_sm --preprocess-sv2v \
+          --engine exact-symbolic 2>&1 | grep -E "ann_guarantee" | head -1; }
 
-echo "=== V.7-c — recoverability of OpenTitan csrng_main_sm (AG EF MainSmIdle) ==="
+echo "=== V.7-c — recoverability of OpenTitan csrng_main_sm (AG EF MainSmIdle), exact-symbolic ==="
 echo
-echo "--- reset available (rst_ni free) — expect HOLDS ---"
-run_variant free
+echo "--- normal operation (init = MainSmIdle) — expect HOLDS ---"
+NORMAL="$(run "${OUT}/normal.sv")"; echo "  ${NORMAL}"
 echo
-echo "--- reset held inactive (rst_ni tied 1'b1) — expect VIOLATED ---"
-run_variant held
+echo "--- fault premise (FSM in MainSmError, reset withheld) — expect VIOLATED ---"
+FAULT="$(run "${OUT}/fault.sv")"; echo "  ${FAULT}"
 echo
-
-FREE_T="$(cell free T)"; FREE_F="$(cell free F)"
-HELD_T="$(cell held T)"; HELD_F="$(cell held F)"
 
 ok=1
-if [[ "${FREE_F}" != "0" || "${FREE_T:-0}" -lt 1 ]]; then
-  echo "FAIL: reset-available expected HOLDS (T>=1, F=0), got T=${FREE_T} F=${FREE_F}" >&2; ok=0
-fi
-if [[ "${HELD_T}" != "0" || "${HELD_F:-0}" -lt 1 ]]; then
-  echo "FAIL: reset-held expected VIOLATED (T=0, F>=1), got T=${HELD_T} F=${HELD_F}" >&2; ok=0
-fi
-[[ "${ok}" == "1" ]] || { rm -rf "${OUT}"; exit 1; }
+grep -qi "HOLDS" <<<"${NORMAL}" || { echo "FAIL: normal operation expected HOLDS, got: ${NORMAL}" >&2; ok=0; }
+grep -qi "VIOLATED" <<<"${FAULT}" || { echo "FAIL: fault premise expected VIOLATED, got: ${FAULT}" >&2; ok=0; }
+[[ "${ok}" == "1" ]] || exit 1
 
-rm -rf "${OUT}"
 echo "=== V.7-c VALIDATION PASSED ==="
-echo "Recovery to MainSmIdle holds while reset is available and fails once reset is"
-echo "withheld — mununu states and soundly decides this branching (AG EF) property"
-echo "on real OpenTitan RTL, with definite verdicts both ways."
+echo "The running FSM always recovers to idle (HOLDS); a fault-induced error state"
+echo "cannot reach idle without reset (VIOLATED) — a branching-time (AG EF)"
+echo "recoverability property decided soundly and exactly on real OpenTitan RTL."


### PR DESCRIPTION
## What

Re-founds the v7 csrng recoverability showcase on the **sound exact-symbolic engine** after an XL.8-article investigation found its reset-dependent "flip" was unsound.

## The problem

The showcase claimed a definite flip — reset-tied → definite-FALSE, free-reset → definite-TRUE — decided over the predicate-cube path (`btor2 cegar`) with the **default sampling may-edges (`may=off`)**. Sampling builds may-edges from one canonical representative per cube and a capped input set, so it **under-approximates** the may-relation (`may ⊆ concrete`), violating the KMTS `concrete ⊆ may` precondition. That is unsound for the outer `AG` box, and it produced a spurious held verdict (`T=0/F=244/⊥=12`) that does not match the RTL — where `MainSmError` self-loops and is a permanent trap without reset.

## The fix — a sound demonstration

Decided by the exact-symbolic engine (full bit-blasted state, no abstraction, no `⊥`):

| setup | `AG EF idle` |
|---|---|
| normal operation (init = `MainSmIdle`) | **HOLDS** — the running FSM always recovers |
| fault premise (FSM forced to `MainSmError`, reset held) | **VIOLATED** — the error state is a permanent trap without reset |

Recovery genuinely depends on reset (the flop's `state_q_next = rst_ni ? state_d : MainSmIdle` mux), now proven soundly. The "reset recovers" side is the mux's definition, so it sidesteps the exact engine's `--no-gate-reset` gap entirely.

## Changes

- **`examples/verify/v7_csrng_recoverability/validate.sh`** — rewritten to the exact engine (normal HOLDS + fault-premise VIOLATED). Verified to run and pass in the `mununu-sva` image.
- **`examples/verify/v7_csrng_recoverability/README.md`** — reframed, with a soundness note on why exact-symbolic rather than the predicate-cube path.
- **`docs/design/recoverability-vs-sva.md`** — §3.2 reframed to the exact result; §3.1 gains the missing may-edge soundness requirement.

## Scope / soundness

verify-auto is **unaffected** — it auto-selects the sound `SmtAllPairs` may-relation for any property referencing inputs or combinational atoms, so the published verdicts and the exact reset-gated HOLDS are sound. Residual tool-soundness gaps (the `abstraction-posture` note over-claim, the `btor2 cegar` `may=off` default, exact `--no-gate-reset`) are filed as roadmap Track A A.3–A.6.

Doc/script-only — no Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
