### PR TITLE
feat(P2): SV-direct verb family — verify / verify-liveness / verify-recoverability

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1085,6 +1085,19 @@ enum SvCommand {
     /// can't bind them) — never given a misleading verdict. Surface peer of
     /// `POST /api/v1/sv/verify-auto` + the extraction-tab verify-auto panel.
     VerifyAuto(SvVerifyAutoArgs),
+    /// Lift SV (sv2v + Yosys) and decide `bad`-reachability of its assertions with
+    /// the multi-engine safety portfolio — one call, no `emit-btor2` step. Surface
+    /// peer of `POST /api/v1/sv/verify`.
+    Verify(SvVerifyArgs),
+    /// Lift SV and decide a response-liveness property `AG(request → AF grant)` — the
+    /// SV-direct peer of `btor2 verify-liveness`. `--request` / `--grant` are single
+    /// register-comparison atoms. Surface peer of `POST /api/v1/sv/verify-liveness`.
+    VerifyLiveness(SvVerifyLivenessArgs),
+    /// Lift SV and decide recoverability `AG EF good` — the branching property SVA
+    /// cannot state, checked directly against raw SV in one call. `--target` is a
+    /// single register-comparison atom. Surface peer of
+    /// `POST /api/v1/sv/verify-recoverability`.
+    VerifyRecoverability(SvVerifyRecoverabilityArgs),
 }
 
 #[derive(Args, Debug)]
@@ -1342,6 +1355,56 @@ struct SvVerifyAutoArgs {
     /// BDD size (a design too large to bit-blast ⇒ the property is `Skipped`).
     #[arg(long, value_enum, default_value_t = EngineArg::Explicit)]
     engine: EngineArg,
+}
+
+/// Shared SV → BTOR2 lift inputs for the SV-direct verbs (`sv verify` /
+/// `verify-liveness` / `verify-recoverability`).
+#[derive(Args, Debug)]
+struct SvLiftArgs {
+    /// Primary SystemVerilog source file (.sv / .v).
+    #[arg(value_name = "SV_FILE")]
+    file: PathBuf,
+    /// Additional SV sources (packages, `include` targets), staged alongside the
+    /// primary input. Repeatable.
+    #[arg(long = "source", value_name = "FILE")]
+    sources: Vec<PathBuf>,
+    /// Top module for the SV → BTOR2 Yosys lift (auto-detect when omitted).
+    #[arg(long = "top", value_name = "NAME")]
+    top: Option<String>,
+    /// Run sv2v before Yosys. Required for modern SV (`import pkg::*;`, structs,
+    /// interfaces) — essentially all real OpenTitan / Caliptra / ibex RTL.
+    #[arg(long = "preprocess-sv2v")]
+    preprocess_sv2v: bool,
+}
+
+/// Arguments for `mununu sv verify` — SV-direct safety portfolio.
+#[derive(Args, Debug)]
+struct SvVerifyArgs {
+    #[command(flatten)]
+    lift: SvLiftArgs,
+}
+
+/// Arguments for `mununu sv verify-liveness` — SV-direct response liveness.
+#[derive(Args, Debug)]
+struct SvVerifyLivenessArgs {
+    #[command(flatten)]
+    lift: SvLiftArgs,
+    /// The request atom — a register comparison, e.g. `"st == 1"`.
+    #[arg(long, value_name = "ATOM")]
+    request: String,
+    /// The grant atom that must eventually follow on every path, e.g. `"st == 2"`.
+    #[arg(long, value_name = "ATOM")]
+    grant: String,
+}
+
+/// Arguments for `mununu sv verify-recoverability` — SV-direct `AG EF good`.
+#[derive(Args, Debug)]
+struct SvVerifyRecoverabilityArgs {
+    #[command(flatten)]
+    lift: SvLiftArgs,
+    /// The `good` atom to recover to — a register comparison, e.g. `"state_q == 3"`.
+    #[arg(long, value_name = "ATOM")]
+    target: String,
 }
 
 #[derive(Args, Debug)]
