### PR TITLE
feat(P1): wire the native engine into the portfolio + scale-curve validation

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/native_bmc.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_bmc.rs
@@ -45,6 +45,16 @@ use crate::adapter::sidecar::predicate_image::btor2_encode::{
 };
 use z3::ast::{Ast, BV, Bool};
 
+/// Default unrolling / induction depth bound for the portfolio-facing native
+/// engine — mirrors [`crate::adapter::btormc::DEFAULT_KMAX`].
+pub const DEFAULT_MAX_K: u32 = 40;
+
+/// Default per-check Z3 wall-clock budget (milliseconds) for the portfolio-facing
+/// native engine. A check that exceeds it returns `Unknown`, and the engine
+/// **abstains** (never a wrong verdict) — the in-process analogue of the
+/// subprocess members' kill-on-timeout.
+pub const DEFAULT_TIMEOUT_MS: u32 = 5_000;
+
 /// The outcome of a bounded model-checking run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BmcOutcome {
@@ -284,7 +294,22 @@ pub fn bmc_bad_reachable(file: &Btor2File, max_k: u32) -> Result<BmcOutcome, Bmc
 /// may return `Unknown`). The base and step run on independent solvers over the
 /// SAME frame variables (shared Z3 consts, separate assertion stacks), so the
 /// step's free initial state does not clash with the base's pinned init.
