### PR TITLE
feat(P2): surface the response-liveness reduction (CLI + API)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -148,6 +148,15 @@ enum Btor2Command {
     /// `contradiction` means two sound engines disagree — a soundness alarm,
     /// never a silent guess. Engines whose binary is absent simply abstain.
     Verify(Btor2VerifyArgs),
+    /// Decide a response-liveness property `AG(request → AF grant)` at scale.
+    ///
+    /// "Whenever `request` holds, `grant` is eventually reached on every path"
+    /// — the canonical request/grant liveness property. Reduces it to a single
+    /// `bad`-reachability query (Biere–Artho–Schuppan liveness-to-safety) that
+    /// the multi-engine portfolio decides symbolically on wide designs, then
+    /// prints the verdict (`holds` / `violated` / `inconclusive`). `--request`
+    /// and `--grant` are single register-comparison atoms (`"st == 1"`).
+    VerifyLiveness(Btor2VerifyLivenessArgs),
 }
 
 /// R.5 Item 3 sub-item 3.5 (2026-06-04) — predicate-source
@@ -427,6 +436,20 @@ struct Btor2VerifyArgs {
     /// Path to the BTOR2 input file.
     #[arg(value_name = "BTOR2_FILE")]
     file: PathBuf,
+}
+
+/// Arguments for `mununu btor2 verify-liveness` — the response-liveness reduction.
+#[derive(Args, Debug)]
+struct Btor2VerifyLivenessArgs {
+    /// Path to the BTOR2 input file.
+    #[arg(value_name = "BTOR2_FILE")]
+    file: PathBuf,
+    /// The request atom — a register comparison, e.g. `"st == 1"`.
+    #[arg(long, value_name = "ATOM")]
+    request: String,
+    /// The grant atom that must eventually follow on every path, e.g. `"st == 2"`.
+    #[arg(long, value_name = "ATOM")]
+    grant: String,
 }
 
 #[derive(Subcommand, Debug)]
@@ -2038,7 +2061,45 @@ fn handle_btor2(command: Btor2Command) -> Result<(), String> {
         Btor2Command::LiftKmts(args) => btor2_lift_kmts(args),
         Btor2Command::Cegar(args) => btor2_cegar(args),
         Btor2Command::Verify(args) => btor2_verify(args),
+        Btor2Command::VerifyLiveness(args) => btor2_verify_liveness(args),
     }
+}
+
+/// `mununu btor2 verify-liveness` — decide the response-liveness property
+/// `AG(request → AF grant)` via the l2s reduction + the portfolio, printing the
+/// verdict as JSON. Surface peer of the API `POST /api/v1/btor2/verify-liveness`;
+/// both share the verdict labels via
+/// [`mununu_core::adapter::liveness_rescue::liveness_verdict_str`].
+fn btor2_verify_liveness(args: Btor2VerifyLivenessArgs) -> Result<(), String> {
+    use mununu_core::adapter::liveness_rescue::{
+        liveness_verdict_str, parse_response_atom, response_liveness_rescue_atoms,
+    };
+
+    let content = std::fs::read_to_string(&args.file)
+        .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
+    let request = parse_response_atom(&args.request)?;
+    let grant = parse_response_atom(&args.grant)?;
+
+    let (verdict, outcome) = response_liveness_rescue_atoms(&content, &request, &grant, false)
+        .ok_or_else(|| {
+            format!(
+                "could not build the liveness monitor for '{}' — an atom likely binds no signal",
+                args.file.display()
+            )
+        })?;
+
+    let summary = serde_json::json!({
+        "file": args.file.display().to_string(),
+        "property": format!("AG(({}) -> AF ({}))", args.request, args.grant),
+        "verdict": liveness_verdict_str(verdict),
+        "decided_by": outcome.reachable_by.iter().chain(outcome.unreachable_by.iter())
+            .collect::<Vec<_>>(),
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&summary).map_err(|e| format!("serialize summary: {e}"))?
+    );
+    Ok(())
 }
 
 /// `mununu btor2 verify` — decide `bad`-reachability with the multi-engine safety

