### PR TITLE
refactor(verdict): unify the verify-surface vocabulary on PropertyVerdict (envelope 1/3)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2068,12 +2068,13 @@ fn handle_btor2(command: Btor2Command) -> Result<(), String> {
 /// `mununu btor2 verify-liveness` — decide the response-liveness property
 /// `AG(request → AF grant)` via the l2s reduction + the portfolio, printing the
 /// verdict as JSON. Surface peer of the API `POST /api/v1/btor2/verify-liveness`;
-/// both share the verdict labels via
-/// [`mununu_core::adapter::liveness_rescue::liveness_verdict_str`].
+/// both share the canonical verdict label via
+/// [`mununu_core::verdict::PropertyVerdict`].
 fn btor2_verify_liveness(args: Btor2VerifyLivenessArgs) -> Result<(), String> {
     use mununu_core::adapter::liveness_rescue::{
-        liveness_verdict_str, parse_response_atom, response_liveness_rescue_atoms,
+        parse_response_atom, response_liveness_rescue_atoms,
     };
+    use mununu_core::verdict::PropertyVerdict;
 
     let content = std::fs::read_to_string(&args.file)
         .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
@@ -2091,7 +2092,7 @@ fn btor2_verify_liveness(args: Btor2VerifyLivenessArgs) -> Result<(), String> {
     let summary = serde_json::json!({
         "file": args.file.display().to_string(),
         "property": format!("AG(({}) -> AF ({}))", args.request, args.grant),
-        "verdict": liveness_verdict_str(verdict),
+        "verdict": PropertyVerdict::from(verdict).as_str(),
         "decided_by": outcome.reachable_by.iter().chain(outcome.unreachable_by.iter())
             .collect::<Vec<_>>(),
     });
@@ -2103,11 +2104,13 @@ fn btor2_verify_liveness(args: Btor2VerifyLivenessArgs) -> Result<(), String> {
 }
 
 /// `mununu btor2 verify` — decide `bad`-reachability with the multi-engine safety
-/// portfolio and print the merged verdict + per-engine breakdown as JSON. Surface
-/// peer of the API `POST /api/v1/btor2/verify`; both share the verdict labels via
-/// [`mununu_core::adapter::reach_portfolio::ReachVerdict::as_str`].
+/// portfolio and print the canonical property verdict (`holds` = `bad` unreachable,
+/// `violated` = reachable, `unknown` = undecided) + the per-engine reachability
+/// breakdown as JSON. Surface peer of the API `POST /api/v1/btor2/verify`; both share
+/// the verdict label via [`mununu_core::verdict::PropertyVerdict`].
 fn btor2_verify(args: Btor2VerifyArgs) -> Result<(), String> {
     use mununu_core::adapter::reach_portfolio::decide_reach_portfolio_parallel;
+    use mununu_core::verdict::PropertyVerdict;
 
     let content = std::fs::read_to_string(&args.file)
         .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
@@ -2120,7 +2123,7 @@ fn btor2_verify(args: Btor2VerifyArgs) -> Result<(), String> {
 
     let summary = serde_json::json!({
         "file": args.file.display().to_string(),
-        "verdict": outcome.verdict.as_str(),
+        "verdict": PropertyVerdict::from(outcome.verdict).as_str(),
         "reachable_by": outcome.reachable_by,
         "unreachable_by": outcome.unreachable_by,
         "contradiction": outcome.verdict

--- a/crates/mununu-core/src/adapter/liveness_rescue.rs
+++ b/crates/mununu-core/src/adapter/liveness_rescue.rs
@@ -282,16 +282,10 @@ pub fn parse_response_atom(s: &str) -> Result<Atom, String> {
     }
 }
 
-/// Stable lowercase label for a [`LivenessVerdict`] — the single source of truth
-/// shared by the CLI (`mununu btor2 verify-liveness`) and the API
-/// (`POST /api/v1/btor2/verify-liveness`) so the two surfaces never drift.
-pub fn liveness_verdict_str(v: LivenessVerdict) -> &'static str {
-    match v {
-        LivenessVerdict::Holds => "holds",
-        LivenessVerdict::Violated => "violated",
-        LivenessVerdict::Inconclusive => "inconclusive",
-    }
-}
+// The surface verdict label comes from the canonical
+// [`crate::verdict::PropertyVerdict`] (`From<LivenessVerdict>`), so
+// `btor2 verify-liveness` reports the same `holds`/`violated`/`unknown` vocabulary as
+// every other verify surface (`Inconclusive` folds to `unknown`).
 
 #[cfg(test)]
 mod tests {
@@ -451,7 +445,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_response_atom_rejects_relational_and_reports_labels() {
+    fn parse_response_atom_rejects_relational() {
         assert!(
             parse_response_atom("x == y").is_err(),
             "relational atom rejected"
@@ -460,11 +454,24 @@ mod tests {
             parse_response_atom("not an atom !!").is_err(),
             "garbage rejected"
         );
-        assert_eq!(liveness_verdict_str(LivenessVerdict::Holds), "holds");
-        assert_eq!(liveness_verdict_str(LivenessVerdict::Violated), "violated");
+    }
+
+    // The surface label comes from the canonical PropertyVerdict — Inconclusive folds
+    // to the shared `unknown`, not a bespoke `inconclusive`.
+    #[test]
+    fn liveness_verdict_maps_to_canonical_vocabulary() {
+        use crate::verdict::PropertyVerdict;
         assert_eq!(
-            liveness_verdict_str(LivenessVerdict::Inconclusive),
-            "inconclusive"
+            PropertyVerdict::from(LivenessVerdict::Holds).as_str(),
+            "holds"
+        );
+        assert_eq!(
+            PropertyVerdict::from(LivenessVerdict::Violated).as_str(),
+            "violated"
+        );
+        assert_eq!(
+            PropertyVerdict::from(LivenessVerdict::Inconclusive).as_str(),
+            "unknown"
         );
     }
 }

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -56,19 +56,11 @@ pub enum ReachVerdict {
     Contradiction,
 }
 
-impl ReachVerdict {
-    /// Stable lowercase string form — the single source of truth for the verdict
-    /// label across the CLI (`mununu btor2 verify`) and the API
-    /// (`POST /api/v1/btor2/verify`), so the two surfaces never drift.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            ReachVerdict::Reachable => "reachable",
-            ReachVerdict::Unreachable => "unreachable",
-            ReachVerdict::Unknown => "unknown",
-            ReachVerdict::Contradiction => "contradiction",
-        }
-    }
-}
+// The surface verdict label comes from the canonical
+// [`crate::verdict::PropertyVerdict`] (`From<ReachVerdict>`), not a per-enum string,
+// so `btor2 verify` reports the same `holds`/`violated`/`unknown` vocabulary as every
+// other verify surface. The reachability *detail* stays in `reachable_by` /
+// `unreachable_by` + the `Contradiction` alarm.
 
 /// The portfolio outcome: the merged verdict plus which engines reached each
 /// definite conclusion (empty lists ⇒ that side was undecided by all).

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -645,7 +645,9 @@ pub async fn btor2_verify_handler(
 
     let outcome = decide_reach_portfolio_parallel(&file);
     Ok(Json(Btor2VerifyResponse {
-        verdict: outcome.verdict.as_str().to_string(),
+        verdict: crate::verdict::PropertyVerdict::from(outcome.verdict)
+            .as_str()
+            .to_string(),
         reachable_by: outcome.reachable_by.iter().map(|s| s.to_string()).collect(),
         unreachable_by: outcome
             .unreachable_by
@@ -660,14 +662,12 @@ pub async fn btor2_verify_handler(
 /// (`POST /api/v1/btor2/verify-liveness`). Surface peer of the CLI
 /// `mununu btor2 verify-liveness`: reduces the property to a single
 /// `bad`-reachability query (Biere–Artho–Schuppan liveness-to-safety) the portfolio
-/// decides, returning `"holds"` / `"violated"` / `"inconclusive"`. A malformed atom
-/// or unparseable BTOR2 is a `BadRequest`.
+/// decides, returning the canonical `"holds"` / `"violated"` / `"unknown"` verdict.
+/// A malformed atom or unparseable BTOR2 is a `BadRequest`.
 pub async fn btor2_verify_liveness_handler(
     Json(request): Json<Btor2VerifyLivenessRequest>,
 ) -> ApiResult<Json<Btor2VerifyLivenessResponse>> {
-    use crate::adapter::liveness_rescue::{
-        liveness_verdict_str, parse_response_atom, response_liveness_rescue_atoms,
-    };
+    use crate::adapter::liveness_rescue::{parse_response_atom, response_liveness_rescue_atoms};
 
     let bad_req = |message: String| ApiError::BadRequest {
         message,
@@ -685,7 +685,9 @@ pub async fn btor2_verify_liveness_handler(
         })?;
 
     Ok(Json(Btor2VerifyLivenessResponse {
-        verdict: liveness_verdict_str(verdict).to_string(),
+        verdict: crate::verdict::PropertyVerdict::from(verdict)
+            .as_str()
+            .to_string(),
         property: format!("AG(({}) -> AF ({}))", request.request, request.grant),
         decided_by: outcome
             .reachable_by
@@ -3881,7 +3883,9 @@ members = ["x"]
         let Json(out) = btor2_verify_handler(Json(request))
             .await
             .expect("verify runs");
-        assert_eq!(out.verdict, "reachable", "outcome: {out:?}");
+        // Canonical verdict: `bad` reachable ⇒ the safety property is VIOLATED. The
+        // reachability detail (which engine found it) stays in `reachable_by`.
+        assert_eq!(out.verdict, "violated", "outcome: {out:?}");
         assert!(
             out.reachable_by.contains(&"exact".to_string()),
             "the exact engine should decide the small reachable counter: {out:?}"

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -896,8 +896,10 @@ pub struct Btor2VerifyRequest {
 /// [`crate::adapter::reach_portfolio::ReachOutcome`].
 #[derive(Debug, Serialize)]
 pub struct Btor2VerifyResponse {
-    /// Merged verdict: `"reachable"` | `"unreachable"` | `"unknown"` |
-    /// `"contradiction"` (via [`crate::adapter::reach_portfolio::ReachVerdict::as_str`]).
+    /// Canonical property verdict — `"holds"` (`bad` unreachable) | `"violated"`
+    /// (reachable) | `"unknown"` (undecided / contradiction), via
+    /// [`crate::verdict::PropertyVerdict`]. The reachability *detail* is in the
+    /// `reachable_by` / `unreachable_by` lists + the `contradiction` alarm.
     pub verdict: String,
     /// Engines that found `bad` reachable (a real counterexample).
     pub reachable_by: Vec<String>,
@@ -926,8 +928,8 @@ pub struct Btor2VerifyLivenessRequest {
 /// [`crate::adapter::liveness_rescue::LivenessVerdict`].
 #[derive(Debug, Serialize)]
 pub struct Btor2VerifyLivenessResponse {
-    /// The verdict: `"holds"` | `"violated"` | `"inconclusive"` (via
-    /// [`crate::adapter::liveness_rescue::liveness_verdict_str`]).
+    /// Canonical property verdict — `"holds"` | `"violated"` | `"unknown"`, via
+    /// [`crate::verdict::PropertyVerdict`].
     pub verdict: String,
     /// The reduced property, echoed for provenance:
     /// `AG((<request>) -> AF (<grant>))`.

--- a/crates/mununu-core/src/lib.rs
+++ b/crates/mununu-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod ltl;
 pub mod mu_calculus;
 pub mod mununu_annotations;
 pub mod persistence;
+pub mod verdict;
 pub mod verify;
 
 #[cfg(any(test, feature = "test_support"))]

--- a/crates/mununu-core/src/verdict.rs
+++ b/crates/mununu-core/src/verdict.rs
@@ -1,0 +1,114 @@
+//! Canonical property-verdict vocabulary — the single source of truth for the
+//! verdict string every verify surface reports.
+//!
+//! Model checking answers a property with one of four outcomes. Historically each
+//! surface spelled them differently — `holds`/`violated`/`unknown` on the flagship
+//! `sv verify-auto` and extraction, but `reachable`/`unreachable`/`contradiction` on
+//! `btor2 verify` and `inconclusive` on `btor2 verify-liveness`. [`PropertyVerdict`]
+//! fixes ONE spelling and every surface maps its engine-specific verdict into it via
+//! the `From` impls here, so the surfaces cannot drift.
+//!
+//! The vocabulary is the one the flagship already uses: `holds` / `violated` /
+//! `unknown` / `skipped`. Surface-specific *detail* (which engines decided, a
+//! soundness-contradiction alarm, cube-cell counts) stays in the surface's own
+//! response fields alongside this canonical verdict.
+
+use crate::adapter::liveness_rescue::LivenessVerdict;
+use crate::adapter::reach_portfolio::ReachVerdict;
+
+/// The canonical answer to "did the property hold?", shared by every verify surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PropertyVerdict {
+    /// The property holds on every reachable state / path — a sound proof.
+    Holds,
+    /// The property is violated — a real counterexample exists.
+    Violated,
+    /// No engine decided: abstention, over-cap, timeout, or a soundness alarm. The
+    /// caller surfaces the *reason* (e.g. a `contradiction` flag) separately.
+    Unknown,
+    /// The property was not evaluated — out of the supported fragment, or filtered
+    /// out before the run.
+    Skipped,
+}
+
+impl PropertyVerdict {
+    /// The stable lowercase label — identical across CLI, HTTP API, and UI.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PropertyVerdict::Holds => "holds",
+            PropertyVerdict::Violated => "violated",
+            PropertyVerdict::Unknown => "unknown",
+            PropertyVerdict::Skipped => "skipped",
+        }
+    }
+}
+
+impl From<ReachVerdict> for PropertyVerdict {
+    /// The safety reading of `bad`-reachability: `bad` **unreachable** = the
+    /// assertion HOLDS; **reachable** = VIOLATED; undecided or a contradiction alarm
+    /// = UNKNOWN (the alarm is surfaced separately by the caller's `contradiction`
+    /// flag + the per-engine `reachable_by` / `unreachable_by` breakdown).
+    fn from(v: ReachVerdict) -> Self {
+        match v {
+            ReachVerdict::Unreachable => PropertyVerdict::Holds,
+            ReachVerdict::Reachable => PropertyVerdict::Violated,
+            ReachVerdict::Unknown | ReachVerdict::Contradiction => PropertyVerdict::Unknown,
+        }
+    }
+}
+
+impl From<LivenessVerdict> for PropertyVerdict {
+    fn from(v: LivenessVerdict) -> Self {
+        match v {
+            LivenessVerdict::Holds => PropertyVerdict::Holds,
+            LivenessVerdict::Violated => PropertyVerdict::Violated,
+            LivenessVerdict::Inconclusive => PropertyVerdict::Unknown,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_are_the_canonical_vocabulary() {
+        assert_eq!(PropertyVerdict::Holds.as_str(), "holds");
+        assert_eq!(PropertyVerdict::Violated.as_str(), "violated");
+        assert_eq!(PropertyVerdict::Unknown.as_str(), "unknown");
+        assert_eq!(PropertyVerdict::Skipped.as_str(), "skipped");
+    }
+
+    #[test]
+    fn reach_verdict_maps_to_the_safety_reading() {
+        assert_eq!(
+            PropertyVerdict::from(ReachVerdict::Unreachable),
+            PropertyVerdict::Holds
+        );
+        assert_eq!(
+            PropertyVerdict::from(ReachVerdict::Reachable),
+            PropertyVerdict::Violated
+        );
+        assert_eq!(
+            PropertyVerdict::from(ReachVerdict::Unknown),
+            PropertyVerdict::Unknown
+        );
+        // A contradiction is undecided at the property level; the alarm is a flag.
+        assert_eq!(
+            PropertyVerdict::from(ReachVerdict::Contradiction),
+            PropertyVerdict::Unknown
+        );
+    }
+
+    #[test]
+    fn liveness_inconclusive_folds_to_unknown() {
+        assert_eq!(
+            PropertyVerdict::from(LivenessVerdict::Inconclusive),
+            PropertyVerdict::Unknown
+        );
+        assert_eq!(
+            PropertyVerdict::from(LivenessVerdict::Holds),
+            PropertyVerdict::Holds
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First slice of the output-envelope unification (you asked whether the verdict formats across engines were cohesive — they weren't). Introduces `crate::verdict::PropertyVerdict { Holds, Violated, Unknown, Skipped }` — **one** canonical spelling of the model-checking answer, with `as_str()` returning the `holds`/`violated`/`unknown`/`skipped` vocabulary the flagship `sv verify-auto` + extraction **already** use. Every surface maps its engine-specific verdict into it via `From` impls, so the surfaces can't drift.

## The drift this fixes

The two surfaces added earlier this session had diverged from the flagship:
- `btor2 verify` reported `reachable`/`unreachable`/`unknown`/`contradiction`;
- `btor2 verify-liveness` reported `inconclusive` for the flagship's `unknown`.

## What changed

- **`btor2 verify`**: `verdict` now reports the **property reading** of `bad`-reachability — `bad` unreachable = `"holds"`, reachable = `"violated"`, undecided/contradiction = `"unknown"`. The reachability detail is preserved in `reachable_by` / `unreachable_by` + the `contradiction` alarm flag (no information lost).
- **`btor2 verify-liveness`**: `inconclusive` → the shared `unknown`.
- Removed the now-superseded `ReachVerdict::as_str` + `liveness_verdict_str` per-surface helpers.

Verified e2e: `counter → violated`, `wide-safe → holds`, `staller → violated`. CLI + API + docs updated; the reachable-counter handler test now asserts the canonical `violated`. `make ci` green (2161 lib + 15 cli, 0 failed). UI type updates in mununu-ui.

## Roadmap for the rest

- **Slice 2**: standardize the verdict FIELD NAME (flagship `PropertyVerdictView.outcome` / `AnchorResultApi.outcome` vs `verdict`) + UI types.
- **Slice 3**: reconcile the legacy surfaces (`context/verify` `satisfied: bool`, `cegar` cell-counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)