### PR TITLE
fix(exact-engine): don't freeze uext-aliased registers (next_funcs symbol keying)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -253,13 +253,26 @@ impl BddBitBlaster {
             WalkError::Backend(msg) => msg,
         })?;
 
-        // Pass 3 — collect the per-register next-state functions. A state's
-        // symbol is looked up from its declaration.
+        // Pass 3 — collect the per-register next-state functions, keyed by the
+        // state's symbol. This MUST use the SAME `collect_symbols` alias
+        // resolution `build()` used to name the leaf cells (line ~176): on
+        // flattened yosys output the `state` line loses its symbol and the
+        // user-visible name (`bit_cnt_q`) survives only on a `uext _ NID 0 NAME`
+        // alias, so `build()` names the cell `bit_cnt_q` via `collect_symbols`.
+        // Keying `next_funcs` off the RAW state symbol instead yields `state_<nid>`,
+        // which then MISSES the `next_funcs.get(&cell.symbol)` lookup in
+        // `exact_model()` — leaving the register with no next-state function, i.e.
+        // silently FROZEN at its init value. That is unsound: liveness/reachability
+        // over that register is decided against a model where it never transitions
+        // (a false `EF`-VIOLATED / vacuous `AG AF`-HOLDS). Resolve identically here.
+        let symbols = crate::adapter::btor2::parser::collect_symbols(file);
         let mut nid_symbol: HashMap<Nid, String> = HashMap::new();
         for line in &file.lines {
             if let Node::State { symbol, .. } = &line.node {
-                let sym = symbol
-                    .clone()
+                let sym = symbols
+                    .get(&line.nid)
+                    .cloned()
+                    .or_else(|| symbol.clone())
                     .unwrap_or_else(|| format!("state_{}", line.nid));
                 nid_symbol.insert(line.nid, sym);
             }
@@ -3094,6 +3107,73 @@ mod tests {
         );
     }
 
+    // Frozen-register regression (2026-07-05) — a register that LOADS a nonzero
+    // value from a free input `ld` (`reg_next = ld ? 10 : reg`). Two shapes that
+    // MUST decide identically:
+    //   (A) the state line carries the symbol directly (`state 2 bit_cnt_q`);
+    //   (B) the state line is UNNAMED and the user-visible name survives only on a
+    //       `uext _ NID 0 NAME` alias (`state 2` + `uext 2 4 0 bit_cnt_q`) — the
+    //       exact shape yosys emits after flatten + async2sync + dffunmap.
+    // The bit-blaster names its cells via `collect_symbols` (alias-aware), so both
+    // cells are named `bit_cnt_q`. The bug: `next_funcs` was keyed off the RAW
+    // state symbol (`state_<nid>` for (B)), so `next_funcs.get(&cell.symbol)` missed
+    // and (B)'s register was left with NO next-state function — silently FROZEN at
+    // its init value. `EF(bit_cnt_q != 0)` then read `Violated` (a reachable state
+    // reported unreachable) for (B) while (A) correctly read `Holds`. From any
+    // state, asserting `ld` reaches `bit_cnt_q = 10`, so the sound verdict is
+    // `Holds` for BOTH.
+    const FROZEN_REG_ATOM_ON_STATE: &str = r#"
+1 sort bitvec 1
+2 sort bitvec 4
+3 input 1 ld
+4 state 2 bit_cnt_q
+5 const 2 0000
+6 const 2 1010
+7 ite 2 3 6 4
+8 next 2 4 7
+"#;
+    const FROZEN_REG_ATOM_ON_UEXT_ALIAS: &str = r#"
+1 sort bitvec 1
+2 sort bitvec 4
+3 input 1 ld
+4 state 2
+5 const 2 0000
+6 const 2 1010
+7 ite 2 3 6 4
+8 next 2 4 7
+9 uext 2 4 0 bit_cnt_q
+"#;
+
+    #[test]
+    fn exact_next_func_binds_to_uext_aliased_register_not_frozen() {
+        // The regression: named-state and uext-aliased-state must decide the SAME.
+        let ef = crate::mu_calculus::parser::parse("mu Y. ((not (bit_cnt_q == 0)) or <> Y)")
+            .expect("EF formula");
+        let named = exact_symbolic_verdict(FROZEN_REG_ATOM_ON_STATE, &ef).expect("verdict");
+        let aliased = exact_symbolic_verdict(FROZEN_REG_ATOM_ON_UEXT_ALIAS, &ef).expect("verdict");
+        assert_eq!(
+            named,
+            ExactVerdict::Holds,
+            "EF(bit_cnt_q != 0) is reachable (assert `ld`), so a named state decides Holds"
+        );
+        assert_eq!(
+            aliased, named,
+            "a uext-ALIASED state must decide identically to a named one — not a frozen \
+             register (Violated) from a `next_funcs` key that missed the alias resolution"
+        );
+        // The AF-liveness companion also agrees: with `ld` free, `ld=0` forever holds
+        // the loaded value, so `AG AF(bit_cnt_q == 0)` is a real Violated on BOTH.
+        let agaf = crate::mu_calculus::parser::parse(
+            "nu X. ((mu Y. ((bit_cnt_q == 0) or [] Y)) and [] X)",
+        )
+        .expect("AGAF formula");
+        assert_eq!(
+            exact_symbolic_verdict(FROZEN_REG_ATOM_ON_UEXT_ALIAS, &agaf).expect("verdict"),
+            exact_symbolic_verdict(FROZEN_REG_ATOM_ON_STATE, &agaf).expect("verdict"),
+            "AG AF must also decide identically for named vs uext-aliased state"
+        );
+    }
+
     /// D1.7 — the exact engine DEGRADES GRACEFULLY on a design too large to
     /// bit-blast. `BddBitBlaster::build` rejects a design whose register+input
     /// bit count exceeds `MAX_BITBLAST_BITS` (40) with a clean `Err` — and does so
