### PR TITLE
feat(P1): per-engine wall-clock timeouts + parallel reachability portfolio

### DIFF
--- a/crates/mununu-core/src/adapter/btormc/mod.rs
+++ b/crates/mununu-core/src/adapter/btormc/mod.rs
@@ -63,9 +63,9 @@
 //! EMISSION (property → augmented BTOR2) is H.O.1b; the `McOracle` differential +
 //! real-RTL e2e is H.O.1c.
 
-use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Command;
+use std::time::Duration;
 
 use crate::adapter::{AdapterError, AdapterErrorKind};
 
@@ -73,6 +73,11 @@ use crate::adapter::{AdapterError, AdapterErrorKind};
 /// reach a CEX or close k-induction on the small FSM fragments H.O targets, while
 /// bounding wall-clock on the e2e. Callers can override per-invocation.
 pub const DEFAULT_KMAX: u32 = 40;
+
+/// Default wall-clock timeout for a [`run_btormc`] invocation. `-kmax` bounds the
+/// unroll DEPTH, but each SAT check on a wide design can still be slow; this caps
+/// the total run so a portfolio member cannot hang the whole decision.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// A discovered `btormc` binary + its parsed version (diagnostic only — mununu
 /// does not gate on a minimum version).
@@ -172,52 +177,28 @@ pub fn count_bad_properties(btor2: &str) -> usize {
 /// hard error (e.g. a malformed BTOR2 — a bug in the emission, not an
 /// inconclusive verdict) with no parseable verdict on stdout. A clean run with
 /// neither `sat` nor `unsat` is [`McVerdict::Unknown`], not an error.
-pub fn run_btormc(bin: &BtormcBin, btor2: &str, kmax: u32) -> Result<McVerdict, AdapterError> {
-    let mut child = Command::new(&bin.path)
-        .arg("--kind")
-        .arg("-kmax")
-        .arg(kmax.to_string())
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+pub fn run_btormc(
+    bin: &BtormcBin,
+    btor2: &str,
+    kmax: u32,
+    timeout: Duration,
+) -> Result<McVerdict, AdapterError> {
+    let mut command = Command::new(&bin.path);
+    command.arg("--kind").arg("-kmax").arg(kmax.to_string());
+    let outcome = crate::adapter::run_with_timeout(&mut command, Some(btor2.as_bytes()), timeout)
         .map_err(|e| AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: format!(
-                "adapter/btormc: failed to spawn `{}`: {e}",
-                bin.path.display()
-            ),
-            location: None,
-        })?;
-
-    // Write the BTOR2 to stdin, then drop the handle to signal EOF (the fragment
-    // is small, so the pipe buffer never fills before `wait_with_output` drains
-    // stdout — no deadlock).
-    {
-        let mut stdin = child.stdin.take().ok_or_else(|| AdapterError {
-            kind: AdapterErrorKind::UnsupportedConstruct,
-            message: "adapter/btormc: child stdin unavailable".to_string(),
-            location: None,
-        })?;
-        stdin
-            .write_all(btor2.as_bytes())
-            .map_err(|e| AdapterError {
-                kind: AdapterErrorKind::UnsupportedConstruct,
-                message: format!("adapter/btormc: failed writing BTOR2 to stdin: {e}"),
-                location: None,
-            })?;
-    }
-
-    let output = child.wait_with_output().map_err(|e| AdapterError {
         kind: AdapterErrorKind::UnsupportedConstruct,
         message: format!(
-            "adapter/btormc: failed waiting for `{}`: {e}",
+            "adapter/btormc: failed to run `{}`: {e}",
             bin.path.display()
         ),
         location: None,
     })?;
+    // Timed out ⇒ inconclusive (never a wrong verdict).
+    let Some((status, stdout, stderr)) = outcome else {
+        return Ok(McVerdict::Unknown);
+    };
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
     // MULTI-PROPERTY SOUNDNESS FIX — `--kind` reports per property and may STOP after
     // proving ONE property of a multi-`bad` design safe (printing `unsat bN`) while a
     // DIFFERENT property is reachable. `parse_btormc_output` returns on the first
@@ -234,14 +215,13 @@ pub fn run_btormc(bin: &BtormcBin, btor2: &str, kmax: u32) -> Result<McVerdict, 
     // A clean Unknown (exit 0, empty stdout) is valid. But if btormc reported a
     // hard error (non-zero exit, e.g. a BTOR2 parse error) AND produced no
     // verdict, surface it — that signals a malformed monitor, not inconclusiveness.
-    if verdict == McVerdict::Unknown && !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    if verdict == McVerdict::Unknown && !status.success() {
         return Err(AdapterError {
             kind: AdapterErrorKind::UnsupportedConstruct,
             message: format!(
                 "adapter/btormc: `{}` exited with status {} and no verdict; stderr: {}",
                 bin.path.display(),
-                output.status,
+                status,
                 stderr.trim()
             ),
             location: None,
@@ -267,10 +247,11 @@ pub fn run_btormc(bin: &BtormcBin, btor2: &str, kmax: u32) -> Result<McVerdict, 
 pub fn decide_via_btormc(
     file: &crate::adapter::btor2::ast::Btor2File,
     kmax: u32,
+    timeout: Duration,
 ) -> Result<McVerdict, AdapterError> {
     let btor2 = crate::adapter::btor2::emit::emit_btor2(file);
     let bin = locate_btormc()?;
-    run_btormc(&bin, &btor2, kmax)
+    run_btormc(&bin, &btor2, kmax, timeout)
 }
 
 #[cfg(test)]
@@ -372,7 +353,7 @@ mod tests {
     fn run_btormc_reach_is_violated() {
         let bin = locate_btormc().expect("btormc present");
         assert_eq!(
-            run_btormc(&bin, REACH_BTOR2, DEFAULT_KMAX).unwrap(),
+            run_btormc(&bin, REACH_BTOR2, DEFAULT_KMAX, DEFAULT_TIMEOUT).unwrap(),
             McVerdict::Violated
         );
     }
@@ -383,7 +364,7 @@ mod tests {
         let bin = locate_btormc().expect("btormc present");
         // `--kind` (set by run_btormc) is what lets this conclude Safe.
         assert_eq!(
-            run_btormc(&bin, SAFE_BTOR2, DEFAULT_KMAX).unwrap(),
+            run_btormc(&bin, SAFE_BTOR2, DEFAULT_KMAX, DEFAULT_TIMEOUT).unwrap(),
             McVerdict::Safe
         );
     }
@@ -396,13 +377,13 @@ mod tests {
         // the emit hand-off end-to-end (the emitted text is btormc's input).
         let reach = crate::adapter::btor2::parser::parse(REACH_BTOR2).expect("parse reach");
         assert_eq!(
-            decide_via_btormc(&reach, DEFAULT_KMAX).unwrap(),
+            decide_via_btormc(&reach, DEFAULT_KMAX, DEFAULT_TIMEOUT).unwrap(),
             McVerdict::Violated,
             "emit→btormc must decide the reachable-bad model as Violated"
         );
         let safe = crate::adapter::btor2::parser::parse(SAFE_BTOR2).expect("parse safe");
         assert_eq!(
-            decide_via_btormc(&safe, DEFAULT_KMAX).unwrap(),
+            decide_via_btormc(&safe, DEFAULT_KMAX, DEFAULT_TIMEOUT).unwrap(),
             McVerdict::Safe,
             "emit→btormc must decide the safe model as Safe"
         );

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -486,6 +486,73 @@ pub(crate) fn locate_tool(
     Ok((path, version))
 }
 
+/// Run a subprocess with a **wall-clock timeout**, draining stdout/stderr on
+/// separate threads (so a large witness trace can't deadlock the pipe) and
+/// killing the child if it exceeds `timeout`.
+///
+/// Returns `Ok(None)` on timeout — the caller treats a timed-out model checker as
+/// *inconclusive* (`Unknown`), never as a wrong verdict. `Ok(Some((status, stdout,
+/// stderr)))` when the child completes on its own. `stdin_data`, when present, is
+/// written to the child's stdin (then EOF); pass `None` for a file-arg tool.
+///
+/// std-only (no `wait-timeout` crate, no coreutils `timeout`) so it is portable
+/// and adds no dependency: model checkers like Pono's IC3 can run unbounded, and
+/// this is the portfolio's guard against a single member hanging the whole run.
+pub(crate) fn run_with_timeout(
+    command: &mut std::process::Command,
+    stdin_data: Option<&[u8]>,
+    timeout: std::time::Duration,
+) -> std::io::Result<Option<(std::process::ExitStatus, String, String)>> {
+    use std::io::{Read, Write};
+    use std::process::Stdio;
+    let mut child = command
+        .stdin(if stdin_data.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    // Feed stdin on its own thread (owned copy) so a large input can't deadlock
+    // against a tool that interleaves reading stdin with writing stdout — the
+    // writer, stdout-reader, and stderr-reader all run concurrently.
+    if let Some(mut si) = child.stdin.take() {
+        let data = stdin_data.unwrap_or_default().to_vec();
+        std::thread::spawn(move || {
+            let _ = si.write_all(&data); // drop `si` ⇒ EOF to the child
+        });
+    }
+    // Drain both pipes concurrently so the child never blocks on a full buffer.
+    let mut so = child.stdout.take().expect("piped stdout");
+    let mut se = child.stderr.take().expect("piped stderr");
+    let so_h = std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = so.read_to_string(&mut s);
+        s
+    });
+    let se_h = std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = se.read_to_string(&mut s);
+        s
+    });
+    let start = std::time::Instant::now();
+    let status = loop {
+        if let Some(st) = child.try_wait()? {
+            break Some(st);
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait(); // reap; closing the pipes unblocks the readers
+            break None;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    };
+    let stdout = so_h.join().unwrap_or_default();
+    let stderr = se_h.join().unwrap_or_default();
+    Ok(status.map(|st| (st, stdout, stderr)))
+}
+
 /// Detect the source format from a file extension.
 pub fn detect_format_by_extension(path: &std::path::Path) -> Option<&'static str> {
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");

--- a/crates/mununu-core/src/adapter/pono/mod.rs
+++ b/crates/mununu-core/src/adapter/pono/mod.rs
@@ -35,6 +35,7 @@
 
 use std::path::PathBuf;
 use std::process::Command;
+use std::time::Duration;
 
 use crate::adapter::btormc::{McVerdict, count_bad_properties};
 use crate::adapter::{AdapterError, AdapterErrorKind};
@@ -44,6 +45,13 @@ use crate::adapter::{AdapterError, AdapterErrorKind};
 /// finds shallow counterexamples (`sat`); deep-CEX designs are btormc's strength
 /// in the portfolio.
 pub const DEFAULT_ENGINE: &str = "ic3bits";
+
+/// Default wall-clock budget for a single Pono run. Pono's IC3/PDR has **no
+/// native wall-clock bound** (only depth caps on the bounded engines), so a hard
+/// instance can run unbounded — the external kill in
+/// [`crate::adapter::run_with_timeout`] is the only backstop. A timeout is a sound
+/// abstention: it yields [`McVerdict::Unknown`], never a wrong verdict.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// A discovered `pono` binary + its parsed version (diagnostic only).
 #[derive(Debug, Clone)]
@@ -97,7 +105,12 @@ pub fn parse_pono_output(stdout: &str) -> McVerdict {
 /// multi-property `Safe`-downgrade mirrors [`crate::adapter::btormc::run_btormc`].
 /// `Err` only when the subprocess could not run; a clean run with no `sat`/`unsat`
 /// is [`McVerdict::Unknown`], not an error.
-pub fn run_pono(bin: &PonoBin, btor2: &str, engine: &str) -> Result<McVerdict, AdapterError> {
+pub fn run_pono(
+    bin: &PonoBin,
+    btor2: &str,
+    engine: &str,
+    timeout: Duration,
+) -> Result<McVerdict, AdapterError> {
     use std::sync::atomic::{AtomicU64, Ordering};
     // Pono reads a file (not stdin). Write to a uniquely-named temp file — the
     // codebase's `std::env::temp_dir` convention (as in the verilator wrapper),
@@ -116,16 +129,19 @@ pub fn run_pono(bin: &PonoBin, btor2: &str, engine: &str) -> Result<McVerdict, A
         ))
     })?;
 
-    let result = Command::new(&bin.path)
-        .arg("-e")
-        .arg(engine)
-        .arg(&tmp_path)
-        .output();
+    // Pono's IC3/PDR has no native wall-clock bound — enforce one externally so a
+    // hard instance abstains (Unknown) rather than hanging the portfolio.
+    let mut command = Command::new(&bin.path);
+    command.arg("-e").arg(engine).arg(&tmp_path);
+    let result = crate::adapter::run_with_timeout(&mut command, None, timeout);
     let _ = std::fs::remove_file(&tmp_path);
-    let output =
-        result.map_err(|e| err(format!("failed to spawn `{}`: {e}", bin.path.display())))?;
+    let outcome =
+        result.map_err(|e| err(format!("failed to run `{}`: {e}", bin.path.display())))?;
+    // Timed out ⇒ inconclusive (never a wrong verdict).
+    let Some((status, stdout, stderr)) = outcome else {
+        return Ok(McVerdict::Unknown);
+    };
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
     // MULTI-PROPERTY SOUNDNESS — Pono checks property index 0 by default, so an
     // `unsat` on a design with >1 `bad` proves only that one property safe. Downgrade
     // a `Safe` parse to `Unknown`; a `sat` (some property reachable) stays `Violated`.
@@ -137,12 +153,11 @@ pub fn run_pono(bin: &PonoBin, btor2: &str, engine: &str) -> Result<McVerdict, A
 
     // A clean Unknown is valid; a hard error (non-zero exit, no verdict) is not —
     // surface it as a malformed-input signal rather than inconclusiveness.
-    if verdict == McVerdict::Unknown && !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    if verdict == McVerdict::Unknown && !status.success() {
         return Err(err(format!(
             "`{}` exited with status {} and no verdict; stderr: {}",
             bin.path.display(),
-            output.status,
+            status,
             stderr.trim()
         )));
     }
@@ -155,10 +170,11 @@ pub fn run_pono(bin: &PonoBin, btor2: &str, engine: &str) -> Result<McVerdict, A
 pub fn decide_via_pono(
     file: &crate::adapter::btor2::ast::Btor2File,
     engine: &str,
+    timeout: Duration,
 ) -> Result<McVerdict, AdapterError> {
     let btor2 = crate::adapter::btor2::emit::emit_btor2(file);
     let bin = locate_pono()?;
-    run_pono(&bin, &btor2, engine)
+    run_pono(&bin, &btor2, engine, timeout)
 }
 
 fn err(message: String) -> AdapterError {
@@ -202,12 +218,12 @@ mod tests {
         // a reachable-bad model is Violated, a safe one is Safe.
         let reach = parser::parse(REACH).expect("parse reach");
         assert_eq!(
-            decide_via_pono(&reach, DEFAULT_ENGINE).unwrap(),
+            decide_via_pono(&reach, DEFAULT_ENGINE, DEFAULT_TIMEOUT).unwrap(),
             McVerdict::Violated
         );
         let safe = parser::parse(SAFE).expect("parse safe");
         assert_eq!(
-            decide_via_pono(&safe, DEFAULT_ENGINE).unwrap(),
+            decide_via_pono(&safe, DEFAULT_ENGINE, DEFAULT_TIMEOUT).unwrap(),
             McVerdict::Safe
         );
     }

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -14,9 +14,15 @@
 //!   rather than a guess. Since all three engines are sound, a disagreement can
 //!   only mean a real bug — exactly what the differential oracle exists to catch.
 //!
-//! This is the *sequential* portfolio. A parallel variant + per-engine timeouts
-//! (Pono's IC3 can run unbounded on a hard instance) are follow-ups; today the
-//! members run in order and an engine that errors / times out simply abstains.
+//! Both a **sequential** ([`decide_reach_portfolio`]) and a **parallel**
+//! ([`decide_reach_portfolio_parallel`]) driver are provided. They merge
+//! identically — the parallel variant only overlaps the two subprocess members
+//! (and the in-process exact engine) in wall-clock, which matters once a
+//! per-engine timeout is in play: a slow member no longer serialises in front of
+//! a fast one. Every member carries a **wall-clock timeout** (Pono's IC3 has no
+//! native bound and can run unbounded on a hard instance); a member that errors,
+//! times out, or is undecided simply abstains — a timeout is a sound
+//! [`ReachVerdict::Unknown`], never a wrong verdict.
 
 use crate::adapter::btor2::ast::Btor2File;
 use crate::adapter::btor2::emit::emit_btor2;
@@ -67,45 +73,87 @@ impl ReachOutcome {
     }
 }
 
+/// The exact engine's optional verdict: `Some(true)` reachable, `Some(false)`
+/// unreachable, `None` abstained (over-cap / free-init / error).
+fn run_exact(content: &str) -> Option<bool> {
+    exact_bad_reachable(content).ok()
+}
+
+/// Merge the three members' verdicts into a [`ReachOutcome`], in the fixed
+/// engine order (`exact`, `btormc`, `pono`) so the outcome is deterministic
+/// regardless of which driver (sequential / parallel) produced them.
+fn collect(
+    exact: Option<bool>,
+    btormc_v: Option<McVerdict>,
+    pono_v: Option<McVerdict>,
+) -> ReachOutcome {
+    let mut reachable_by: Vec<&'static str> = Vec::new();
+    let mut unreachable_by: Vec<&'static str> = Vec::new();
+    match exact {
+        Some(true) => reachable_by.push("exact"),
+        Some(false) => unreachable_by.push("exact"),
+        None => {}
+    }
+    for (name, v) in [("btormc", btormc_v), ("pono", pono_v)] {
+        match v {
+            Some(McVerdict::Violated) => reachable_by.push(name),
+            Some(McVerdict::Safe) => unreachable_by.push(name),
+            Some(McVerdict::Unknown) | None => {}
+        }
+    }
+    ReachOutcome::from_sets(reachable_by, unreachable_by)
+}
+
 /// Decide `bad`-reachability of `file` across the exact BDD engine + the btormc
 /// and Pono subprocess members, merged under the differential-oracle discipline.
 ///
 /// Each member abstains gracefully: the exact engine on an over-cap / free-init
-/// design (`Err`), a subprocess member when its binary is absent (`Err`) or it is
-/// inconclusive (`Unknown`). The emitted BTOR2 (from [`emit_btor2`]) is the shared
-/// input, so a *reduced / transformed* model is decided consistently by all three.
+/// design (`Err`), a subprocess member when its binary is absent (`Err`), it is
+/// inconclusive (`Unknown`), or it hits its wall-clock timeout. The emitted BTOR2
+/// (from [`emit_btor2`]) is the shared input, so a *reduced / transformed* model
+/// is decided consistently by all three.
+///
+/// This is the **sequential** driver — members run one after another. Use
+/// [`decide_reach_portfolio_parallel`] to overlap them in wall-clock.
 pub fn decide_reach_portfolio(file: &Btor2File) -> ReachOutcome {
-    let mut reachable_by: Vec<&'static str> = Vec::new();
-    let mut unreachable_by: Vec<&'static str> = Vec::new();
-
+    let content = emit_btor2(file);
     // Exact BDD engine — sound both ways (REACHABLE is always sound; an
     // UNREACHABLE verdict is refused on free-init state), within the bit cap.
-    let content = emit_btor2(file);
-    match exact_bad_reachable(&content) {
-        Ok(true) => reachable_by.push("exact"),
-        Ok(false) => unreachable_by.push("exact"),
-        Err(_) => {}
-    }
-
+    let exact = run_exact(&content);
     // btormc — BMC (CEX) + k-induction (proof).
-    if let Ok(v) = btormc::decide_via_btormc(file, btormc::DEFAULT_KMAX) {
-        match v {
-            McVerdict::Violated => reachable_by.push("btormc"),
-            McVerdict::Safe => unreachable_by.push("btormc"),
-            McVerdict::Unknown => {}
-        }
-    }
-
+    let btormc_v =
+        btormc::decide_via_btormc(file, btormc::DEFAULT_KMAX, btormc::DEFAULT_TIMEOUT).ok();
     // Pono — IC3/PDR (proof + shallow CEX).
-    if let Ok(v) = pono::decide_via_pono(file, pono::DEFAULT_ENGINE) {
-        match v {
-            McVerdict::Violated => reachable_by.push("pono"),
-            McVerdict::Safe => unreachable_by.push("pono"),
-            McVerdict::Unknown => {}
-        }
-    }
+    let pono_v = pono::decide_via_pono(file, pono::DEFAULT_ENGINE, pono::DEFAULT_TIMEOUT).ok();
+    collect(exact, btormc_v, pono_v)
+}
 
-    ReachOutcome::from_sets(reachable_by, unreachable_by)
+/// The **parallel** driver: run the exact engine (in-process) and the two
+/// subprocess members concurrently, then merge identically to
+/// [`decide_reach_portfolio`]. Scoped threads borrow `file` directly — the scope
+/// guarantees the borrows end before this returns, so no clone / `Arc` is needed.
+///
+/// The merge is unchanged, so the verdict is identical to the sequential driver;
+/// only the wall-clock differs (≈ the slowest single member instead of the sum).
+/// This matters once per-engine timeouts are in play — a member that burns its
+/// full budget no longer serialises in front of a fast one.
+pub fn decide_reach_portfolio_parallel(file: &Btor2File) -> ReachOutcome {
+    let content = emit_btor2(file);
+    std::thread::scope(|scope| {
+        let btormc_h = scope.spawn(|| {
+            btormc::decide_via_btormc(file, btormc::DEFAULT_KMAX, btormc::DEFAULT_TIMEOUT).ok()
+        });
+        let pono_h = scope.spawn(|| {
+            pono::decide_via_pono(file, pono::DEFAULT_ENGINE, pono::DEFAULT_TIMEOUT).ok()
+        });
+        // The exact engine is in-process BDD work — run it on this thread while the
+        // two subprocess members run on theirs.
+        let exact = run_exact(&content);
+        // A panicked member thread abstains (None) rather than poisoning the merge.
+        let btormc_v = btormc_h.join().unwrap_or(None);
+        let pono_v = pono_h.join().unwrap_or(None);
+        collect(exact, btormc_v, pono_v)
+    })
 }
 
 #[cfg(test)]
@@ -153,6 +201,22 @@ mod tests {
             out.unreachable_by.is_empty(),
             "no engine should call the reachable counter unreachable"
         );
+    }
+
+    #[test]
+    fn parallel_driver_agrees_with_sequential() {
+        // The parallel driver must return the *identical* outcome to the
+        // sequential one — it only overlaps members in wall-clock, never changes
+        // the merge. With no subprocess members on PATH both reduce to the
+        // exact-only verdict; the point is they agree byte-for-byte.
+        const COUNTER: &str = "1 sort bitvec 3\n2 zero 1\n3 state 1\n4 init 1 3 2\n5 one 1\n\
+                               6 add 1 3 5\n7 next 1 3 6\n8 ones 1\n9 sort bitvec 1\n\
+                               10 eq 9 3 8\n11 bad 10\n";
+        let file = parser::parse(COUNTER).expect("parse");
+        let seq = decide_reach_portfolio(&file);
+        let par = decide_reach_portfolio_parallel(&file);
+        assert_eq!(seq, par, "parallel and sequential drivers must agree");
+        assert_eq!(par.verdict, ReachVerdict::Reachable);
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -5080,7 +5080,9 @@ endmodule
     use crate::adapter::btor2::bad_monitor::{
         emit_ag_implies_next_monitor, emit_ag_state_atom_monitor,
     };
-    use crate::adapter::btormc::{DEFAULT_KMAX, McVerdict, locate_btormc, run_btormc};
+    use crate::adapter::btormc::{
+        DEFAULT_KMAX, DEFAULT_TIMEOUT, McVerdict, locate_btormc, run_btormc,
+    };
 
     /// MC analog of [`spurious_verdict`]: `Some(reason)` iff a DEFINITE cube
     /// verdict and the external model checker *contradict*. `McVerdict::Unknown`
@@ -5154,7 +5156,7 @@ endmodule
         let bin = locate_btormc().expect("btormc present");
         let monitor =
             emit_ag_state_atom_monitor(WIDE_INPUT_FSM, "cnt", CmpOp::Ne, 3, false).unwrap();
-        let mc = run_btormc(&bin, &monitor, DEFAULT_KMAX).unwrap();
+        let mc = run_btormc(&bin, &monitor, DEFAULT_KMAX, DEFAULT_TIMEOUT).unwrap();
         assert_eq!(
             mc,
             McVerdict::Safe,
@@ -5256,7 +5258,8 @@ endmodule
             .expect("emit |=> monitor on real-RTL (binds state_q + cfg_enable_i)");
 
         let bin = locate_btormc().expect("btormc present");
-        let mc = run_btormc(&bin, &monitor, 60).expect("btormc runs on the sysrst monitor");
+        let mc = run_btormc(&bin, &monitor, 60, DEFAULT_TIMEOUT)
+            .expect("btormc runs on the sysrst monitor");
         eprintln!("\n=== H.O.1c sysrst sva_0 external-MC verdict: {mc:?} ===");
 
         // Soundness gate (always): verify_auto's HOLDS (Trit::True) must not be

--- a/crates/mununu-core/tests/differential_oracle_e2e.rs
+++ b/crates/mununu-core/tests/differential_oracle_e2e.rs
@@ -17,7 +17,9 @@
 use mununu_core::adapter::btor2::symbolic_bitblast::{
     ExactVerdict, exact_bad_reachable, exact_symbolic_verdict,
 };
-use mununu_core::adapter::btormc::{DEFAULT_KMAX, McVerdict, locate_btormc, run_btormc};
+use mununu_core::adapter::btormc::{
+    DEFAULT_KMAX, DEFAULT_TIMEOUT, McVerdict, locate_btormc, run_btormc,
+};
 use mununu_core::adapter::slang::verify_auto::{
     PortfolioMode, VerifyAutoOptions, VerifyOutcome, verify_auto,
 };
@@ -69,7 +71,7 @@ fn reachability_differential(btor2: &str, ef_formula: &str) -> ReachDifferential
     );
     let bin = locate_btormc().expect("btormc present (mununu-sva)");
     let btormc_reachable = matches!(
-        run_btormc(&bin, btor2, DEFAULT_KMAX).expect("btormc runs"),
+        run_btormc(&bin, btor2, DEFAULT_KMAX, DEFAULT_TIMEOUT).expect("btormc runs"),
         McVerdict::Violated, // a reachable `bad` ⇒ the atom is reachable
     );
     ReachDifferential {
@@ -144,7 +146,7 @@ fn hwmcc_style_coverage_study() {
             .unwrap_or_else(|e| panic!("read {fname}: {e}"));
         // Our exact engine's bad-reachability, and btormc's (the independent oracle).
         let ours = exact_bad_reachable(&content);
-        let mc = run_btormc(&bin, &content, DEFAULT_KMAX).expect("btormc runs");
+        let mc = run_btormc(&bin, &content, DEFAULT_KMAX, DEFAULT_TIMEOUT).expect("btormc runs");
         let mc_reach = match mc {
             McVerdict::Violated => Some(true), // bad reachable
             McVerdict::Safe => Some(false),    // proved unreachable


### PR DESCRIPTION
## What

Per-engine **wall-clock timeouts** for the subprocess portfolio members, plus a **parallel** reachability-portfolio driver.

The subprocess members have no native wall-clock bound — btormc's `-kmax` and Pono's engine flags cap unroll *depth*, not time, and Pono's IC3/PDR can run unbounded on a hard instance. A single slow member could hang the whole portfolio decision. This adds an external, std-only wall-clock guard and lets members overlap instead of serialising.

## Changes

- **`adapter::run_with_timeout`** — a shared, std-only subprocess runner:
  - drains stdout/stderr on separate threads (a large witness trace can't deadlock the pipe),
  - feeds stdin on its own thread (a large input can't deadlock a tool that interleaves read/write),
  - kills + reaps the child once it exceeds `timeout`,
  - returns `Ok(None)` on timeout so a timed-out checker is treated as **inconclusive** (`Unknown`), never a wrong verdict.

  No `wait-timeout` crate, no coreutils `timeout` — portable, zero new deps.

- **btormc / Pono** — `run_btormc` / `run_pono` (and the `decide_via_*` seam entry points) now take a `timeout: Duration` and route through the shared runner. Each exposes `DEFAULT_TIMEOUT = 60s`. A timeout yields `McVerdict::Unknown`.

- **reach_portfolio** — `decide_reach_portfolio_parallel` runs the in-process exact engine and the two subprocess members concurrently via **scoped threads** (borrow `file` directly — no clone / `Arc`), then merges **identically** to the sequential driver. Verdict is unchanged; only wall-clock differs (≈ slowest single member instead of the sum). The merge is factored into a shared `collect(exact, btormc, pono)` used by both drivers, in fixed engine order so the outcome is deterministic regardless of completion order.

## Soundness

A timeout is a sound abstention. Every member still yields only sound verdicts; a member that errors, times out, or is undecided abstains, and the first-definite + contradiction-alarm merge rule is untouched. The parallel driver returns byte-for-byte the same `ReachOutcome` as the sequential one.

## Tests

- `parallel_driver_agrees_with_sequential` — asserts the two drivers produce an identical `ReachOutcome` (and both decide the in-cap counter `Reachable` via the exact engine, no subprocess needed).
- The `#[ignore]`d btormc / Pono e2e + the differential-oracle e2e are updated to pass `DEFAULT_TIMEOUT`.
- `make ci` green (fmt + `clippy --workspace --all-features --all-targets -D warnings` + `cargo test --workspace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
