### PR TITLE
feat(P1): bank the reach-rescue primitive + reducibility census (validated, no current target)

### DIFF
--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -53,6 +53,7 @@ pub mod partition;
 pub mod pono;
 pub mod promela;
 pub mod reach_portfolio;
+pub mod reach_rescue;
 pub mod sidecar;
 pub mod slang;
 pub mod state_enum;

--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -1,0 +1,379 @@
+//! ⊥-rescue bridge — reduce a mu-calculus **safety invariant** to a BTOR2 `bad`
+//! monitor and decide it with the subprocess reachability portfolio.
+//!
+//! verify_auto's internal engines (exact-symbolic BDD, cube CEGAR) leave a
+//! property ⊥ when it escapes their reach — a datapath wider than the exact
+//! engine's 40-bit cone cap, or an input the cube abstraction cannot pin. The
+//! subprocess members (btormc's k-induction, Pono's IC3) decide such a property
+//! SYMBOLICALLY, with no enumeration. This module is the bridge: it turns the
+//! `AG(state ⋈ value)` fragment of a ⊥ property into the `bad` monitor
+//! [`crate::adapter::btor2::bad_monitor`] emits, decides it via
+//! [`crate::adapter::reach_portfolio`], and maps the reachability verdict back to
+//! HOLDS / VIOLATED.
+//!
+//! # Conservative by construction (soundness-critical)
+//!
+//! [`reduce_ag_invariant`] returns `Some` ONLY for the exact
+//! `nu X. ((signal ⋈ value) && [] X)` shape — a single literal comparison of one
+//! register under an UNCONSTRAINED box. Every other shape returns `None`:
+//!
+//! - an implication (`|->` → `nu X. ((!a || b) && []X)`, `|=>` →
+//!   `nu X. ((!a || []b) && []X)`) — the body is an `Or`, not a bare atom;
+//! - an `EF` cover (`mu X. (b || <>X)`) — the root is `Mu`, not `Nu`;
+//! - a compound / relational body (`a && b`, `x == y`) — not a single `Cmp`;
+//! - a **guarded** box (`[(labels=…)] X`) — a stronger property than the
+//!   all-reachable-states monitor checks.
+//!
+//! A `None` is a sound abstention: the caller leaves the property ⊥. A monitor
+//! built for the WRONG shape would be a soundness bug, so the classifier errs
+//! toward `None` — it never guesses. Once reduced, the monitor's verdict is sound
+//! because every reachability-portfolio member is sound (Bruns–Godefroid for the
+//! exact engine within its cap; k-induction / IC3 for the subprocess members).
+//!
+//! # Status — validated primitive, no current target (2026-07-07)
+//!
+//! This bridge is **proven sound but not yet wired into `verify_auto`**, because a
+//! payoff hunt found no real target for it:
+//!
+//! - The **reducibility census** ([`e2e_reach_rescue_reducibility_census`] in
+//!   `tests/differential_oracle_e2e.rs`) measured the whole OpenTitan FSM corpus in
+//!   the `mununu-sva` image: the internal portfolio (exact-symbolic → cube CEGAR)
+//!   decides **all 19 safety properties across 18 designs — 0 ⊥**. Nothing to rescue.
+//! - A literature/RTL hunt for a wide single-register `AG(reg ⋈ const)` invariant
+//!   genuinely beyond the cube abstraction came up structurally empty: wide
+//!   invariants that HOLD are almost always 1-inductive (the cube engine closes them
+//!   in one QF_BV query), and the ones beyond cube are relational/conditional (this
+//!   reducer rejects them) or have astronomically deep counterexamples. The one lead
+//!   (ibex PMP bounds) turned out purely combinational (0 state) — btormc "deciding"
+//!   it is a trivial bound-0 SAT, not the deep reachability the portfolio targets.
+//!
+//! So the module is **banked**: the primitive + the census are kept as a standing
+//! re-anchoring instrument (the census fires the moment a future corpus design goes
+//! ⊥-and-reducible), but no user-facing `portfolio-mc` surface is wired — that would
+//! be surface for a capability with no demonstrated real payoff. The mechanism is
+//! validated end-to-end by the `#[ignore]`d `e2e_rescue_*` tests below (both verdict
+//! directions + the beyond-40-bit-cap case, with live btormc/Pono).
+
+use crate::adapter::btor2::bad_monitor::emit_ag_state_atom_monitor;
+use crate::adapter::btor2::parser;
+use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr, parse_predicate_expr};
+use crate::adapter::reach_portfolio::{ReachOutcome, ReachVerdict, decide_reach_portfolio};
+use crate::mu_calculus::{Formula, FormulaVarId, Guard, ModalKind, Node, NodeId};
+
+/// A reducible single-atom AG safety invariant: `AG(signal ⋈ value)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgInvariant {
+    /// The register the invariant constrains (a state cell, checked by the
+    /// monitor emitter — a non-state signal makes the rescue abstain).
+    pub signal: String,
+    /// The comparison operator (`==`, `!=`, `<`, …); the monitor watches its
+    /// NEGATION (the violation).
+    pub op: CmpOp,
+    /// The literal right-hand side of the comparison.
+    pub value: u128,
+}
+
+/// The rescue verdict for a single property, from the reachability portfolio's
+/// verdict on the property's `bad` monitor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RescueVerdict {
+    /// `bad` proven unreachable ⇒ the invariant holds in every reachable state.
+    Holds,
+    /// `bad` reachable ⇒ a reachable state violates the invariant.
+    Violated,
+    /// Undecided by every member, or a soundness contradiction alarm — never a
+    /// silently-picked side.
+    Inconclusive,
+}
+
+/// Conservatively classify `formula` as the simple AG invariant
+/// `nu X. ((signal ⋈ value) && [] X)`. Returns `None` for every other shape (see
+/// the module docs) so the reduction never mis-reduces a property it does not
+/// fully recognise.
+pub fn reduce_ag_invariant(formula: &Formula) -> Option<AgInvariant> {
+    // Root must be `nu X. BODY` (a greatest fixpoint — the AG shape; an `EF`
+    // cover is `mu X.`, rejected here).
+    let Node::Nu { var, body } = formula.node(formula.root()) else {
+        return None;
+    };
+    // BODY must be `atom && [] X` — an `And` of the invariant body and the box
+    // recursion. An implication body is an `Or`, so this rejects `|->` / `|=>`.
+    let Node::And(l, r) = formula.node(*body) else {
+        return None;
+    };
+    // Exactly one side is the box-to-var recursion; the other is the atom.
+    let (atom_id, modal_id) = classify_and(formula, *l, *r, *var)?;
+    // The box must be UNCONSTRAINED (a guarded box is a different, stronger
+    // property than the monitor — which checks EVERY reachable state — verifies).
+    let Node::Modal {
+        kind: ModalKind::Box,
+        guard,
+        target,
+    } = formula.node(modal_id)
+    else {
+        return None;
+    };
+    if *guard != Guard::default() {
+        return None;
+    }
+    match formula.node(*target) {
+        Node::Variable(v) if *v == *var => {}
+        _ => return None,
+    }
+    // The atom must be a single literal comparison of one register.
+    let Node::Predicate(atom) = formula.node(atom_id) else {
+        return None;
+    };
+    match parse_predicate_expr(atom) {
+        Ok(PredicateExpr::Cmp {
+            register,
+            op,
+            value,
+        }) => Some(AgInvariant {
+            signal: register,
+            op,
+            value: value as u128,
+        }),
+        // A relational (`CmpReg`), compound, or unparseable atom is not reducible.
+        _ => None,
+    }
+}
+
+/// Return `(atom_node, modal_node)` iff exactly one of `l` / `r` is a box-to-`var`
+/// and the other is not. `None` if neither or both look like the box recursion,
+/// keeping the shape match unambiguous.
+fn classify_and(
+    formula: &Formula,
+    l: NodeId,
+    r: NodeId,
+    var: FormulaVarId,
+) -> Option<(NodeId, NodeId)> {
+    match (
+        is_box_to_var(formula, l, var),
+        is_box_to_var(formula, r, var),
+    ) {
+        (true, false) => Some((r, l)),
+        (false, true) => Some((l, r)),
+        _ => None,
+    }
+}
+
+/// A `[…] X` box whose target is exactly the fixpoint variable `var` (guard
+/// unchecked here — [`reduce_ag_invariant`] enforces the unconstrained guard).
+fn is_box_to_var(formula: &Formula, id: NodeId, var: FormulaVarId) -> bool {
+    matches!(
+        formula.node(id),
+        Node::Modal { kind: ModalKind::Box, target, .. }
+            if matches!(formula.node(*target), Node::Variable(v) if *v == var)
+    )
+}
+
+/// Reduce a ⊥ safety property to a `bad` monitor over the lifted design and decide
+/// it with the reachability portfolio.
+///
+/// Returns `None` when the property is not a reducible AG invariant (the caller
+/// leaves it ⊥) or the monitor cannot be built (e.g. the signal does not resolve
+/// to a state cell — the emitter's own check). `design_btor2` MUST be the same
+/// reset/config-pinned BTOR2 verify_auto reasoned over, so the reachable-state set
+/// matches; `reset_pinned` mirrors verify_auto's reset-gating (whether recognized
+/// resets were pinned inactive) so the monitor resolves the signal through the
+/// async-reset mux consistently.
+///
+/// On `Some`, the second component is the raw [`ReachOutcome`] (which engines
+/// decided each side), for diagnostics / a witness note.
+pub fn reach_portfolio_rescue(
+    design_btor2: &str,
+    formula: &Formula,
+    reset_pinned: bool,
+) -> Option<(RescueVerdict, ReachOutcome)> {
+    let inv = reduce_ag_invariant(formula)?;
+    // bad = !(signal ⋈ value); the emitter validates `signal` resolves to a state
+    // cell (a non-state signal ⇒ Err ⇒ abstain).
+    let monitored =
+        emit_ag_state_atom_monitor(design_btor2, &inv.signal, inv.op, inv.value, reset_pinned)
+            .ok()?;
+    let file = parser::parse(&monitored).ok()?;
+    let outcome = decide_reach_portfolio(&file);
+    let verdict = match outcome.verdict {
+        ReachVerdict::Unreachable => RescueVerdict::Holds,
+        ReachVerdict::Reachable => RescueVerdict::Violated,
+        // Undecided, or a contradiction alarm — never silently pick a side.
+        ReachVerdict::Unknown | ReachVerdict::Contradiction => RescueVerdict::Inconclusive,
+    };
+    Some((verdict, outcome))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mu_calculus::parser as mu_parser;
+
+    fn parse(s: &str) -> Formula {
+        mu_parser::parse(s).unwrap_or_else(|e| panic!("parse `{s}`: {e:?}"))
+    }
+
+    #[test]
+    fn reduces_simple_eq_invariant() {
+        // `assert property (cnt == 3)` → `nu X. ((cnt == 3) && [] X)`.
+        let inv = reduce_ag_invariant(&parse("nu X. ((cnt == 3) && [] X)")).expect("reducible");
+        assert_eq!(
+            inv,
+            AgInvariant {
+                signal: "cnt".to_string(),
+                op: CmpOp::Eq,
+                value: 3
+            }
+        );
+    }
+
+    #[test]
+    fn reduces_bare_boolean_invariant() {
+        // A bare-boolean `assert property (b)` translates to `(b != 0)`.
+        let inv = reduce_ag_invariant(&parse("nu X. ((flag != 0) && [] X)")).expect("reducible");
+        assert_eq!(inv.signal, "flag");
+        assert_eq!(inv.op, CmpOp::Ne);
+        assert_eq!(inv.value, 0);
+    }
+
+    #[test]
+    fn reduces_relational_literal_invariant() {
+        // `AG(cnt <= 7)` is still a single literal comparison — reducible.
+        let inv = reduce_ag_invariant(&parse("nu X. ((cnt <= 7) && [] X)")).expect("reducible");
+        assert_eq!(inv.op, CmpOp::Le);
+        assert_eq!(inv.value, 7);
+    }
+
+    #[test]
+    fn atom_operand_order_is_symmetric() {
+        // The classifier must accept `[] X && atom` as well as `atom && [] X`.
+        let inv = reduce_ag_invariant(&parse("nu X. (([] X) && (cnt == 1))")).expect("reducible");
+        assert_eq!(inv.value, 1);
+    }
+
+    #[test]
+    fn abstains_on_implication_shapes() {
+        // `a |-> b` and `a |=> b` — the body is an `Or`, not a bare atom.
+        assert!(reduce_ag_invariant(&parse("nu X. ((!(a != 0) || (b != 0)) && [] X)")).is_none());
+        assert!(
+            reduce_ag_invariant(&parse("nu X. ((!(a != 0) || [] (b != 0)) && [] X)")).is_none()
+        );
+    }
+
+    #[test]
+    fn abstains_on_ef_cover() {
+        // `cover property (b)` → `mu X. (b || <> X)` — a least fixpoint, not `Nu`.
+        assert!(reduce_ag_invariant(&parse("mu X. ((b != 0) || <> X)")).is_none());
+    }
+
+    #[test]
+    fn abstains_on_compound_body() {
+        // A conjunctive invariant body is not a single `Cmp`.
+        assert!(reduce_ag_invariant(&parse("nu X. (((a == 1) && (b == 2)) && [] X)")).is_none());
+    }
+
+    #[test]
+    fn abstains_on_guarded_box() {
+        // A box constrained to specific labels is a stronger property than the
+        // all-reachable-states monitor — the classifier must abstain.
+        let f = parse("nu X. ((cnt == 1) && [(labels = {step})] X)");
+        assert!(
+            reduce_ag_invariant(&f).is_none(),
+            "a guarded box must not reduce to the all-states monitor"
+        );
+    }
+
+    #[test]
+    fn rescue_abstains_on_non_reducible_formula() {
+        // The full rescue returns None (no subprocess spawned) when the shape is
+        // not reducible — the design text is never even parsed.
+        let f = parse("mu X. ((b != 0) || <> X)");
+        assert!(reach_portfolio_rescue("1 sort bitvec 1\n", &f, false).is_none());
+    }
+
+    // ---- docker-validated (`mununu-sva`): full rescue path with live btormc/Pono ----
+    // These exercise reduce_ag_invariant → emit monitor → reach_portfolio →
+    // verdict with the real subprocess members. Run with `--ignored` in mununu-sva.
+
+    /// A 2-bit counter `cnt` cycling 0→1→2→0 (input `w` wide but irrelevant).
+    /// `AG(cnt != 3)` HOLDS (3 is never reached); `AG(cnt != 2)` is VIOLATED.
+    const WIDE_INPUT_FSM: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 sort bitvec 8
+4 input 3 w
+5 zero 2
+6 state 2 cnt
+7 one 2
+8 constd 2 2
+9 eq 1 6 8
+10 add 2 6 7
+11 ite 2 9 5 10
+12 next 2 6 11
+13 init 2 6 5
+";
+
+    /// A 64-bit register `big` that stays 0 — `AG(big == 0)` HOLDS and is
+    /// 1-inductive. The 64-bit cone EXCEEDS the exact engine's 40-bit cap, so the
+    /// exact member abstains and only the subprocess members (btormc k-induction /
+    /// Pono IC3) can decide it — the "beyond the BDD cap" value proof.
+    const WIDE_STATE: &str = "\
+1 sort bitvec 64
+2 zero 1
+3 state 1 big
+4 init 1 3 2
+5 next 1 3 3
+";
+
+    #[test]
+    #[ignore = "requires btormc + pono (mununu-sva); run with --ignored"]
+    fn e2e_rescue_flips_true_invariant_to_holds() {
+        // AG(cnt != 3) is TRUE — the rescue reduces it and the portfolio proves
+        // the `bad` (cnt == 3) unreachable ⇒ Holds.
+        let f = parse("nu X. ((cnt != 3) && [] X)");
+        let (verdict, outcome) =
+            reach_portfolio_rescue(WIDE_INPUT_FSM, &f, false).expect("reducible + monitor builds");
+        assert_eq!(verdict, RescueVerdict::Holds, "outcome: {outcome:?}");
+        assert!(
+            !outcome.unreachable_by.is_empty(),
+            "at least one engine must prove unreachable; got {outcome:?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires btormc + pono (mununu-sva); run with --ignored"]
+    fn e2e_rescue_flips_false_invariant_to_violated() {
+        // AG(cnt != 2) is FALSE — cnt reaches 2, so `bad` (cnt == 2) is reachable
+        // ⇒ Violated. Confirms the other verdict direction through the full path.
+        let f = parse("nu X. ((cnt != 2) && [] X)");
+        let (verdict, outcome) =
+            reach_portfolio_rescue(WIDE_INPUT_FSM, &f, false).expect("reducible + monitor builds");
+        assert_eq!(verdict, RescueVerdict::Violated, "outcome: {outcome:?}");
+        assert!(
+            !outcome.reachable_by.is_empty(),
+            "at least one engine must find the violating state; got {outcome:?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires btormc + pono (mununu-sva); run with --ignored"]
+    fn e2e_rescue_decides_beyond_exact_cap() {
+        // A 64-bit invariant the exact BDD engine cannot touch (over its 40-bit
+        // cap) — proving the subprocess members extend reach past the cap. The
+        // exact member must ABSTAIN; a subprocess member must carry the verdict.
+        let f = parse("nu X. ((big == 0) && [] X)");
+        let (verdict, outcome) =
+            reach_portfolio_rescue(WIDE_STATE, &f, false).expect("reducible + monitor builds");
+        assert_eq!(verdict, RescueVerdict::Holds, "outcome: {outcome:?}");
+        assert!(
+            !outcome.unreachable_by.contains(&"exact"),
+            "the exact engine must abstain on the 64-bit (over-cap) design; got {outcome:?}"
+        );
+        assert!(
+            outcome
+                .unreachable_by
+                .iter()
+                .any(|e| *e == "btormc" || *e == "pono"),
+            "a subprocess member must carry the beyond-cap verdict; got {outcome:?}"
+        );
+    }
+}

--- a/crates/mununu-core/tests/differential_oracle_e2e.rs
+++ b/crates/mununu-core/tests/differential_oracle_e2e.rs
@@ -1336,3 +1336,69 @@ fn p3_verilator_replays_ag_ef_trap_counterexample() {
         "trap st_o==3 must be absorbing across the persistence tail; full dump: {stdout}"
     );
 }
+
+/// REACH-RESCUE reducibility census — measures the real-corpus payoff of the
+/// subprocess `reach_portfolio_rescue` BEFORE any surface wiring. For every corpus
+/// design it runs the full internal portfolio (`PortfolioSequential`), collects
+/// the properties it leaves ⊥, and reports how many of those are the reducible
+/// `AG(state ⋈ value)` shape [`reduce_ag_invariant`] recognises. Only reducible ⊥
+/// properties can be rescued by the subprocess portfolio, so this count is the
+/// upper bound on the feature's corpus payoff. Diagnostic (no assertion) — the
+/// `--nocapture` output is the deliverable. Needs only slang+sv2v+yosys (no
+/// btormc/pono): reducibility is a pure formula-shape question.
+#[test]
+#[ignore = "requires slang + sv2v + yosys (mununu-sva image); run with --ignored"]
+fn e2e_reach_rescue_reducibility_census() {
+    use mununu_core::adapter::reach_rescue::reduce_ag_invariant;
+
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let (mut total, mut definite, mut bot, mut reducible) = (0u32, 0u32, 0u32, 0u32);
+    let mut designs_ran = 0u32;
+    eprintln!(
+        "\n============ reach-rescue reducibility census (portfolio-⊥ properties) ============"
+    );
+    for d in CORPUS {
+        let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            corpus_report(d, Engine::PortfolioSequential)
+        }));
+        let report = match report {
+            Ok(r) => r,
+            Err(_) => {
+                eprintln!("  {:28} SETUP-ERROR (skipped)", d.name);
+                continue;
+            }
+        };
+        designs_ran += 1;
+        eprintln!("  {:28} {} properties", d.name, report.properties.len());
+        for p in &report.properties {
+            total += 1;
+            if outcome_verdict(&p.outcome) != LedgerVerdict::Indefinite {
+                definite += 1;
+                continue;
+            }
+            bot += 1;
+            let red = mununu_core::mu_calculus::parser::parse(&p.formula)
+                .ok()
+                .and_then(|f| reduce_ag_invariant(&f));
+            let tag = match &red {
+                Some(inv) => {
+                    reducible += 1;
+                    format!("REDUCIBLE({} {:?} {})", inv.signal, inv.op, inv.value)
+                }
+                None => "not-reducible".to_string(),
+            };
+            eprintln!("  {:28} {:36} ⊥  [{tag}]", d.name, p.name);
+        }
+    }
+    std::panic::set_hook(prev);
+    eprintln!("----------------------------------------------------------------------------------");
+    eprintln!(
+        "  designs ran: {designs_ran}/{}   total properties: {total}   definite: {definite}",
+        CORPUS.len()
+    );
+    eprintln!("  portfolio-⊥ properties: {bot}   reducible to AG(state ⋈ value): {reducible}");
+    eprintln!(
+        "==================================================================================\n"
+    );
+}


