### PR TITLE
feat(P1): surface the multi-engine safety portfolio (CLI + API)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -136,6 +136,18 @@ enum Btor2Command {
     /// warning + falls back to the `wp` heuristic automatically.
     /// See `docs/external-tools.md` for CVC5 install instructions.
     Cegar(Btor2CegarArgs),
+    /// Decide `bad`-reachability with the multi-engine safety portfolio.
+    ///
+    /// Runs every available sound engine over the BTOR2 design and merges
+    /// them under the differential-oracle discipline: the exact BDD engine,
+    /// the in-house native (BMC + k-induction) and SPACER (IC3/PDR +
+    /// interpolation) engines — all in-process — plus the `btormc` and
+    /// `Pono` subprocess members when their binaries are on PATH. Prints the
+    /// merged verdict (`reachable` / `unreachable` / `unknown` /
+    /// `contradiction`) and which engines reached each conclusion. A
+    /// `contradiction` means two sound engines disagree — a soundness alarm,
+    /// never a silent guess. Engines whose binary is absent simply abstain.
+    Verify(Btor2VerifyArgs),
 }
 
 /// R.5 Item 3 sub-item 3.5 (2026-06-04) — predicate-source
@@ -407,6 +419,14 @@ struct Btor2LiftKmtsArgs {
     /// means no cap.
     #[arg(long, value_name = "N")]
     max_predicates: Option<usize>,
+}
+
+/// Arguments for `mununu btor2 verify` — the multi-engine safety portfolio.
+#[derive(Args, Debug)]
+struct Btor2VerifyArgs {
+    /// Path to the BTOR2 input file.
+    #[arg(value_name = "BTOR2_FILE")]
+    file: PathBuf,
 }
 
 #[derive(Subcommand, Debug)]
@@ -2017,7 +2037,39 @@ fn handle_btor2(command: Btor2Command) -> Result<(), String> {
         Btor2Command::Discover(args) => btor2_discover(args),
         Btor2Command::LiftKmts(args) => btor2_lift_kmts(args),
         Btor2Command::Cegar(args) => btor2_cegar(args),
+        Btor2Command::Verify(args) => btor2_verify(args),
     }
+}
+
+/// `mununu btor2 verify` — decide `bad`-reachability with the multi-engine safety
+/// portfolio and print the merged verdict + per-engine breakdown as JSON. Surface
+/// peer of the API `POST /api/v1/btor2/verify`; both share the verdict labels via
+/// [`mununu_core::adapter::reach_portfolio::ReachVerdict::as_str`].
+fn btor2_verify(args: Btor2VerifyArgs) -> Result<(), String> {
+    use mununu_core::adapter::reach_portfolio::decide_reach_portfolio_parallel;
+
+    let content = std::fs::read_to_string(&args.file)
+        .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
+    let file = mununu_core::adapter::btor2::parser::parse(&content)
+        .map_err(|e| format!("BTOR2 parse error in '{}': {e}", args.file.display()))?;
+
+    // Parallel driver: identical merge to the sequential one, but wall-clock is
+    // bounded by the slowest single engine rather than their sum.
+    let outcome = decide_reach_portfolio_parallel(&file);
+
+    let summary = serde_json::json!({
+        "file": args.file.display().to_string(),
+        "verdict": outcome.verdict.as_str(),
+        "reachable_by": outcome.reachable_by,
+        "unreachable_by": outcome.unreachable_by,
+        "contradiction": outcome.verdict
+            == mununu_core::adapter::reach_portfolio::ReachVerdict::Contradiction,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&summary).map_err(|e| format!("serialize summary: {e}"))?
+    );
+    Ok(())
 }
 
 /// R.5 Item 3 sub-item 3.5 (2026-06-04) — CEGAR refinement

--- a/crates/mununu-core/src/adapter/btor2/native_spacer.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_spacer.rs
@@ -80,13 +80,7 @@ pub fn decide_bad_safety_spacer(
         return Ok(SafetyVerdict::Safe { k: 0 });
     }
 
