### PR TITLE
refactor(AR-GO): seam/doc honesty + #242 resolver drift guard + locator dedup

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/concrete_oracle.rs
+++ b/crates/mununu-core/src/adapter/btor2/concrete_oracle.rs
@@ -204,8 +204,12 @@ fn cmp_holds(op: CmpOp, lhs: u128, rhs: u128) -> bool {
 /// seeder follows it. Pass `false` when reset is a free input (the register only
 /// equals the state while reset is inactive, which free enumeration breaks).
 fn resolve_signal_symbol(file: &Btor2File, signal: &str, allow_reset_mux: bool) -> Option<String> {
-    let nid = parser::resolve_state_alias(file, signal, allow_reset_mux)?;
-    parser::collect_symbols(file).get(&nid).cloned()
+    // AR-GO-1 — the STRICT (value-identical-alias) resolution, made explicit.
+    parser::resolve_to_canonical_name(
+        file,
+        signal,
+        parser::ResolveStrictness::Strict { allow_reset_mux },
+    )
 }
 
 /// Concrete `AG (signal ⋈ value)` oracle over a **state-register** signal (or a

--- a/crates/mununu-core/src/adapter/btor2/parser.rs
+++ b/crates/mununu-core/src/adapter/btor2/parser.rs
@@ -741,6 +741,41 @@ fn follow_state_alias(
     }
 }
 
+/// AR-GO-1 — the strictness of the reverse `name → state-cell` resolution: whether an
+/// alias name resolves to a state cell only via a **value-identical** alias
+/// ([`Strict`](ResolveStrictness::Strict) — the sound oracle path) or via the looser
+/// "nearest state in the signal's cone" BFS ([`Loose`](ResolveStrictness::Loose) — the
+/// lift / predicate path). The two are genuinely different and both correct for their
+/// caller; making the choice an explicit parameter of one entry keeps the divergence
+/// **visible** rather than a silent structural duplication (the #242-family hazard: two
+/// resolution paths that can quietly disagree).
+pub enum ResolveStrictness {
+    /// Value-identical alias only ([`resolve_state_alias`]); `allow_reset_mux` widens
+    /// it to an async-reset next-mux.
+    Strict { allow_reset_mux: bool },
+    /// Nearest state in the signal's cone ([`resolve_state_by_symbol`]).
+    Loose,
+}
+
+/// Resolve a user-visible `name` to the canonical state-cell symbol the bit-blast / SMT
+/// view binds against, under an explicit [`ResolveStrictness`]. Both the strict oracle
+/// path (`concrete_oracle::resolve_signal_symbol`) and the loose lift path
+/// (`BtorSts::resolve_register`) route through this, so the strict-vs-loose choice is a
+/// named argument, not two look-alike wrappers that can drift.
+pub fn resolve_to_canonical_name(
+    file: &Btor2File,
+    name: &str,
+    strictness: ResolveStrictness,
+) -> Option<String> {
+    let nid = match strictness {
+        ResolveStrictness::Strict { allow_reset_mux } => {
+            resolve_state_alias(file, name, allow_reset_mux)?
+        }
+        ResolveStrictness::Loose => resolve_state_by_symbol(file, name)?,
+    };
+    collect_symbols(file).get(&nid).cloned()
+}
+
 /// True when `nid` is a constant, or a `uext`/`sext`-by-0 passthrough of one
 /// (the shape `async2sync` gives a reset value).
 fn resolves_to_const(file: &Btor2File, nid: Nid) -> bool {

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -135,6 +135,29 @@ struct Cell {
     varnos: Vec<VarNo>,
 }
 
+/// Resolve a BTOR2 leaf cell (state/input) NID to its canonical user-visible symbol
+/// via `collect_symbols` alias resolution — a `uext _ NID 0 NAME` alias name wins over
+/// a missing `state`-line symbol (the flattened-yosys shape), falling back to
+/// `{tag}_{nid}` for a truly anonymous cell.
+///
+/// **AR-GO-1 / #242 drift guard.** Cell naming in [`BddBitBlaster::build`] and the
+/// `next_funcs` keying MUST resolve identically, else `next_funcs.get(&cell.symbol)`
+/// misses and the register is silently frozen at its init value (the #242 soundness
+/// bug). Routing both through this one function makes that drift impossible by
+/// construction rather than by two matching comments.
+fn resolve_cell_symbol(
+    symbols: &HashMap<Nid, String>,
+    nid: Nid,
+    raw_symbol: &Option<String>,
+    tag: &str,
+) -> String {
+    symbols
+        .get(&nid)
+        .cloned()
+        .or_else(|| raw_symbol.clone())
+        .unwrap_or_else(|| format!("{tag}_{nid}"))
+}
+
 /// A BDD bit-blaster over one BTOR2 file. Owns one OxiDD manager; every node's
 /// value is a `Vec<BDDFunction>` over the register-bit + input-bit variables.
 pub struct BddBitBlaster {
@@ -173,11 +196,8 @@ impl BddBitBlaster {
             };
             let width = bv_width(file, sort)
                 .ok_or_else(|| format!("NID {}: {tag} has non-bitvec sort", line.nid))?;
-            let symbol = symbols
-                .get(&line.nid)
-                .cloned()
-                .or(symbol)
-                .unwrap_or_else(|| format!("{tag}_{}", line.nid));
+            // AR-GO-1 / #242 drift guard — same resolver as the `next_funcs` keying below.
+            let symbol = resolve_cell_symbol(&symbols, line.nid, &symbol, tag);
             leaf_specs.push((line.nid, symbol, is_state, width));
         }
 
@@ -253,27 +273,15 @@ impl BddBitBlaster {
             WalkError::Backend(msg) => msg,
         })?;
 