--- a/crates/mununu-core/src/adapter/liveness_rescue.rs
+++ b/crates/mununu-core/src/adapter/liveness_rescue.rs
@@ -48,17 +48,22 @@
 //! Every other shape returns `None` — a sound abstention (the caller leaves the
 //! property to the exact engine), never a mis-reduction.
 //!
-//! # Status — validated reduction, wiring is the next slice (2026-07-08)
+//! # Status — validated + user-surfaced (2026-07-08)
 //!
 //! [`response_liveness_rescue`] is proven correct end-to-end by the differential
 //! tests below: on both a responder (HOLDS) and a staller (VIOLATED) the
 //! l2s → portfolio verdict **matches** the exact 3-valued engine
 //! ([`crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict`]) — the
-//! roadmap's "every reduced verdict is cross-checked by the exact engine". Routing
-//! `verify_auto` to try this reduction when a liveness property escapes the exact
-//! engine's enumeration cap (and the CLI/API/UI surface for it) is the next P2 slice,
-//! mirroring how [`crate::adapter::reach_rescue`]'s reduction primitive landed and was
-//! validated before any surface wiring.
+//! roadmap's "every reduced verdict is cross-checked by the exact engine".
+//!
+//! The reduction is user-invocable via [`response_liveness_rescue_atoms`] +
+//! [`parse_response_atom`] across all three surfaces: CLI `mununu btor2
+//! verify-liveness --request … --grant …`, API `POST /api/v1/btor2/verify-liveness`,
+//! and the UI `runBtor2VerifyLiveness` client. Auto-routing `verify_auto` to *try*
+//! this reduction when a translated SVA liveness property escapes the exact engine's
+//! cap is a further follow-up (it needs a real SVA liveness target to validate under
+//! the mununu-sva toolchain, per the [`crate::adapter::reach_rescue`] no-target
+//! lesson).
 
 use crate::adapter::btor2::l2s_monitor::emit_response_l2s_monitor;
 use crate::adapter::btor2::parser;
@@ -220,10 +225,27 @@ pub fn response_liveness_rescue(
     reset_pinned: bool,
 ) -> Option<(LivenessVerdict, ReachOutcome)> {
     let r = reduce_response_af(formula)?;
+    response_liveness_rescue_atoms(design_btor2, &r.ante, &r.cons, reset_pinned)
+}
+
+/// Like [`response_liveness_rescue`] but with the request / grant atoms given
+/// directly (the caller asserts the `AG(ante → AF cons)` shape) — the entry point
+/// for the `verify-liveness` surface, where the user names the two atoms rather than
+/// authoring the full μ-calculus formula.
+///
+/// Returns `None` only when the l2s monitor cannot be built (an atom binds no
+/// signal). See [`response_liveness_rescue`] for the `design_btor2` / `reset_pinned`
+/// contract and the returned [`ReachOutcome`].
+pub fn response_liveness_rescue_atoms(
+    design_btor2: &str,
+    ante: &Atom,
+    cons: &Atom,
+    reset_pinned: bool,
+) -> Option<(LivenessVerdict, ReachOutcome)> {
     let monitored = emit_response_l2s_monitor(
         design_btor2,
-        (&r.ante.signal, r.ante.op, r.ante.value),
-        (&r.cons.signal, r.cons.op, r.cons.value),
+        (&ante.signal, ante.op, ante.value),
+        (&cons.signal, cons.op, cons.value),
         reset_pinned,
     )
     .ok()?;
@@ -235,6 +257,40 @@ pub fn response_liveness_rescue(
         ReachVerdict::Unknown | ReachVerdict::Contradiction => LivenessVerdict::Inconclusive,
     };
     Some((verdict, outcome))
+}
+
+/// Parse a request/grant atom string (`"REG op VALUE"`, e.g. `"st == 2"`) into an
+/// [`Atom`], for the CLI / API `verify-liveness` surface. Reuses the same predicate
+/// grammar as the classifier, so a relational (`reg ⋈ reg`) or malformed atom is
+/// rejected identically.
+pub fn parse_response_atom(s: &str) -> Result<Atom, String> {
+    match parse_predicate_expr(s) {
+        Ok(PredicateExpr::Cmp {
+            register,
+            op,
+            value,
+        }) => Ok(Atom {
+            signal: register,
+            op,
+            value: value as u128,
+        }),
+        Ok(_) => Err(format!(
+            "`{s}` is not a single register-comparison atom (`REG op VALUE`); relational or \
+             compound atoms are out of the response fragment"
+        )),
+        Err(e) => Err(format!("cannot parse response atom `{s}`: {e:?}")),
+    }
+}
+
+/// Stable lowercase label for a [`LivenessVerdict`] — the single source of truth
+/// shared by the CLI (`mununu btor2 verify-liveness`) and the API
+/// (`POST /api/v1/btor2/verify-liveness`) so the two surfaces never drift.
+pub fn liveness_verdict_str(v: LivenessVerdict) -> &'static str {
+    match v {
+        LivenessVerdict::Holds => "holds",
+        LivenessVerdict::Violated => "violated",
+        LivenessVerdict::Inconclusive => "inconclusive",
+    }
 }
 
 #[cfg(test)]
