### PR TITLE
feat(P1): native k-induction — in-house unbounded safety proof on the Z3 seam

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/native_bmc.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_bmc.rs
@@ -40,7 +40,9 @@
 use std::collections::HashMap;
 
 use crate::adapter::btor2::ast::{Btor2File, Nid, Node};
-use crate::adapter::sidecar::predicate_image::btor2_encode::{EncodeError, encode_design};
+use crate::adapter::sidecar::predicate_image::btor2_encode::{
+    Btor2SmtView, EncodeError, encode_design,
+};
 use z3::ast::{Ast, BV, Bool};
 
 /// The outcome of a bounded model-checking run.
@@ -52,6 +54,21 @@ pub enum BmcOutcome {
     /// No `bad` is reachable within `k` steps. **Bounded** — this is NOT a proof
     /// of safety (a deeper counterexample may exist; k-induction / IMC decide that).
     NoCexWithin { k: u32 },
+}
+
+/// A complete safety verdict from the k-induction driver
+/// ([`decide_bad_safety`]) — BMC's bounded outcome plus a genuine SAFE proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SafetyVerdict {
+    /// A `bad` is reachable at `depth` steps — a sound counterexample (BMC base).
+    Violated { depth: u32 },
+    /// The `bad` is proven UNREACHABLE: the property is `k`-inductive (base holds
+    /// through depth `k` and the inductive step at `k` is unsatisfiable). A sound,
+    /// unbounded safety proof.
+    Safe { k: u32 },
+    /// Neither a counterexample nor a `k`-inductive proof within `max_k` —
+    /// inconclusive (a larger bound, a strengthening, or IMC may decide it).
+    Unknown { k: u32 },
 }
 
 /// Why a BMC run could not produce a verdict.
@@ -73,6 +90,141 @@ impl std::fmt::Display for BmcError {
     }
 }
 