@@ -3404,16 +3484,27 @@ mod tests {
         }
     }
 
-    /// D1 HEADLINE (docker-gated) — exact ROBDD μ-calculus MC decides on real
-    /// OpenTitan `uart_tx` the `AF`-liveness that predicate abstraction returns ⊥
-    /// for: `AG AF (bit_cnt_q == 0)` — the transmit bit counter always eventually
-    /// returns to idle — is **Holds** (definite), from the correct 0-reset init.
-    /// The `bit_cnt_q` atom binds via `collect_symbols` (cell naming) +
-    /// `resolve_register` (atom rewrite: `bit_cnt_q → bit_cnt_d`); the init pins
-    /// every register to its reset value (0 default), so the verdict is checked
-    /// from the actual reset state, not an over-broad free-init set. Companion
-    /// verdicts confirm soundness on the design: `AG EF` (recoverability) + `EF` +
-    /// `AG (bit_cnt < 12)` (a real bounded-counter safety invariant) all Holds.
+    /// D1 HEADLINE (docker-gated) — exact ROBDD μ-calculus MC *decides* on real
+    /// OpenTitan `uart_tx` an `AF`-liveness that predicate abstraction returns ⊥
+    /// for: `AG AF (bit_cnt_q == 0)` — "a transmission in progress always completes"
+    /// — is **Violated** (definite), and the engine returns a concrete stall lasso.
+    /// The counter does NOT always drain: `bit_cnt_q` loads on a write, and a
+    /// persistently-asserted `wr` (or a stalled `tick_baud_x16`) holds it non-zero
+    /// forever — a real liveness failure. The value of the exact engine is that it
+    /// decides this **definitely with a counterexample** where the predicate-cube
+    /// path answers ⊥ (an `AF` needs a ranking predicate abstraction cannot
+    /// synthesize).
+    ///
+    /// REGRESSION for the frozen-register fix (2026-07-05): this asserted `Holds`
+    /// until the `next_funcs` keying bug was fixed. `bit_cnt_q`'s name survives only
+    /// on a `uext` alias of an unnamed state (post flatten/async2sync/dffunmap); the
+    /// bug keyed `next_funcs` off the raw state symbol, so the lookup missed and the
+    /// register was silently FROZEN at its 0 init — making `AG AF` a *vacuous*
+    /// `Holds`. With the register actually transitioning, the true verdict is
+    /// `Violated`. Companion verdicts remain definite + sound: `AG EF`
+    /// (recoverability — idle always reachable, since reset drains the counter) and
+    /// `EF (bit_cnt==0)` are `Holds`; `AG (bit_cnt < 12)` (a real bounded-counter
+    /// safety invariant) is `Holds`.
     /// `#[ignore]`; the SV is read at run time so `make ci` only compiles it.
     #[test]
     #[ignore = "needs sv2v + yosys — run in the mununu-sva docker image"]