-    // Select SPACER — Z3's IC3/PDR + interpolation CHC engine — explicitly, rather
-    // than relying on the Fixedpoint auto-config to route these bit-vector Horn rules
-    // there. `fp.engine` is a module parameter, so it is pinned on the `Config` that
-    // builds the context; context-scoped, it does not perturb the `Solver`-based
-    // native BMC / k-induction engines.
-    let mut cfg = z3::Config::new();
-    cfg.set_param_value("fp.engine", "spacer");
+    let cfg = z3::Config::new();
     z3::with_z3_config(&cfg, || {
         let view = encode_design(file)?;
 
@@ -110,11 +104,19 @@ pub fn decide_bad_safety_spacer(
         let err = FuncDecl::new("Err", &[], &bool_sort);
 
         let fp = z3::Fixedpoint::new();
+        // Select SPACER — Z3's IC3/PDR + interpolation CHC engine — explicitly. The
+        // Fixedpoint default is `auto-config`, which routes *these* bit-vector Horn
+        // rules to SPACER anyway, but pinning it keeps the choice robust against
+        // auto-config heuristics. NB: `engine` is a *Fixedpoint-object* parameter set
+        // via `set_params`, NOT a Config/global one (setting `fp.engine` on the Config
+        // is rejected by Z3 with a warning). Context-scoped — it does not perturb the
+        // `Solver`-based native BMC / k-induction engines.
+        let mut params = z3::Params::new();
+        params.set_symbol("engine", "spacer");
         if let Some(ms) = timeout_ms {
-            let mut params = z3::Params::new();
             params.set_u32("timeout", ms);
-            fp.set_params(&params);
         }
+        fp.set_params(&params);
         fp.register_relation(&inv);
         fp.register_relation(&err);
 

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -56,6 +56,20 @@ pub enum ReachVerdict {
     Contradiction,
 }
 
+impl ReachVerdict {
+    /// Stable lowercase string form — the single source of truth for the verdict
+    /// label across the CLI (`mununu btor2 verify`) and the API
+    /// (`POST /api/v1/btor2/verify`), so the two surfaces never drift.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReachVerdict::Reachable => "reachable",
+            ReachVerdict::Unreachable => "unreachable",
+            ReachVerdict::Unknown => "unknown",
+            ReachVerdict::Contradiction => "contradiction",
+        }
+    }
+}
+
 /// The portfolio outcome: the merged verdict plus which engines reached each
 /// definite conclusion (empty lists ⇒ that side was undecided by all).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -623,6 +623,39 @@ pub async fn btor2_cegar_handler(
     Ok(Json(run_cegar_build_response(params)?))
 }
 
+/// Decide `bad`-reachability of a BTOR2 design with the multi-engine safety
+/// portfolio (`POST /api/v1/btor2/verify`). Surface peer of the CLI
+/// `mununu btor2 verify`: runs every available sound engine (exact ⊕ native ⊕
+/// spacer ⊕ btormc ⊕ Pono) via the **parallel** driver — its wall-clock is bounded
+/// by the slowest single engine, keeping the request within the extended client's
+/// budget even when the subprocess members are present — and returns the merged
+/// verdict + per-engine breakdown. A `"contradiction"` verdict means two sound
+/// engines disagree (a soundness alarm), never a silent guess.
+pub async fn btor2_verify_handler(
+    Json(request): Json<Btor2VerifyRequest>,
+) -> ApiResult<Json<Btor2VerifyResponse>> {
+    use crate::adapter::reach_portfolio::{ReachVerdict, decide_reach_portfolio_parallel};
+
+    let file = crate::adapter::btor2::parser::parse(&request.content).map_err(|e| {
+        ApiError::BadRequest {
+            message: format!("BTOR2 parse error: {e}"),
+            details: None,
+        }
+    })?;
+
+    let outcome = decide_reach_portfolio_parallel(&file);
+    Ok(Json(Btor2VerifyResponse {
+        verdict: outcome.verdict.as_str().to_string(),
+        reachable_by: outcome.reachable_by.iter().map(|s| s.to_string()).collect(),
+        unreachable_by: outcome
+            .unreachable_by
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        contradiction: outcome.verdict == ReachVerdict::Contradiction,
+    }))
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — SV-direct CEGAR in one call.
 ///
 /// Lifts SystemVerilog to a single flattened BTOR2 (sv2v + Yosys, the
@@ -3792,5 +3825,43 @@ members = ["x"]
             }
             other => panic!("expected BadRequest, got {other:?}"),
         }
+    }
+
+    /// The safety-portfolio endpoint decides a small reachable counter (the exact
+    /// engine is enough — btormc/Pono may be absent) and reports the deciding engine.
+    #[tokio::test]
+    async fn btor2_verify_handler_decides_reachable_counter() {
+        // 3-bit counter incrementing to `ones`; `bad = (c == 7)` is reachable.
+        let btor2 = "1 sort bitvec 3\n2 zero 1\n3 state 1\n4 init 1 3 2\n5 one 1\n\
+                     6 add 1 3 5\n7 next 1 3 6\n8 ones 1\n9 sort bitvec 1\n\
+                     10 eq 9 3 8\n11 bad 10\n";
+        let request = Btor2VerifyRequest {
+            content: btor2.to_string(),
+        };
+        let Json(out) = btor2_verify_handler(Json(request))
+            .await
+            .expect("verify runs");
+        assert_eq!(out.verdict, "reachable", "outcome: {out:?}");
+        assert!(
+            out.reachable_by.contains(&"exact".to_string()),
+            "the exact engine should decide the small reachable counter: {out:?}"
+        );
+        assert!(
+            !out.contradiction,
+            "no sound engine should disagree: {out:?}"
+        );
+    }
+
+    /// Malformed BTOR2 is a `BadRequest`, not a 500 — the parse guard runs before
+    /// any engine work.
+    #[tokio::test]
+    async fn btor2_verify_handler_rejects_malformed_btor2() {
+        let request = Btor2VerifyRequest {
+            content: "this is not btor2".to_string(),
+        };
+        let err = btor2_verify_handler(Json(request))
+            .await
+            .expect_err("malformed BTOR2 must be rejected");
+        assert!(matches!(err, ApiError::BadRequest { .. }));
     }
 }

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -882,6 +882,31 @@ pub struct Btor2CegarRequest {
     pub engine: Option<String>,
 }
 