+/// The property / init / assumption node references extracted from a BTOR2 file:
+/// `(bad operands, (state, init-value) pairs, constraint operands)`.
+type Props = (Vec<Nid>, Vec<(Nid, Nid)>, Vec<Nid>);
+
+fn extract_props(file: &Btor2File) -> Props {
+    let mut bad_ops = Vec::new();
+    let mut init_pairs = Vec::new();
+    let mut constraint_ops = Vec::new();
+    for l in &file.lines {
+        match &l.node {
+            Node::Bad { signal } => bad_ops.push(signal.nid()),
+            Node::Init { state, value, .. } => init_pairs.push((*state, value.nid())),
+            Node::Constraint { signal } => constraint_ops.push(signal.nid()),
+            _ => {}
+        }
+    }
+    (bad_ops, init_pairs, constraint_ops)
+}
+
+/// The shared unrolling machinery: fresh per-frame state/input Z3 variables and
+/// the frame-instantiated `bad` / `transition` / `constraint` terms. Built once
+/// per run inside a [`z3::with_z3_config`] scope; BMC and k-induction both drive it.
+struct Unroller<'a> {
+    view: &'a Btor2SmtView,
+    bad_ops: &'a [Nid],
+    constraint_ops: &'a [Nid],
+    /// `frame_state[j][nid]` — state cell `nid`'s value at frame `j`.
+    frame_state: Vec<HashMap<Nid, BV>>,
+    /// `frame_input[j][nid]` — input `nid`'s value at frame `j`.
+    frame_input: Vec<HashMap<Nid, BV>>,
+    /// The 1-bit constant `1`, reused for `bad`/`constraint` truth (`op == 1`).
+    one1: BV,
+}
+
+impl<'a> Unroller<'a> {
+    /// Build fresh frame variables for depths `0..=n`.
+    fn build(
+        view: &'a Btor2SmtView,
+        bad_ops: &'a [Nid],
+        constraint_ops: &'a [Nid],
+        n: usize,
+    ) -> Self {
+        let fresh = |src: &HashMap<Nid, BV>, prefix: &str| -> HashMap<Nid, BV> {
+            src.iter()
+                .map(|(nid, bv)| (*nid, BV::fresh_const(prefix, bv.get_size())))
+                .collect()
+        };
+        Unroller {
+            view,
+            bad_ops,
+            constraint_ops,
+            frame_state: (0..=n).map(|_| fresh(&view.state_curr, "bmc_s")).collect(),
+            frame_input: (0..=n).map(|_| fresh(&view.inputs, "bmc_i")).collect(),
+            one1: BV::from_u64(1, 1),
+        }
+    }
+
+    /// Current-cycle BV of a `bad`/`constraint` operand, falling back through
+    /// `state_curr`/`inputs` so a property referencing a state cell or input
+    /// directly (`bad = q`) is not dropped.
+    fn curr_bv(&self, nid: &Nid) -> Option<&BV> {
+        self.view
+            .signal_bvs
+            .get(nid)
+            .or_else(|| self.view.state_curr.get(nid))
+            .or_else(|| self.view.inputs.get(nid))
+    }
+
+    /// `(state_curr → frame j) ∪ (inputs → frame j)` — instantiates a current-cycle
+    /// term at frame `j`.
+    fn curr_subs(&self, j: usize) -> Vec<(&BV, &BV)> {
+        let mut pairs: Vec<(&BV, &BV)> = Vec::new();
+        for (nid, bv) in &self.view.state_curr {
+            pairs.push((bv, &self.frame_state[j][nid]));
+        }
+        for (nid, bv) in &self.view.inputs {
+            pairs.push((bv, &self.frame_input[j][nid]));
+        }
+        pairs
+    }
+
+    /// The transition relation for frame `j → j+1`.
+    fn transition_at(&self, j: usize) -> Bool {
+        let mut pairs = self.curr_subs(j);
+        for (nid, bv) in &self.view.state_next {
+            pairs.push((bv, &self.frame_state[j + 1][nid]));
+        }
+        self.view.transition.substitute(&pairs)
+    }
+
+    /// `bad` at frame `j`: OR over all `bad` operands of `(operand == 1)`.
+    fn bad_at(&self, j: usize) -> Bool {
+        let pairs = self.curr_subs(j);
+        let disj: Vec<Bool> = self
+            .bad_ops
+            .iter()
+            .filter_map(|op| {
+                self.curr_bv(op)
+                    .map(|bv| bv.substitute(&pairs).eq(&self.one1))
+            })
+            .collect();
+        let refs: Vec<&Bool> = disj.iter().collect();
+        if refs.is_empty() {
+            Bool::from_bool(false)
+        } else {
+            Bool::or(&refs)
+        }
+    }
+
+    /// Each `constraint` at frame `j`: `(operand == 1)`.
+    fn constraints_at(&self, j: usize) -> Vec<Bool> {
+        let pairs = self.curr_subs(j);
+        self.constraint_ops
+            .iter()
+            .filter_map(|op| {
+                self.curr_bv(op)
+                    .map(|bv| bv.substitute(&pairs).eq(&self.one1))
+            })
+            .collect()
+    }
+
+    /// Assert the design's `init` values on frame 0 into `solver` (init-less state
+    /// cells stay free — BTOR2's nondeterministic-init semantics).
+    fn assert_init(&self, solver: &z3::Solver, init_pairs: &[(Nid, Nid)]) {
+        for (state, value_nid) in init_pairs {
+            if let (Some(s0), Some(vbv)) = (
+                self.frame_state[0].get(state),
+                self.view.signal_bvs.get(value_nid),
+            ) {
+                solver.assert(s0.eq(vbv));
+            }
+        }
+    }
+}
+
 /// Bounded model check: is a `bad` reachable within `max_k` steps of the BTOR2
 /// transition relation? See [`BmcOutcome`] for the verdict semantics.
 ///