@@ -3436,18 +3527,22 @@ mod tests {
             exact_symbolic_verdict(&btor2, &ff).expect("definite verdict, binds")
         };
 
-        // THE HEADLINE: `AG AF (bit_cnt_q == 0)` — the transmit counter always
-        // eventually returns to idle — is decided **Holds** (definite liveness) on
-        // real OpenTitan RTL. The predicate-abstraction path answers this ⊥ (no
-        // ranking); exact ROBDD MC decides it, from the correct 0-reset init.
+        // THE HEADLINE: `AG AF (bit_cnt_q == 0)` — "a transmission always completes"
+        // — is decided **Violated** (definite liveness failure) on real OpenTitan
+        // RTL: a persistently-asserted `wr` (or a stalled tick) holds the counter
+        // non-zero forever. The predicate-abstraction path answers this ⊥ (no
+        // ranking); exact ROBDD MC decides it definitely, with a stall lasso. This
+        // is the frozen-register-fix regression: a false `Holds` here means the
+        // `next_funcs` alias-keying bug regressed and `bit_cnt_q` is frozen again.
         assert_eq!(
             verdict("nu X. ((mu Y. ((bit_cnt_q == 0) or [] Y)) and [] X)"),
-            ExactVerdict::Holds,
-            "AG AF (bit_cnt_q==0) holds on uart_tx"
+            ExactVerdict::Violated,
+            "AG AF (bit_cnt_q==0) is Violated on uart_tx (a stalled/persistently-written \
+             counter never drains) — NOT the vacuous Holds of a frozen register"
         );
-        // Companion sanity: `AG EF` (recoverability) holds; `EF (bit_cnt==0)` holds
-        // trivially (0 at reset); `AG (bit_cnt < 12)` is a real bounded-counter
-        // safety invariant — the exact engine proves it definitely.
+        // Companion sanity (all definite + sound): `AG EF` (recoverability — idle is
+        // always reachable because reset drains the counter) and `EF (bit_cnt==0)`
+        // hold; `AG (bit_cnt < 12)` is a real bounded-counter safety invariant.
         assert_eq!(
             verdict("nu Y. ((mu X. ((bit_cnt_q == 0) or <> X)) and [] Y)"),
             ExactVerdict::Holds,

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -4903,16 +4903,17 @@ endmodule
     /// the headline `AG AF (bit_cnt_q == 0)` liveness property; `verify_auto` with
     /// `exact_symbolic: true` must route it through the exact full-state ROBDD MC
     /// (`exact_symbolic_verdict`) — the same engine `e2e_d1_uart_tx_exact_liveness_verdict`
-    /// exercises directly — and return a **definite Holds**, where the predicate-cube
-    /// path answers this ⊥ (no ranking for `AF`).
+    /// exercises directly — and return a **definite Violated** (with a stall lasso),
+    /// where the predicate-cube path answers this ⊥ (no ranking for `AF`).
     ///
     /// This validates the CLI/API `--engine exact-symbolic` wiring, not the D1 thesis
     /// itself (that is the direct test's job): the annotation guarantee flows through
     /// scan → merge → the hoisted exact branch (which runs BEFORE cube seeding, so it
-    /// is never gated behind a seeding skip). The btor2 here is reset-gated +
-    /// `$past`-shadow-augmented (unlike the direct test's raw btor2); reset-gating
-    /// pins the reset input inactive, so a genuinely-holding liveness property stays
-    /// Holds.
+    /// is never gated behind a seeding skip). Regression for the frozen-register fix
+    /// (2026-07-05): this asserted `Holds` while `bit_cnt_q` (a `uext`-aliased register)
+    /// was silently frozen by the `next_funcs` keying bug; the true verdict is
+    /// `Violated` (the counter can be held non-zero forever by a persistent write or a
+    /// stalled tick).
     #[test]
     #[ignore = "requires slang + sv2v + Yosys (use the mununu-sva docker image); run with --ignored"]
     fn e2e_d1_6_verify_auto_exact_symbolic_route_uart_tx() {
@@ -4963,9 +4964,11 @@ endmodule
             guarantee.name, guarantee.formula, guarantee.outcome
         );
         assert!(
-            matches!(guarantee.outcome, VerifyOutcome::Holds),
-            "AG AF (bit_cnt_q==0) must be decided Holds by the exact-symbolic route \
-             through verify_auto; got {:?}",
+            matches!(guarantee.outcome, VerifyOutcome::Violated { .. }),
+            "AG AF (bit_cnt_q==0) must be decided Violated by the exact-symbolic route \
+             through verify_auto (the counter can be held non-zero forever) — a false \
+             Holds means the frozen-register `next_funcs` alias-keying bug regressed; \
+             got {:?}",
             guarantee.outcome
         );
     }