-        // Pass 3 — collect the per-register next-state functions, keyed by the
-        // state's symbol. This MUST use the SAME `collect_symbols` alias
-        // resolution `build()` used to name the leaf cells (line ~176): on
-        // flattened yosys output the `state` line loses its symbol and the
-        // user-visible name (`bit_cnt_q`) survives only on a `uext _ NID 0 NAME`
-        // alias, so `build()` names the cell `bit_cnt_q` via `collect_symbols`.
-        // Keying `next_funcs` off the RAW state symbol instead yields `state_<nid>`,
-        // which then MISSES the `next_funcs.get(&cell.symbol)` lookup in
-        // `exact_model()` — leaving the register with no next-state function, i.e.
-        // silently FROZEN at its init value. That is unsound: liveness/reachability
-        // over that register is decided against a model where it never transitions
-        // (a false `EF`-VIOLATED / vacuous `AG AF`-HOLDS). Resolve identically here.
-        let symbols = crate::adapter::btor2::parser::collect_symbols(file);
+        // Pass 3 — collect the per-register next-state functions, keyed by the state's
+        // symbol. AR-GO-1 / #242 drift guard: this MUST resolve identically to the cell
+        // naming in Pass 1 (both via `resolve_cell_symbol`) — else `next_funcs.get(&cell.symbol)`
+        // in `exact_model()` misses and the register is silently frozen at its init value
+        // (the #242 soundness bug: a false `EF`-VIOLATED / vacuous `AG AF`-HOLDS).
         let mut nid_symbol: HashMap<Nid, String> = HashMap::new();
         for line in &file.lines {
             if let Node::State { symbol, .. } = &line.node {
-                let sym = symbols
-                    .get(&line.nid)
-                    .cloned()
-                    .or_else(|| symbol.clone())
-                    .unwrap_or_else(|| format!("state_{}", line.nid));
+                let sym = resolve_cell_symbol(&symbols, line.nid, symbol, "state");
                 nid_symbol.insert(line.nid, sym);
             }
         }

--- a/crates/mununu-core/src/adapter/btormc/mod.rs
+++ b/crates/mununu-core/src/adapter/btormc/mod.rs
@@ -101,41 +101,15 @@ pub enum McVerdict {
 /// is absent or the version probe fails — callers fall back gracefully (the
 /// oracle is simply unavailable).
 pub fn locate_btormc() -> Result<BtormcBin, AdapterError> {
-    let path = if let Ok(p) = std::env::var("MUNUNU_BTORMC_PATH") {
-        PathBuf::from(p)
-    } else {
-        PathBuf::from("btormc")
-    };
-
-    let output = Command::new(&path)
-        .arg("--version")
-        .output()
-        .map_err(|e| AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/btormc: failed to invoke `{} --version`: {e}. \
-                 Set MUNUNU_BTORMC_PATH or install btormc (oss-cad-suite, or the \
-                 Homebrew `yosys` formula which bundles the btor2tools).",
-                path.display()
-            ),
-            location: None,
-        })?;
-
-    if !output.status.success() {
-        return Err(AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/btormc: `{} --version` exited with status {}",
-                path.display(),
-                output.status
-            ),
-            location: None,
-        });
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let version = parse_btormc_version(&stdout).unwrap_or_else(|| "<unparseable>".to_string());
-
+    // AR-GO-2 — shared locate body; see `crate::adapter::locate_tool`.
+    let (path, version) = crate::adapter::locate_tool(
+        "MUNUNU_BTORMC_PATH",
+        "btormc",
+        "btormc",
+        "Set MUNUNU_BTORMC_PATH or install btormc (oss-cad-suite, or the Homebrew \
+         `yosys` formula which bundles the btor2tools).",
+        parse_btormc_version,
+    )?;
     Ok(BtormcBin { path, version })
 }
 

