### PR TITLE
feat(H.5-GR1): assume-guarantee recoverability showcase on csrng (exact-symbolic)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -5049,4 +5049,96 @@ endmodule
             probe.formula
         );
     }
+
+    /// H.5-GR1 — the assume-guarantee liveness showcase on real OpenTitan RTL,
+    /// decided by the exact-symbolic engine. The recoverability property
+    /// `AG EF MainSmIdle` (`nu Y. ((mu X. ((state_q == 55) or <> X)) and [] Y)`) —
+    /// "from every reachable state, can the FSM get back to idle?" — is a
+    /// there-exists-a-path (`EF`) property SVA structurally cannot phrase. Its
+    /// verdict flips on a single explicit environment assumption:
+    ///   - `local_escalate_i` FREE           → VIOLATED: a local security escalation
+    ///     latches the FSM in the terminal `MainSmError` trap (SEC_CM design;
+    ///     `CsrngMainErrorStStable_A`), so idle is unreachable.
+    ///   - assume `G !local_escalate_i` (=0)  → HOLDS: with no escalation the FSM
+    ///     always cycles back to idle.
+    /// Both verdicts are 2-valued definite (the exact engine has no ⊥). The example
+    /// at `examples/verify/v8_csrng_escalation_recoverability/` reproduces this via
+    /// the CLI. Regression-critical: the frozen-register bug (fixed) made BOTH sides
+    /// a vacuous HOLDS, erasing the flip.
+    #[test]
+    #[ignore = "requires slang + sv2v + yosys (mununu-sva image); run with --ignored"]
+    fn e2e_h5gr1_csrng_recoverability_escalation_flip() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/verify");
+        let csrng = root.join("m2_opentitan_csrng_main_sm/source");
+        let prim = root.join("m0_opentitan_prim_arbiter/source");
+        let read = |p: PathBuf| {
+            std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+        };
+        let outcome = |cfg: &[(&str, u64)]| -> VerifyOutcome {
+            let sm = read(csrng.join("csrng_main_sm.sv"));
+            let annotated = format!(
+                "// @mununu_guarantee nu Y. ((mu X. ((state_q == 55) or <> X)) and [] Y)\n{sm}"
+            );
+            let sources = vec![
+                ("csrng_main_sm.sv".to_string(), annotated),
+                ("csrng_pkg.sv".to_string(), read(csrng.join("csrng_pkg.sv"))),
+                (
+                    "prim_assert.sv".to_string(),
+                    read(prim.join("prim_assert.sv")),
+                ),
+                (
+                    "prim_assert_standard_macros.svh".to_string(),
+                    read(prim.join("prim_assert_standard_macros.svh")),
+                ),
+                (
+                    "prim_assert_sec_cm.svh".to_string(),
+                    read(prim.join("prim_assert_sec_cm.svh")),
+                ),
+                (
+                    "prim_flop_macros.sv".to_string(),
+                    read(prim.join("prim_flop_macros.sv")),
+                ),
+            ];
+            let yopts = YosysOptions {
+                top: Some("csrng_main_sm".to_string()),
+                use_sv2v: true,
+                additional_sources: sources[1..].to_vec(),
+                ..Default::default()
+            };
+            let config_values: HashMap<String, u64> =
+                cfg.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+            let report = verify_auto(
+                &sources,
+                &yopts,
+                &VerifyAutoOptions {
+                    exact_symbolic: true,
+                    config_values,
+                    ..Default::default()
+                },
+            )
+            .expect("verify_auto exact-symbolic on csrng_main_sm");
+            report
+                .properties
+                .iter()
+                .find(|p| p.name.contains("ann_guarantee"))
+                .map(|p| p.outcome.clone())
+                .expect("the @mununu_guarantee recoverability property is present")
+        };
+
+        // No assumption: a security escalation wedges the FSM in MainSmError.
+        let free = outcome(&[]);
+        assert!(
+            matches!(free, VerifyOutcome::Violated { .. }),
+            "AG EF idle must be VIOLATED with local_escalate_i free (escalation → \
+             MainSmError trap); got {free:?}"
+        );
+        // Under the no-escalation assumption: the FSM always recovers to idle.
+        let assumed = outcome(&[("local_escalate_i", 0)]);
+        assert!(
+            matches!(assumed, VerifyOutcome::Holds),
+            "AG EF idle must HOLD under the assumption G !local_escalate_i; got {assumed:?}"
+        );
+    }
 }

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -5055,16 +5055,16 @@ endmodule
     /// `AG EF MainSmIdle` (`nu Y. ((mu X. ((state_q == 55) or <> X)) and [] Y)`) —
     /// "from every reachable state, can the FSM get back to idle?" — is a
     /// there-exists-a-path (`EF`) property SVA structurally cannot phrase. Its
