### PR TITLE
fix(soundness): Track A close-out — cegar may=off warn, exact free-reset reject, recoverability root-cause (A.4–A.6)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -764,6 +764,34 @@ pub fn cegar_refine_loop(
             location: None,
         });
     }
+    // A.4 (soundness-ledger, 2026-07-05) — sampling may-relation is an
+    // UNDER-approximation. `MayEdgeInference::Off` samples one canonical
+    // representative per source cube over a capped input enumeration, so it can
+    // MISS a real may-successor. A `Box` ([]) modality quantifies universally
+    // over may-successors, so a missing successor makes `[]φ` vacuously easier
+    // to satisfy — a definite HOLDS (`KleeneT`) on a box property is then NOT
+    // guaranteed sound (a missed successor can hide a violation). Surface this
+    // on the `btor2 cegar` / `sv cegar` / `/cegar` surface as a WARNING (not a
+    // reject: sampling is fast and exact when the input space is small enough to
+    // be exhaustively enumerated). `effective_may` already accounts for the
+    // compound/derived force to SmtAllPairs above, so this fires only when the
+    // run genuinely uses the sampling path.
+    let box_count = formula.box_modality_count();
+    if effective_may == crate::adapter::btor2::kmts_lift::MayEdgeInference::Off && box_count > 0 {
+        warnings.push(crate::adapter::AdapterWarning {
+            kind: crate::adapter::WarningKind::ApproximateTranslation,
+            location: None,
+            message: format!(
+                "adapter/btor2/cegar (A.4): may_edge_inference = Off (sampling) with {box_count} \
+                 box ([]) modality/-ies. The sampling may-relation is an UNDER-approximation \
+                 (one canonical representative per cube + a capped input enumeration) that can \
+                 MISS a real may-successor, so a definite HOLDS on a box property is NOT \
+                 guaranteed sound — a missed successor can hide a violation. Re-run with \
+                 `--may-edge-inference smt-all-pairs` for a sound over-approximating may-relation, \
+                 or use the exact-symbolic engine for an abstraction-free verdict.",
+            ),
+        });
+    }
     // R-Y5 (2026-06-08) — register names load-bearing for
     // `KleeneBot` verdicts across iterations. Populated at the
     // failure-subgame consumption point; surfaced in the final