--- a/crates/mununu-core/src/adapter/cvc5/mod.rs
+++ b/crates/mununu-core/src/adapter/cvc5/mod.rs
@@ -75,41 +75,15 @@ pub struct Cvc5Bin {
 /// are expected to fall back gracefully (see sub-item 3.4 for the
 /// CEGAR-loop wiring).
 pub fn locate_cvc5() -> Result<Cvc5Bin, AdapterError> {
-    let path = if let Ok(p) = std::env::var("MUNUNU_CVC5_PATH") {
-        PathBuf::from(p)
-    } else {
-        PathBuf::from("cvc5")
-    };
-
-    let output = Command::new(&path)
-        .arg("--version")
-        .output()
-        .map_err(|e| AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/cvc5: failed to invoke `{} --version`: {e}. \
-                 Set MUNUNU_CVC5_PATH or install cvc5 ≥ 1.0 (Homebrew: \
-                 `brew install cvc5`; Debian: `apt install cvc5`).",
-                path.display()
-            ),
-            location: None,
-        })?;
-
-    if !output.status.success() {
-        return Err(AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/cvc5: `{} --version` exited with status {}",
-                path.display(),
-                output.status
-            ),
-            location: None,
-        });
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let version = parse_cvc5_version(&stdout).unwrap_or_else(|| "<unparseable>".to_string());
-
+    // AR-GO-2 — shared locate body; see `crate::adapter::locate_tool`.
+    let (path, version) = crate::adapter::locate_tool(
+        "MUNUNU_CVC5_PATH",
+        "cvc5",
+        "cvc5",
+        "Set MUNUNU_CVC5_PATH or install cvc5 ≥ 1.0 (Homebrew: `brew install cvc5`; \
+         Debian: `apt install cvc5`).",
+        parse_cvc5_version,
+    )?;
     Ok(Cvc5Bin { path, version })
 }
 

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -438,6 +438,52 @@ impl fmt::Display for AdapterError {
 
 impl std::error::Error for AdapterError {}
 
+/// AR-GO-2 — the shared "locate + version-probe a `--version` subprocess tool" body.
+/// The per-tool `locate_*` wrappers (`slang`/`btormc`/`cvc5`/`verilator`) were
+/// copy-paste-identical modulo the env var, default binary, adapter tag, install hint,
+/// and version parser; this factors their common env-or-default → `--version` →
+/// status-check body so they cannot drift. Returns `(resolved path, parsed version)`;
+/// a missing binary or a failed probe is `Err(UnsupportedConstruct)` so callers degrade
+/// gracefully (the tool is simply unavailable).
+pub(crate) fn locate_tool(
+    env_var: &str,
+    default_bin: &str,
+    adapter_tag: &str,
+    install_hint: &str,
+    parse_version: impl Fn(&str) -> Option<String>,
+) -> Result<(std::path::PathBuf, String), AdapterError> {
+    use std::path::PathBuf;
+    use std::process::Command;
+    let path = std::env::var(env_var)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(default_bin));
+    let output = Command::new(&path)
+        .arg("--version")
+        .output()
+        .map_err(|e| AdapterError {
+            kind: AdapterErrorKind::UnsupportedConstruct,
+            message: format!(
+                "adapter/{adapter_tag}: failed to invoke `{} --version`: {e}. {install_hint}",
+                path.display()
+            ),
+            location: None,
+        })?;
+    if !output.status.success() {
+        return Err(AdapterError {
+            kind: AdapterErrorKind::UnsupportedConstruct,
+            message: format!(
+                "adapter/{adapter_tag}: `{} --version` exited with status {}",
+                path.display(),
+                output.status
+            ),
+            location: None,
+        });
+    }
+    let version = parse_version(&String::from_utf8_lossy(&output.stdout))
+        .unwrap_or_else(|| "<unparseable>".to_string());
+    Ok((path, version))
+}
+
 /// Detect the source format from a file extension.
 pub fn detect_format_by_extension(path: &std::path::Path) -> Option<&'static str> {
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");

--- a/crates/mununu-core/src/adapter/slang/mod.rs
+++ b/crates/mununu-core/src/adapter/slang/mod.rs
@@ -49,41 +49,16 @@ pub struct SlangBin {
 /// SVA-extraction feature degrades; model verification + mununu-annotation
 /// properties are unaffected), the cvc5 precedent.
 pub fn locate_slang() -> Result<SlangBin, AdapterError> {
-    let path = if let Ok(p) = std::env::var("MUNUNU_SLANG_PATH") {
-        PathBuf::from(p)
-    } else {
-        PathBuf::from("slang")
-    };
-
-    let output = Command::new(&path)
-        .arg("--version")
-        .output()
-        .map_err(|e| AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/slang: failed to invoke `{} --version`: {e}. Set \
-                 MUNUNU_SLANG_PATH or install slang \
-                 (https://github.com/MikePopoloski/slang — Linux + macOS-arm64 prebuilts \
-                 on the releases page; build from source elsewhere). See docs/external-tools.md.",
-                path.display()
-            ),
-            location: None,
-        })?;
-
-    if !output.status.success() {
-        return Err(AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/slang: `{} --version` exited with status {}",
-                path.display(),
-                output.status
-            ),
-            location: None,
-        });
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let version = parse_slang_version(&stdout).unwrap_or_else(|| "<unparseable>".to_string());
+    // AR-GO-2 — shared locate body; see `crate::adapter::locate_tool`.
+    let (path, version) = crate::adapter::locate_tool(
+        "MUNUNU_SLANG_PATH",
+        "slang",
+        "slang",
+        "Set MUNUNU_SLANG_PATH or install slang \
+         (https://github.com/MikePopoloski/slang — Linux + macOS-arm64 prebuilts on the \
+         releases page; build from source elsewhere). See docs/external-tools.md.",
+        parse_slang_version,
+    )?;
     Ok(SlangBin { path, version })
 }
 

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -1,16 +1,20 @@
 //! Symbolic Transition System IR — the frontend-agnostic abstraction seam.
 //!