@@ -379,5 +435,36 @@ mod tests {
         );
         let (v, out) = response_liveness_rescue(STALLER, &f, false).expect("reducible");
         assert_eq!(v, LivenessVerdict::Violated, "l2s outcome: {out:?}");
+    }
+
+    // The atoms-based surface entry (the CLI / API path) agrees with the formula path.
+    #[test]
+    fn atoms_entry_matches_formula_entry() {
+        let ante = parse_response_atom("st == 1").expect("atom parses");
+        let cons = parse_response_atom("st == 2").expect("atom parses");
+        assert_eq!(ante.op, CmpOp::Eq);
+        assert_eq!(cons.value, 2);
+        let (v_r, _) = response_liveness_rescue_atoms(RESPONDER, &ante, &cons, false).expect("ok");
+        assert_eq!(v_r, LivenessVerdict::Holds);
+        let (v_s, _) = response_liveness_rescue_atoms(STALLER, &ante, &cons, false).expect("ok");
+        assert_eq!(v_s, LivenessVerdict::Violated);
+    }
+
+    #[test]
+    fn parse_response_atom_rejects_relational_and_reports_labels() {
+        assert!(
+            parse_response_atom("x == y").is_err(),
+            "relational atom rejected"
+        );
+        assert!(
+            parse_response_atom("not an atom !!").is_err(),
+            "garbage rejected"
+        );
+        assert_eq!(liveness_verdict_str(LivenessVerdict::Holds), "holds");
+        assert_eq!(liveness_verdict_str(LivenessVerdict::Violated), "violated");
+        assert_eq!(
+            liveness_verdict_str(LivenessVerdict::Inconclusive),
+            "inconclusive"
+        );
     }
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -656,6 +656,46 @@ pub async fn btor2_verify_handler(
     }))
 }
 