+/// Request for the multi-engine safety portfolio endpoint
+/// (`POST /api/v1/btor2/verify`). Mirrors the CLI `mununu btor2 verify`: decides
+/// `bad`-reachability of a BTOR2 design across every available sound engine.
+#[derive(Debug, Deserialize)]
+pub struct Btor2VerifyRequest {
+    /// BTOR2 source content.
+    pub content: String,
+}
+
+/// Response for `POST /api/v1/btor2/verify` — the merged portfolio verdict plus
+/// which engines reached each definite conclusion. Mirrors
+/// [`crate::adapter::reach_portfolio::ReachOutcome`].
+#[derive(Debug, Serialize)]
+pub struct Btor2VerifyResponse {
+    /// Merged verdict: `"reachable"` | `"unreachable"` | `"unknown"` |
+    /// `"contradiction"` (via [`crate::adapter::reach_portfolio::ReachVerdict::as_str`]).
+    pub verdict: String,
+    /// Engines that found `bad` reachable (a real counterexample).
+    pub reachable_by: Vec<String>,
+    /// Engines that proved `bad` unreachable (a real safety proof).
+    pub unreachable_by: Vec<String>,
+    /// `true` when two sound engines disagree — a soundness alarm, not a guess.
+    pub contradiction: bool,
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — request for the SV-direct
 /// CEGAR endpoint (`POST /api/v1/sv/cegar`). Mirrors the CLI
 /// `mununu sv cegar`: lifts SystemVerilog to a single flattened BTOR2

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -109,6 +109,10 @@ fn create_router() -> Router {
         )
         .route("/api/v1/verify", post(handlers::verify_project_handler))
         .route("/api/v1/btor2/cegar", post(handlers::btor2_cegar_handler))
+        // Multi-engine safety portfolio — decide `bad`-reachability across every
+        // sound engine (exact ⊕ native ⊕ spacer ⊕ btormc ⊕ Pono), merged under the
+        // differential-oracle discipline. Surface peer of the CLI `mununu btor2 verify`.
+        .route("/api/v1/btor2/verify", post(handlers::btor2_verify_handler))
         // cegar-extraction Stage 2 — SV-direct CEGAR one-call (sv2v +
         // Yosys → flattened BTOR2 → cegar_refine_loop). Surface peer of
         // the CLI `mununu sv cegar`; lets the extraction-tab SV workflow


### PR DESCRIPTION
## Summary

Wire the internal 5-engine reachability portfolio (exact ⊕ native ⊕ **spacer** ⊕ btormc ⊕ Pono) to the user surfaces so a self-checking multi-engine BTOR2 safety verdict is directly invocable. Until now the whole in-house safety track was internal (consumed by `reach_rescue` + differential/HWMCC tests only).

- **CLI**: `mununu btor2 verify <file.btor2>` → parse, run the parallel portfolio, print the merged verdict + per-engine breakdown + contradiction flag as JSON.
- **API**: `POST /api/v1/btor2/verify {content}` → `{verdict, reachable_by, unreachable_by, contradiction}`. Always the **parallel** driver so wall-clock is bounded by the slowest single engine (within the extended-client budget even when the subprocess members are present). Malformed BTOR2 → `BadRequest`, not 500.
- **UI**: `runBtor2Verify` typed client — lands in **mununu-ui** (PR linked below).

`ReachVerdict::as_str()` is the single source of truth for the verdict label (`reachable` / `unreachable` / `unknown` / `contradiction`) so CLI and API never drift. Two API handler tests (decides a reachable counter; rejects malformed input).

## Bundled fix (native_spacer — surfaced by the CLI)

SPACER was selecting its engine via `Config::set_param_value("fp.engine", "spacer")`, which Z3 **rejects** as an unknown *global* parameter — printing `WARNING: unknown parameter 'fp.engine'` to stderr on **every** call (it would pollute CLI output and API server logs) while SPACER ran only because auto-config happened to route large-bitvector CHC there. `engine` is a *Fixedpoint-object* parameter: set it via `fp.set_params(set_symbol("engine", "spacer"))`. SPACER is now selected **explicitly** (confirmed by SPACER-keyed statistics on every solve, incl. the trivial cases auto-config previously sent to datalog) and the warning is gone. The old comment claiming the Config pinned the engine was false; corrected.

## Verified end-to-end

```
$ mununu btor2 verify counter.btor2      # 3-bit counter, bad=(c==7)
  verdict: reachable   reachable_by: [exact, native, spacer]
$ mununu btor2 verify wide_stall.btor2   # 64-bit stall-at-0, bad=(c==MAX)
  verdict: unreachable unreachable_by: [spacer]   # exact over-cap, native abstains
```

Full `make ci` gate passed locally (mununu-core 2145 lib tests + mununu-cli 15, 0 failed); api handler tests pass under `--all-features`; CLI verified with no stderr warning.

## Surface parity

CLI (`btor2 verify`) + API (`/btor2/verify`) + UI (`runBtor2Verify`) ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)