-//! > Status: planning / P0 canonical seam (IR-unification track). Design:
-//! > `docs/design/sts-ir.md`. This module defines the *interface* the two
-//! > abstraction engines need from a symbolic transition system, plus one
-//! > implementation ([`BtorSts`]) that wraps a parsed BTOR2 file by
-//! > delegating to existing, already-shipped functions. **No existing
-//! > call site is rewired yet** — `bit_blast` and `predicate_cube_lift`
-//! > still talk to BTOR2 directly; P1 reroutes them onto this seam. P0
-//! > makes the seam the *canonical, faithful* interface: register-name
-//! > resolution ([`SymbolicTransitionSystem::resolve_register`], the home
-//! > of the DR1 #1 blocker fix) and a memory-aware SMT encode (array
-//! > theory), so P1 can consume it without behaviour drift.
+//! > Status (as-built, 2026-07-05 AR audit): the canonical seam, **partially
+//! > adopted**. Design: `docs/design/sts-ir.md`. This module defines the *interface*
+//! > the abstraction engines need from a symbolic transition system, plus one
+//! > implementation ([`BtorSts`]) wrapping a parsed BTOR2 file. **Live call sites:**
+//! > the eager predicate-cube lift routes its opt-in `SmtAllPairs` may/must/hyper-must
+//! > edges + `combinational_labels` + register-name resolution through this seam
+//! > (`kmts_lift.rs`); the exact engine uses it for `resolve_register`. **Still
+//! > bypassing the seam** (the IR-unification P1 goal, un-finished — see
+//! > `measurements/AR-architecture-review.md`, the "full seam adoption" NO-GO-for-now
+//! > item): the *default* sampling cube path (`cube_sampling_edges` +
+//! > `smt_must_edge::*`), `bit_blast` (uses the shared step *primitive*, not the trait
+//! > type), and both BDD engines (`BddBitBlaster` reads `Btor2File` directly). So the
+//! > seam is canonical + faithful, but the "single de-duplicated predicate image" goal
+//! > is not yet met — three predicate-image implementations coexist (#242 was a
+//! > symptom of two symbol-resolution paths drifting).
 //!
 //! The seam is two traits over a shared metadata trait:
 //!
@@ -276,12 +280,12 @@ impl SymbolicTransitionSystem for BtorSts<'_> {
     }
 
     fn resolve_register(&self, name: &str) -> Option<String> {
-        // BFS-backward from any node carrying `name` (direct state match,
-        // or an Op / Output alias) to the nearest state cell, then return
-        // that cell's own symbol — the name the SMT view + predicate-image
-        // bind against. Mirrors the sidecar resolver's `drives` path.
-        let nid = parser::resolve_state_by_symbol(self.file, name)?;
-        parser::collect_symbols(self.file).get(&nid).cloned()
+        // AR-GO-1 — the LOOSE resolution ("nearest state in the signal's cone"), made
+        // explicit. BFS-backward from any node carrying `name` (direct state match, or an
+        // Op / Output alias) to the nearest state cell, then return that cell's own symbol
+        // — the name the SMT view + predicate-image bind against. Mirrors the sidecar
+        // resolver's `drives` path.
+        parser::resolve_to_canonical_name(self.file, name, parser::ResolveStrictness::Loose)
     }
 }
 

--- a/crates/mununu-core/src/adapter/verilator/mod.rs
+++ b/crates/mununu-core/src/adapter/verilator/mod.rs
@@ -77,42 +77,15 @@ pub struct VerilatorBin {
 /// the predicate-seeding-pipeline wiring; the pattern is the same
 /// optional-subprocess fallback CVC5 / Craig interpolation uses).
 pub fn locate_verilator() -> Result<VerilatorBin, AdapterError> {
-    let path = if let Ok(p) = std::env::var("MUNUNU_VERILATOR_PATH") {
-        PathBuf::from(p)
-    } else {
-        PathBuf::from("verilator")
-    };
-
-    let output = Command::new(&path)
-        .arg("--version")
-        .output()
-        .map_err(|e| AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/verilator: failed to invoke `{} --version`: {e}. \
-                 Set MUNUNU_VERILATOR_PATH or install verilator ≥ 4.0 \
-                 (Homebrew: `brew install verilator`; Debian: \
-                 `apt install verilator`).",
-                path.display()
-            ),
-            location: None,
-        })?;
-
-    if !output.status.success() {
-        return Err(AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/verilator: `{} --version` exited with status {}",
-                path.display(),
-                output.status
-            ),
-            location: None,
-        });
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let version = parse_verilator_version(&stdout).unwrap_or_else(|| "<unparseable>".to_string());
-
+    // AR-GO-2 — shared locate body; see `crate::adapter::locate_tool`.
+    let (path, version) = crate::adapter::locate_tool(
+        "MUNUNU_VERILATOR_PATH",
+        "verilator",
+        "verilator",
+        "Set MUNUNU_VERILATOR_PATH or install verilator ≥ 4.0 (Homebrew: \
+         `brew install verilator`; Debian: `apt install verilator`).",
+        parse_verilator_version,
+    )?;
     Ok(VerilatorBin { path, version })
 }
 