@@ -4298,7 +4361,93 @@ fn handle_sv(command: SvCommand) -> Result<(), String> {
         SvCommand::Cegar(args) => sv_cegar(args),
         SvCommand::ExtractSva(args) => sv_extract_sva(args),
         SvCommand::VerifyAuto(args) => sv_verify_auto(args),
+        SvCommand::Verify(args) => sv_verify(args),
+        SvCommand::VerifyLiveness(args) => sv_verify_liveness(args),
+        SvCommand::VerifyRecoverability(args) => sv_verify_recoverability(args),
     }
+}
+
+/// Read the primary + additional SV sources named by `args` into a core `SvLift`.
+fn read_sv_lift(args: &SvLiftArgs) -> Result<mununu_core::adapter::sv_verify::SvLift, String> {
+    let source = std::fs::read_to_string(&args.file)
+        .map_err(|e| format!("Failed to read SV '{}': {e}", args.file.display()))?;
+    let mut additional_sources = Vec::new();
+    for p in &args.sources {
+        let content = std::fs::read_to_string(p)
+            .map_err(|e| format!("Failed to read '{}': {e}", p.display()))?;
+        let name = p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("source.sv")
+            .to_string();
+        additional_sources.push((name, content));
+    }
+    Ok(mununu_core::adapter::sv_verify::SvLift {
+        source,
+        additional_sources,
+        top: args.top.clone(),
+        use_sv2v: args.preprocess_sv2v,
+    })
+}
+
+/// `mununu sv verify` — lift SV and decide `bad`-reachability with the portfolio.
+fn sv_verify(args: SvVerifyArgs) -> Result<(), String> {
+    use mununu_core::adapter::sv_verify::sv_verify_safety;
+    use mununu_core::verdict::PropertyVerdict;
+
+    let file = args.lift.file.display().to_string();
+    let outcome = sv_verify_safety(&read_sv_lift(&args.lift)?)?;
+    let summary = serde_json::json!({
+        "file": file,
+        "verdict": PropertyVerdict::from(outcome.verdict).as_str(),
+        "reachable_by": outcome.reachable_by,
+        "unreachable_by": outcome.unreachable_by,
+        "contradiction": outcome.verdict
+            == mununu_core::adapter::reach_portfolio::ReachVerdict::Contradiction,
+    });
+    print_json_summary(&summary)
+}
+
+/// `mununu sv verify-liveness` — lift SV and decide `AG(request → AF grant)`.
+fn sv_verify_liveness(args: SvVerifyLivenessArgs) -> Result<(), String> {
+    use mununu_core::adapter::sv_verify::sv_verify_liveness as core_sv_verify_liveness;
+    use mununu_core::verdict::PropertyVerdict;
+
+    let file = args.lift.file.display().to_string();
+    let (verdict, outcome) =
+        core_sv_verify_liveness(&read_sv_lift(&args.lift)?, &args.request, &args.grant)?;
+    let summary = serde_json::json!({
+        "file": file,
+        "property": format!("AG(({}) -> AF ({}))", args.request, args.grant),
+        "verdict": PropertyVerdict::from(verdict).as_str(),
+        "decided_by": outcome.reachable_by.iter().chain(outcome.unreachable_by.iter())
+            .collect::<Vec<_>>(),
+    });
+    print_json_summary(&summary)
+}
+
+/// `mununu sv verify-recoverability` — lift SV and decide `AG EF good`.
+fn sv_verify_recoverability(args: SvVerifyRecoverabilityArgs) -> Result<(), String> {
+    use mununu_core::adapter::recoverability::recoverability_property_str;
+    use mununu_core::adapter::sv_verify::sv_verify_recoverability as core_sv_verify_recoverability;
+
+    let file = args.lift.file.display().to_string();
+    let verdict = core_sv_verify_recoverability(&read_sv_lift(&args.lift)?, &args.target)?;
+    let summary = serde_json::json!({
+        "file": file,
+        "property": recoverability_property_str(&args.target),
+        "verdict": verdict.as_str(),
+    });
+    print_json_summary(&summary)
+}
+
+/// Pretty-print a JSON summary to stdout.
+fn print_json_summary(summary: &serde_json::Value) -> Result<(), String> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(summary).map_err(|e| format!("serialize summary: {e}"))?
+    );
+    Ok(())
 }
 
 /// Build the skeleton `SvAnnotation` from discovered state cells (the pure,

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -60,6 +60,7 @@ pub mod sidecar;
 pub mod slang;
 pub mod state_enum;
 pub mod sts_ir;
