### PR TITLE
fix(ci): clear crossbeam-epoch RUSTSEC-2026-0204 + a test-only clippy lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/mununu-core/src/adapter/btor2/bv.rs
+++ b/crates/mununu-core/src/adapter/btor2/bv.rs
@@ -566,9 +566,9 @@ mod tests {
                 &((BigUint::from(a) * BigUint::from(b)) & biguint_mask(w.min(128))),
             );
             assert_eq!(av.mul(&bv).to_u128(), Some(mref(mul_ref, w)), "mul w={w}");
-            if b != 0 {
-                assert_eq!(av.udiv(&bv).to_u128(), Some(mref(a / b, w)), "udiv w={w}");
-                assert_eq!(av.urem(&bv).to_u128(), Some(mref(a % b, w)), "urem w={w}");
+            if let (Some(q), Some(r)) = (a.checked_div(b), a.checked_rem(b)) {
+                assert_eq!(av.udiv(&bv).to_u128(), Some(mref(q, w)), "udiv w={w}");
+                assert_eq!(av.urem(&bv).to_u128(), Some(mref(r, w)), "urem w={w}");
             }
             // Shifts by a random amount in 0..=w+2 (covers the ≥ w saturation).
             let n = (rng.next() % (w as u128 + 3)) as u32;


### PR DESCRIPTION
Restores green CI on `main` after #249/#250.

- **security-audit**: bump `crossbeam-epoch` 0.9.18 → 0.9.20 (patched for **RUSTSEC-2026-0204**, a newly-published 2026-07-06 advisory on a transitive dep — not introduced by #249/#250; #248 passed audit hours earlier). Remaining audit lines are pre-existing informational warnings #248 already passed with.
- **lint-and-test**: fix `clippy::manual_checked_ops` in the `Bv` differential test (`if b != 0 { a / b }` → `checked_div`/`checked_rem`). Escaped locally because the pre-commit hook clippies `--lib`, not `--all-targets`.

Verified `cargo clippy --workspace --all-targets -- -D warnings` clean + `cargo audit` no longer reports the vulnerability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)