--- a/docs/design/post-rf5-architecture.md
+++ b/docs/design/post-rf5-architecture.md
@@ -66,24 +66,26 @@ flowchart TD
   end
 
   SV -->|"slang --ast-json"| TR["SVA translator<br/>(adapter/slang/translate.rs)<br/>→ mu-calculus formula + predicate atoms"]
-  SV -->|"sv2v + yosys (no flatten)"| B2["BTOR2 IR<br/>(Btor2File / Node)"]
+  SV -->|"sv2v + yosys (flatten + async2sync)"| B2["BTOR2 IR<br/>(Btor2File / Node)"]
 
   B2 --> STS["STS-IR seam<br/>StsVar + StepEval + SmtEncode<br/>(BtorSts wraps Btor2File; hides Z3/NID)"]
 
-  STS -->|"StepEval::step"| ENUM["Explicit-Enumerate strategy<br/>(bit_blast) — Sharp CLTS"]
-  STS -->|"SmtEncode::may_edges + must<br/>(--engine explicit, default)"| CUBE["Explicit predicate-cube lift<br/>(kmts_lift::predicate_cube_lift)"]
-  STS -->|"BDD relation build (--engine symbolic)"| SYM["Symbolic predicate-cube (BDD)<br/>(symbolic_bitblast::BddBitBlaster<br/>→ AbstractRelation)"]
+  STS -->|"StepEval::step (via bit_blast primitive)"| ENUM["Explicit-Enumerate strategy<br/>(bit_blast) — Sharp CLTS"]
+  STS -->|"SmtEncode::may_edges + must (opt-in SmtAllPairs);<br/>sampling default reaches Btor2File directly<br/>(--engine explicit, default)"| CUBE["Explicit predicate-cube lift<br/>(kmts_lift::predicate_cube_lift)"]
+  B2 -->|"BDD relation build (--engine symbolic; reads Btor2File)"| SYM["Symbolic predicate-cube (BDD)<br/>(symbolic_bitblast::BddBitBlaster<br/>→ AbstractRelation)"]
+  B2 -->|"full-state bit-blast (--engine exact-symbolic; reads Btor2File)"| EXACT["Exact-symbolic MC<br/>(symbolic_bitblast::exact_symbolic_verdict<br/>→ ExactModel, 2-valued definite)"]
 
   ENUM --> CLTS["Clts (K)MTS<br/>states + may/must transitions + 3-valued labels"]
   CUBE --> CLTS
 
   CLTS --> EVX["Explicit evaluator<br/>evaluate / evaluate_tri<br/>(BoolDom / KleeneDom over BitVec)"]
-  SYM --> EVS["Symbolic evaluator<br/>SymbolicKmts::evaluate — BDD image/preimage fixpoint<br/>(TritBdd = must/may BDD pair)"]
+  SYM --> EVS["Symbolic evaluator<br/>AbstractRelation::evaluate — BDD image/preimage fixpoint<br/>(TritBdd = must/may BDD pair)"]
 
   OTH --> CLTS
 
   EVX --> V["Verdict"]
   EVS --> V