-    /// verdict flips on a single explicit environment assumption:
-    ///   - `local_escalate_i` FREE           → VIOLATED: a local security escalation
-    ///     latches the FSM in the terminal `MainSmError` trap (SEC_CM design;
-    ///     `CsrngMainErrorStStable_A`), so idle is unreachable.
-    ///   - assume `G !local_escalate_i` (=0)  → HOLDS: with no escalation the FSM
-    ///     always cycles back to idle.
-    /// Both verdicts are 2-valued definite (the exact engine has no ⊥). The example
-    /// at `examples/verify/v8_csrng_escalation_recoverability/` reproduces this via
-    /// the CLI. Regression-critical: the frozen-register bug (fixed) made BOTH sides
-    /// a vacuous HOLDS, erasing the flip.
+    /// verdict flips on a single explicit environment assumption. With
+    /// `local_escalate_i` FREE the verdict is VIOLATED — a local security escalation
+    /// latches the FSM in the terminal `MainSmError` trap (SEC_CM design;
+    /// `CsrngMainErrorStStable_A`), so idle is unreachable. Under the assumption
+    /// `G !local_escalate_i` (`=0`) the verdict is HOLDS — with no escalation the FSM
+    /// always cycles back to idle. Both verdicts are 2-valued definite (the exact
+    /// engine has no ⊥). The example at
+    /// `examples/verify/v8_csrng_escalation_recoverability/` reproduces this via the
+    /// CLI. Regression-critical: the frozen-register bug (fixed) made BOTH sides a
+    /// vacuous HOLDS, erasing the flip.
     #[test]
     #[ignore = "requires slang + sv2v + yosys (mununu-sva image); run with --ignored"]
     fn e2e_h5gr1_csrng_recoverability_escalation_flip() {

--- a/examples/verify/v8_csrng_escalation_recoverability/README.md
+++ b/examples/verify/v8_csrng_escalation_recoverability/README.md
@@ -1,0 +1,71 @@
+# v8 — csrng assume-guarantee recoverability (exact-symbolic)
+
+> **Source of truth:** [`adapter::btor2::symbolic_bitblast::exact_symbolic_verdict`](../../../crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs), the `@mununu_guarantee` carrier ([`scan_annotation_properties`](../../../crates/mununu-core/src/adapter/slang/verify_auto.rs)), and `--engine exact-symbolic` / `--config-value` on `mununu sv verify-auto` — surface: CLI+API+UI.
+
+An **assume-guarantee liveness** showcase on real OpenTitan RTL, decided by the
+[exact-symbolic engine](../../../wiki/Exact-Symbolic-Engine.md). It demonstrates the
+mununu-exclusive wedge: a **branching-time (`AG EF`) recoverability** verdict SVA
+structurally cannot phrase, decided **exactly** (2-valued, never `⊥`), whose value
+**flips on a single explicit environment assumption**.
+
+## The property
+
+Recoverability — "from every reachable state, can the FSM get back to `MainSmIdle`?":
+
+```
+always_recoverable = νY. ((μX. (idle ∨ ⟨⟩X)) ∧ [] Y)      -- AG EF idle
+```
+
+with `idle = (state_q == 55 = MainSmIdle)`. The inner `μX` is `EF idle` — *there
+exists a path back to idle* — and the outer `νY` insists it holds at every reachable
+state. The `EF` (existence of a continuation) is the obstruction for SVA and any
+linear-time logic; in the mu-calculus it is one formula.
+
+## The flip
+
+The design's own SVA (`CsrngMainErrorStStable_A`) says `MainSmError` is a **stable
+trap**: once there, the FSM stays there until reset. The only reachable path into it,
+out of reset, is the input `local_escalate_i` (csrng_main_sm.sv:54-56 — a local
+security escalation forces `state_d = MainSmError`). So recoverability depends
+entirely on whether escalation is admitted:
+
+| environment assumption | `AG EF idle` (exact-symbolic) |
+|---|---|
+| **none** — `local_escalate_i` free | **VIOLATED** (definite) — escalation latches the FSM in the `MainSmError` trap; idle unreachable |
+| **`G ¬local_escalate_i`** — no escalation | **HOLDS** (definite) — the FSM always cycles back to idle |
+
+The assumption is applied as an input concretization (`--config-value
+local_escalate_i=0`), which the exact engine bakes into the model before checking.
+Both verdicts are 2-valued and definite — the exact engine uses no abstraction, so
+there is no `⊥` and both answers transfer to the modeled design.
+
+## Run it
+
+```bash
+LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli   # once
+examples/verify/v8_csrng_escalation_recoverability/validate.sh
+```
+
+Requires `sv2v` and `yosys` on `PATH` (and `z3`). The script annotates a temp copy of
+`csrng_main_sm.sv` with the recoverability guarantee, runs `sv verify-auto --engine
+exact-symbolic` twice (with and without the `local_escalate_i=0` assumption), and
+checks the flip.
+
+The same flip is a non-docker-optional regression at
+[`e2e_h5gr1_csrng_recoverability_escalation_flip`](../../../crates/mununu-core/src/adapter/slang/verify_auto.rs)
+(run in the `mununu-sva` image with `--ignored`).
+
+## Honesty notes (claims-integrity)
+
+- **Design-pattern demonstration, not a vulnerability finding.** The
+  escalation-latching behaviour is the SEC_CM design intent — a local escalate is
+  *supposed* to wedge the FSM in error until reset. The showcase demonstrates the
+  *property class* on real silicon, not a bug.
+- **Recoverability with reset available** is a companion question (the model here has
+  reset gated inactive, so "recover" means "without a further reset"). The
+  reset-availability variant is the sibling [v7](../v7_csrng_recoverability/) example,
+  decided over the predicate-cube CEGAR path.
+- **Exact means exact for the model.** The verdict is exact for the bit-blasted BTOR2
+  yosys emits; its transfer to silicon still rests on the extraction (black-boxing,
+  `setundef` discipline, the reset model) — the standard
+  [claims-integrity](../../../docs/policies/claims-integrity.md) boundary.

--- a/examples/verify/v8_csrng_escalation_recoverability/validate.sh
+++ b/examples/verify/v8_csrng_escalation_recoverability/validate.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# validate.sh — H.5-GR1 assume-guarantee recoverability showcase on OpenTitan
+# csrng_main_sm, decided by the exact-symbolic engine.
+#
+# Recoverability — "from every reachable state, can the FSM get back to MainSmIdle?" —
+#     always_recoverable = nu Y. ((mu X. (idle || <> X)) && [] Y)   (AG EF idle)
+# is a there-exists-a-path (EF) property that SVA structurally cannot phrase. The
+# exact-symbolic engine decides it over the full bit-blasted state: 2-valued and
+# definite, never ⊥. The verdict flips on a single explicit environment assumption:
+#
+#   * local_escalate_i FREE            -> VIOLATED (definite): a local security
+#       escalation drives the FSM to the terminal MainSmError trap (csrng_main_sm.sv
+#       lines 54-56; the trap is stable, per the design's own SVA
+#       CsrngMainErrorStStable_A), from which idle is unreachable.
+#   * assume  G !local_escalate_i      -> HOLDS (definite): with no escalation the FSM
+#       always cycles back to idle. The assumption is applied as an input
+#       concretization (--config-value local_escalate_i=0).
+#
+# This is the mununu-exclusive wedge: an assume-guarantee liveness verdict on a
+# branching-time property, on real silicon, that flips on the explicit assumption —
+# and it is decided exactly, so both HOLDS and VIOLATED transfer to the modeled design
+# (Bruns-Godefroid; here trivially, since the exact engine uses no abstraction).
+#
+# Pedigree: csrng_main_sm.sv is real OpenTitan RTL (Apache-2.0), vendored + pinned
+# under ../m2_opentitan_csrng_main_sm/source/ (M.2); the prim_assert macros come from
+# ../m0_opentitan_prim_arbiter/source/ (M.0). This is a design-pattern demonstration
+# of the property class on real hardware, NOT a vulnerability finding — the
+# escalation-latching behaviour is the SEC_CM design intent.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+CSRNG="examples/verify/m2_opentitan_csrng_main_sm/source"
+PRIM="examples/verify/m0_opentitan_prim_arbiter/source"
+MUNUNU="${MUNUNU:-./target/debug/mununu}"
+export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu not found at ${MUNUNU} — build with: LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in sv2v yosys; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "validate.sh: required tool '${tool}' not on PATH" >&2; exit 2; }
+done
+
+OUT="$(mktemp -d -t mununu-h5gr1-XXXXXX)"
+trap 'rm -rf "${OUT}"' EXIT
+
+# The recoverability property is a mununu-exclusive annotation (distinct from the
+# design's own SVA) — prepend it as a @mununu_guarantee. idle = (state_q == 55 =
+# MainSmIdle = 6'b110111; MainSmError = 6'b101001 = 41 — csrng_pkg.sv).
+{ echo '// @mununu_guarantee nu Y. ((mu X. ((state_q == 55) or <> X)) and [] Y)'
+  cat "${CSRNG}/csrng_main_sm.sv"; } > "${OUT}/csrng_main_sm.sv"
+
+SRC=(--source "${CSRNG}/csrng_pkg.sv"
+     --source "${PRIM}/prim_assert.sv"
+     --source "${PRIM}/prim_assert_standard_macros.svh"
+     --source "${PRIM}/prim_assert_sec_cm.svh"
+     --source "${PRIM}/prim_flop_macros.sv")
+
+run() {
+  # --preprocess-sv2v: run sv2v first (as the reset-gated exact path expects), which
+  # resolves the prim_assert include dispatch and flattens before yosys.
+  "${MUNUNU}" sv verify-auto "${OUT}/csrng_main_sm.sv" "${SRC[@]}" \
+    --top csrng_main_sm --engine exact-symbolic --preprocess-sv2v "$@"
+}
+
+echo "=== H.5-GR1 — csrng recoverability (AG EF MainSmIdle), exact-symbolic ==="
+echo
+echo "--- no assumption (local_escalate_i free) — expect VIOLATED ---"
+run > "${OUT}/free.out" 2>&1 || true
+grep -E "ann_guarantee" "${OUT}/free.out" || true
+echo
+echo "--- assume G !local_escalate_i (--config-value local_escalate_i=0) — expect HOLDS ---"
+run --config-value local_escalate_i=0 > "${OUT}/assumed.out" 2>&1 || true
+grep -E "ann_guarantee" "${OUT}/assumed.out" || true
+echo
+
+ok=1
+grep -qE "ann_guarantee.*: VIOLATED" "${OUT}/free.out" \
+  || { echo "FAIL: no-assumption run expected VIOLATED" >&2; ok=0; }
+grep -qE "ann_guarantee.*: HOLDS" "${OUT}/assumed.out" \
+  || { echo "FAIL: no-escalation-assumption run expected HOLDS" >&2; ok=0; }
+[[ "${ok}" == "1" ]] || exit 1
+
+echo "=== H.5-GR1 VALIDATION PASSED ==="
+echo "csrng recovers to MainSmIdle under the no-escalation assumption and fails once a"
+echo "security escalation is admitted — an assume-guarantee branching-time (AG EF)"
+echo "verdict SVA cannot phrase, decided exactly (2-valued, no bottom) on real OpenTitan RTL."