+pub mod sv_verify;
 pub mod systemverilog;
 pub mod templates;
 pub mod tlsf;

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -1,0 +1,124 @@
+//! SV-direct property verbs — lift a SystemVerilog module to BTOR2 (sv2v + Yosys)
+//! and decide a property in **one** call.
+//!
+//! An external tool (e.g. an agent writing RTL) can hand raw SV plus a target atom
+//! and get a verdict, with no manual `sv emit-btor2-per-module` → `btor2 verify-*`
+//! round-trip. Each function is a thin bridge: [`sv_to_btor2`] then the matching
+//! BTOR2 verb core ([`decide_reach_portfolio_parallel`],
+//! [`response_liveness_rescue_atoms`], [`verify_recoverability`]). The SV → BTOR2
+//! lift requires sv2v + Yosys on the host (see [`docs/verifying-rtl.md`]); a missing
+//! tool returns a structured error.
+//!
+//! Atoms are validated **before** the (toolchain-gated) lift, so a malformed
+//! request fails fast and identically to the BTOR2-direct verbs.
+//!
+//! **Reset**: these verbs lift the design with the reset as a *free input* (no
+//! reset-gating). Sound, and the honest default — recoverability in particular is
+//! reset-dependent (see `docs/design/recoverability-vs-sva.md` §3.2). Reset-gating
+//! (as `sv verify-auto` offers) is a future option.
+
+use crate::adapter::btor2::parser;
+use crate::adapter::btor2::predicate_expr::parse_predicate_expr;
+use crate::adapter::liveness_rescue::{
+    Atom, LivenessVerdict, parse_response_atom, response_liveness_rescue_atoms,
+};
+use crate::adapter::reach_portfolio::{ReachOutcome, decide_reach_portfolio_parallel};
+use crate::adapter::recoverability::verify_recoverability;
+use crate::adapter::yosys::{YosysOptions, sv_to_btor2};
+use crate::verdict::PropertyVerdict;
+
+/// The SV → BTOR2 lift inputs shared by every SV-direct verb.
+pub struct SvLift {
+    /// Primary SystemVerilog source.
+    pub source: String,
+    /// Additional SV sources (packages / includes) as `(name, content)`.
+    pub additional_sources: Vec<(String, String)>,
+    /// Top module (Yosys auto-detects when `None`).
+    pub top: Option<String>,
+    /// Run sv2v before Yosys (modern SV module-header imports, etc.).
+    pub use_sv2v: bool,
+}
+
+impl SvLift {
+    /// Lift to a single flattened BTOR2 string (sv2v optional + Yosys).
+    fn lift(&self) -> Result<String, String> {
+        let yopts = YosysOptions {
+            top: self.top.clone(),
+            additional_sources: self.additional_sources.clone(),
+            use_sv2v: self.use_sv2v,
+            ..Default::default()
+        };
+        sv_to_btor2(&self.source, &yopts)
+            .map_err(|e| format!("SV → BTOR2 (sv2v + Yosys): {}", e.message))
+    }
+}
+
+/// `sv verify` — lift SV and decide `bad`-reachability of its assertions with the
+/// multi-engine safety portfolio.
+pub fn sv_verify_safety(lift: &SvLift) -> Result<ReachOutcome, String> {
+    let btor2 = lift.lift()?;
+    let file =
+        parser::parse(&btor2).map_err(|e| format!("parsing the lifted BTOR2: {}", e.message))?;
+    Ok(decide_reach_portfolio_parallel(&file))
+}
+
+/// `sv verify-liveness` — lift SV and decide `AG(request → AF grant)` via the l2s
+/// reduction + the portfolio. The atoms are parsed first (a malformed atom errors
+/// before the lift).
+pub fn sv_verify_liveness(
+    lift: &SvLift,
+    request: &str,
+    grant: &str,
+) -> Result<(LivenessVerdict, ReachOutcome), String> {
+    let ante: Atom = parse_response_atom(request)?;
+    let cons: Atom = parse_response_atom(grant)?;
+    let btor2 = lift.lift()?;
+    response_liveness_rescue_atoms(&btor2, &ante, &cons, false).ok_or_else(|| {
+        "could not build the liveness monitor — an atom likely binds no signal in the design"
+            .to_string()
+    })
+}
+
+/// `sv verify-recoverability` — lift SV and decide `AG EF target`. The target atom is
+/// validated before the lift.
+pub fn sv_verify_recoverability(lift: &SvLift, target: &str) -> Result<PropertyVerdict, String> {
+    parse_predicate_expr(target).map_err(|e| {
+        format!("recoverability target `{target}` is not a register-comparison atom: {e:?}")
+    })?;
+    let btor2 = lift.lift()?;
+    verify_recoverability(&btor2, target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lift_of(source: &str) -> SvLift {
+        SvLift {
+            source: source.to_string(),
+            additional_sources: Vec::new(),
+            top: None,
+            use_sv2v: false,
+        }
+    }
+
+    // The atom guards fire BEFORE the toolchain-gated lift, so they are testable in
+    // make-ci (no sv2v / Yosys needed).
+    #[test]
+    fn liveness_rejects_malformed_atom_before_lift() {
+        let e = sv_verify_liveness(&lift_of("module m; endmodule"), "x == y", "st == 1");
+        assert!(
+            e.is_err(),
+            "a relational request atom must be rejected pre-lift"
+        );
+    }
+
+    #[test]
+    fn recoverability_rejects_malformed_target_before_lift() {
+        let e = sv_verify_recoverability(&lift_of("module m; endmodule"), "not an atom !!");
+        assert!(e.is_err(), "a malformed target must be rejected pre-lift");
+    }
+
+    // The full lift → verdict path needs sv2v + Yosys; covered by the e2e suite in
+    // the mununu-sva image, not make-ci.
+}

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -722,6 +722,115 @@ pub async fn btor2_verify_recoverability_handler(
     }))
 }
 
