### PR TITLE
fix(exact-mc): accept a bare-boolean atom as `sig != 0`

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/predicate_expr.rs
+++ b/crates/mununu-core/src/adapter/btor2/predicate_expr.rs
@@ -659,6 +659,31 @@ pub fn parse_predicate_expr(s: &str) -> Result<PredicateExpr, PredicateExprParse
     Ok(expr)
 }
 
+/// Parse a predicate atom, tolerating a **bare boolean identifier** as `sig != 0`.
+///
+/// A single-identifier atom (`bnd_viol_o`, no comparison operator) is the
+/// mu-calculus "signal is true" reading; `!= 0` — not `== 1` — is the SOUND
+/// encoding (for a multi-bit signal `== 1` would spuriously exclude the truthy
+/// values 2, 3, …). Everything else delegates to the strict
+/// [`parse_predicate_expr`] grammar, so a malformed atom still errors.
+///
+/// This is a **caller-opt-in** relaxation. The verify_auto seeder deliberately
+/// keeps the strict parser (its own `Err`-path routes bare atoms into the
+/// combinational-input soundness machinery), so only callers that want the bare
+/// boolean read directly — the exact-symbolic engine parsing mu-calculus atoms —
+/// use this entry point.
+pub fn parse_predicate_atom_bool(s: &str) -> Result<PredicateExpr, PredicateExprParseError> {
+    let tokens = tokenize(s)?;
+    if let [Token::Ident(name)] = tokens.as_slice() {
+        return Ok(PredicateExpr::Cmp {
+            register: name.clone(),
+            op: CmpOp::Ne,
+            value: 0,
+        });
+    }
+    parse_predicate_expr(s)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -824,6 +849,60 @@ mod tests {
             parse_predicate_expr("state_q == 5").unwrap(),
             PredicateExpr::eq("state_q", 5)
         );
+    }
+
+    #[test]
+    fn parse_predicate_atom_bool_bare_is_ne_zero() {
+        // A lone identifier atom (no comparison operator) is the mu-calculus
+        // "signal is true" reading, normalised to `register != 0` — matching the
+        // SVA translator's bool_expr. `!= 0` (not `== 1`) is the sound multi-bit form.
+        assert_eq!(
+            parse_predicate_atom_bool("bnd_viol_o").unwrap(),
+            PredicateExpr::Cmp {
+                register: "bnd_viol_o".into(),
+                op: CmpOp::Ne,
+                value: 0,
+            }
+        );
+        // Hierarchical BTOR2 symbol names (`$`/`.`) work as bare booleans too.
+        assert_eq!(
+            parse_predicate_atom_bool("top.err_o").unwrap(),
+            PredicateExpr::Cmp {
+                register: "top.err_o".into(),
+                op: CmpOp::Ne,
+                value: 0,
+            }
+        );
+        // The STRICT parser is unchanged — the seeder relies on a bare atom erroring
+        // so it can route it through its own combinational-input machinery.
+        assert!(parse_predicate_expr("bnd_viol_o").is_err());
+    }
+
+    #[test]
+    fn parse_predicate_atom_bool_delegates_for_non_bare() {
+        // A comparison atom delegates to the strict grammar (no change).
+        assert_eq!(
+            parse_predicate_atom_bool("cnt == 3").unwrap(),
+            PredicateExpr::eq("cnt", 3)
+        );
+        assert_eq!(
+            parse_predicate_atom_bool("state_q == state_q__past").unwrap(),
+            PredicateExpr::eq_reg("state_q", "state_q__past")
+        );
+        // Only a LONE identifier is rescued — a bare operand inside a compound is
+        // still an error (the exact engine receives pre-normalised compounds).
+        assert!(parse_predicate_atom_bool("en && cnt == 3").is_err());
+        // A malformed atom still errors.
+        assert!(parse_predicate_atom_bool("cnt ==").is_err());
+    }
+
+    #[test]
+    fn bare_boolean_atom_bool_evals_as_nonzero() {
+        // `flag` (≡ flag != 0) is true iff the register is nonzero.
+        let e = parse_predicate_atom_bool("flag").unwrap();
+        assert!(e.eval(&regs(&[("flag", 1)])));
+        assert!(e.eval(&regs(&[("flag", 7)])));
+        assert!(!e.eval(&regs(&[("flag", 0)])));
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -109,7 +109,7 @@ use oxidd::{BooleanFunction, FunctionSubst, Manager, ManagerRef, Subst, VarNo};
 
 use crate::adapter::btor2::ast::{Btor2File, ConstValue, Nid, Node, Op, Operand};
 use crate::adapter::btor2::bit_blast::eval_const_value;
-use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr, parse_predicate_expr};
+use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr, parse_predicate_atom_bool};
 use crate::adapter::btor2::term_backend::{BvTermBackend, WalkError, walk_design};
 // R-F5.4.1 — the symbolic mu-calculus evaluator reuses the (must, may) `TritBdd`
 // pair + the crate `Trit` verdict; the mu-calculus `Node` is aliased to avoid a
@@ -2136,7 +2136,11 @@ pub fn exact_symbolic_verdict_with_witness(
             if exprs.iter().any(|(n, _)| n == name) {
                 continue;
             }
-            let expr = parse_predicate_expr(name)
+            // The exact engine reads mu-calculus atoms directly, so a bare-boolean
+            // atom (`sig`, no comparison) is admitted as `sig != 0` — the "signal is
+            // true" reading. (The seeder keeps the strict parser; see
+            // `parse_predicate_atom_bool`.)
+            let expr = parse_predicate_atom_bool(name)
                 .map_err(|e| format!("exact MC: atom `{name}` is not a predicate: {e}"))?;
             let expr = resolve_predicate_expr_registers(&expr, &resolve);
             collect_predicate_registers(&expr, &mut seed_regs);


### PR DESCRIPTION
## What

The exact-symbolic engine parses mu-calculus atoms directly through `parse_predicate_expr`, which hard-requires a comparison operator. A bare-boolean atom like `bnd_viol_o` (no `== value`) errored *"expected a comparison operator"*, so the exact engine **skipped** any property built on one — surfaced while probing ibex_pmp (`atom bnd_viol_o is not a predicate`).

## Fix (localized to the exact engine)

A new `parse_predicate_atom_bool` helper reads a **lone-identifier** atom as `sig != 0` — the mu-calculus "signal is true" reading. Anything that is not a single identifier (a comparison, a compound, a malformed atom) delegates to the strict `parse_predicate_expr` unchanged. Only the exact-engine call site opts in.

- **`!= 0`, not `== 1`** — the sound multi-bit form: `== 1` would spuriously exclude truthy values 2, 3, … and could report a false VIOLATED.

## Why not a global parser change

The verify_auto **seeder relies on a bare atom erroring** so it can route it through its own combinational-input soundness machinery (H.B free-input / H.E derived ⊥-label / H.U cube-dim). An earlier global relaxation broke 7 seeder tests (`bare_one_bit_state_signal_seeds_eq_one`, `h_b_bare_input_boolean_seeds_eq_one_as_free`, the slice3/h_u routing guards). So the strict grammar and the seeder's routing are untouched; only the exact engine opts into the bare read.

## Tests

3 unit tests on `parse_predicate_atom_bool` (bare → `!= 0`; delegation for comparisons/compounds; strict parser still errors on a bare atom; nonzero eval). `make ci` green — full workspace test suite (2118 lib tests) + `clippy --workspace --all-features --all-targets -D warnings` + fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