### PR DESCRIPTION
## Summary

A **soundness bug in the D1 exact-symbolic engine** (`BddBitBlaster`): on flattened real-design BTOR2 it silently **froze** any register whose user-visible name survives only on a `uext` alias, so exact-engine liveness/reachability verdicts were computed against a model where those registers never transition. Found while investigating a uart_tx liveness anomaly; isolated to an 8-line reproducer and root-caused.

## The bug

The bit-blaster names its leaf state **cells** via `collect_symbols` (which resolves the user name off the `uext _ NID 0 NAME` alias yosys leaves after `flatten`+`async2sync`+`dffunmap`) but keyed its per-register next-state map `next_funcs` off the **raw** `state`-line symbol. On flattened output the `state` line has no symbol, so:

- cell symbol = `collect_symbols[nid]` = `bit_cnt_q`
- `next_funcs` key = raw symbol = `state_<nid>`

`exact_model()`'s `next_funcs.get(&cell.symbol)` then **misses** → the register gets no next-state function → **silently frozen at its init value**.

**Minimal reproducer** (added as a non-ignored regression): identical 8-line design, `EF(bit_cnt_q != 0)` → `Holds` when the state is named directly, `Violated` (frozen) when the name is on a `uext` alias. Both must decide `Holds`.

## The fix (one location) + audit

Key `next_funcs` with the same `collect_symbols` resolution the cell naming and `initial_state_bdd` already use. An audit of every NID→symbol derivation in `symbolic_bitblast.rs` confirms `next_funcs` was the **sole** mismatched site; the may/must edges (`abstract_relation`), `may_holds`/`must_holds`, and the lasso extractors consume `next_funcs`/`register_bits`/`cell.symbol` and inherit the fix. Also repairs the `--engine symbolic` R-F5 BDD-cube path (shares `abstract_relation`). The default `--engine explicit` cube/CEGAR path uses the separate SMT lift and was **never affected**.

## True verdicts revealed

The two docker-gated uart_tx exact tests asserted a **false `Holds`** while `bit_cnt_q` was frozen; updated to the true verdicts:

- uart_tx `AG AF (bit_cnt_q == 0)` → **Violated** (a persistent `wr` / stalled tick holds the counter non-zero forever) — decided definitely, with a stall lasso, where predicate abstraction returns ⊥. Companions `AG EF` / `EF` / `AG(bit_cnt<12)` remain definite `Holds`.

> ⚠ **Author note (out of band):** the same frozen-register `Holds` underlies the two headline verdicts in the published XL.8 Part 2 (uart_tx `AG AF` and csrng `AG EF idle`), which are now VIOLATED under the corrected engine. Flagged in the private evidence notes for the author to handle; the article thesis (the exact engine *decides* these where abstraction ⊥s) survives — the verdicts are VIOLATED-with-counterexample, not HOLDS. The **v7_csrng example is not affected** (it uses the cube path, not the exact engine).

## Validation (mununu-sva image)

- `cargo fmt --check` clean; `cargo clippy -p mununu-core --all-features -D warnings` clean.
- Full `mununu-core` lib suite **2194 passed / 0 failed / 32 ignored**.
- New regression `exact_next_func_binds_to_uext_aliased_register_not_frozen` passes; both updated uart_tx e2e tests (`e2e_d1_uart_tx_exact_liveness_verdict`, `e2e_d1_6_verify_auto_exact_symbolic_route_uart_tx`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