@@ -80,144 +232,112 @@ impl std::fmt::Display for BmcError {
 /// depth; the returned `Violated { depth }` is the SHALLOWEST counterexample
 /// (frames are checked in increasing order), which is the most useful witness.
 pub fn bmc_bad_reachable(file: &Btor2File, max_k: u32) -> Result<BmcOutcome, BmcError> {
-    // Extract the property + init + assumption node references (pure, pre-Z3).
-    let bad_ops: Vec<Nid> = file
-        .lines
-        .iter()
-        .filter_map(|l| match &l.node {
-            Node::Bad { signal } => Some(signal.nid()),
-            _ => None,
-        })
-        .collect();
+    let (bad_ops, init_pairs, constraint_ops) = extract_props(file);
     if bad_ops.is_empty() {
         return Err(BmcError::NoBadProperty);
     }
-    let init_pairs: Vec<(Nid, Nid)> = file
-        .lines
-        .iter()
-        .filter_map(|l| match &l.node {
-            Node::Init { state, value, .. } => Some((*state, value.nid())),
-            _ => None,
-        })
-        .collect();
-    let constraint_ops: Vec<Nid> = file
-        .lines
-        .iter()
-        .filter_map(|l| match &l.node {
-            Node::Constraint { signal } => Some(signal.nid()),
-            _ => None,
-        })
-        .collect();
-
+    let n = max_k as usize;
     let cfg = z3::Config::new();
     z3::with_z3_config(&cfg, || {
         let view = encode_design(file).map_err(BmcError::Encode)?;
+        let u = Unroller::build(&view, &bad_ops, &constraint_ops, n);
 
-        // Fresh Z3 variables for every frame's state + inputs. Frame j's state is
-        // `frame_state[j]`; its inputs `frame_input[j]` drive the transition to
-        // frame j+1 (and any combinational `bad`/`constraint` read at frame j).
-        let n = max_k as usize;
-        let fresh = |src: &HashMap<Nid, BV>, prefix: &str| -> HashMap<Nid, BV> {
-            src.iter()
-                .map(|(nid, bv)| (*nid, BV::fresh_const(prefix, bv.get_size())))
-                .collect()
-        };
-        let frame_state: Vec<HashMap<Nid, BV>> =
-            (0..=n).map(|_| fresh(&view.state_curr, "bmc_s")).collect();
-        let frame_input: Vec<HashMap<Nid, BV>> =
-            (0..=n).map(|_| fresh(&view.inputs, "bmc_i")).collect();
-
-        let one1 = BV::from_u64(1, 1);
-
-        // Current-cycle BV of a `bad`/`constraint` operand. `signal_bvs` holds the
-        // encode-walk cache (combinational nodes), but a property can reference a
-        // STATE cell or an INPUT directly (`bad = q`) — fall back to those maps so
-        // such operands are not silently dropped.
-        let curr_bv = |nid: &Nid| -> Option<&BV> {
-            view.signal_bvs
-                .get(nid)
-                .or_else(|| view.state_curr.get(nid))
-                .or_else(|| view.inputs.get(nid))
-        };
-
-        // (state_curr → frame j) ∪ (inputs → frame j) — the substitution that
-        // instantiates a current-cycle term (a `bad`/`constraint` condition) at
-        // frame j.
-        let curr_subs = |j: usize| -> Vec<(&BV, &BV)> {
-            let mut pairs: Vec<(&BV, &BV)> = Vec::new();
-            for (nid, bv) in &view.state_curr {
-                pairs.push((bv, &frame_state[j][nid]));
-            }
-            for (nid, bv) in &view.inputs {
-                pairs.push((bv, &frame_input[j][nid]));
-            }
-            pairs
-        };
-
-        // The transition relation instantiated for frame j → j+1: current state +
-        // inputs at frame j, next state at frame j+1.
-        let transition_at = |j: usize| -> Bool {
-            let mut pairs = curr_subs(j);
-            for (nid, bv) in &view.state_next {
-                pairs.push((bv, &frame_state[j + 1][nid]));
-            }
-            view.transition.substitute(&pairs)
-        };
-
-        // `bad` at frame j: OR over all `bad` operands of (operand == 1).
-        let bad_at = |j: usize| -> Bool {
-            let pairs = curr_subs(j);
-            let disj: Vec<Bool> = bad_ops
-                .iter()
-                .filter_map(|op| curr_bv(op).map(|bv| bv.substitute(&pairs).eq(&one1)))
-                .collect();
-            let refs: Vec<&Bool> = disj.iter().collect();
-            if refs.is_empty() {
-                Bool::from_bool(false)
-            } else {
-                Bool::or(&refs)
-            }
-        };
-
-        // Each `constraint` at frame j: (operand == 1). Applied at every frame.
-        let constraints_at = |j: usize| -> Vec<Bool> {
-            let pairs = curr_subs(j);
-            constraint_ops
-                .iter()
-                .filter_map(|op| curr_bv(op).map(|bv| bv.substitute(&pairs).eq(&one1)))
-                .collect()
-        };
-
+        // A single init-constrained path: check `bad` at each frame, extend if clean.
         let solver = z3::Solver::new();
-        // Init at frame 0 (init-less states stay free — BTOR2 semantics).
-        for (state, value_nid) in &init_pairs {
-            if let (Some(s0), Some(vbv)) =
-                (frame_state[0].get(state), view.signal_bvs.get(value_nid))
-            {
-                solver.assert(s0.eq(vbv));
-            }
-        }
-        for c in constraints_at(0) {
+        u.assert_init(&solver, &init_pairs);
+        for c in u.constraints_at(0) {
             solver.assert(&c);
         }
-
-        // Incremental unroll: check `bad` at each frame, extend the path if clean.
         for k in 0..=n {
             solver.push();
-            solver.assert(bad_at(k));
+            solver.assert(u.bad_at(k));
             let sat = matches!(solver.check(), z3::SatResult::Sat);
             solver.pop(1);
             if sat {
                 return Ok(BmcOutcome::Violated { depth: k as u32 });
             }
             if k < n {
-                solver.assert(transition_at(k));
-                for c in constraints_at(k + 1) {
+                solver.assert(u.transition_at(k));
+                for c in u.constraints_at(k + 1) {
                     solver.assert(&c);
                 }
             }
         }
         Ok(BmcOutcome::NoCexWithin { k: max_k })
+    })
+}
+
+/// Decide `bad`-reachability by **k-induction**: BMC for counterexamples + an
+/// inductive-step proof for safety. Runs entirely in-process on Z3.
+///
+/// For increasing `k = 0..=max_k`, on the shared [`Unroller`]:
+/// - **Base** — is `bad` reachable at frame `k` from an initial state? SAT ⇒
+///   [`SafetyVerdict::Violated`] (the shallowest counterexample).
+/// - **Step** — is the property `k`-inductive? Over UNCONSTRAINED frames (no
+///   init), with `¬bad` assumed at frames `0..k` and the transitions chained, is
+///   `bad` at frame `k` unsatisfiable? UNSAT ⇒ [`SafetyVerdict::Safe`] (base has
+///   been verified through depth `k`, so k-induction gives a sound safety proof).
+///
+/// If neither fires by `max_k`, [`SafetyVerdict::Unknown`]. This is plain
+/// k-induction — sound in both directions, but not guaranteed complete (a design
+/// whose shortest inductive certificate needs a *simple-path* restriction, or IMC,
+/// may return `Unknown`). The base and step run on independent solvers over the
+/// SAME frame variables (shared Z3 consts, separate assertion stacks), so the
+/// step's free initial state does not clash with the base's pinned init.
+pub fn decide_bad_safety(file: &Btor2File, max_k: u32) -> Result<SafetyVerdict, BmcError> {
+    let (bad_ops, init_pairs, constraint_ops) = extract_props(file);
+    if bad_ops.is_empty() {
+        return Err(BmcError::NoBadProperty);
+    }
+    let n = max_k as usize;
+    let cfg = z3::Config::new();
+    z3::with_z3_config(&cfg, || {
+        let view = encode_design(file).map_err(BmcError::Encode)?;
+        let u = Unroller::build(&view, &bad_ops, &constraint_ops, n);
+
+        // Base: an init-constrained path (as in `bmc_bad_reachable`).
+        let base = z3::Solver::new();
+        u.assert_init(&base, &init_pairs);
+        for c in u.constraints_at(0) {
+            base.assert(&c);
+        }
+        // Step: a FREE path (no init) accumulating `¬bad ∧ transition` per frame;
+        // if `bad` at the current frame is then unsatisfiable, the property is
+        // k-inductive.
+        let step = z3::Solver::new();
+        for c in u.constraints_at(0) {
+            step.assert(&c);
+        }
+
+        for k in 0..=n {
+            // Base — reachable counterexample?
+            base.push();
+            base.assert(u.bad_at(k));
+            let base_sat = matches!(base.check(), z3::SatResult::Sat);
+            base.pop(1);
+            if base_sat {
+                return Ok(SafetyVerdict::Violated { depth: k as u32 });
+            }
+            // Step — k-inductive? (base has held through depth k, checked above.)
+            step.push();
+            step.assert(u.bad_at(k));
+            let step_sat = matches!(step.check(), z3::SatResult::Sat);
+            step.pop(1);
+            if !step_sat {
+                return Ok(SafetyVerdict::Safe { k: k as u32 });
+            }
+            if k < n {
+                // Extend both paths to frame k+1.
+                base.assert(u.transition_at(k));
+                step.assert(u.bad_at(k).not()); // assume ¬bad on the inductive path
+                step.assert(u.transition_at(k));
+                for c in u.constraints_at(k + 1) {
+                    base.assert(&c);
+                    step.assert(&c);
+                }
+            }
+        }
+        Ok(SafetyVerdict::Unknown { k: max_k })
     })
 }
 
@@ -326,5 +446,58 @@ mod tests {
                            6 add 1 4 3\n7 next 1 4 6\n8 constd 1 3\n9 sort bitvec 1\n\
                            10 eq 9 4 8\n12 not 9 10\n13 constraint 12\n11 bad 10\n";
         assert_eq!(bmc(constrained, 5), BmcOutcome::NoCexWithin { k: 5 });
+    }
+
+    // ---- k-induction (decide_bad_safety) — the SAFE-proving slice ----
+
+    fn safety(content: &str, max_k: u32) -> SafetyVerdict {
+        let file = parser::parse(content).expect("parse btor2");
+        decide_bad_safety(&file, max_k).expect("k-induction runs")
+    }
+
+    #[test]
+    fn k_induction_proves_a_1_inductive_invariant_safe() {
+        // `q` stays 0, `bad = q`. `q == 0` is not 0-inductive (a free state can be
+        // 1) but IS 1-inductive (the transition pins next q to 0) — proven SAFE.
+        assert_eq!(safety(SAFE, 10), SafetyVerdict::Safe { k: 1 });
+    }
+
+    #[test]
+    fn k_induction_finds_the_counterexample_first() {
+        // The base case finds the depth-1 CEX before the step could prove safety.
+        assert_eq!(safety(REACH, 10), SafetyVerdict::Violated { depth: 1 });
+    }
+
+    #[test]
+    fn k_induction_proves_safe_beyond_the_exact_40_bit_cap() {
+        // A 64-bit register that stays 0, `bad = (big != 0)`. The exact BDD engine
+        // abstains (over-cap); native k-induction proves it SAFE (1-inductive)
+        // bit-precisely — an in-house UNBOUNDED safety proof past the cap.
+        let wide_safe = "1 sort bitvec 64\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
+                         5 next 1 3 3\n6 sort bitvec 1\n7 neq 6 3 2\n8 bad 7\n";
+        assert_eq!(safety(wide_safe, 10), SafetyVerdict::Safe { k: 1 });
+    }
+
+    #[test]
+    fn k_induction_agrees_with_the_exact_engine() {
+        // Differential-oracle cross-check: a DEFINITE k-induction verdict must
+        // match the exact engine's reachability — never a spurious Safe/Violated.
+        use crate::adapter::btor2::symbolic_bitblast::exact_bad_reachable;
+        for (content, name) in [(REACH, "reach"), (SAFE, "safe")] {
+            let exact_reachable = exact_bad_reachable(content).expect("exact decides in-cap");
+            match safety(content, 20) {
+                SafetyVerdict::Violated { .. } => assert!(
+                    exact_reachable,
+                    "{name}: SOUNDNESS — k-induction Violated but exact says unreachable"
+                ),
+                SafetyVerdict::Safe { .. } => assert!(
+                    !exact_reachable,
+                    "{name}: SOUNDNESS — k-induction Safe but exact says reachable"
+                ),
+                SafetyVerdict::Unknown { .. } => {
+                    panic!("{name}: expected a definite k-induction verdict")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

Slice 2 of P1's in-house scalable-safety back-end: **k-induction** — the SAFE-proving complement to native BMC (#261). mununu can now produce its own **unbounded safety proof** in-process on Z3, no subprocess.

## How

`adapter::btor2::native_bmc::decide_bad_safety(file, max_k) -> SafetyVerdict` runs, for increasing `k`, on a shared `Unroller`:

- **Base** — is `bad` reachable at frame `k` from an initial state? SAT ⇒ `Violated { depth }` (shallowest CEX, same as BMC).
- **Step** — is the property `k`-inductive? Over **unconstrained** frames (no init), with `¬bad` assumed at frames `0..k` and the transitions chained, is `bad` at frame `k` unsatisfiable? UNSAT ⇒ `Safe { k }` — base has been verified through depth `k`, so k-induction gives a sound safety proof.

Neither by `max_k` ⇒ `Unknown { k }`.

The base and step run on **independent solvers over the same frame variables** (shared Z3 consts, separate assertion stacks), so the step's free initial state doesn't clash with the base's pinned init.

## Refactor

The unrolling machinery (fresh per-frame vars + the frame-instantiated `bad`/`transition`/`constraint` terms) is factored out of `bmc_bad_reachable`'s inline closures into a reusable `Unroller` struct with methods. `bmc_bad_reachable` (slice 1) is rewritten to use it — behaviour-identical (its 7 tests still pass) — and `decide_bad_safety` shares it. This is also the foundation for slice 3 (IMC).

## Soundness

k-induction is sound in **both** directions: a `Violated` is a concrete counterexample (BMC base), and a `Safe` is `base_k ∧ step_k` — the standard k-induction theorem. It is plain k-induction (no simple-path restriction yet), so it is sound but not guaranteed complete — a design needing a simple-path certificate or IMC returns `Unknown` rather than a wrong answer. A differential-oracle test cross-checks every definite verdict against the exact engine (never a spurious Safe/Violated).

## Why it matters

No 40-bit BDD cone cap — `k_induction_proves_safe_beyond_the_exact_40_bit_cap` proves a **64-bit** register-stays-0 invariant SAFE bit-precisely, where the exact engine abstains. That is an in-house *unbounded* safety verdict past the cap — exactly the P1 scale target.

## Tests

4 new k-induction tests (1-inductive-safe, CEX-first, beyond-cap SAFE, exact-differential) on top of slice 1's 7 — 11 total, all in make-ci (Z3 linked, no subprocess). Full workspace `clippy --all-features --all-targets -D warnings` + fmt clean.

## Next

Slice 3 — **IMC** (Craig interpolation) for designs k-induction leaves `Unknown`; then portfolio integration (native BMC/k-induction as first-class L4 members alongside btormc/Pono).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