+  EXACT --> V
 
   V --> VA["3-valued per-state:<br/>True / False / ⊥ (Unknown)"]
 ```
@@ -91,12 +93,24 @@ flowchart TD
 **Reading the diagram.**
 - Non-SV frontends build a `Clts` directly and always use the explicit evaluator.
 - The SV frontend forks: the **SVA translator** produces the *property* (a mu-calculus
-  formula); the **sv2v→yosys→BTOR2** path produces the *model*.
-- The BTOR2 model is consumed through the **STS-IR seam**, never directly — that's the
-  frontend-agnostic waist.
-- Three engine strategies consume the seam. The first two produce an explicit `Clts`;
-  the symbolic one (R-F5) builds BDDs and is evaluated by a symbolic fixpoint.
-- All paths converge on the same 3-valued verdict vocabulary.
+  formula); the **sv2v→yosys→BTOR2** path produces the *model* (yosys *flattens* +
+  `async2sync`; the separate `SvModuleHierarchy` discovery pass is the "no-flatten" one).
+- **Four** engine strategies consume the model: explicit-enumerate, explicit
+  predicate-cube (`--engine explicit`, default), symbolic predicate-cube
+  (`--engine symbolic`), and full-state exact-symbolic (`--engine exact-symbolic`,
+  `sv verify-auto` only — 2-valued definite, never ⊥).
+- **STS-IR seam adoption is partial (as-built, 2026-07-05 AR audit).** The seam
+  (`BtorSts`) is the canonical waist for the opt-in `SmtAllPairs`/compound/derived
+  slice + register-name resolution, but the *default* sampling cube path and both BDD
+  engines (symbolic + exact) reach `Btor2File`/z3 directly. The single-de-duplicated-
+  predicate-image goal is not yet met — see `measurements/AR-architecture-review.md`
+  (the "full seam adoption" NO-GO-for-now item). #242 (a frozen register from two
+  drifting symbol-resolution paths) was a symptom.
+- The live symbolic evaluator is `AbstractRelation::evaluate`;
+  `SymbolicKmts::evaluate` (§5) is the R-F5.0 spike / general-CLTS path, validated
+  against `evaluate_tri` but not on a production caller.
+- All paths converge on the same verdict vocabulary (2-valued for exact/Sharp;
+  3-valued Kleene for the abstraction paths).
 
 ---
 

--- a/measurements/AR-architecture-review.md
+++ b/measurements/AR-architecture-review.md
@@ -1,0 +1,149 @@
+# Track AR — Architecture review & consolidation gate
+
+> Analysis + planning only. No edits land without the AR.5 GO verdict (per roadmap Track AR).
+> Run 2026-07-05. Evidence gathered by three parallel `Explore` audits (AR.1 pipeline/seam,
+> AR.2 coupling, AR.3 function inventory). AR.4/AR.5 synthesized from that evidence.
+
+## Executive summary (AR.5 GO/NO-GO up front)
+
+**The architecture is fundamentally sound — NO-GO on any consolidation *rewrite*; GO on four
+surgical, high-confidence, low-blast-radius items.** The three-axis design (abstraction × engine ×
+domain) holds in the code; the STS-IR seam has a single clean implementor; `Clts` is exemplary
+encapsulation. The real debt is *targeted duplication and drift hazards*, not structural rot — and
+one of them (the resolver family) is the exact class of bug that caused #242 this session. That
+makes the case for the drift-guard refactors evidence-backed rather than speculative.
+
+**GO (do these — ordered by value ÷ blast-radius):**
+0. **Diagram/doc honesty — cheapest, do first.** Fix `docs/design/post-rf5-architecture.md` §2 to match
+   the as-built: the model path *flattens* (drop "(no flatten)"); the live symbolic evaluator is
+   `AbstractRelation::evaluate` (not the test-only `SymbolicKmts::evaluate`); add the 4th engine
+   (`exact_symbolic_verdict`); and correct the stale `sts_ir.rs:8-13` module doc ("No existing call
+   site is rewired yet" → the seam is live for the SmtAllPairs/resolve slice). Pure doc; near-zero risk.
+1. **Resolver drift guard (#242 family) — HIGHEST value/effort.** Extract the `build()` cell-naming
+   + `next_funcs` keying in `symbolic_bitblast.rs` into one internal helper so the two halves cannot
+   drift again (VERY LOW blast radius, internal). Then introduce a single
+   `resolve_to_canonical_name(file, name, Strictness)` behind `resolve_signal_symbol` (strict) and
+   `BtorSts::resolve_register` (loose) so the strict-vs-loose divergence is an explicit parameter,
+   not a silent duplication (LOW blast radius, ~9 callers). *Soundness-visible.*
+2. **Subprocess-locator dedup — clearest mechanical DRY win.** `locate_slang`/`btormc`/`cvc5`/
+   `verilator` are copy-paste-identical modulo (env var, default bin, version flag, hint, parser).
+   Extract `locate_tool(...)` into `adapter/subprocess.rs`; the four become 3-line wrappers. Also
+   the verbatim `locate_cmsis_stubs` dup between root `src/main.rs` and `crates/mununu-cli/src/main.rs`
+   (a stale pre-crate-split copy). LOW–MEDIUM blast radius, public signatures unchanged.
+3. **Ergonomic builders for the change-amplifiers.** `TransitionSpec` (IR, ~15 construct sites) and
+   `OriginalTransition` (5 sites + doctests — the exact struct behind the CLAUDE.md pre-push CI pain,
+   K.1b/K.2b) get a `Default` base / builder so a new field defaults everywhere instead of forcing a
+   literal edit at every site (incl. doctests, which the pre-push check historically missed). Factor
+   the shared `(modality, additional_targets)` tail of `OriginalTransition`/`TransitionSpec`/
+   `TransitionDecl` into one `Modality` sub-struct.
+4. **Trim dead option/echo fields (YAGNI).** `CegarOptions`: `lift_strategy::Lazy` "produces the same
+   verdict as Eager" and `CegarTrace::lazy_lift_pending` is "always true"; `CegarTrace::approximant_reuse_enabled`
+   merely echoes `CegarOptions`. Remove the no-op flags + echoes (common coupling → single source of truth).
+
+**NO-GO (for now — but the top structural debt, named):** **full STS-IR seam adoption** — routing the
+default sampling cube path + both BDD engines through `BtorSts`/`SmtEncode` to collapse the *three*
+parallel predicate-image implementations into one. This is the seam's original goal and #242 was its
+symptom, so it is genuinely load-bearing debt — but it is a **large, soundness-critical refactor of
+the core edge-computation** (may/must inference is where verdict soundness is decided), high blast
+radius, and the three impls are currently differential-cross-validated. Defer to a dedicated,
+carefully-gated effort with a per-impl differential harness; do NOT fold it into an incidental
+quality-session. Also NO-GO: a whole-pipeline rewrite; a second STS-IR *frontend* abstraction (one
+implementor — YAGNI); collapsing the `Trit`/`Tristate` or `TritSet`/`TritBdd` layer splits
+(deliberate, differential-guarded).
+
+**Deciding factors (named, not fatigue framing):** (a) the GO items are soundness-adjacent
+(resolver drift = #242) or pure mechanical dedup — high confidence, small blast radius; (b) a big
+restructure has high soundness-critical-seam risk (the evaluator/lift/seam are the load-bearing
+core) for low marginal value over the surgical items; (c) opportunity cost vs Track H/R-F5.6 is real
+— these GO items are cheap enough to interleave, a rewrite is not.
+
+---
+
+## AR.2 — Interface-struct & coupling audit
+
+Full table in the audit; the load-bearing findings:
+
+**Top change-amplifiers (shape-change ripple widest):**
+1. `TransitionSpec` (IR, `adapter/ir.rs:168`) — ~15 frontend-adapter construction sites; widest fan-in.
+2. `OriginalTransition` (`abstraction/unrolling.rs:17`) — 5 prod sites across 3 crates + doctests; the
+   #K.1b/K.2b CI-failure struct.
+3. `PredicateSpec` (`kmts_lift.rs:325`) — 9+ sites, but stable 3-field value object (low risk).
+4. `CegarOptions` (`cegar.rs:137`) — 7 behavior-switch flags, some no-op (control-coupling god-options).
+5. `PredicateCubeLiftOptions` (`kmts_lift.rs:382`) — cross-field invariant (`compound_exprs` requires
+   `may_edge_inference==SmtAllPairs`), enforced at runtime rather than by construction.
+
+**Address verdicts:** builder/Default for #1/#2 (ergonomics); trim dead flags on `CegarOptions` +
+`CegarTrace` echoes; enforce the `PredicateCubeLiftOptions` invariant via a constructor; encapsulate
+`Btor2SmtView` (all-`pub` raw Z3 handles + an *unenforced drop-ordering temporal invariant* — bind
+the Z3-scope lifetime into the type). **Leave (exemplary):** `Clts`, `Transition`, `TritSet`,
+`WitnessCell` — private fields + accessors, the reference for how a seam type should look.
+
+**Near-alias pairs:** `OriginalTransition`/`TransitionSpec`/`TransitionDecl` (shared modality tail →
+one `Modality` sub-struct); `Trit`↔`Tristate` (two 3-valued enums + lossless `From` — leave, layer
+split); `TritSet`↔`TritBdd` (perf reps, differential-guarded — leave); `ir::TransitionSpec` vs
+`clts::TransitionSpec<S,L>` (**name collision** — rename the private builder-internal one); the
+four-way `Guard`/`GuardExpr` family (separate consolidation pass).
+
+## AR.3 — Function inventory & merge candidates
+
+**Surface:** mununu-core = **889 `pub fn`**, concentrated in `clts` (95), `abstraction` (113),
+`mu_calculus` (106), `adapter/btor2` (121). `mununu-cli` = 0 pub fn (binary), `mununu-extract` = 6.
+Full per-module table in the AR.3 audit output.
+
+**Merge-candidate clusters:**
+
+| Cluster | Verdict | Blast radius | Priority |
+|---|---|---|---|
+| Resolver name→nid→name wrappers (`resolve_signal_symbol` strict vs `BtorSts::resolve_register` loose) | **REFACTOR** to a `Strictness`-parameterized helper | LOW | **HIGH** (soundness, #242 family) |
+| #242 `build()` cell-name / `next_funcs` keying | **REFACTOR** to one internal helper (drift guard) | VERY LOW | **HIGH** (best value/effort) |
+| Subprocess locators (`locate_{slang,btormc,cvc5,verilator}`) | **REFACTOR** to shared `locate_tool` | LOW–MED | **HIGH** (mechanical DRY win) |
+| `locate_cmsis_stubs` root/cli verbatim dup | REFACTOR (stale copy) | LOW | Medium |
+| BTOR2 text appenders (`augment/pin/inject` + `emit_*_monitor`) | REFACTOR internals to `Btor2Appender`; keep public API | MEDIUM | Medium |
+| Predicate rewriters (`resolve_predicate_registers` vs `resolve_predicate_expr_registers`) | REFACTOR (tied to Spec/Expr duality) | MEDIUM | Medium |
+| `spurious_verdict*` + production oracles | **LEAVE** (test-only + intentional cross-validation) | NIL | Low |
+| strict/loose resolver *primitives* (`resolve_state_by_symbol` vs `resolve_state_alias`) | **LEAVE** (both correct; co-locate + doc) | — | — |
+
+## AR.1 — As-built pipeline vs the intended mermaid (seam integrity)
+
+**The macro pipeline is backed and faithful; the STS-IR seam is real but only PARTIALLY adopted.**
+`BtorSts` is the canonical `Btor2File → StepEval/SmtEncode` waist, and the opt-in
+`SmtAllPairs`/compound/derived slice + all register-name resolution correctly flow through it. But
+the stated "single de-duplicated waist for the predicate image" goal (`sts_ir.rs:15-29`) is **not
+met** — three engines reach `Btor2File`/z3 directly:
+
+- **B1 — the DEFAULT explicit cube path (sampling `MayEdgeInference::Off`) HARD-BYPASSES the seam**
+  (and it is the default). `cube_sampling_edges` calls `bit_blast::simulate_one_step` directly
+  (`kmts_lift.rs:1587`); must-edges reach `smt_must_edge::*` + `z3::with_z3_config` directly
+  (`kmts_lift.rs:1065-1068,1134-1139`). A second predicate-image implementation living beside the
+  seam's — the exact class of drift that produced #242.
+- **B2 — symbolic cube engine** (`BddBitBlaster::build`, `symbolic_bitblast.rs:156`) reads
+  `Btor2File`/`Node`/`Nid` directly; never constructs `BtorSts`.
+- **B3 — exact-symbolic engine** (`exact_symbolic_verdict`, a shipped CLI-reachable **4th engine
+  absent from the §2 diagram**) builds `BddBitBlaster` directly; uses the seam only for
+  `resolve_register`.
+- B4/B5 — ENUM (`bit_blast`) and the verify-auto orchestrator share the seam *primitive*
+  (`simulate_one_step_observe`) but not the seam *type* (soft bypass; behavior unified).
+
+**Diagram / doc drift (cheap to fix, high-honesty value):** (i) the `SV→B2` "(no flatten)" label is
+wrong — the shipped yosys model script *flattens* (`yosys/mod.rs:863`); "(no flatten)" describes only
+the separate hierarchy-discovery pass. (ii) The `EVS` node names `SymbolicKmts::evaluate`, which has
+**no production caller** (R-F5.0 spike, test-only); the live symbolic evaluator is
+`AbstractRelation::evaluate`. (iii) `exact_symbolic_verdict` (4th engine) is undiagrammed. (iv)
+`sts_ir.rs:8-13` module doc is **stale** ("No existing call site is rewired yet") — contradicted by
+the live `BtorSts` calls in `kmts_lift.rs`.
+
+**Responsibility-bleed:** none structural (translator does not build the model; the lift does not
+evaluate). The only "bleed" is the *duplicated predicate-image logic* across the seam, the sampling
+path, and the BDD engines — a drift hazard, not a layering violation.
+
+## AR.4 — Clean-slate delta (target vs as-built)
+
+The clean-slate architecture (from the README "three orthogonal choices: abstraction × engine ×
+domain") **matches the as-built** at the macro level — the three axes, the seam, the two verdict
+representations all exist as designed. The divergences are all *micro* and already captured above:
+(i) the resolver family has no single canonical entry (drift hazard); (ii) the transition-record
+triple duplicates a modality tail; (iii) subprocess-locator boilerplate; (iv) a name collision
+(`TransitionSpec` ×2) and a four-way `Guard` family; (v) `Btor2SmtView` leaks the Z3 layer. None of
+these is a structural redesign — they're the delta between "designed clean" and "grew organically,"
+and every one is a bounded refactor. **The clean-slate exercise confirms: consolidate the seams, do
+not redraw them.**


### PR DESCRIPTION
## Summary

Track AR consolidation gate — analysis + GO/NO-GO in `measurements/AR-architecture-review.md`, then the three surgical, behavior-preserving GO items. (**NO-GO** on a rewrite; the top structural debt — full STS-IR seam adoption, three parallel predicate-image impls, #242 a symptom — deferred to a gated effort.)

### AR-GO-0 — diagram/doc honesty
`docs/design/post-rf5-architecture.md` §2 corrected to the as-built: the model path **flattens** (was "no flatten"), **four** engines (add the exact engine), the live symbolic evaluator is `AbstractRelation::evaluate` (not the test-only `SymbolicKmts::evaluate`), and the STS-IR seam is only **partially adopted**. Stale `sts_ir.rs` module doc replaced.

### AR-GO-1 — resolver drift guard (the #242 family) 🔒
- (a) `resolve_cell_symbol` helper: the `symbolic_bitblast::build` cell-naming and `next_funcs` keying now call **one** function, so the #242 frozen-register drift is impossible **by construction** (was two matching comments).
- (b) `parser::resolve_to_canonical_name(file, name, ResolveStrictness::{Strict,Loose})` behind `resolve_signal_symbol` (strict oracle) and `BtorSts::resolve_register` (loose lift) — the strict/loose choice is now a **named argument**, not two look-alike wrappers.

### AR-GO-2 — subprocess-locator dedup
`adapter::locate_tool(env, bin, tag, hint, parse)`; `locate_{slang,btormc,cvc5,verilator}` are now 3-line wrappers.

### Deferred to `/quality-session` (the gate's prescribed vehicle)
- **AR-GO-3** (change-amplifier builders): ~20 watch-list-struct sites across 3 crates + a `Modality` sub-struct factoring — wants the pre-push workspace check.
- **AR-GO-4**: turned out to be a **Surface-Parity** change, not dead code — the `CegarTrace` fields are read by `api/handlers.rs` + emitted in the CLI JSON.

## Validation (mununu-sva)

fmt/clippy clean; full `mununu-core` lib suite green; `cargo check -p mununu-cli` clean. Behavior-preserving.

> ⚠ Note: a pre-existing flaky sv2v/yosys subprocess test (`sv2v_include_resolves_staged_additional_source_header`) occasionally fails under parallel load but **passes in isolation** — unrelated to this PR (which doesn't touch the sv2v/yosys path). Re-run CI if it flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)