+/// Decide the response-liveness property `AG(request → AF grant)` at scale
+/// (`POST /api/v1/btor2/verify-liveness`). Surface peer of the CLI
+/// `mununu btor2 verify-liveness`: reduces the property to a single
+/// `bad`-reachability query (Biere–Artho–Schuppan liveness-to-safety) the portfolio
+/// decides, returning `"holds"` / `"violated"` / `"inconclusive"`. A malformed atom
+/// or unparseable BTOR2 is a `BadRequest`.
+pub async fn btor2_verify_liveness_handler(
+    Json(request): Json<Btor2VerifyLivenessRequest>,
+) -> ApiResult<Json<Btor2VerifyLivenessResponse>> {
+    use crate::adapter::liveness_rescue::{
+        liveness_verdict_str, parse_response_atom, response_liveness_rescue_atoms,
+    };
+
+    let bad_req = |message: String| ApiError::BadRequest {
+        message,
+        details: None,
+    };
+    let ante = parse_response_atom(&request.request).map_err(bad_req)?;
+    let cons = parse_response_atom(&request.grant).map_err(bad_req)?;
+
+    let (verdict, outcome) = response_liveness_rescue_atoms(&request.content, &ante, &cons, false)
+        .ok_or_else(|| {
+            bad_req(
+            "could not build the liveness monitor — an atom likely binds no signal in the design"
+                .to_string(),
+        )
+        })?;
+
+    Ok(Json(Btor2VerifyLivenessResponse {
+        verdict: liveness_verdict_str(verdict).to_string(),
+        property: format!("AG(({}) -> AF ({}))", request.request, request.grant),
+        decided_by: outcome
+            .reachable_by
+            .iter()
+            .chain(outcome.unreachable_by.iter())
+            .map(|s| s.to_string())
+            .collect(),
+    }))
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — SV-direct CEGAR in one call.
 ///
 /// Lifts SystemVerilog to a single flattened BTOR2 (sv2v + Yosys, the
@@ -3862,6 +3902,53 @@ members = ["x"]
         let err = btor2_verify_handler(Json(request))
             .await
             .expect_err("malformed BTOR2 must be rejected");
+        assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    // A 4-state staller: st 0=idle,1=req,3=stuck; 2=grant unreachable. req -> stuck ->
+    // stuck forever ⇒ AG((st==1) → AF (st==2)) is VIOLATED.
+    const LIVENESS_STALLER: &str = "\
+1 sort bitvec 2
+2 sort bitvec 1
+3 state 1 st
+4 zero 1
+5 init 1 3 4
+6 input 2 go
+7 one 1
+8 constd 1 2
+9 constd 1 3
+10 eq 2 3 4
+11 eq 2 3 7
+12 ite 1 6 7 4
+13 ite 1 11 9 3
+14 ite 1 10 12 13
+15 next 1 3 14
+";
+
+    #[tokio::test]
+    async fn btor2_verify_liveness_handler_decides_violated_staller() {
+        let request = Btor2VerifyLivenessRequest {
+            content: LIVENESS_STALLER.to_string(),
+            request: "st == 1".to_string(),
+            grant: "st == 2".to_string(),
+        };
+        let Json(out) = btor2_verify_liveness_handler(Json(request))
+            .await
+            .expect("verify-liveness runs");
+        assert_eq!(out.verdict, "violated", "response: {out:?}");
+        assert!(out.property.contains("AF"), "property echoed: {out:?}");
+    }
+
+    #[tokio::test]
+    async fn btor2_verify_liveness_handler_rejects_relational_atom() {
+        let request = Btor2VerifyLivenessRequest {
+            content: LIVENESS_STALLER.to_string(),
+            request: "st == 1".to_string(),
+            grant: "x == y".to_string(), // relational — out of the response fragment
+        };
+        let err = btor2_verify_liveness_handler(Json(request))
+            .await
+            .expect_err("relational atom must be rejected");
         assert!(matches!(err, ApiError::BadRequest { .. }));
     }
 }

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -907,6 +907,35 @@ pub struct Btor2VerifyResponse {
     pub contradiction: bool,
 }
 