### PR DESCRIPTION
## Summary

The **H.5-GR1 assume-guarantee liveness showcase**, finally landed — on **csrng** (real OpenTitan RTL), decided by the corrected [exact-symbolic engine](../wiki/Exact-Symbolic-Engine.md). A branching-time recoverability verdict SVA cannot phrase, decided **exactly** (2-valued definite, never `⊥`), that **flips on a single explicit assumption**.

## The flip

Property: `AG EF MainSmIdle` = `νY. ((μX. (idle ∨ ⟨⟩X)) ∧ [] Y)` — "from every reachable state, can the FSM get back to idle?". MainSmError is a stable trap (the design's own SVA `CsrngMainErrorStStable_A`); the only reachable path into it out of reset is the input `local_escalate_i` (csrng_main_sm.sv:54-56).

| environment assumption | `AG EF idle` (exact-symbolic) |
|---|---|
| none — `local_escalate_i` free | **VIOLATED** — a security escalation latches the FSM in the error trap |
| `G ¬local_escalate_i` (`--config-value local_escalate_i=0`) | **HOLDS** — the FSM always recovers to idle |

## Ships

- `examples/verify/v8_csrng_escalation_recoverability/` — README + `validate.sh` (CLI-reproducible: `sv verify-auto --engine exact-symbolic` ± `--config-value`); **validate.sh passes end-to-end** (`VIOLATED` / `HOLDS`).
- `e2e_h5gr1_csrng_recoverability_escalation_flip` — a docker-gated regression asserting both sides (also the frozen-register-fix regression — that bug made both sides a vacuous HOLDS).

Rides the existing `sv verify-auto` surface (source `@mununu_guarantee` + `--engine` + `--config-value`) — no new flag; CLI+API+UI already expose these. Design-pattern demonstration on Apache-2.0 silicon, **not** a vulnerability finding (escalation latching is the SEC_CM design intent). Supersedes the original uart_tx AF-flip plan (two independent stall sources → no clean flip).

## Validation (mununu-sva)

fmt/clippy clean; the regression test passes; validate.sh passes end-to-end via the built CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)