@@ -2020,6 +2048,141 @@ mod tests {
 8 next 1 3 4
 ";
 
+    // A.5 (2026-07-05) — trap-FSM fixtures for the recoverability soundness
+    // reproduction. State `s` (2 bits): idle = 1, error = 2. The FSM's next-state
+    // is `fsm_next = (s == error) ? error : idle` — error is a permanent trap
+    // (self-loop), every other state moves to idle. No `init` line ⇒ `s` is havoc
+    // (the cube path enumerates all 4 predicate cubes, including the error cube).
+    // Predicates: idle = (s == 1), err = (s == 2).
+    //
+    // `TRAP_FSM_RESET_PINNED` is the "reset held" model: `next(s) = fsm_next` (no
+    // reset mux). From the error cube idle is UNREACHABLE, so `AG EF idle` is
+    // definite-FALSE at the error cube — the sound trap verdict.
+    const TRAP_FSM_RESET_PINNED: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 state 2 s
+4 constd 2 1
+5 constd 2 2
+6 eq 1 3 5
+7 ite 2 6 5 4
+8 next 2 3 7
+";
+
+    // `TRAP_FSM_RESET_FREE` is the SAME FSM with an async active-low reset mux left
+    // as a LIVE input: `next(s) = rst_ni ? fsm_next : idle`. rst_ni is a free
+    // primary input (not constant-folded). From the error cube the ∀∃ must-edge
+    // inference can pick rst_ni = 0 (asserted) ⇒ next = idle, so a must-edge
+    // error → idle is REAL and `AG EF idle` is definite-TRUE at the error cube.
+    // This is the un-pinned-reset artifact behind the recoverability "may=all-pairs
+    // spurious HOLDS": the must inference is correct; the reset was simply not tied.
+    const TRAP_FSM_RESET_FREE: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 state 2 s
+4 constd 2 1
+5 constd 2 2
+6 eq 1 3 5
+7 ite 2 6 5 4
+8 input 1 rst_ni
+9 ite 2 8 7 4
+10 next 2 3 9
+";
+
+    // A.5 helper — run `AG EF idle` over a trap-FSM fixture with the canonical
+    // ∀∃ must-edge inference (`SmtPerTargetStandard`) + the sound over-approximating
+    // may-relation (`SmtAllPairs`), and return the definite verdict at the error
+    // cube (idle = false, err = true). `None` ⇒ the error cube was ⊥.
+    fn a5_err_cube_verdict(btor2: &str) -> Option<crate::mu_calculus::trit::Trit> {
+        use crate::mu_calculus::trit::Trit;
+        let formula = parser::parse("nu X. ((mu Y. (idle || <> Y)) && [] X)")
+            .expect("AG EF idle formula parses");
+        let predicates = vec![
+            PredicateSpec {
+                name: "idle".into(),
+                register: "s".into(),
+                value: 1,
+            },
+            PredicateSpec {
+                name: "err".into(),
+                register: "s".into(),
+                value: 2,
+            },
+        ];
+        let env = Environment::new(4);
+        let cegar_opts = CegarOptions {
+            max_iterations: 1,
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs,
+            must_edge_inference:
+                crate::adapter::btor2::kmts_lift::MustEdgeInference::SmtPerTargetStandard,
+            lift_strategy: LiftStrategy::Eager,
+            ..CegarOptions::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            btor2,
+            predicates,
+            &env,
+            &AdapterOptions::default(),
+            &cegar_opts,
+        )
+        .expect("cegar succeeds on the trap FSM");
+        // Cube index encodes predicate truth bit-per-predicate in `final_predicates`
+        // order. Find the index with idle=false, err=true.
+        let idle_bit = trace
+            .final_predicates
+            .iter()
+            .position(|p| p.name == "idle")
+            .expect("idle predicate present");
+        let err_bit = trace
+            .final_predicates
+            .iter()
+            .position(|p| p.name == "err")
+            .expect("err predicate present");
+        let err_cube = 1usize << err_bit; // err=1, idle=0
+        assert_eq!(err_cube & (1 << idle_bit), 0, "err cube must have idle=0");
+        for i in 0..trace.final_verdict.len() {
+            eprintln!("cube {i}: {:?}", trace.final_verdict.verdict_at(i));
+        }
+        eprintln!(
+            "final_predicates: {:?}",
+            trace
+                .final_predicates
+                .iter()
+                .map(|p| &p.name)
+                .collect::<Vec<_>>()
+        );
+        match trace.final_verdict.verdict_at(err_cube) {
+            Trit::Unknown => None,
+            v => Some(v),
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Z3 (SMT must/may edges); run in the mununu-sva/dev image with --ignored"]
+    fn a5_trap_fsm_pinned_reset_error_is_false_free_reset_is_true() {
+        use crate::mu_calculus::trit::Trit;
+        // Reset PINNED (held): error is a permanent trap ⇒ AG EF idle is definite
+        // FALSE at the error cube. The sound recoverability verdict.
+        let pinned = a5_err_cube_verdict(TRAP_FSM_RESET_PINNED);
+        assert_eq!(
+            pinned,
+            Some(Trit::False),
+            "with the reset pinned, the error cube must be definite-FALSE (idle unreachable from a trap)"
+        );
+        // Reset FREE (un-pinned): the ∀∃ must-edge inference legitimately finds
+        // rst_ni=0 ⇒ next=idle, so AG EF idle is definite-TRUE at the error cube.
+        // This is the "may=all-pairs spurious HOLDS" — sound for a FREE reset,
+        // unsound only if the reset was meant to be tied. Root cause: the reset was
+        // not constant-folded out of the BTOR2 before the may/must SMT seam.
+        let free = a5_err_cube_verdict(TRAP_FSM_RESET_FREE);
+        assert_eq!(
+            free,
+            Some(Trit::True),
+            "with the reset free, the error cube flips to definite-TRUE via the real reset-recovery path"
+        );
+    }
+
     #[test]
     fn cegar_converges_immediately_when_initial_verdict_is_definite() {
         // `true` formula evaluates to KleeneT at every state; no
@@ -3275,6 +3438,111 @@ mod tests {
         assert!(
             trace.warnings.is_empty(),
             "default `true` formula MUST produce no warnings; got: {:?}",
+            trace.warnings
+        );
+    }
+
+    #[test]
+    fn a4_sampling_may_warning_fires_on_box_formula_with_may_off() {
+        // A.4 (2026-07-05) — a box ([]) formula run with the sampling
+        // may-relation (`MayEdgeInference::Off`) MUST emit the A.4 soundness
+        // warning: sampling under-approximates the may-relation, so a definite
+        // HOLDS on the box property is not guaranteed sound.
+        let formula = parser::parse("nu X. (true && [] X)").expect("formula parses");
+        assert_eq!(formula.box_modality_count(), 1);
+
+        let initial = vec![PredicateSpec {
+            name: "p".into(),
+            register: "reg_a".into(),
+            value: 0,
+        }];
+        let env = Environment::new(2);
+        let cegar_opts = CegarOptions {
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            ..CegarOptions::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            SMALL_BTOR2,
+            initial,
+            &env,
+            &AdapterOptions::default(),
+            &cegar_opts,
+        )
+        .expect("cegar succeeds");
+
+        assert!(
+            trace.warnings.iter().any(|w| {
+                w.message.contains("(A.4)") && w.message.contains("may_edge_inference = Off")
+            }),
+            "expected an A.4 sampling-may warning on a box formula with may=off; got: {:?}",
+            trace.warnings
+        );
+    }
+
+    #[test]
+    fn a4_sampling_may_warning_absent_with_smt_all_pairs() {
+        // A.4 (2026-07-05) — the SAME box formula run with the sound
+        // `SmtAllPairs` over-approximating may-relation MUST NOT emit the A.4
+        // warning: the may-relation is then sound for the box.
+        let formula = parser::parse("nu X. (true && [] X)").expect("formula parses");
+        let initial = vec![PredicateSpec {
+            name: "p".into(),
+            register: "reg_a".into(),
+            value: 0,
+        }];
+        let env = Environment::new(2);
+        let cegar_opts = CegarOptions {
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::SmtAllPairs,
+            ..CegarOptions::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            SMALL_BTOR2,
+            initial,
+            &env,
+            &AdapterOptions::default(),
+            &cegar_opts,
+        )
+        .expect("cegar succeeds");
+
+        assert!(
+            !trace.warnings.iter().any(|w| w.message.contains("(A.4)")),
+            "A.4 warning MUST NOT fire when may=SmtAllPairs; got: {:?}",
+            trace.warnings
+        );
+    }
+
+    #[test]
+    fn a4_sampling_may_warning_absent_on_diamond_only_formula() {
+        // A.4 (2026-07-05) — a formula with NO box (diamond-only) MUST NOT emit
+        // the A.4 warning even under may=off: the under-approximation soundness
+        // gap is specific to the universal (box) modality.
+        let formula = parser::parse("mu X. (true || <> X)").expect("formula parses");
+        assert_eq!(formula.box_modality_count(), 0);
+        let initial = vec![PredicateSpec {
+            name: "p".into(),
+            register: "reg_a".into(),
+            value: 0,
+        }];
+        let env = Environment::new(2);
+        let cegar_opts = CegarOptions {
+            may_edge_inference: crate::adapter::btor2::kmts_lift::MayEdgeInference::Off,
+            ..CegarOptions::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            SMALL_BTOR2,
+            initial,
+            &env,
+            &AdapterOptions::default(),
+            &cegar_opts,
+        )
+        .expect("cegar succeeds");
+
+        assert!(
+            !trace.warnings.iter().any(|w| w.message.contains("(A.4)")),
+            "A.4 warning MUST NOT fire on a diamond-only formula; got: {:?}",
             trace.warnings
         );
     }

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1232,6 +1232,38 @@ pub fn verify_auto(
     })?;
     let _ = primary_name;
 
+    // A.6 (soundness-ledger, 2026-07-05) — reject `--engine exact-symbolic` with
+    // `--no-gate-reset`. The exact full-state engine is built for the reset-GATED
+    // regime: the reset input is pinned inactive and the initial state is the
+    // modeled reset state (`init` = the post-reset value injected by
+    // `inject_reset_init`, or 0). With reset-gating OFF, that injection is a no-op
+    // (no `init` line), so the engine starts from the power-on default 0 — an
+    // illegal sparse encoding the real design never occupies — and it does not
+    // explore the async reset (a runtime `state_q_next = rst_ni ? FSM : ResetValue`
+    // next-mux) as a firing transition. The result is a *spurious VIOLATED*
+    // (idle unreachable) presented with the exact engine's 2-valued *definite*
+    // authority — a confident wrong answer. Modeling a freed reset soundly needs a
+    // universal (havoc) initial state + reset-as-transition semantics the exact
+    // engine does not have; until then reject the combination rather than emit an
+    // unsound verdict. Free-reset reachability is available on the cube engine
+    // (drop `--engine exact-symbolic`), whose over-approximating may-relation
+    // soundly includes the reset edge.
+    if opts.exact_symbolic && !opts.gate_reset {
+        return Err(AdapterError {
+            kind: AdapterErrorKind::UnsupportedConstruct,
+            message:
+                "adapter/slang/verify_auto (A.6): `--engine exact-symbolic` is not sound with \
+                      `--no-gate-reset`. The exact engine models the post-reset state space (reset \
+                      pinned inactive, init = the modeled reset state); with reset-gating off it \
+                      starts from the illegal power-on default 0 and does not fire the freed async \
+                      reset as a transition, yielding a spurious (but definite-looking) VIOLATED. \
+                      For free-reset reachability, use the cube engine (drop `--engine \
+                      exact-symbolic`); to use the exact engine, keep reset-gating on."
+                    .to_string(),
+            location: None,
+        });
+    }
+
     // 1. Extract + translate the SVA. When reset-gating, the `disable iff`
     // guards are dropped from the formulas and the recognized reset signals are
     // reported (we pin them inactive in the lift below).
@@ -1924,6 +1956,32 @@ module uart_tx(); endmodule"#;
 
     /// `@mununu_assume` bodies are recorded for provenance (not verified as a
     /// guarantee); a source with no `@mununu` property annotations yields no note.
+    #[test]
+    fn a6_exact_symbolic_with_free_reset_is_rejected() {
+        // A.6 (2026-07-05) — `--engine exact-symbolic` + `--no-gate-reset` is an
+        // unsound combination and MUST be rejected before any elaboration. The
+        // reject fires right after the sources check, so it needs no slang (this
+        // is a non-ignored unit test): the exact engine models the post-reset
+        // state space and would emit a definite-looking but spurious VIOLATED on a
+        // freed reset.
+        let err = verify_auto(
+            &src("module m(); endmodule"),
+            &YosysOptions::default(),
+            &VerifyAutoOptions {
+                exact_symbolic: true,
+                gate_reset: false,
+                ..Default::default()
+            },
+        )
+        .expect_err("exact-symbolic + no-gate-reset must be rejected");
+        assert_eq!(err.kind, AdapterErrorKind::UnsupportedConstruct);
+        assert!(
+            err.message.contains("(A.6)") && err.message.contains("exact-symbolic"),
+            "A.6 reject must name the unsound combination; got: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn h5_gr1_assume_recorded_and_empty_source_has_no_note() {
         let sv = "// @mununu_assume tick_baud_x16 = 1\nmodule m(); endmodule";

--- a/crates/mununu-core/src/mu_calculus/mod.rs
+++ b/crates/mununu-core/src/mu_calculus/mod.rs
@@ -206,6 +206,29 @@ impl Formula {
         depth
     }
 
+    /// Number of `Box` (`[]`) modalities anywhere in the formula.
+    ///
+    /// A box quantifies universally over successors, so it is evaluated
+    /// against the **may** relation. When the may relation is an
+    /// under-approximation (the sampling `MayEdgeInference::Off` path), a
+    /// missing may-successor makes `[]φ` vacuously easier to satisfy — a
+    /// definite `KleeneT` on a box property is then unsound. Callers use this
+    /// to decide whether to emit an A.4 sampling-may soundness warning.
+    pub fn box_modality_count(&self) -> usize {
+        self.nodes
+            .iter()
+            .filter(|n| {
+                matches!(
+                    n,
+                    Node::Modal {
+                        kind: ModalKind::Box,
+                        ..
+                    }
+                )
+            })
+            .count()
+    }
+
     /// Returns true if the subtree rooted at `id` contains a fixpoint of the
     /// opposite kind. `looking_for_nu = true` means we're inside a mu and
     /// looking for a nu (and vice versa).
@@ -672,5 +695,37 @@ mod tests {
     fn mu_obligations_single_for_pure_reachability() {
         let f = parser::parse("mu X. (p || <> X)").unwrap();
         assert_eq!(f.mu_obligations().len(), 1);
+    }
+
+    #[test]
+    fn box_modality_count_counts_only_boxes() {
+        // A.4 (2026-07-05) — counts `[]` nodes; ignores `<>` and non-modal nodes.
+        assert_eq!(parser::parse("true").unwrap().box_modality_count(), 0);
+        assert_eq!(
+            parser::parse("mu X. (p || <> X)")
+                .unwrap()
+                .box_modality_count(),
+            0
+        );
+        assert_eq!(
+            parser::parse("nu X. (p && [] X)")
+                .unwrap()
+                .box_modality_count(),
+            1
+        );
+        // GR(1)-like: one outer [] plus two diamonds → box count = 1.
+        assert_eq!(
+            parser::parse("nu X. ((mu Y1. (A || <> Y1)) && (mu Y2. (B || <> Y2)) && [] X)")
+                .unwrap()
+                .box_modality_count(),
+            1
+        );
+        // Two nested boxes → count = 2.
+        assert_eq!(
+            parser::parse("nu X. ((nu Y. (p && [] Y)) && [] X)")
+                .unwrap()
+                .box_modality_count(),
+            2
+        );
     }
 }


### PR DESCRIPTION
## What

Closes out three Track A soundness-ledger follow-ups surfaced by the XL.8 recoverability investigation. **None affects a published result** — verify-auto auto-selects the sound `SmtAllPairs` may-relation for input/combinational properties and uses the exact engine only in the reset-gated regime. These harden the direct `btor2 cegar` / `sv verify-auto` surfaces against unsound *configurations*.

## A.4 — sampling may-relation is under-approximating; warn on box properties

`MayEdgeInference::Off` (the `btor2 cegar` default) samples one canonical representative per cube over a capped input set, so it **under-approximates** the may-relation and can miss a real may-successor. A box (`[]`) modality is universal over may-successors, so a missed successor makes a definite HOLDS unsound.

`cegar_refine_loop` now emits an A.4 `AdapterWarning` whenever the effective may-relation is `Off` **and** the formula contains ≥1 box, pointing at `--may-edge-inference smt-all-pairs`. New `Formula::box_modality_count()` helper. The warning rides the existing `CegarTrace.warnings` vec → surfaces on `btor2 cegar` / `sv cegar` / `/cegar` / verify-auto with **no new surface wiring** (same pattern as the B.3.b / PO-2 warnings).

## A.5 — recoverability `may=all-pairs` HOLDS root-caused (not a must-edge bug)

Reproduced deterministically with a minimal trap-FSM fixture (**no slang**): error is a permanent trap, `AG EF idle` over `{idle, err}` with `may=SmtAllPairs` + the canonical ∀∃ must (`SmtPerTargetStandard`):

| error cube (idle=F, err=T) | reset **pinned** | reset **free** |
|---|---|---|
| `AG EF idle` | **definite FALSE** (sound trap) | **definite TRUE** |

The ∀∃ must inference is `∀ state ⊨ src. ∃ inputs. next ⊨ tgt` (Bruns–Godefroid CONCUR 2000). With the reset a **live** BTOR2 input, `∃ inputs` legitimately picks `rst_ni = asserted` ⇒ `next = idle`, so `error → idle` is a **real** must-edge. The must inference is correct — the "spurious HOLDS" was the reset **not being constant-folded** out of the BTOR2 before the SMT seam. verify-auto's `pin_inputs_to_constants` (published path) *does* fold it out → sound FALSE. Locked in by `a5_trap_fsm_pinned_reset_error_is_false_free_reset_is_true` (ignored; needs Z3). **No production code change.**

## A.6 — reject `--engine exact-symbolic` + `--no-gate-reset`

The exact full-state engine models the post-reset state space (reset pinned inactive, init = the modeled reset state). With reset-gating off, the reset-init injection is a no-op (init defaults to the illegal power-on `0`) and the engine does not fire the freed async reset as a transition → a **spurious VIOLATED** carrying the engine's 2-valued *definite* authority (a confident wrong answer). `verify_auto` now **hard-rejects** the combination up front (`UnsupportedConstruct`, before elaboration). Free-reset reachability stays available on the cube engine.

## Validation (mununu-sva image)

- `cargo fmt --check` clean; `cargo clippy -p mununu-core --all-features -D warnings` clean.
- Full `mununu-core` lib suite: **2193 passed / 0 failed / 32 ignored**; **57 doctests** pass.
- New tests: A.4 fires/absent (×3) + `box_modality_count` unit; A.6 reject (non-ignored, no slang); A.5 trap-FSM reproduction (ignored, Z3).
- `cargo check -p mununu-cli` clean (surface consumer).

Rebased onto `main` (independent of the open A.3 PR #240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