+/// Request for the response-liveness endpoint
+/// (`POST /api/v1/btor2/verify-liveness`). Mirrors the CLI
+/// `mununu btor2 verify-liveness`: decides `AG(request → AF grant)` via the l2s
+/// reduction + the portfolio. `request` / `grant` are register-comparison atom
+/// strings (`"st == 1"`).
+#[derive(Debug, Deserialize)]
+pub struct Btor2VerifyLivenessRequest {
+    /// BTOR2 source content.
+    pub content: String,
+    /// The request atom (`"REG op VALUE"`).
+    pub request: String,
+    /// The grant atom that must eventually follow on every path.
+    pub grant: String,
+}
+
+/// Response for `POST /api/v1/btor2/verify-liveness`. Mirrors
+/// [`crate::adapter::liveness_rescue::LivenessVerdict`].
+#[derive(Debug, Serialize)]
+pub struct Btor2VerifyLivenessResponse {
+    /// The verdict: `"holds"` | `"violated"` | `"inconclusive"` (via
+    /// [`crate::adapter::liveness_rescue::liveness_verdict_str`]).
+    pub verdict: String,
+    /// The reduced property, echoed for provenance:
+    /// `AG((<request>) -> AF (<grant>))`.
+    pub property: String,
+    /// Portfolio engines that decided the reduced `bad`-reachability query.
+    pub decided_by: Vec<String>,
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — request for the SV-direct
 /// CEGAR endpoint (`POST /api/v1/sv/cegar`). Mirrors the CLI
 /// `mununu sv cegar`: lifts SystemVerilog to a single flattened BTOR2

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -113,6 +113,12 @@ fn create_router() -> Router {
         // sound engine (exact ⊕ native ⊕ spacer ⊕ btormc ⊕ Pono), merged under the
         // differential-oracle discipline. Surface peer of the CLI `mununu btor2 verify`.
         .route("/api/v1/btor2/verify", post(handlers::btor2_verify_handler))
+        // P2 response-liveness at scale — AG(request → AF grant) via liveness-to-
+        // safety + the portfolio. Surface peer of the CLI `mununu btor2 verify-liveness`.
+        .route(
+            "/api/v1/btor2/verify-liveness",
+            post(handlers::btor2_verify_liveness_handler),
+        )
         // cegar-extraction Stage 2 — SV-direct CEGAR one-call (sv2v +
         // Yosys → flattened BTOR2 → cegar_refine_loop). Surface peer of
         // the CLI `mununu sv cegar`; lets the extraction-tab SV workflow


### PR DESCRIPTION
## Summary

P2 slice 2 — makes the `AG(request → AF grant)` liveness-to-safety reduction (#270) **user-invocable at scale** across all three surfaces.

- **CLI**: `mununu btor2 verify-liveness <file> --request "st == 1" --grant "st == 2"` → parse atoms, reduce, run the portfolio, print the verdict (`holds` / `violated` / `inconclusive`) + which engines decided.
- **API**: `POST /api/v1/btor2/verify-liveness {content, request, grant}` → same. A malformed atom (relational / unparseable) or bad BTOR2 is a `BadRequest`, not a 500.
- **UI** (lands in mununu-ui): `runBtor2VerifyLiveness` typed client.

## Core additions (`adapter/liveness_rescue`)

- `response_liveness_rescue_atoms` — the atoms-given entry (surface path: the user names the two atoms rather than authoring the μ-calculus formula); the formula path now delegates to it.
- `parse_response_atom` — reuses the classifier's predicate grammar, so a relational/malformed atom is rejected identically.
- `liveness_verdict_str` — single source of truth for the verdict label shared by CLI + API (mirrors `ReachVerdict::as_str`).

## Verified end-to-end

```
$ mununu btor2 verify-liveness staller.btor2   --request "st == 1" --grant "st == 2"
  verdict: violated   decided_by: [exact, native, spacer]
$ mununu btor2 verify-liveness responder.btor2 --request "st == 1" --grant "st == 2"
  verdict: holds      decided_by: [spacer]   # SPACER's invariant discovery proves
                                             # the l2s monitor safe ⇒ liveness holds
```

4 new tests (2 API handler: violated staller + relational-atom rejection; 2 core: atoms==formula agreement + parse/label). `make ci` green (2157 lib + 15 cli, 0 failed); api tests pass under `--all-features`; CLI verified with no stderr warning.

## Scope note

This surfaces the reduction as a standalone `verify-liveness` command (peer of `btor2 verify`). Auto-routing `verify_auto` to *try* the reduction when a translated SVA liveness property escapes the exact engine's cap is a further follow-up — it needs a real SVA liveness target to validate under the mununu-sva toolchain (per the `reach_rescue` no-target lesson).

## Surface parity

CLI (`btor2 verify-liveness`) + API (`/btor2/verify-liveness`) + UI (`runBtor2VerifyLiveness`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)