### PR DESCRIPTION
## What

Banks the **reach-rescue** primitive — the verify_auto-facing bridge that reduces a ⊥ safety property to a BTOR2 `bad` monitor and decides it with the subprocess reachability portfolio (btormc/Pono, PRs #254–#257) — plus the **reducibility census** that measured why it stays unwired.

**Proven sound, deliberately unwired.** No user-facing `portfolio-mc` surface, because a payoff hunt found no real target for it.

## Changes

- **`adapter::reach_rescue`**
  - `reduce_ag_invariant` — conservatively classifies the `nu X.((signal ⋈ value) && []X)` safety-invariant shape. Returns `None` on every other shape (implication `|->`/`|=>`, `EF` cover, compound/relational body, guarded box) — a wrong monitor would be a soundness bug, so it never guesses.
  - `reach_portfolio_rescue` — chains reduce → `emit_ag_state_atom_monitor` → `decide_reach_portfolio` → `Holds`/`Violated`/`Inconclusive`.
  - 9 make-ci unit tests (reduction + every abstention path); 3 `#[ignore]`d mununu-sva e2e prove the full path with live btormc/Pono: `Holds`, `Violated`, and the beyond-40-bit-BDD-cap case (exact member abstains, a subprocess member carries the verdict).

- **`e2e_reach_rescue_reducibility_census`** (differential_oracle_e2e) — a standing re-anchoring instrument. Runs the full internal portfolio over the whole OpenTitan corpus and reports how many ⊥ properties are reducible.

## Why banked, not wired

A payoff hunt (census + literature/RTL prospector + a target-executor probe of the one lead) found no real target:

- **Census result: 18/18 designs, 19/19 properties DEFINITE, 0 ⊥.** The internal engines (exact-symbolic BDD → cube CEGAR) already decide the whole corpus — nothing to rescue.
- Wide `AG(reg⋈const)` invariants that hold are almost always 1-inductive (the cube engine closes them in one QF_BV query); the ones beyond cube are relational/conditional (this reducer rejects them) or astronomically deep.
- The one lead, ibex PMP bounds, is purely combinational (0 state) — btormc "deciding" it is a trivial bound-0 SAT, not the deep reachability the portfolio targets.

Wiring a `portfolio-mc` surface for zero demonstrated payoff would violate YAGNI + claims-integrity. The primitive is kept as validated infrastructure; the census is the guard that fires the moment a future design goes ⊥-and-reducible. Module docs record this in full.

## Validation

`make ci` green (fmt + `clippy --workspace --all-features --all-targets -D warnings` + `cargo test --workspace`). The 3 e2e + the census are `#[ignore]`d (need slang/sv2v/yosys + btormc/Pono) and were validated in the `mununu-sva` image this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