-pub fn decide_bad_safety(file: &Btor2File, max_k: u32) -> Result<SafetyVerdict, BmcError> {
+///
+/// `timeout_ms` sets a per-check Z3 wall-clock budget: a check that exceeds it
+/// returns `Unknown`, and the engine **abstains** ([`SafetyVerdict::Unknown`]) —
+/// never a wrong verdict. `None` = unbounded (QF_BV is decidable, so it still
+/// terminates). This is what lets the portfolio bound the in-process member the
+/// way it kills a timed-out subprocess.
+///
+/// **Soundness of the SAT/UNSAT/UNKNOWN handling.** `Violated` is returned ONLY on
+/// a definite base `Sat`; `Safe` ONLY on a definite step `Unsat`. Any `Unknown`
+/// (a timeout, or Z3 giving up) abstains — crucially, a step `Unknown` must NOT be
+/// read as "not satisfiable ⇒ inductive" (that would be a spurious `Safe`).
+pub fn decide_bad_safety(
+    file: &Btor2File,
+    max_k: u32,
+    timeout_ms: Option<u32>,
+) -> Result<SafetyVerdict, BmcError> {
     let (bad_ops, init_pairs, constraint_ops) = extract_props(file);
     if bad_ops.is_empty() {
         return Err(BmcError::NoBadProperty);
@@ -297,34 +322,43 @@ pub fn decide_bad_safety(file: &Btor2File, max_k: u32) -> Result<SafetyVerdict, 
 
         // Base: an init-constrained path (as in `bmc_bad_reachable`).
         let base = z3::Solver::new();
-        u.assert_init(&base, &init_pairs);
-        for c in u.constraints_at(0) {
-            base.assert(&c);
-        }
         // Step: a FREE path (no init) accumulating `¬bad ∧ transition` per frame;
         // if `bad` at the current frame is then unsatisfiable, the property is
         // k-inductive.
         let step = z3::Solver::new();
+        if let Some(ms) = timeout_ms {
+            let mut params = z3::Params::new();
+            params.set_u32("timeout", ms);
+            base.set_params(&params);
+            step.set_params(&params);
+        }
+        u.assert_init(&base, &init_pairs);
         for c in u.constraints_at(0) {
+            base.assert(&c);
             step.assert(&c);
         }
 
         for k in 0..=n {
-            // Base — reachable counterexample?
+            // Base — reachable counterexample? Violated ONLY on a definite Sat.
             base.push();
             base.assert(u.bad_at(k));
-            let base_sat = matches!(base.check(), z3::SatResult::Sat);
+            let base_res = base.check();
             base.pop(1);
-            if base_sat {
-                return Ok(SafetyVerdict::Violated { depth: k as u32 });
+            match base_res {
+                z3::SatResult::Sat => return Ok(SafetyVerdict::Violated { depth: k as u32 }),
+                z3::SatResult::Unknown => return Ok(SafetyVerdict::Unknown { k: k as u32 }),
+                z3::SatResult::Unsat => {}
             }
-            // Step — k-inductive? (base has held through depth k, checked above.)
+            // Step — k-inductive? Safe ONLY on a definite Unsat; an Unknown abstains
+            // (must NOT be read as "inductive"). Base has held through depth k above.
             step.push();
             step.assert(u.bad_at(k));
-            let step_sat = matches!(step.check(), z3::SatResult::Sat);
+            let step_res = step.check();
             step.pop(1);
-            if !step_sat {
-                return Ok(SafetyVerdict::Safe { k: k as u32 });
+            match step_res {
+                z3::SatResult::Unsat => return Ok(SafetyVerdict::Safe { k: k as u32 }),
+                z3::SatResult::Unknown => return Ok(SafetyVerdict::Unknown { k: k as u32 }),
+                z3::SatResult::Sat => {}
             }
             if k < n {
                 // Extend both paths to frame k+1.
@@ -452,7 +486,7 @@ mod tests {
 
     fn safety(content: &str, max_k: u32) -> SafetyVerdict {
         let file = parser::parse(content).expect("parse btor2");
-        decide_bad_safety(&file, max_k).expect("k-induction runs")
+        decide_bad_safety(&file, max_k, None).expect("k-induction runs")
     }
 
     #[test]
@@ -498,6 +532,39 @@ mod tests {
                     panic!("{name}: expected a definite k-induction verdict")
                 }
             }
+        }
+    }
+
+    #[test]
+    fn scale_curve_native_decides_past_the_exact_40_bit_cap() {
+        // The roadmap's `synth_pipeline(W)` signal, distilled to a scale CURVE: a
+        // W-bit register that stays 0 (`AG(big == 0)`, encoded `bad = big != 0`),
+        // swept over widths. The native k-induction engine proves it SAFE at EVERY
+        // width; the exact BDD engine ABSTAINS once the cone exceeds its 40-bit cap.
+        // That is the in-house scale win charted, not asserted by hand.
+        use crate::adapter::btor2::symbolic_bitblast::exact_bad_reachable;
+        let wide_safe = |w: u32| -> String {
+            format!(
+                "1 sort bitvec {w}\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
+                 5 next 1 3 3\n6 sort bitvec 1\n7 neq 6 3 2\n8 bad 7\n"
+            )
+        };
+        // Native proves SAFE at every width — including far past the BDD cap.
+        for w in [8u32, 20, 40, 64, 128, 256, 512] {
+            let file = parser::parse(&wide_safe(w)).expect("parse");
+            assert_eq!(
+                decide_bad_safety(&file, 5, None).expect("native runs"),
+                SafetyVerdict::Safe { k: 1 },
+                "native must prove W={w} SAFE"
+            );
+        }
+        // The exact engine abstains once the cone is over-cap (≥64 bits here),
+        // where the native engine still decides — the scale delta.
+        for w in [64u32, 128, 256, 512] {
+            assert!(
+                exact_bad_reachable(&wide_safe(w)).is_err(),
+                "the exact engine must abstain (over-cap) at W={w}"
+            );
         }
     }
 }

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -1,18 +1,24 @@
 //! Reachability portfolio — decide BTOR2 `bad`-reachability with every available
 //! engine and merge under the **differential-oracle discipline**.
 //!
-//! The P1 payoff made usable: the exact BDD engine
-//! ([`exact_bad_reachable`](crate::adapter::btor2::symbolic_bitblast::exact_bad_reachable)),
-//! btormc (BMC + k-induction), and Pono (IC3/PDR) each decide a *different*
-//! slice of designs — the exact engine within its 40-bit cone cap, btormc on
-//! deep counterexamples, Pono on IC3-provable/violated instances. Running them
-//! together (the emit seam feeds the two subprocess members) decides strictly
-//! more than any one, and — crucially — every engine's verdict is **sound**, so:
+//! The P1 payoff made usable — four sound engines, each deciding a *different*
+//! slice of designs:
+//! - the **exact** BDD engine
+//!   ([`exact_bad_reachable`](crate::adapter::btor2::symbolic_bitblast::exact_bad_reachable))
+//!   within its 40-bit cone cap;
+//! - the in-house **native** engine (BMC + k-induction on the Z3 seam,
+//!   [`native_bmc`](crate::adapter::btor2::native_bmc)) — no bit cap, no
+//!   subprocess: mununu's own scalable safety member;
+//! - **btormc** (BMC + k-induction) on deep counterexamples;
+//! - **Pono** (IC3/PDR) on IC3-provable / violated instances.
+//!
+//! Running them together decides strictly more than any one, and — crucially —
+//! every engine's verdict is **sound**, so:
 //!
 //! - **first definite wins** — any engine's `Reachable` / `Unreachable` decides it;
 //! - **two DEFINITE verdicts that DISAGREE raise a soundness alarm** ([`ReachVerdict::Contradiction`])
-//!   rather than a guess. Since all three engines are sound, a disagreement can
-//!   only mean a real bug — exactly what the differential oracle exists to catch.
+//!   rather than a guess. Since all engines are sound, a disagreement can only mean
+//!   a real bug — exactly what the differential oracle exists to catch.
 //!
 //! Both a **sequential** ([`decide_reach_portfolio`]) and a **parallel**
 //! ([`decide_reach_portfolio_parallel`]) driver are provided. They merge
@@ -26,6 +32,7 @@
 
 use crate::adapter::btor2::ast::Btor2File;
 use crate::adapter::btor2::emit::emit_btor2;
+use crate::adapter::btor2::native_bmc::{self, SafetyVerdict};
 use crate::adapter::btor2::symbolic_bitblast::exact_bad_reachable;
 use crate::adapter::btormc::{self, McVerdict};
 use crate::adapter::pono;
@@ -79,21 +86,43 @@ fn run_exact(content: &str) -> Option<bool> {
     exact_bad_reachable(content).ok()
 }
 
-/// Merge the three members' verdicts into a [`ReachOutcome`], in the fixed
-/// engine order (`exact`, `btormc`, `pono`) so the outcome is deterministic
+/// The in-house **native engine** (BMC + k-induction on the Z3 seam) verdict:
+/// `Some(true)` reachable (a counterexample), `Some(false)` unreachable (a
+/// k-inductive safety proof), `None` abstained (Unknown / timeout / encode error).
+/// Unlike the exact BDD engine it has no 40-bit cone cap, and unlike btormc/Pono
+/// it needs no subprocess — mununu's own scalable safety member.
+fn run_native(file: &Btor2File) -> Option<bool> {
+    match native_bmc::decide_bad_safety(
+        file,
+        native_bmc::DEFAULT_MAX_K,
+        Some(native_bmc::DEFAULT_TIMEOUT_MS),
+    ) {
+        Ok(SafetyVerdict::Violated { .. }) => Some(true),
+        Ok(SafetyVerdict::Safe { .. }) => Some(false),
+        Ok(SafetyVerdict::Unknown { .. }) | Err(_) => None,
+    }
+}
+
+/// Merge the members' verdicts into a [`ReachOutcome`], in the fixed engine order
+/// (`exact`, `native`, `btormc`, `pono`) so the outcome is deterministic
 /// regardless of which driver (sequential / parallel) produced them.
 fn collect(
     exact: Option<bool>,
+    native: Option<bool>,
     btormc_v: Option<McVerdict>,
     pono_v: Option<McVerdict>,
 ) -> ReachOutcome {
     let mut reachable_by: Vec<&'static str> = Vec::new();
     let mut unreachable_by: Vec<&'static str> = Vec::new();
-    match exact {
-        Some(true) => reachable_by.push("exact"),
-        Some(false) => unreachable_by.push("exact"),
-        None => {}
+    // In-house engines report reachability as a bool (`Some(true)` = reachable).
+    for (name, v) in [("exact", exact), ("native", native)] {
+        match v {
+            Some(true) => reachable_by.push(name),
+            Some(false) => unreachable_by.push(name),
+            None => {}
+        }
     }
+    // Subprocess members report an `McVerdict`.
     for (name, v) in [("btormc", btormc_v), ("pono", pono_v)] {
         match v {
             Some(McVerdict::Violated) => reachable_by.push(name),
@@ -120,12 +149,14 @@ pub fn decide_reach_portfolio(file: &Btor2File) -> ReachOutcome {
     // Exact BDD engine — sound both ways (REACHABLE is always sound; an
     // UNREACHABLE verdict is refused on free-init state), within the bit cap.
     let exact = run_exact(&content);
+    // Native engine — in-house BMC + k-induction on the Z3 seam, no bit cap.
+    let native = run_native(file);
     // btormc — BMC (CEX) + k-induction (proof).
     let btormc_v =
         btormc::decide_via_btormc(file, btormc::DEFAULT_KMAX, btormc::DEFAULT_TIMEOUT).ok();
     // Pono — IC3/PDR (proof + shallow CEX).
     let pono_v = pono::decide_via_pono(file, pono::DEFAULT_ENGINE, pono::DEFAULT_TIMEOUT).ok();
-    collect(exact, btormc_v, pono_v)
+    collect(exact, native, btormc_v, pono_v)
 }
 
 /// The **parallel** driver: run the exact engine (in-process) and the two
@@ -146,13 +177,17 @@ pub fn decide_reach_portfolio_parallel(file: &Btor2File) -> ReachOutcome {
         let pono_h = scope.spawn(|| {
             pono::decide_via_pono(file, pono::DEFAULT_ENGINE, pono::DEFAULT_TIMEOUT).ok()
         });
+        // The native engine is in-process Z3 work — its own thread so it overlaps
+        // the exact engine + the subprocess members rather than serialising.
+        let native_h = scope.spawn(|| run_native(file));
         // The exact engine is in-process BDD work — run it on this thread while the
-        // two subprocess members run on theirs.
+        // other members run on theirs.
         let exact = run_exact(&content);
         // A panicked member thread abstains (None) rather than poisoning the merge.
+        let native = native_h.join().unwrap_or(None);
         let btormc_v = btormc_h.join().unwrap_or(None);
         let pono_v = pono_h.join().unwrap_or(None);
-        collect(exact, btormc_v, pono_v)
+        collect(exact, native, btormc_v, pono_v)
     })
 }
 
@@ -200,6 +235,28 @@ mod tests {
         assert!(
             out.unreachable_by.is_empty(),
             "no engine should call the reachable counter unreachable"
+        );
+    }
+
+    #[test]
+    fn native_engine_decides_beyond_the_exact_cap_in_portfolio() {
+        // A 64-bit register that stays 0, `bad = (big != 0)`: SAFE, but the 64-bit
+        // cone is over the exact engine's 40-bit cap. With no btormc/pono on PATH
+        // and the exact engine abstaining, the portfolio would previously be
+        // Unknown; the in-house native engine (k-induction) now proves it
+        // Unreachable — the scale win, in-process, no subprocess.
+        const WIDE_SAFE: &str = "1 sort bitvec 64\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
+                                 5 next 1 3 3\n6 sort bitvec 1\n7 neq 6 3 2\n8 bad 7\n";
+        let file = parser::parse(WIDE_SAFE).expect("parse");
+        let out = decide_reach_portfolio(&file);
+        assert_eq!(out.verdict, ReachVerdict::Unreachable, "outcome: {out:?}");
+        assert!(
+            out.unreachable_by.contains(&"native"),
+            "the native engine must carry the beyond-cap verdict: {out:?}"
+        );
+        assert!(
+            !out.unreachable_by.contains(&"exact"),
+            "the exact engine must abstain on the over-cap 64-bit design: {out:?}"
         );
     }
 


### PR DESCRIPTION
## What

Wires the in-house **native engine** (BMC + k-induction, #261/#262) into the reachability portfolio as a first-class L4 member alongside the exact BDD engine and the btormc/Pono subprocess members — and adds a **scale-curve** test charting the in-house scale win. Also a **soundness hardening** to k-induction that the timeout made necessary.

## Portfolio integration

`reach_portfolio` now runs four sound engines and merges under the same first-definite + contradiction-alarm discipline:
- **exact** BDD (≤40-bit cone cap),
- **native** — in-house BMC + k-induction on the Z3 seam, **no bit cap, no subprocess** (mununu's own scalable safety member),
- **btormc**, **Pono** (subprocess).

`run_native` maps `SafetyVerdict` → reachability (`Violated`→reachable, `Safe`→unreachable, `Unknown`/error→abstain). Both the sequential and parallel drivers gain the member; in the parallel driver it runs on its own thread (in-process Z3) so it overlaps the exact engine and the subprocess members.

`native_engine_decides_beyond_the_exact_cap_in_portfolio`: on a 64-bit safe design where the exact engine abstains (over-cap) and no subprocess is present, the portfolio now returns **Unreachable** — carried by the native engine, in-process.

## Soundness hardening (k-induction)

`decide_bad_safety` now concludes `Violated` **only** on a definite base `Sat` and `Safe` **only** on a definite step `Unsat`; any `Unknown` **abstains**. The previous code read `!step_sat` as "inductive" — with QF_BV that never mattered (decidable ⇒ no `Unknown`), but adding a Z3 timeout makes `Unknown` reachable, and reading it as `Safe` would be a **spurious safety proof**. Now a timeout is a sound abstention.

`decide_bad_safety` gains a `timeout_ms: Option<u32>` per-check Z3 budget (via `Params`), so the portfolio can bound the in-process member the way it kills a timed-out subprocess. `DEFAULT_MAX_K = 40`, `DEFAULT_TIMEOUT_MS = 5000`.

## Scale validation (the roadmap's `synth_pipeline(W)` signal)

`scale_curve_native_decides_past_the_exact_40_bit_cap`: a W-bit register-stays-0 invariant swept over `W ∈ {8,20,40,64,128,256,512}`. The native engine proves it **SAFE at every width**; the exact engine **abstains** once the cone exceeds 40 bits. The in-house scale win, charted rather than asserted by hand.

## Tests

3 new/changed tests (portfolio beyond-cap, scale curve, and the k-induction callers updated for the new signature). All in make-ci (Z3 linked, no subprocess). Full workspace `clippy --all-features --all-targets -D warnings` + fmt clean.

## Next

Slice 3 — IMC (Craig interpolation) for designs k-induction leaves `Unknown` — is deferred (needs the cvc5 interpolation seam, a cross-solver integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
