### PR TITLE
feat(P2): liveness-to-safety reduction for the response property AG(a → AF b)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -67,7 +67,7 @@ fn err(message: String) -> AdapterError {
 
 /// BTOR2 keyword for an *unsigned* comparison (the internal oracle compares
 /// `u128`, so unsigned is the matching semantics).
-fn btor2_cmp_keyword(op: CmpOp) -> &'static str {
+pub(crate) fn btor2_cmp_keyword(op: CmpOp) -> &'static str {
     match op {
         CmpOp::Eq => "eq",
         CmpOp::Ne => "neq",
@@ -91,7 +91,7 @@ fn negate_cmp(op: CmpOp) -> CmpOp {
 }
 
 /// Find an existing `sort bitvec 1` line, or append one. Returns its NID.
-fn find_or_make_bool_sort(
+pub(crate) fn find_or_make_bool_sort(
     file: &crate::adapter::btor2::ast::Btor2File,
     next_nid: &mut Nid,
     appended: &mut Vec<String>,
@@ -112,7 +112,7 @@ fn find_or_make_bool_sort(
 
 /// Resolve a STATE signal (value-alias / reset-mux aware) to `(value_nid,
 /// sort_nid)`. `None` when it is not a state cell.
-fn state_nid_and_sort(
+pub(crate) fn state_nid_and_sort(
     file: &crate::adapter::btor2::ast::Btor2File,
     signal: &str,
     reset_pinned: bool,
@@ -125,7 +125,7 @@ fn state_nid_and_sort(
 }
 
 /// Resolve a 1-bit (or any) primary-input signal to `(nid, sort_nid)`.
-fn input_nid_and_sort(
+pub(crate) fn input_nid_and_sort(
     file: &crate::adapter::btor2::ast::Btor2File,
     signal: &str,
 ) -> Option<(Nid, Nid)> {

--- a/crates/mununu-core/src/adapter/btor2/l2s_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/l2s_monitor.rs
@@ -1,0 +1,245 @@
+//! P2 — liveness-to-safety `bad` monitor for the response property
+//! `AG(a → AF b)` (Biere–Artho–Schuppan).
+//!
+//! The classifier [`crate::adapter::liveness_rescue::reduce_response_af`] recognises
+//! the property; this module emits the `bad` line that makes its violation — a
+//! **reachable `b`-free cycle carrying an outstanding request** — a reachability
+//! query the portfolio decides. Like [`crate::adapter::btor2::bad_monitor`] and
+//! [`crate::adapter::btor2::shadow`], it works at the BTOR2 **text** level: it
+//! appends lines with fresh NIDs above the current max, so it composes with the
+//! bit-blaster / lift / model checker that re-parse the text.
+//!
+//! # The construction
+//!
+//! Let `a`, `b` be the request / grant atoms. The augmentation adds:
+//!
+//! - `pending` (latch, init 0): `next = (pending ∨ a) ∧ ¬b` — an outstanding
+//!   request, set by `a`, cleared by `b`.
+//! - `save` (fresh 1-bit input) and `saved` (latch, init 0): a nondeterministic,
+//!   at-most-once snapshot trigger — `save_en = save ∧ ¬saved ∧ pending` (only
+//!   snapshot when a request is outstanding); `next(saved) = saved ∨ save_en`.
+//! - a **shadow** copy `sh_i` of every original state cell `s_i`:
+//!   `next(sh_i) = save_en ? s_i : sh_i` (no init — free, only read after a save).
+//! - `looped = saved ∧ ⋀_i (s_i == sh_i)` — the snapshotted state has recurred, so
+//!   a cycle closed.
+//! - `b_seen` (latch, init 0): whether `b` held anywhere on the loop —
+//!   `next = save_en ? b : (saved ? (b_seen ∨ b) : 0)`.
+//! - `bad = looped ∧ ¬b_seen` (the `and` carries [`bad_monitor::BAD_COND_SYMBOL`]).
+//!
+//! A reachable `bad` ⇒ a reachable cycle on which an outstanding request is never
+//! granted ⇒ `AG(a → AF b)` **VIOLATED**; an unreachable `bad` (a portfolio safety
+//! proof) ⇒ **HOLDS**. The construction is **sound** (a `bad` witness is a genuine
+//! `b`-free lasso through a pending request) and **complete** (a real violation has
+//! a suffix cycle on which `pending` stays 1 and `b` never holds, which the
+//! nondeterministic `save` can snapshot).
+
+use crate::adapter::btor2::ast::{Nid, Node};
+use crate::adapter::btor2::bad_monitor::{
+    BAD_COND_SYMBOL, btor2_cmp_keyword, find_or_make_bool_sort, input_nid_and_sort,
+    state_nid_and_sort,
+};
+use crate::adapter::btor2::parser;
+use crate::adapter::btor2::predicate_expr::CmpOp;
+use crate::adapter::{AdapterError, AdapterErrorKind};
+
+fn err(message: String) -> AdapterError {
+    AdapterError {
+        kind: AdapterErrorKind::UnsupportedConstruct,
+        message,
+        location: None,
+    }
+}
+
+/// A BTOR2-text line appender that hands out fresh NIDs above the design's max.
+struct Emit {
+    next: Nid,
+    lines: Vec<String>,
+}
+
+impl Emit {
+    /// Append `"<fresh-nid> <body>"` and return the fresh NID.
+    fn push(&mut self, body: impl AsRef<str>) -> Nid {
+        let nid = self.next;
+        self.next += 1;
+        self.lines.push(format!("{nid} {}", body.as_ref()));
+        nid
+    }
+}
+
+/// Emit the request / grant atom `signal ⋈ value` as a 1-bit node, returning its
+/// NID. `signal` may resolve to a state cell (value-alias / reset-mux aware) or a
+/// primary input.
+fn emit_atom(
+    file: &crate::adapter::btor2::ast::Btor2File,
+    e: &mut Emit,
+    bool_sort: Nid,
+    atom: (&str, CmpOp, u128),
+    reset_pinned: bool,
+    role: &str,
+) -> Result<Nid, AdapterError> {
+    let (signal, op, value) = atom;
+    let (nid, sort) = state_nid_and_sort(file, signal, reset_pinned)
+        .or_else(|| input_nid_and_sort(file, signal))
+        .ok_or_else(|| {
+            err(format!(
+                "adapter/btor2/l2s_monitor: {role} `{signal}` is neither a state cell nor a \
+                 primary input, so the response monitor cannot bind it"
+            ))
+        })?;
+    let cst = e.push(format!("constd {sort} {value}"));
+    Ok(e.push(format!("{} {bool_sort} {nid} {cst}", btor2_cmp_keyword(op))))
+}
+
+/// Append the liveness-to-safety `bad` monitor for `AG(ante → AF cons)` to `content`.
+///
+/// See the module docs for the construction. Returns an error when an atom does not
+/// resolve to a signal.
+pub fn emit_response_l2s_monitor(
+    content: &str,
+    ante: (&str, CmpOp, u128),
+    cons: (&str, CmpOp, u128),
+    reset_pinned: bool,
+) -> Result<String, AdapterError> {
+    let file = parser::parse(content).map_err(|mut e| {
+        e.message = format!("adapter/btor2/l2s_monitor: {}", e.message);
+        e
+    })?;
+
+    // Original state cells (before augmentation): the shadow copies these.
+    let states: Vec<(Nid, Nid)> = file
+        .lines
+        .iter()
+        .filter_map(|l| match &l.node {
+            Node::State { sort, .. } => Some((l.nid, *sort)),
+            _ => None,
+        })
+        .collect();
+
+    let next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut e = Emit {
+        next: next_nid,
+        lines: Vec::new(),
+    };
+    let mut prelude: Vec<String> = Vec::new();
+    let bool_sort = find_or_make_bool_sort(&file, &mut e.next, &mut prelude);
+    e.lines.extend(prelude);
+
+    // Request / grant atoms.
+    let a = emit_atom(&file, &mut e, bool_sort, ante, reset_pinned, "antecedent")?;
+    let b = emit_atom(&file, &mut e, bool_sort, cons, reset_pinned, "consequent")?;
+
+    // A fresh `zero` of the boolean sort for the 1-bit latch inits.
+    let zero1 = e.push(format!("zero {bool_sort}"));
+
+    // pending: next = (pending || a) && !b.
+    let pending = e.push(format!("state {bool_sort} mununu_l2s_pending"));
+    e.push(format!("init {bool_sort} {pending} {zero1}"));
+    let p_or_a = e.push(format!("or {bool_sort} {pending} {a}"));
+    let not_b = e.push(format!("not {bool_sort} {b}"));
+    let next_pending = e.push(format!("and {bool_sort} {p_or_a} {not_b}"));
+    e.push(format!("next {bool_sort} {pending} {next_pending}"));
+
+    // save input + saved latch + save_en = save && !saved && pending.
+    let saved = e.push(format!("state {bool_sort} mununu_l2s_saved"));
+    e.push(format!("init {bool_sort} {saved} {zero1}"));
+    let save_in = e.push(format!("input {bool_sort} mununu_l2s_save"));
+    let not_saved = e.push(format!("not {bool_sort} {saved}"));
+    let save_np = e.push(format!("and {bool_sort} {save_in} {not_saved}"));
+    let save_en = e.push(format!("and {bool_sort} {save_np} {pending}"));
+    let next_saved = e.push(format!("or {bool_sort} {saved} {save_en}"));
+    e.push(format!("next {bool_sort} {saved} {next_saved}"));
+
+    // Shadow copy of each original state cell + per-cell equality.
+    let mut eq_terms: Vec<Nid> = Vec::new();
+    for (s_nid, s_sort) in &states {
+        let sh = e.push(format!("state {s_sort} mununu_l2s_sh_{s_nid}"));
+        // next(sh) = ite(save_en, s, sh); no init — free, only read after a save.
+        let nx = e.push(format!("ite {s_sort} {save_en} {s_nid} {sh}"));
+        e.push(format!("next {s_sort} {sh} {nx}"));
+        eq_terms.push(e.push(format!("eq {bool_sort} {s_nid} {sh}")));
+    }
+    // all_eq = ⋀ eq_terms; the empty conjunction (stateless design) is `one`.
+    let all_eq = if let Some((&first, rest)) = eq_terms.split_first() {
+        rest.iter().fold(first, |acc, &t| {
+            e.push(format!("and {bool_sort} {acc} {t}"))
+        })
+    } else {
+        e.push(format!("one {bool_sort}"))
+    };
+    let looped = e.push(format!("and {bool_sort} {saved} {all_eq}"));
+
+    // b_seen: next = ite(save_en, b, ite(saved, b_seen || b, 0)).
+    let b_seen = e.push(format!("state {bool_sort} mununu_l2s_bseen"));
+    e.push(format!("init {bool_sort} {b_seen} {zero1}"));
+    let bseen_or_b = e.push(format!("or {bool_sort} {b_seen} {b}"));
+    let inner = e.push(format!("ite {bool_sort} {saved} {bseen_or_b} {zero1}"));
+    let next_bseen = e.push(format!("ite {bool_sort} {save_en} {b} {inner}"));
+    e.push(format!("next {bool_sort} {b_seen} {next_bseen}"));
+
+    // bad = looped && !b_seen — a b-free closed loop carrying a pending request.
+    let not_bseen = e.push(format!("not {bool_sort} {b_seen}"));
+    let bad_cond = e.push(format!(
+        "and {bool_sort} {looped} {not_bseen} {BAD_COND_SYMBOL}"
+    ));
+    e.push(format!("bad {bad_cond}"));
+
+    Ok(format!("{}\n{}\n", content.trim_end(), e.lines.join("\n")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A 2-state request/grant FSM: `st` 0=idle, 1=busy. Input `req` drives idle→busy;
+    // busy→idle unconditionally, asserting `grant` (grant = st==1). `req` pending in
+    // idle is always granted next cycle ⇒ AG(req→AF grant) HOLDS.
+    const RESPONDER: &str = "\
+1 sort bitvec 1
+2 state 1 st
+3 zero 1
+4 init 1 2 3
+5 input 1 req
+6 one 1
+7 ite 1 2 3 5
+8 next 1 2 7
+";
+
+    #[test]
+    fn emitted_monitor_parses_and_has_bad_and_latches() {
+        // req atom = (st == 0) proxy via input `req`; grant = (st == 1).
+        let out = emit_response_l2s_monitor(
+            RESPONDER,
+            ("req", CmpOp::Eq, 1),
+            ("st", CmpOp::Eq, 1),
+            false,
+        )
+        .expect("emit");
+        let file = parser::parse(&out).expect("emitted BTOR2 re-parses");
+        // The monitor added the l2s latches + a bad line.
+        assert!(out.contains("mununu_l2s_pending"), "pending latch present");
+        assert!(out.contains("mununu_l2s_saved"), "saved latch present");
+        assert!(out.contains("mununu_l2s_save"), "save input present");
+        assert!(out.contains("mununu_l2s_bseen"), "b_seen latch present");
+        assert!(
+            out.contains("mununu_l2s_sh_2"),
+            "shadow of state cell 2 present"
+        );
+        assert!(
+            file.lines
+                .iter()
+                .any(|l| matches!(l.node, Node::Bad { .. })),
+            "a bad line is present"
+        );
+    }
+
+    #[test]
+    fn unresolvable_atom_errors() {
+        let e = emit_response_l2s_monitor(
+            RESPONDER,
+            ("nonexistent", CmpOp::Eq, 1),
+            ("st", CmpOp::Eq, 1),
+            false,
+        );
+        assert!(e.is_err(), "an atom that binds no signal must error");
+    }
+}

--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -28,6 +28,7 @@ pub mod concrete_oracle;
 pub mod dep_graph;
 pub mod emit;
 pub mod kmts_lift;
+pub mod l2s_monitor;
 pub mod native_bmc;
 pub mod native_spacer;
 pub mod parser;

--- a/crates/mununu-core/src/adapter/liveness_rescue.rs
+++ b/crates/mununu-core/src/adapter/liveness_rescue.rs
@@ -1,0 +1,383 @@
+//! P2 liveness-to-safety — reduce the **response** liveness property
+//! `AG(a → AF b)` to a BTOR2 `bad` monitor and decide it with the reachability
+//! portfolio at scale.
+//!
+//! # The property and why it reduces
+//!
+//! `AG(a → AF b)` — "whenever `a` holds, `b` is eventually reached on *every*
+//! path" — is the canonical request/response (request/grant) liveness property.
+//! In the modal-μ calculus it is
+//!
+//! ```text
+//!   ν Z. ((¬a ∨ μ Y. (b ∨ [] Y)) ∧ [] Z)
+//! ```
+//!
+//! a νμ alternation (`PropertyClass::Liveness`). The **exact** 3-valued KMTS engine
+//! decides it directly but only within its enumeration cap; this module reduces it
+//! to a single `bad`-reachability query the scalable portfolio (native ⊕ spacer ⊕
+//! btormc ⊕ Pono) decides symbolically on wide designs, and the exact engine
+//! cross-checks the small cases.
+//!
+//! # Liveness-to-safety (Biere–Artho–Schuppan)
+//!
+//! `AG(a → AF b)` **fails** iff the design has a *reachable* infinite path on which
+//! some `a` is never followed by `b` — equivalently, a **reachable lasso** (a
+//! reachable cycle) that contains a state where `a` holds and contains **no** state
+//! where `b` holds (on the cycle the outstanding request is never granted). The l2s
+//! construction ([`crate::adapter::btor2::l2s_monitor::emit_response_l2s_monitor`])
+//! makes "a reachable `b`-free cycle containing an `a`" a `bad` state via a
+//! nondeterministically-snapshotted shadow copy of the state, so:
+//!
+//! - `bad` **reachable** ⇒ such a lasso exists ⇒ `AG(a → AF b)` **VIOLATED**;
+//! - `bad` **unreachable** (a portfolio safety proof) ⇒ no such lasso ⇒ **HOLDS**.
+//!
+//! # A note on `F` in mununu's LTL front-end
+//!
+//! mununu's LTL translator lowers `G(a → F b)` with the **diamond** reading of `F`
+//! (`μ Y. (b ∨ <> Y)` = `EF`), giving `AG(a → EF b)` — the weaker *recoverability*
+//! response ("`b` is reachable"), a νμ property that does **not** collapse to a
+//! single safety query. This module targets the **box** reading `AF b`
+//! (`μ Y. (b ∨ [] Y)` — "`b` on every path"), the true "always eventually granted"
+//! liveness that l2s reduces. Author the property as the μ-calculus formula above
+//! (box recursion in the inner `μ`), not via the LTL `F`.
+//!
+//! # Conservative by construction (soundness-critical)
+//!
+//! [`reduce_response_af`] returns `Some` ONLY for the exact single-atom shape above
+//! with **unconstrained** boxes and both `a`, `b` single register-comparison atoms.
+//! Every other shape returns `None` — a sound abstention (the caller leaves the
+//! property to the exact engine), never a mis-reduction.
+//!
+//! # Status — validated reduction, wiring is the next slice (2026-07-08)
+//!
+//! [`response_liveness_rescue`] is proven correct end-to-end by the differential
+//! tests below: on both a responder (HOLDS) and a staller (VIOLATED) the
+//! l2s → portfolio verdict **matches** the exact 3-valued engine
+//! ([`crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict`]) — the
+//! roadmap's "every reduced verdict is cross-checked by the exact engine". Routing
+//! `verify_auto` to try this reduction when a liveness property escapes the exact
+//! engine's enumeration cap (and the CLI/API/UI surface for it) is the next P2 slice,
+//! mirroring how [`crate::adapter::reach_rescue`]'s reduction primitive landed and was
+//! validated before any surface wiring.
+
+use crate::adapter::btor2::l2s_monitor::emit_response_l2s_monitor;
+use crate::adapter::btor2::parser;
+use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr, parse_predicate_expr};
+use crate::adapter::reach_portfolio::{ReachOutcome, ReachVerdict, decide_reach_portfolio};
+use crate::mu_calculus::{Formula, FormulaVarId, Guard, ModalKind, Node, NodeId};
+
+/// A single register-comparison atom `signal ⋈ value` (the `a` / `b` of the
+/// response property).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Atom {
+    /// The register (or input) the atom compares.
+    pub signal: String,
+    /// The comparison operator.
+    pub op: CmpOp,
+    /// The literal right-hand side.
+    pub value: u128,
+}
+
+/// A reducible response-liveness property `AG(a → AF b)` over two single atoms.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResponseAf {
+    /// The antecedent `a` — the request.
+    pub ante: Atom,
+    /// The consequent `b` — the grant that must eventually follow on every path.
+    pub cons: Atom,
+}
+
+/// Conservatively classify `formula` as the response-liveness shape
+/// `ν Z. ((¬a ∨ μ Y. (b ∨ [] Y)) ∧ [] Z)` with single-atom `a`, `b`. Returns
+/// `None` for every other shape (see the module docs) so the reduction never
+/// mis-reduces a property it does not fully recognise.
+pub fn reduce_response_af(formula: &Formula) -> Option<ResponseAf> {
+    // Root must be `ν Z. BODY` (the outer `AG`).
+    let Node::Nu { var: z, body } = formula.node(formula.root()) else {
+        return None;
+    };
+    // BODY = `core ∧ [] Z`.
+    let Node::And(l, r) = formula.node(*body) else {
+        return None;
+    };
+    let (core_id, _boxz_id) = split_and_box_to_var(formula, *l, *r, *z)?;
+    // core = `¬a ∨ (μ Y. (b ∨ [] Y))`.
+    let Node::Or(cl, cr) = formula.node(core_id) else {
+        return None;
+    };
+    let (neg_ante_id, af_id) = classify_or_notpred_mu(formula, *cl, *cr)?;
+    // ¬a = `Not(Predicate(a))`.
+    let Node::Not(a_pred_id) = formula.node(neg_ante_id) else {
+        return None;
+    };
+    let ante = predicate_atom(formula, *a_pred_id)?;
+    // AF b = `μ Y. (b ∨ [] Y)`.
+    let Node::Mu {
+        var: y,
+        body: mbody,
+    } = formula.node(af_id)
+    else {
+        return None;
+    };
+    let Node::Or(ml, mr) = formula.node(*mbody) else {
+        return None;
+    };
+    let (cons_id, _boxy_id) = split_and_box_to_var(formula, *ml, *mr, *y)?;
+    let cons = predicate_atom(formula, cons_id)?;
+    Some(ResponseAf { ante, cons })
+}
+
+/// Return `(other, box_to_var)` iff exactly one of `l` / `r` is an unconstrained
+/// `[] var` box and the other is not — the unambiguous "`X ∧ [] var`" /
+/// "`X ∨ [] var`" split. `None` if neither or both look like the box recursion.
+fn split_and_box_to_var(
+    formula: &Formula,
+    l: NodeId,
+    r: NodeId,
+    var: FormulaVarId,
+) -> Option<(NodeId, NodeId)> {
+    match (
+        is_unconstrained_box_to_var(formula, l, var),
+        is_unconstrained_box_to_var(formula, r, var),
+    ) {
+        (true, false) => Some((r, l)),
+        (false, true) => Some((l, r)),
+        _ => None,
+    }
+}
+
+/// Return `(not_pred, mu)` iff exactly one of `l` / `r` is a `Not` node and the
+/// other is a `Mu` fixpoint — the `¬a ∨ AF b` split. `None` otherwise.
+fn classify_or_notpred_mu(formula: &Formula, l: NodeId, r: NodeId) -> Option<(NodeId, NodeId)> {
+    let is_not = |id: NodeId| matches!(formula.node(id), Node::Not(_));
+    let is_mu = |id: NodeId| matches!(formula.node(id), Node::Mu { .. });
+    match (is_not(l) && is_mu(r), is_not(r) && is_mu(l)) {
+        (true, false) => Some((l, r)),
+        (false, true) => Some((r, l)),
+        _ => None,
+    }
+}
+
+/// A `[] var` box whose target is exactly `var` and whose guard is unconstrained
+/// (a guarded box is a stronger property than the monitor checks).
+fn is_unconstrained_box_to_var(formula: &Formula, id: NodeId, var: FormulaVarId) -> bool {
+    matches!(
+        formula.node(id),
+        Node::Modal { kind: ModalKind::Box, guard, target }
+            if *guard == Guard::default()
+                && matches!(formula.node(*target), Node::Variable(v) if *v == var)
+    )
+}
+
+/// Parse a `Predicate` node as a single register-comparison atom. `None` for a
+/// relational (`reg ⋈ reg`), compound, or unparseable atom.
+fn predicate_atom(formula: &Formula, id: NodeId) -> Option<Atom> {
+    let Node::Predicate(atom) = formula.node(id) else {
+        return None;
+    };
+    match parse_predicate_expr(atom) {
+        Ok(PredicateExpr::Cmp {
+            register,
+            op,
+            value,
+        }) => Some(Atom {
+            signal: register,
+            op,
+            value: value as u128,
+        }),
+        _ => None,
+    }
+}
+
+/// The response-liveness verdict, from the reachability portfolio's verdict on the
+/// l2s `bad` monitor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LivenessVerdict {
+    /// `bad` proven unreachable ⇒ no `b`-free request-pending lasso ⇒ the response
+    /// property holds.
+    Holds,
+    /// `bad` reachable ⇒ a reachable lasso leaves a request forever ungranted.
+    Violated,
+    /// Undecided by every portfolio member, or a soundness contradiction alarm —
+    /// never a silently-picked side.
+    Inconclusive,
+}
+
+/// Reduce a response-liveness property `AG(a → AF b)` to an l2s `bad` monitor over
+/// `design_btor2` and decide it with the reachability portfolio.
+///
+/// Returns `None` when the property is not the reducible response shape (the caller
+/// leaves it to the exact engine) or the monitor cannot be built (an atom binds no
+/// signal). `design_btor2` MUST be the same reset/config-pinned BTOR2 the exact
+/// engine reasoned over, so the reachable-state set matches; `reset_pinned` mirrors
+/// that reset-gating so the atoms resolve through the async-reset mux consistently.
+///
+/// On `Some`, the second component is the raw [`ReachOutcome`] (which engines decided
+/// each side) for diagnostics / a witness note.
+pub fn response_liveness_rescue(
+    design_btor2: &str,
+    formula: &Formula,
+    reset_pinned: bool,
+) -> Option<(LivenessVerdict, ReachOutcome)> {
+    let r = reduce_response_af(formula)?;
+    let monitored = emit_response_l2s_monitor(
+        design_btor2,
+        (&r.ante.signal, r.ante.op, r.ante.value),
+        (&r.cons.signal, r.cons.op, r.cons.value),
+        reset_pinned,
+    )
+    .ok()?;
+    let file = parser::parse(&monitored).ok()?;
+    let outcome = decide_reach_portfolio(&file);
+    let verdict = match outcome.verdict {
+        ReachVerdict::Unreachable => LivenessVerdict::Holds,
+        ReachVerdict::Reachable => LivenessVerdict::Violated,
+        ReachVerdict::Unknown | ReachVerdict::Contradiction => LivenessVerdict::Inconclusive,
+    };
+    Some((verdict, outcome))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mu_calculus::parser as mu_parser;
+
+    fn parse(s: &str) -> Formula {
+        mu_parser::parse(s).unwrap_or_else(|e| panic!("parse `{s}`: {e:?}"))
+    }
+
+    // The canonical response shape, both atom orders inside the inner Or.
+    #[test]
+    fn reduces_response_af() {
+        let f = parse("nu Z. ((!(req == 1) || mu Y. ((grant == 1) || [] Y)) && [] Z)");
+        let r = reduce_response_af(&f).expect("reducible");
+        assert_eq!(r.ante.signal, "req");
+        assert_eq!(r.ante.op, CmpOp::Eq);
+        assert_eq!(r.ante.value, 1);
+        assert_eq!(r.cons.signal, "grant");
+        assert_eq!(r.cons.op, CmpOp::Eq);
+        assert_eq!(r.cons.value, 1);
+    }
+
+    // Order independence: `[] Z && core`, `[] Y || b`, `AF b || !a`.
+    #[test]
+    fn reduces_response_af_reordered() {
+        let f = parse("nu Z. (([] Z) && ((mu Y. (([] Y) || (b != 0))) || !(a == 3)))");
+        let r = reduce_response_af(&f).expect("reducible under reordering");
+        assert_eq!(r.ante.signal, "a");
+        assert_eq!(r.ante.value, 3);
+        assert_eq!(r.cons.signal, "b");
+        assert_eq!(r.cons.op, CmpOp::Ne);
+    }
+
+    // The DIAMOND response (mununu's LTL `G(a->F b)` = AG(a->EF b)) is NOT this
+    // shape — the inner recursion is `<> Y`, not `[] Y`. Must abstain.
+    #[test]
+    fn rejects_diamond_ef_response() {
+        let f = parse("nu Z. ((!(req == 1) || mu Y. ((grant == 1) || <> Y)) && [] Z)");
+        assert!(reduce_response_af(&f).is_none());
+    }
+
+    // A bare AG invariant (no inner Mu) is not a response.
+    #[test]
+    fn rejects_ag_invariant() {
+        let f = parse("nu Z. ((cnt == 3) && [] Z)");
+        assert!(reduce_response_af(&f).is_none());
+    }
+
+    // A guarded outer box is a stronger property than the monitor checks.
+    #[test]
+    fn rejects_guarded_box() {
+        let f = parse(
+            "nu Z. ((!(req == 1) || mu Y. ((grant == 1) || [] Y)) && [(ctrl = controllable)] Z)",
+        );
+        assert!(reduce_response_af(&f).is_none());
+    }
+
+    // A relational consequent (`reg ⋈ reg`) is not a single literal atom.
+    #[test]
+    fn rejects_relational_atom() {
+        let f = parse("nu Z. ((!(req == 1) || mu Y. ((x == y) || [] Y)) && [] Z)");
+        assert!(reduce_response_af(&f).is_none());
+    }
+
+    // --- Differential correctness: l2s + portfolio vs the exact 3-valued engine ---
+    //
+    // Both atoms are STATE predicates (`st == k`) so the state-based exact engine can
+    // serve as the ground-truth oracle. `go` is a free input (nondeterministic
+    // idle→req choice) — allowed; it is not an atom.
+
+    // 3-state responder: st 0=idle, 1=req, 2=grant. idle -go-> req; req -> grant
+    // (deterministic); grant -> idle. AG((st==1) → AF (st==2)) HOLDS.
+    const RESPONDER: &str = "\
+1 sort bitvec 2
+2 sort bitvec 1
+3 state 1 st
+4 zero 1
+5 init 1 3 4
+6 input 2 go
+7 one 1
+8 constd 1 2
+9 eq 2 3 4
+10 eq 2 3 7
+11 ite 1 6 7 4
+12 ite 1 10 8 4
+13 ite 1 9 11 12
+14 next 1 3 13
+";
+
+    // 4-state staller: st 0=idle, 1=req, 3=stuck; 2=grant is UNREACHABLE. idle -go->
+    // req; req -> stuck; stuck -> stuck. AG((st==1) → AF (st==2)) VIOLATED — a req
+    // enters the stuck cycle and grant never comes.
+    const STALLER: &str = "\
+1 sort bitvec 2
+2 sort bitvec 1
+3 state 1 st
+4 zero 1
+5 init 1 3 4
+6 input 2 go
+7 one 1
+8 constd 1 2
+9 constd 1 3
+10 eq 2 3 4
+11 eq 2 3 7
+12 ite 1 6 7 4
+13 ite 1 11 9 3
+14 ite 1 10 12 13
+15 next 1 3 14
+";
+
+    fn response_formula() -> Formula {
+        parse("nu Z. ((!(st == 1) || mu Y. ((st == 2) || [] Y)) && [] Z)")
+    }
+
+    #[test]
+    fn l2s_holds_matches_exact_on_responder() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        let f = response_formula();
+        // Exact 3-valued engine — the ground-truth oracle.
+        let exact = exact_symbolic_verdict(RESPONDER, &f).expect("exact decides");
+        assert_eq!(
+            exact,
+            ExactVerdict::Holds,
+            "responder: AG(req→AF grant) holds"
+        );
+        // l2s → portfolio must agree.
+        let (v, out) = response_liveness_rescue(RESPONDER, &f, false).expect("reducible");
+        assert_eq!(v, LivenessVerdict::Holds, "l2s outcome: {out:?}");
+    }
+
+    #[test]
+    fn l2s_violated_matches_exact_on_staller() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        let f = response_formula();
+        let exact = exact_symbolic_verdict(STALLER, &f).expect("exact decides");
+        assert_eq!(
+            exact,
+            ExactVerdict::Violated,
+            "staller: AG(req→AF grant) violated"
+        );
+        let (v, out) = response_liveness_rescue(STALLER, &f, false).expect("reducible");
+        assert_eq!(v, LivenessVerdict::Violated, "l2s outcome: {out:?}");
+    }
+}

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -48,6 +48,7 @@ pub mod emit;
 pub mod extraction;
 pub mod ir;
 pub mod langgraph;
+pub mod liveness_rescue;
 pub mod microcode;
 pub mod partition;
 pub mod pono;


### PR DESCRIPTION
## Summary

First slice of the **P2 reduction layer** (branching-time verification at scale). Reduces the canonical request/response liveness property

```
AG(a → AF b)  =  ν Z. ((¬a ∨ μ Y. (b ∨ [] Y)) ∧ [] Z)
```

to a **single `bad`-reachability query** the scalable portfolio (native ⊕ spacer ⊕ btormc ⊕ Pono) decides symbolically on wide designs — where the exact 3-valued engine's enumeration would blow up — and cross-checks against the exact engine on small models.

## Pieces

- **classifier** `reduce_response_af` (`adapter/liveness_rescue`): conservatively matches the single-atom box/AF shape; abstains (`None`) on everything else — including the **diamond** response mununu's LTL `G(a → F b)` produces (`AG(a → EF b)`, a *nested* recoverability property that does **not** collapse to one query), guarded boxes, and relational atoms.
- **l2s emitter** `emit_response_l2s_monitor` (`adapter/btor2/l2s_monitor`): the Biere–Artho–Schuppan construction — a `pending` latch (set by `a`, cleared by `b`), a nondeterministic at-most-once `save` snapshotting a **shadow copy of every state cell**, loop-close detection, and `b_seen`; `bad = looped ∧ ¬b_seen` (a reachable `b`-free cycle carrying an outstanding request). Sound + complete (reasoned in the module docs).
- **wiring** `response_liveness_rescue`: reduce → emit → `decide_reach_portfolio` → map (`Unreachable = Holds`, `Reachable = Violated`).

## Differential validation (the soundness gate)

On a state-only **responder** (HOLDS) and **staller** (VIOLATED), the l2s + portfolio verdict **matches `exact_symbolic_verdict`** on **both polarities** — the roadmap's *"every reduced verdict is cross-checked by the exact engine."* 10 new tests (classifier shape/abstention + emitter structure + the two differentials); full `make ci` green (2155 lib tests, 0 failed).

## Status / next slice

Validated reduction **primitive** — `pub` but not yet routed to a user surface, mirroring how `reach_rescue`'s primitive landed and was validated before wiring. The next P2 slice routes `verify_auto` to try this reduction when a liveness property escapes the exact engine's cap, with the CLI/API/UI surface.

Exposes 4 `bad_monitor` BTOR2 helpers as `pub(crate)` for reuse (`btor2_cmp_keyword`, `find_or_make_bool_sort`, `state`/`input_nid_and_sort`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)