### PR TITLE
feat(P1): native SPACER — in-house IC3/PDR safety proof via Z3 Fixedpoint CHC

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -29,6 +29,7 @@ pub mod dep_graph;
 pub mod emit;
 pub mod kmts_lift;
 pub mod native_bmc;
+pub mod native_spacer;
 pub mod parser;
 pub mod pin;
 pub mod predicate_expr;

--- a/crates/mununu-core/src/adapter/btor2/native_spacer.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_spacer.rs
@@ -1,0 +1,270 @@
+//! Native SPACER — in-house IC3/PDR + interpolation via Z3's **Fixedpoint (CHC)**
+//! engine.
+//!
+//! Slice 3 of P1's in-house scalable-safety back-end. It decides SAFE properties
+//! native k-induction ([`crate::adapter::btor2::native_bmc::decide_bad_safety`])
+//! leaves `Unknown` — the *non-k-inductive* ones that need an inductive-invariant
+//! search. Z3's **SPACER** does interpolation-based IC3 INTERNALLY, so this stays
+//! in-process: no cvc5 cross-solver bridge, no subprocess, commercially clean like
+//! the rest of the native engine.
+//!
+//! # The Horn encoding
+//!
+//! The BTOR2 safety problem is posed as constrained Horn clauses over a single
+//! invariant relation `Inv` (one bit-vector argument per state cell):
+//!
+//! ```text
+//!   Init(s)  ∧ C(s)          ⟹ Inv(s)         -- initial states are reachable
+//!   Inv(s) ∧ T(s,i,s') ∧ C(s) ⟹ Inv(s')        -- reachability is closed under T
+//!   Inv(s) ∧ Bad(s)          ⟹ Err            -- a reachable bad state is an error
+//! ```
+//!
+//! and `query(Err)`: **SAT** ⇒ `Err` is derivable ⇒ a bad state is reachable
+//! ([`SafetyVerdict::Violated`]); **UNSAT** ⇒ SPACER found an inductive invariant
+//! ([`SafetyVerdict::Safe`]); **Unknown** ⇒ timeout / gave up.
+//!
+//! SPACER gives no natural counterexample *depth* or inductive *k*, so those
+//! fields carry `0` here (the verdict, not the witness, is the product).
+
+use crate::adapter::btor2::ast::{Btor2File, Nid, Node};
+use crate::adapter::btor2::native_bmc::SafetyVerdict;
+use crate::adapter::sidecar::predicate_image::btor2_encode::{EncodeError, encode_design};
+use z3::ast::{Ast, BV, Bool};
+use z3::{FuncDecl, Sort};
+
+/// `a ⟹ b`. Must be a real `(=> a b)` (not the `¬a ∨ b` rewrite): SPACER inspects
+/// the *syntactic* head of each rule and rejects an `(or …)` head as "not an
+/// uninterpreted predicate", so the implication node is load-bearing.
+fn implies(a: &Bool, b: &Bool) -> Bool {
+    a.implies(b)
+}
+
+/// Conjunction of a slice of `Bool`s; the empty conjunction is `true`.
+fn and_all(cs: &[Bool]) -> Bool {
+    if cs.is_empty() {
+        Bool::from_bool(true)
+    } else {
+        let refs: Vec<&Bool> = cs.iter().collect();
+        Bool::and(&refs)
+    }
+}
+
+/// Decide `bad`-reachability of `file` with Z3's SPACER (Fixedpoint/CHC) engine —
+/// an in-house IC3/PDR + interpolation model checker. See the module docs for the
+/// Horn encoding and verdict semantics. `timeout_ms` bounds the SPACER solve (a
+/// timeout returns [`SafetyVerdict::Unknown`] — never a wrong verdict).
+pub fn decide_bad_safety_spacer(
+    file: &Btor2File,
+    timeout_ms: Option<u32>,
+) -> Result<SafetyVerdict, EncodeError> {
+    let mut bad_ops: Vec<Nid> = Vec::new();
+    let mut init_pairs: Vec<(Nid, Nid)> = Vec::new();
+    let mut constraint_ops: Vec<Nid> = Vec::new();
+    for l in &file.lines {
+        match &l.node {
+            Node::Bad { signal } => bad_ops.push(signal.nid()),
+            Node::Init { state, value, .. } => init_pairs.push((*state, value.nid())),
+            Node::Constraint { signal } => constraint_ops.push(signal.nid()),
+            _ => {}
+        }
+    }
+    if bad_ops.is_empty() {
+        // No property ⇒ nothing can be violated.
+        return Ok(SafetyVerdict::Safe { k: 0 });
+    }
+
+    // Select SPACER — Z3's IC3/PDR + interpolation CHC engine — explicitly, rather
+    // than relying on the Fixedpoint auto-config to route these bit-vector Horn rules
+    // there. `fp.engine` is a module parameter, so it is pinned on the `Config` that
+    // builds the context; context-scoped, it does not perturb the `Solver`-based
+    // native BMC / k-induction engines.
+    let mut cfg = z3::Config::new();
+    cfg.set_param_value("fp.engine", "spacer");
+    z3::with_z3_config(&cfg, || {
+        let view = encode_design(file)?;
+
+        // Deterministic state-cell ordering for the `Inv` relation's argument list.
+        let mut states: Vec<Nid> = view.state_curr.keys().copied().collect();
+        states.sort();
+        if states.is_empty() {
+            // A purely combinational design: `Inv` has no state; fall back is a
+            // single-step check — but SPACER needs a state relation, so defer such
+            // designs to BMC (return Unknown here rather than mis-encode).
+            return Ok(SafetyVerdict::Unknown { k: 0 });
+        }
+
+        let sorts: Vec<Sort> = states
+            .iter()
+            .map(|n| Sort::bitvector(view.state_curr[n].get_size()))
+            .collect();
+        let sort_refs: Vec<&Sort> = sorts.iter().collect();
+        let bool_sort = Sort::bool();
+        let inv = FuncDecl::new("Inv", &sort_refs, &bool_sort);
+        let err = FuncDecl::new("Err", &[], &bool_sort);
+
+        let fp = z3::Fixedpoint::new();
+        if let Some(ms) = timeout_ms {
+            let mut params = z3::Params::new();
+            params.set_u32("timeout", ms);
+            fp.set_params(&params);
+        }
+        fp.register_relation(&inv);
+        fp.register_relation(&err);
+
+        // `Inv` applied to the current / next state variables (in `states` order).
+        // Inlined (not a `dyn Fn` picker) so the borrow is inferred against `view`
+        // rather than erased to `'static` by the trait object.
+        let inv_curr = {
+            let args: Vec<&dyn Ast> = states
+                .iter()
+                .map(|n| &view.state_curr[n] as &dyn Ast)
+                .collect();
+            inv.apply(&args).as_bool().expect("Inv is a Bool relation")
+        };
+        let inv_next = {
+            let args: Vec<&dyn Ast> = states
+                .iter()
+                .map(|n| &view.state_next[n] as &dyn Ast)
+                .collect();
+            inv.apply(&args).as_bool().expect("Inv is a Bool relation")
+        };
+        let err_app = err.apply(&[]).as_bool().expect("Err is a Bool relation");
+
+        let one1 = BV::from_u64(1, 1);
+        let curr_bv = |nid: &Nid| -> Option<&BV> {
+            view.signal_bvs
+                .get(nid)
+                .or_else(|| view.state_curr.get(nid))
+                .or_else(|| view.inputs.get(nid))
+        };
+        // Constraints (over the current state / inputs) — asserted on every rule.
+        let constr: Vec<Bool> = constraint_ops
+            .iter()
+            .filter_map(|op| curr_bv(op).map(|bv| bv.eq(&one1)))
+            .collect();
+        let constr_conj = and_all(&constr);
+
+        // Init(s): the design's `init` values pin the initialised cells; init-less
+        // cells stay free (BTOR2 nondeterministic-init semantics).
+        let init_conj: Vec<Bool> = init_pairs
+            .iter()
+            .filter_map(|(state, val)| {
+                match (view.state_curr.get(state), view.signal_bvs.get(val)) {
+                    (Some(sc), Some(vbv)) => Some(sc.eq(vbv)),
+                    _ => None,
+                }
+            })
+            .collect();
+        let init_pred = and_all(&init_conj);
+
+        // Bad(s): OR over the `bad` operands of `operand == 1`.
+        let bad_disj: Vec<Bool> = bad_ops
+            .iter()
+            .filter_map(|op| curr_bv(op).map(|bv| bv.eq(&one1)))
+            .collect();
+        let bad_pred = if bad_disj.is_empty() {
+            Bool::from_bool(false)
+        } else {
+            Bool::or(&bad_disj.iter().collect::<Vec<_>>())
+        };
+
+        // Quantifier bounds.
+        let curr_bounds: Vec<&dyn Ast> = states
+            .iter()
+            .map(|n| &view.state_curr[n] as &dyn Ast)
+            .collect();
+        let mut all_bounds: Vec<&dyn Ast> = curr_bounds.clone();
+        for bv in view.inputs.values() {
+            all_bounds.push(bv as &dyn Ast);
+        }
+        for n in &states {
+            all_bounds.push(&view.state_next[n] as &dyn Ast);
+        }
+
+        // Rule 1: Init(s) ∧ C(s) ⟹ Inv(s).
+        let body1 = implies(&and_all(&[init_pred, constr_conj.clone()]), &inv_curr);
+        fp.add_rule(&z3::ast::forall_const(&curr_bounds, &[], &body1), None);
+        // Rule 2: Inv(s) ∧ T(s,i,s') ∧ C(s) ⟹ Inv(s').
+        let body2 = implies(
+            &and_all(&[
+                inv_curr.clone(),
+                view.transition.clone(),
+                constr_conj.clone(),
+            ]),
+            &inv_next,
+        );
+        fp.add_rule(&z3::ast::forall_const(&all_bounds, &[], &body2), None);
+        // Rule 3: Inv(s) ∧ Bad(s) ⟹ Err.
+        let body3 = implies(&and_all(&[inv_curr, bad_pred]), &err_app);
+        fp.add_rule(&z3::ast::forall_const(&curr_bounds, &[], &body3), None);
+
+        // SPACER query semantics over the *exact* Horn encoding of the concrete
+        // transition relation: SAT ⇒ `Err` derivable ⇒ a real Init →* bad path exists
+        // ([`SafetyVerdict::Violated`]); UNSAT ⇒ SPACER exhibited an inductive
+        // invariant excluding every bad state ([`SafetyVerdict::Safe`]).
+        // SOUNDNESS: both definite verdicts are exact (no over/under-approximation —
+        // Init pins only the design's `init` values, init-less cells stay free per
+        // BTOR2 semantics). UNDEF (timeout / gave up) maps to `Unknown` — abstain,
+        // never a wrong verdict, matching the native BMC / k-induction contract.
+        Ok(match fp.query(&err_app) {
+            z3::SatResult::Sat => SafetyVerdict::Violated { depth: 0 },
+            z3::SatResult::Unsat => SafetyVerdict::Safe { k: 0 },
+            z3::SatResult::Unknown => SafetyVerdict::Unknown { k: 0 },
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::parser;
+
+    fn spacer(content: &str) -> SafetyVerdict {
+        let file = parser::parse(content).expect("parse btor2");
+        decide_bad_safety_spacer(&file, Some(10_000)).expect("spacer runs")
+    }
+
+    // `q` init 0, `next q = 1`, `bad = q`. Reachable at step 1.
+    const REACH: &str = "1 sort bitvec 1\n2 zero 1\n3 one 1\n4 state 1 q\n5 init 1 4 2\n\
+                         6 next 1 4 3\n7 bad 4\n";
+    // `q` init 0, `next q = 0`, `bad = q`. Safe (invariant q==0).
+    const SAFE: &str = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 next 1 3 2\n\
+                        6 bad 3\n";
+
+    #[test]
+    fn spacer_finds_violation() {
+        assert_eq!(spacer(REACH), SafetyVerdict::Violated { depth: 0 });
+    }
+
+    #[test]
+    fn spacer_proves_safe() {
+        assert_eq!(spacer(SAFE), SafetyVerdict::Safe { k: 0 });
+    }
+
+    #[test]
+    fn spacer_decides_a_safe_property_that_k_induction_abstains_on() {
+        // An 8-bit counter that STALLS at 0: init 0, next = (c == 0) ? 0 : c+1,
+        // bad = (c == 255). The reachable set is exactly {0}, so `c == 255` is
+        // unreachable ⇒ SAFE. But *simple* k-induction (no loop-free constraint) can
+        // build an unreachable free path 1 → 2 → … → 255 that stays ¬bad until the
+        // last step, keeping the step case satisfiable for every depth below 255 — so
+        // native k-induction ABSTAINS at its default cap. SPACER discovers the
+        // inductive invariant `c == 0` and proves the property outright. This is the
+        // gap the SPACER portfolio member exists to close.
+        let stall = "1 sort bitvec 8\n2 zero 1\n3 one 1\n4 state 1 c\n5 init 1 4 2\n\
+                     6 sort bitvec 1\n7 eq 6 4 2\n8 add 1 4 3\n9 ite 1 7 2 8\n\
+                     10 next 1 4 9\n11 ones 1\n12 eq 6 4 11\n13 bad 12\n";
+        let file = parser::parse(stall).expect("parse btor2");
+
+        // Native k-induction abstains: its default cap (40) is far below depth 255.
+        let native = crate::adapter::btor2::native_bmc::decide_bad_safety(&file, 40, Some(10_000))
+            .expect("native k-induction runs");
+        assert!(
+            matches!(native, SafetyVerdict::Unknown { .. }),
+            "expected native k-induction to abstain below the required depth, got {native:?}"
+        );
+
+        // SPACER decides it Safe via invariant discovery.
+        assert_eq!(spacer(stall), SafetyVerdict::Safe { k: 0 });
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of the in-house scalable-safety back-end (after native BMC #261 and native k-induction #262). Adds `decide_bad_safety_spacer` — the BTOR2 bad-reachability problem posed as constrained Horn clauses over one invariant relation `Inv`, solved by **Z3's SPACER** engine (interpolation-based IC3/PDR, run **in-process**). No cvc5 cross-solver bridge, no subprocess — commercially clean like the rest of the native engine.

## Why

SPACER closes the gap native k-induction cannot: **safe** properties whose inductive invariant is not reachable by *simple* k-induction below a large depth. The differential test builds an 8-bit stall-at-0 counter (reachable set `{0}`, `bad = (c == 255)` unreachable): native k-induction **abstains** at its default cap while SPACER discovers `c == 0` and proves Safe.

## Encoding & soundness

- **Parity with `native_bmc`**: identical bad / constraint / init operand handling (the `curr_bv` fallback chain, `op == 1`, init via `signal_bvs`). SPACER quantifies over the raw view vars instead of per-frame substitution.
- **SOUNDNESS**: exact Horn encoding of the concrete transition relation — no over/under-approximation. Definite `SAT` (Violated) / `UNSAT` (Safe) transfer; `UNDEF` (timeout / gave up) abstains to `Unknown`, matching the BMC/k-induction contract.

## z3-integration lessons (encoded in comments)

- SPACER needs real `(=> body head)` rules; the `¬body ∨ head` rewrite makes z3 read the whole `(or …)` as the head and reject it (*"Illegal head. The head predicate needs to be uninterpreted"*). Uses `Bool::implies`.
- `fp.engine=spacer` is a module parameter bound at context creation — pinned on the `Config` that builds the context (a post-hoc per-object set is silently ignored).

## Tests

3 unit tests: reachable → `Violated`, safe → `Safe`, and the k-induction-abstains differential (native `Unknown`, SPACER `Safe`). Full `make ci` gate passed locally (2144 lib tests, 0 failed).

## Follow-up (slice 3b, separate PR)

Wire SPACER into the safety/reach portfolio + CLI/API/UI surfaces — mirroring how native k-induction was wired in #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)