### PR TITLE
fix(cli): btor2 cegar default engine → explicit; + engine-routing map (P0.1/P3.1)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -441,13 +441,11 @@ struct Btor2CegarArgs {
     /// human-readable format.
     #[arg(long)]
     json: bool,
-    /// Engine selector. **Default `portfolio-sequential`** (2026-07-06): run exact →
-    /// symbolic → explicit, stopping when every property is decided — the most
-    /// precise sound choice, no slower than `explicit` on designs `explicit` already
-    /// decides (exact runs first and usually decides FSMs outright). Single-engine
-    /// values (`explicit`, `symbolic`, `exact-symbolic`) and `portfolio-parallel`
-    /// remain available.
-    #[arg(long, value_enum, default_value_t = EngineArg::PortfolioSequential)]
+    /// Cube-CEGAR engine. **Default `explicit`** (SMT edges + refinement loop);
+    /// `symbolic` uses the R-F5 BDD relation (no per-cube-pair SMT). The
+    /// `exact-symbolic` and `portfolio-*` engines are `sv verify-auto`-only (they need
+    /// the reset-gated model verify-auto builds), so `btor2 cegar` rejects them.
+    #[arg(long, value_enum, default_value_t = EngineArg::Explicit)]
     engine: EngineArg,
     /// R.6.6 / V.6 (2026-06-09) — name of a BTOR2 input symbol the
     /// controller drives. Repeated to declare multiple controllable

--- a/docs/design/engine-routing.md
+++ b/docs/design/engine-routing.md
@@ -1,0 +1,48 @@
+# Engine routing — which engine decides which property, and why
+
+> Status: reference. The map from a verification request to the engine that actually
+> decides it, plus the soundness class each engine covers. Written for the agent/CI
+> differentiation program (P0.1) so investment targets the *defensible* paths.
+
+mununu has **two distinct portfolios** and one exact oracle. Getting a property to the
+right one is the whole game: safety at scale wants the word-level reachability engines;
+branching (νμ) properties can only go through the 3-valued engines.
+
+## The engines
+
+| Engine | Decides | Soundness | Scale ceiling |
+|---|---|---|---|
+| **exact-symbolic** (BDD bit-blast) | full modal-μ incl. νμ, at the *initial state* | definite (exact, no abstraction) | ~40-bit cone (enumeration) |
+| **cube CEGAR** (+ `smt-hyper-must`) | full modal-μ incl. νμ, over a **predicate abstraction** | Bruns–Godefroid 3-valued (definite verdicts transfer; ⊥ ⇒ refine) | predicate-count bound; needs the right predicates |
+| **reach portfolio** (exact ⊕ native BMC/k-induction ⊕ SPACER ⊕ btormc ⊕ Pono) | **`bad`-reachability only** (safety) | each member sound; first-definite wins; disagreement ⇒ contradiction alarm | word-level, **no bit cap** (native/SPACER/btormc/Pono) |
+
+> Source of truth: [`exact_symbolic_verdict`](../../crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs#L2095) · [`cegar_refine_loop`](../../crates/mununu-core/src/adapter/btor2/cegar.rs) · [`decide_reach_portfolio_parallel`](../../crates/mununu-core/src/adapter/reach_portfolio.rs#L202) — surface: (CLI+API+UI)
+
+## Per-surface routing
+
+| Surface / property | Path → engine | Predicates? |
+|---|---|---|
+| `btor2/sv verify` (safety) | `decide_reach_portfolio` → **reach portfolio** | none |
+| `btor2/sv verify-liveness` (`AG(a→AF b)`) | Biere l2s → `bad`-monitor → **reach portfolio** | none |
+| `btor2/sv verify-recoverability` (`AG EF good`) | `exact_symbolic_verdict` → **exact-symbolic** | **none** |
+| `sv verify-auto` (default `portfolio-sequential`) | **exact-symbolic → symbolic → explicit**, early-exit | exact leg none; cube legs **auto-seeded** |
+| `sv verify-auto` safety ⊥ | escalate → reduce → **reach portfolio** | none |
+| `btor2 cegar` (explicit) | `cegar_refine_loop` → **cube** | hand-`--predicate` unless auto-seeded upstream |
+
+> Source of truth: [`engine_selection`](../../crates/mununu-core/src/adapter/slang/verify_auto.rs#L587) + [`verify_auto_portfolio`](../../crates/mununu-core/src/adapter/slang/verify_auto.rs#L1329) (the 3-engine sequential/parallel portfolio) — surface: CLI+API.
+
+**The predicate-avoidance rule (P0.2), confirmed by the 2026-07-08 csrng spike:**
+
+1. `verify-auto`'s default (`portfolio-sequential`) tries **exact-symbolic first** — which needs **no predicates** and, on a real OpenTitan FSM, decides recoverability directly (the FSM cone fits under the 40-bit cap).
+2. Only when exact-symbolic is **over-cap** does it fall to the cube legs, which **auto-seed** predicates from the formula's atoms (`seed_from_formula`) — still no hand-written predicates.
+3. Hand-written predicates / `config_values` / `counter_bounds` are the **residual** — needed only for the cube's ⊥ ceiling (combinational-input FSM control signals whose cone explodes). That residual is the target of P0.2's follow-up (auto-derive the missing concretizations).
+
+So: **hand-written predicates are already the exception, not the rule** — the default path is auto.
+
+## Defensibility (which paths to lead with)
+
+- **`AG EF` recoverability via exact-symbolic / cube+hyper-must — DEFENSIBLE.** A branching νμ property SVA/LTL cannot express, decided soundly, on real RTL, with no predicates at FSM scale. No mainstream tool offers it. **This is the wedge — invest here (P1).**
+- **Response-liveness via l2s — partly defensible.** Sound concrete reduction, but liveness-to-safety is known art; keep, don't lead.
+- **Safety via the reach portfolio — TABLE-STAKES.** SymbiYosys/commercial do BMC/PDR safety at scale, often better. Keep for completeness + the ⊥ escalation; don't position as the differentiator.
+
+The investment thesis that falls out: **branching properties on the FSM cone** (where mununu is unique *and* under the cap *and* predicate-free) is the defensible core — exactly the P1 auto-property-synthesis + bug-finder target.


### PR DESCRIPTION
Two items from the agent/CI differentiation pre-work.

## P3.1 — `btor2 cegar` engine-default regression (spike-surfaced)

`Btor2CegarArgs.engine` defaulted to `portfolio-sequential`, but `btor2 cegar` is a single-engine cube surface and *rejects* `portfolio-*` / `exact-symbolic` (they need the reset-gated model `sv verify-auto` builds). So `btor2 cegar … --formula …` with no `--engine` **always errored** — the v7 `validate.sh` (which omits `--engine`) would fail. Default restored to `explicit`; stale doc comment corrected. Verified: the cube path on the real csrng FSM now runs (`T=4 F=0 ⊥=0` = recoverable), matching the exact engine + V.7-c.

## P0.1 — engine-path & defensibility map

`docs/design/engine-routing.md` — which engine decides which property class and the soundness each covers, with source-of-truth anchors. Confirmed conclusions (from the csrng spike + verifying the routing):
- verify-auto's default `portfolio-sequential` tries **exact-symbolic first** (no predicates) → **hand-written predicates are the exception, not the rule** (cube legs auto-seed; hand predicates only for the ⊥ ceiling).
- The **defensible** paths are the branching νμ ones (recoverability via exact-symbolic / cube+hyper-must — SVA can't express them); safety via the reach portfolio is table-stakes.

This focuses the P1 bet on **branching properties on the FSM cone**. `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)