+// --- SV-direct verbs: lift SV (sv2v + Yosys) then decide, in one call. Surface peers
+// of the CLI `sv verify` / `verify-liveness` / `verify-recoverability`; they return
+// the same `Btor2Verify*Response` shapes as the BTOR2-direct verbs. The lift needs
+// sv2v + Yosys on the host (a missing tool → BadRequest). ---
+
+/// `POST /api/v1/sv/verify` — lift SV and decide `bad`-reachability of its assertions
+/// with the multi-engine safety portfolio.
+pub async fn sv_verify_handler(
+    Json(request): Json<SvVerifyRequest>,
+) -> ApiResult<Json<Btor2VerifyResponse>> {
+    use crate::adapter::reach_portfolio::ReachVerdict;
+    use crate::adapter::sv_verify::{SvLift, sv_verify_safety};
+
+    let lift = SvLift {
+        source: request.source,
+        additional_sources: request
+            .additional_sources
+            .into_iter()
+            .map(|f| (f.name, f.content))
+            .collect(),
+        top: request.top,
+        use_sv2v: request.use_sv2v,
+    };
+    let outcome = sv_verify_safety(&lift).map_err(|message| ApiError::BadRequest {
+        message,
+        details: None,
+    })?;
+    Ok(Json(Btor2VerifyResponse {
+        verdict: crate::verdict::PropertyVerdict::from(outcome.verdict)
+            .as_str()
+            .to_string(),
+        reachable_by: outcome.reachable_by.iter().map(|s| s.to_string()).collect(),
+        unreachable_by: outcome
+            .unreachable_by
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        contradiction: outcome.verdict == ReachVerdict::Contradiction,
+    }))
+}
+
+/// `POST /api/v1/sv/verify-liveness` — lift SV and decide `AG(request → AF grant)`.
+pub async fn sv_verify_liveness_handler(
+    Json(request): Json<SvVerifyLivenessRequest>,
+) -> ApiResult<Json<Btor2VerifyLivenessResponse>> {
+    use crate::adapter::sv_verify::{SvLift, sv_verify_liveness};
+
+    let property = format!("AG(({}) -> AF ({}))", request.request, request.grant);
+    let lift = SvLift {
+        source: request.source,
+        additional_sources: request
+            .additional_sources
+            .into_iter()
+            .map(|f| (f.name, f.content))
+            .collect(),
+        top: request.top,
+        use_sv2v: request.use_sv2v,
+    };
+    let (verdict, outcome) =
+        sv_verify_liveness(&lift, &request.request, &request.grant).map_err(|message| {
+            ApiError::BadRequest {
+                message,
+                details: None,
+            }
+        })?;
+    Ok(Json(Btor2VerifyLivenessResponse {
+        verdict: crate::verdict::PropertyVerdict::from(verdict)
+            .as_str()
+            .to_string(),
+        property,
+        decided_by: outcome
+            .reachable_by
+            .iter()
+            .chain(outcome.unreachable_by.iter())
+            .map(|s| s.to_string())
+            .collect(),
+    }))
+}
+
+/// `POST /api/v1/sv/verify-recoverability` — lift SV and decide `AG EF target`.
+pub async fn sv_verify_recoverability_handler(
+    Json(request): Json<SvVerifyRecoverabilityRequest>,
+) -> ApiResult<Json<Btor2VerifyRecoverabilityResponse>> {
+    use crate::adapter::recoverability::recoverability_property_str;
+    use crate::adapter::sv_verify::{SvLift, sv_verify_recoverability};
+
+    let property = recoverability_property_str(&request.target);
+    let lift = SvLift {
+        source: request.source,
+        additional_sources: request
+            .additional_sources
+            .into_iter()
+            .map(|f| (f.name, f.content))
+            .collect(),
+        top: request.top,
+        use_sv2v: request.use_sv2v,
+    };
+    let verdict = sv_verify_recoverability(&lift, &request.target).map_err(|message| {
+        ApiError::BadRequest {
+            message,
+            details: None,
+        }
+    })?;
+    Ok(Json(Btor2VerifyRecoverabilityResponse {
+        verdict: verdict.as_str().to_string(),
+        property,
+    }))
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — SV-direct CEGAR in one call.
 ///
 /// Lifts SystemVerilog to a single flattened BTOR2 (sv2v + Yosys, the
@@ -4004,6 +4113,40 @@ members = ["x"]
         let err = btor2_verify_recoverability_handler(Json(request))
             .await
             .expect_err("malformed target must be rejected");
+        assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    // SV-direct verbs validate the atoms BEFORE the (toolchain-gated) SV→BTOR2 lift,
+    // so the guard is a BadRequest reachable in make-ci without sv2v / Yosys. The full
+    // lift → verdict path is covered by the mununu-sva e2e suite.
+    #[tokio::test]
+    async fn sv_verify_liveness_handler_rejects_malformed_atom_before_lift() {
+        let request = SvVerifyLivenessRequest {
+            source: "module m; endmodule".to_string(),
+            additional_sources: vec![],
+            top: None,
+            use_sv2v: false,
+            request: "x == y".to_string(), // relational — rejected before the lift
+            grant: "st == 1".to_string(),
+        };
+        let err = sv_verify_liveness_handler(Json(request))
+            .await
+            .expect_err("relational request atom must be rejected pre-lift");
+        assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    #[tokio::test]
+    async fn sv_verify_recoverability_handler_rejects_malformed_target_before_lift() {
+        let request = SvVerifyRecoverabilityRequest {
+            source: "module m; endmodule".to_string(),
+            additional_sources: vec![],
+            top: None,
+            use_sv2v: false,
+            target: "not an atom !!".to_string(),
+        };
+        let err = sv_verify_recoverability_handler(Json(request))
+            .await
+            .expect_err("malformed target must be rejected pre-lift");
         assert!(matches!(err, ApiError::BadRequest { .. }));
     }
 }

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -963,6 +963,65 @@ pub struct Btor2VerifyRecoverabilityResponse {
     pub property: String,
 }
 
+/// The SV → BTOR2 lift inputs shared by the SV-direct verb endpoints
+/// (`/api/v1/sv/verify`, `/sv/verify-liveness`, `/sv/verify-recoverability`). These
+/// lift the module (sv2v + Yosys) and then decide the corresponding BTOR2 property,
+/// returning the same `Btor2Verify*Response` shapes — one call, no `emit-btor2` step.
+#[derive(Debug, Deserialize)]
+pub struct SvVerifyRequest {
+    /// SystemVerilog primary source content.
+    pub source: String,
+    /// Additional SV sources (packages / includes).
+    #[serde(default)]
+    pub additional_sources: Vec<FileContent>,
+    /// Top module for the lift (auto-detect when omitted).
+    #[serde(default)]
+    pub top: Option<String>,
+    /// Run sv2v before Yosys (modern SV). Default `false`.
+    #[serde(default)]
+    pub use_sv2v: bool,
+}
+
+/// Request for `POST /api/v1/sv/verify-liveness` — the SV lift fields plus the
+/// response-liveness atoms.
+#[derive(Debug, Deserialize)]
+pub struct SvVerifyLivenessRequest {
+    /// SystemVerilog primary source content.
+    pub source: String,
+    /// Additional SV sources (packages / includes).
+    #[serde(default)]
+    pub additional_sources: Vec<FileContent>,
+    /// Top module for the lift (auto-detect when omitted).
+    #[serde(default)]
+    pub top: Option<String>,
+    /// Run sv2v before Yosys. Default `false`.
+    #[serde(default)]
+    pub use_sv2v: bool,
+    /// The request atom (`"REG op VALUE"`).
+    pub request: String,
+    /// The grant atom that must eventually follow on every path.
+    pub grant: String,
+}
+
+/// Request for `POST /api/v1/sv/verify-recoverability` — the SV lift fields plus the
+/// recoverability target atom.
+#[derive(Debug, Deserialize)]
+pub struct SvVerifyRecoverabilityRequest {
+    /// SystemVerilog primary source content.
+    pub source: String,
+    /// Additional SV sources (packages / includes).
+    #[serde(default)]
+    pub additional_sources: Vec<FileContent>,
+    /// Top module for the lift (auto-detect when omitted).
+    #[serde(default)]
+    pub top: Option<String>,
+    /// Run sv2v before Yosys. Default `false`.
+    #[serde(default)]
+    pub use_sv2v: bool,
+    /// The `good` atom to recover to (`"REG op VALUE"`).
+    pub target: String,
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — request for the SV-direct
 /// CEGAR endpoint (`POST /api/v1/sv/cegar`). Mirrors the CLI
 /// `mununu sv cegar`: lifts SystemVerilog to a single flattened BTOR2

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -143,6 +143,18 @@ fn create_router() -> Router {
             "/api/v1/sv/verify-auto",
             post(handlers::sv_verify_auto_handler),
         )
+        // SV-direct verbs — lift SV (sv2v + Yosys) then decide a property in one call
+        // (safety / response-liveness / recoverability). Surface peers of the CLI
+        // `sv verify` / `verify-liveness` / `verify-recoverability`.
+        .route("/api/v1/sv/verify", post(handlers::sv_verify_handler))
+        .route(
+            "/api/v1/sv/verify-liveness",
+            post(handlers::sv_verify_liveness_handler),
+        )
+        .route(
+            "/api/v1/sv/verify-recoverability",
+            post(handlers::sv_verify_recoverability_handler),
+        )
         .route(
             "/api/v1/verify/memory-check",
             post(handlers::memory_check_handler),

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -146,16 +146,23 @@ supported environment). See [`external-tools.md`](external-tools.md).
 
 `sv verify-auto` checks the SVA the design *carries*; it takes no formula. An agent
 that emits RTL **with** `assert property` statements gets those checked automatically.
-An agent that emits assertion-free RTL gets zero properties back — it must either
-embed SVA, or use the **explicit-property path**:
+An agent that emits assertion-free RTL gets zero properties back — it names the
+property it cares about with an **SV-direct verb**, which lifts the module *and*
+decides the property in one call:
+
+> Source of truth: [`sv_verify::sv_verify_recoverability`](../crates/mununu-core/src/adapter/sv_verify.rs#L84) — surface: (CLI+API+UI)
 
 ```bash
-mununu sv emit-btor2-per-module my_module.sv   # SV → BTOR2 (one file per module)
-mununu btor2 verify-recoverability my_module.btor2 --target "state_q == 3"
+mununu sv verify-recoverability my_module.sv --target "state_q == 3"
+mununu sv verify-liveness      my_module.sv --request "req == 1" --grant "grant == 1"
+mununu sv verify               my_module.sv                       # safety of its assertions
 ```
 
-The BTOR2-direct verbs above let the agent name *any* property — including the
-branching ones (recoverability) that SVA cannot state at all — against its design.
+Same over HTTP: `POST /api/v1/sv/verify` · `/sv/verify-liveness` ·
+`/sv/verify-recoverability`. These let the agent name *any* property — including the
+branching ones (recoverability) SVA cannot state at all — against raw SV, no BTOR2
+round-trip. (The two-step `sv emit-btor2-per-module` → `btor2 verify-*` path still
+works when you want the intermediate BTOR2.)
 
 ### 3. Coverage is a fragment, and verdicts are honest
 


### PR DESCRIPTION
## Summary

Lift a SystemVerilog module (sv2v + Yosys) and decide a property in **one call** — so an external tool (e.g. an agent writing RTL) can POST raw SV plus a target atom and get a verdict, with **no** `sv emit-btor2-per-module` → `btor2 verify-*` round-trip. This closes the agent-usability gap identified in `docs/verifying-rtl.md`.

- **CLI**: `mununu sv verify` / `sv verify-liveness --request … --grant …` / `sv verify-recoverability --target …` (a shared, flattened `SvLiftArgs` for `file` / `--top` / `--source` / `--preprocess-sv2v`).
- **API**: `POST /api/v1/sv/verify` · `/sv/verify-liveness` · `/sv/verify-recoverability` — returning the **same** `Btor2Verify*Response` shapes as the BTOR2-direct verbs.
- **UI** (mununu-ui): `runSvVerify` / `runSvVerifyLiveness` / `runSvVerifyRecoverability`.

## Design

Core `adapter::sv_verify` is a thin bridge — `sv_to_btor2` (the same lift `sv cegar` uses) then the matching BTOR2 verb core (`decide_reach_portfolio_parallel` / `response_liveness_rescue_atoms` / `verify_recoverability`). Atoms are validated **before** the toolchain-gated lift, so a malformed request fails fast and the guard is testable in make-ci without sv2v / Yosys (4 guard tests, 2 core + 2 API). The full lift → verdict path is covered by the mununu-sva e2e suite.

**Reset**: lifts with the reset as a free input (no reset-gating) — sound, the honest default; reset-gating (as `verify-auto` offers) is a future option.

`docs/verifying-rtl.md` updated: the agent "explicit-property path" is now a single SV-direct call (with a source-of-truth anchor); the two-step `emit-btor2` path noted as still available. `make ci` green (2167 lib + 15 cli, 0 failed).

## Surface parity

CLI (`sv verify` / `verify-liveness` / `verify-recoverability`) + API (`/sv/verify*`) + UI (`runSvVerify*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)