### PR TITLE
fix(P1): land the illegal-encoding pivot for check-fsm (supersedes #280)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -263,14 +263,16 @@ enum Btor2Command {
     /// use `btor2 cegar … --must-edge-inference smt-hyper-must` for wider designs).
     /// `--target` is a single register-comparison atom (`"state_q == 3"`).
     VerifyRecoverability(Btor2VerifyRecoverabilityArgs),
-    /// Auto-scan every FSM-like state register for an unrecoverable trap — no input.
+    /// Auto-scan every FSM-like state register for a reachable illegal encoding — no input.
     ///
-    /// For each narrow (≤ `--max-width` bit) state register, derive its idle/reset
-    /// state as the register's init value and check recoverability `AG EF (reg ==
-    /// idle)` with reset left free. A `violated` register is an **unrecoverable trap**
-    /// — a reachable state the FSM can never get back to idle from, even with reset (a
-    /// bug SVA can't state and can't detect). Intended reset-dependence still `holds`
-    /// (reset is free). Prints one line per register; exits non-zero on any trap.
+    /// For each narrow (≤ `--max-width` bit) state register, derive its legal encodings
+    /// from the design (the constants its own logic compares it against, plus its reset
+    /// value) and check — from the real reset state — whether any value **outside** that
+    /// set is reachable. A `violated` register has a reachable **illegal encoding**: some
+    /// input drives the FSM past its enum (an incomplete `case`, a missing `default`), an
+    /// unambiguous bug. A `holds` register provably stays within its encoding. Decided by
+    /// the word-level reachability portfolio (scales past the exact engine). Prints one
+    /// line per register; exits non-zero on any reachable illegal encoding.
     CheckFsm(Btor2CheckFsmArgs),
 }
 
@@ -2304,28 +2306,28 @@ fn handle_btor2(command: Btor2Command) -> Result<(), String> {
 /// traps (no user input) and print the per-register recoverability result as JSON.
 /// Exits non-zero on any trap (via `--fail-on`).
 fn btor2_check_fsm(args: Btor2CheckFsmArgs) -> Result<(), String> {
-    use mununu_core::adapter::fsm_scan::fsm_recoverability_scan;
+    use mununu_core::adapter::fsm_scan::fsm_encoding_scan;
     use mununu_core::verdict::PropertyVerdict;
 
     let content = std::fs::read_to_string(&args.file)
         .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
-    let findings = fsm_recoverability_scan(&content, args.max_width)?;
+    let findings = fsm_encoding_scan(&content, args.max_width)?;
 
     let registers: Vec<serde_json::Value> = findings
         .iter()
         .map(|f| {
             serde_json::json!({
                 "register": f.register,
-                "idle_value": f.idle_value,
+                "legal_encodings": f.legal_encodings,
                 "verdict": f.verdict.as_str(),
-                "unrecoverable_trap": f.is_finding(),
+                "illegal_encoding_reachable": f.is_finding(),
             })
         })
         .collect();
     let summary = serde_json::json!({
         "file": args.file.display().to_string(),
         "fsm_registers_checked": findings.len(),
-        "traps_found": findings.iter().filter(|f| f.is_finding()).count(),
+        "illegal_encodings_found": findings.iter().filter(|f| f.is_finding()).count(),
         "registers": registers,
     });
     print_json_summary(&summary)?;

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1223,6 +1223,12 @@ enum SvCommand {
     /// single register-comparison atom. Surface peer of
     /// `POST /api/v1/sv/verify-recoverability`.
     VerifyRecoverability(SvVerifyRecoverabilityArgs),
+    /// Lift SV and auto-scan every FSM-like state register for a reachable illegal
+    /// encoding — no input. The SV-direct one-call peer of `btor2 check-fsm`: derives
+    /// each register's legal encodings from the design and reports any register that can
+    /// reach a value outside its enum (an unambiguous bug). Surface peer of
+    /// `POST /api/v1/sv/check-fsm`.
+    CheckFsm(SvCheckFsmArgs),
 }
 
 #[derive(Args, Debug)]
@@ -1542,6 +1548,18 @@ struct SvVerifyRecoverabilityArgs {
     /// The `good` atom to recover to — a register comparison, e.g. `"state_q == 3"`.
     #[arg(long, value_name = "ATOM")]
     target: String,
+    #[command(flatten)]
+    ci: CiArgs,
+}
+
+/// Arguments for `mununu sv check-fsm` — SV-direct auto illegal-encoding scan.
+#[derive(Args, Debug)]
+struct SvCheckFsmArgs {
+    #[command(flatten)]
+    lift: SvLiftArgs,
+    /// Max state-register width to treat as an FSM (wider = datapath/counter, skipped).
+    #[arg(long, value_name = "BITS", default_value_t = mununu_core::adapter::fsm_scan::DEFAULT_FSM_MAX_WIDTH)]
+    max_width: u32,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -4581,6 +4599,7 @@ fn handle_sv(command: SvCommand) -> Result<(), String> {
         SvCommand::Verify(args) => sv_verify(args),
         SvCommand::VerifyLiveness(args) => sv_verify_liveness(args),
         SvCommand::VerifyRecoverability(args) => sv_verify_recoverability(args),
+        SvCommand::CheckFsm(args) => sv_check_fsm(args),
     }
 }
 
@@ -4664,6 +4683,39 @@ fn sv_verify_recoverability(args: SvVerifyRecoverabilityArgs) -> Result<(), Stri
     });
     print_json_summary(&summary)?;
     ci_gate_exit(verdict.as_str(), args.ci.fail_on);
+    Ok(())
+}
+
+/// `mununu sv check-fsm` — lift SV then auto-scan every FSM register for a reachable
+/// illegal encoding. SV-direct peer of `btor2 check-fsm`; same JSON + CI exit.
+fn sv_check_fsm(args: SvCheckFsmArgs) -> Result<(), String> {
+    use mununu_core::adapter::sv_verify::sv_check_fsm as core_sv_check_fsm;
+    use mununu_core::verdict::PropertyVerdict;
+
+    let file = args.lift.file.display().to_string();
+    let findings = core_sv_check_fsm(&read_sv_lift(&args.lift)?, args.max_width)?;
+
+    let registers: Vec<serde_json::Value> = findings
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "register": f.register,
+                "legal_encodings": f.legal_encodings,
+                "verdict": f.verdict.as_str(),
+                "illegal_encoding_reachable": f.is_finding(),
+            })
+        })
+        .collect();
+    let summary = serde_json::json!({
+        "file": file,
+        "fsm_registers_checked": findings.len(),
+        "illegal_encodings_found": findings.iter().filter(|f| f.is_finding()).count(),
+        "registers": registers,
+    });
+    print_json_summary(&summary)?;
+
+    let worst = worst_verdict(findings.iter().map(|f| PropertyVerdict::as_str(f.verdict)));
+    ci_gate_exit(worst, args.ci.fail_on);
     Ok(())
 }
 

--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -184,6 +184,71 @@ pub fn emit_ag_state_atom_monitor(
     Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
 }
 
+/// P1 — append a `bad` monitor for `AG (signal ∈ legal)`, the FSM-encoding-legality
+/// invariant. `signal` must resolve to a state register (value-alias / reset-mux
+/// aware). The emitted `bad` fires when `signal` holds a value **outside** `legal` (an
+/// illegal encoding): `bad = ⋀_{c ∈ legal} (signal != c)`. `legal` must be non-empty
+/// and is deduplicated by the caller; the final `and` node carries [`BAD_COND_SYMBOL`].
+pub fn emit_ag_state_in_set_monitor(
+    content: &str,
+    signal: &str,
+    legal: &[u64],
+    reset_pinned: bool,
+) -> Result<String, AdapterError> {
+    if legal.is_empty() {
+        return Err(err(
+            "adapter/btor2/bad_monitor: the state-in-set monitor needs a non-empty legal set"
+                .to_string(),
+        ));
+    }
+    let file = parser::parse(content).map_err(|mut e| {
+        e.message = format!("adapter/btor2/bad_monitor: {}", e.message);
+        e
+    })?;
+
+    let (sig_nid, sig_sort) = state_nid_and_sort(&file, signal, reset_pinned).ok_or_else(|| {
+        err(format!(
+            "adapter/btor2/bad_monitor: `{signal}` does not resolve to a state cell \
+             (the AG(state ∈ set) monitor requires a state register or a value-alias of one)"
+        ))
+    })?;
+
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut appended: Vec<String> = Vec::new();
+    let bool_sort = find_or_make_bool_sort(&file, &mut next_nid, &mut appended);
+
+    // neq_c = (signal != c) for each legal encoding c.
+    let mut terms: Vec<Nid> = Vec::with_capacity(legal.len());
+    for &c in legal {
+        let const_nid = next_nid;
+        next_nid += 1;
+        appended.push(format!("{const_nid} constd {sig_sort} {c}"));
+        let neq_nid = next_nid;
+        next_nid += 1;
+        appended.push(format!("{neq_nid} neq {bool_sort} {sig_nid} {const_nid}"));
+        terms.push(neq_nid);
+    }
+
+    // illegal = ⋀ terms; fold with `and`, naming the final node so it can be observed.
+    let mut acc = terms[0];
+    let last = terms.len() - 1;
+    for (i, &t) in terms.iter().enumerate().skip(1) {
+        let and_nid = next_nid;
+        next_nid += 1;
+        let sym = if i == last {
+            format!(" {BAD_COND_SYMBOL}")
+        } else {
+            String::new()
+        };
+        appended.push(format!("{and_nid} and {bool_sort} {acc} {t}{sym}"));
+        acc = and_nid;
+    }
+
+    let bad_line = next_nid;
+    appended.push(format!("{bad_line} bad {acc}"));
+    Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
+}
+
 /// H.O.1b — append a `bad` monitor for `ante |=> cons` (= `AG (ante → AX cons)`).
 ///
 /// `cons` must resolve to a state register; `ante` may be a state register OR a

--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -195,6 +195,29 @@ pub fn emit_ag_state_in_set_monitor(
     legal: &[u64],
     reset_pinned: bool,
 ) -> Result<String, AdapterError> {
+    let file = parser::parse(content).map_err(|mut e| {
+        e.message = format!("adapter/btor2/bad_monitor: {}", e.message);
+        e
+    })?;
+    let (sig_nid, sig_sort) = state_nid_and_sort(&file, signal, reset_pinned).ok_or_else(|| {
+        err(format!(
+            "adapter/btor2/bad_monitor: `{signal}` does not resolve to a state cell \
+             (the AG(state ∈ set) monitor requires a state register or a value-alias of one)"
+        ))
+    })?;
+    emit_ag_state_in_set_monitor_by_nid(content, sig_nid, sig_sort, legal)
+}
+
+/// As [`emit_ag_state_in_set_monitor`], but with the state cell already resolved to its
+/// `(value_nid, sort_nid)` — for callers (the FSM-encoding scan) that discover the cell
+/// directly and would otherwise have to round-trip through a name that a combinational
+/// alias may shadow.
+pub fn emit_ag_state_in_set_monitor_by_nid(
+    content: &str,
+    sig_nid: Nid,
+    sig_sort: Nid,
+    legal: &[u64],
+) -> Result<String, AdapterError> {
     if legal.is_empty() {
         return Err(err(
             "adapter/btor2/bad_monitor: the state-in-set monitor needs a non-empty legal set"
@@ -204,13 +227,6 @@ pub fn emit_ag_state_in_set_monitor(
     let file = parser::parse(content).map_err(|mut e| {
         e.message = format!("adapter/btor2/bad_monitor: {}", e.message);
         e
-    })?;
-
-    let (sig_nid, sig_sort) = state_nid_and_sort(&file, signal, reset_pinned).ok_or_else(|| {
-        err(format!(
-            "adapter/btor2/bad_monitor: `{signal}` does not resolve to a state cell \
-             (the AG(state ∈ set) monitor requires a state register or a value-alias of one)"
-        ))
     })?;
 
     let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;

--- a/crates/mununu-core/src/adapter/fsm_scan.rs
+++ b/crates/mununu-core/src/adapter/fsm_scan.rs
@@ -42,7 +42,7 @@
 //!   engine's ceiling); a definite `Holds` / `Violated` is sound.
 
 use crate::adapter::btor2::ast::{Btor2File, Nid, Node, Op};
-use crate::adapter::btor2::bad_monitor::emit_ag_state_in_set_monitor;
+use crate::adapter::btor2::bad_monitor::emit_ag_state_in_set_monitor_by_nid;
 use crate::adapter::btor2::bit_blast::resolve_btor2_constant;
 use crate::adapter::btor2::parser;
 use crate::adapter::btor2::pin::pin_inputs_to_constants;
@@ -91,34 +91,33 @@ pub fn fsm_encoding_scan(btor2: &str, max_width: u32) -> Result<Vec<FsmFinding>,
     let (pinned, _) = pin_inputs_to_constants(&seeded, &resets);
     seeded = pinned;
 
-    // Enumerate NAMED signals and resolve each to its underlying state cell (directly
-    // or via a `uext`/reset-mux alias). Dedup by the resolved cell. Deterministic order.
-    let mut named: Vec<(&Nid, &String)> = symbols.iter().collect();
-    named.sort_by_key(|(nid, _)| **nid);
+    // The FSM-like state registers: `collect_symbols` already traces each user name
+    // (incl. Yosys `uext _ _ 0 NAME` aliases) back to its state cell, so an entry whose
+    // nid IS a state cell names that register — no re-resolution (a combinational alias
+    // like `state_d` can shadow the register's name and would fail to re-resolve).
+    // Deterministic order by cell nid.
+    let mut registers: Vec<(Nid, Nid, &String)> = symbols
+        .iter()
+        .filter_map(|(&nid, name)| match file.lookup(nid).map(|l| &l.node) {
+            Some(Node::State { sort, .. }) => Some((nid, *sort, name)),
+            _ => None,
+        })
+        .collect();
+    registers.sort_by_key(|(nid, _, _)| *nid);
 
-    let mut seen_cells: HashSet<Nid> = HashSet::new();
     let mut out = Vec::new();
-    for (_, sym) in named {
-        let Some(state_nid) = parser::resolve_state_alias(&file, sym, true) else {
-            continue;
-        };
-        if !seen_cells.insert(state_nid) {
-            continue;
-        }
-        let Some(Node::State { sort, .. }) = file.lookup(state_nid).map(|l| &l.node) else {
-            continue;
-        };
-        let Some(width) = parser::bv_width(&file, *sort) else {
+    for (cell_nid, sort, name) in registers {
+        let Some(width) = parser::bv_width(&file, sort) else {
             continue;
         };
         if width == 0 || width > max_width {
             continue;
         }
 
-        // Legal encodings = the constants the register's logic compares it against, plus
-        // its reset/init value. Skip a register with no non-trivial enum: fewer than two
+        // Legal encodings = the constants the register is assigned / compared against +
+        // its reset value. Skip a register with no non-trivial enum: fewer than two
         // legal values, or a legal set already covering every value of its width.
-        let legal = legal_encodings(&file, state_nid, &symbols);
+        let legal = legal_encodings(&file, cell_nid, &symbols);
         if legal.len() < 2 {
             continue;
         }
@@ -130,19 +129,19 @@ pub fn fsm_encoding_scan(btor2: &str, max_width: u32) -> Result<Vec<FsmFinding>,
 
         // bad = (reg ∉ legal); reachable from the (reset) start ⇒ an illegal encoding
         // is reachable (a bug). Decided by the word-level safety portfolio.
-        let monitored =
-            emit_ag_state_in_set_monitor(&seeded, sym, &legal_vec, true).map_err(|e| {
+        let monitored = emit_ag_state_in_set_monitor_by_nid(&seeded, cell_nid, sort, &legal_vec)
+            .map_err(|e| {
                 format!(
-                    "building the illegal-encoding monitor for `{sym}`: {}",
+                    "building the illegal-encoding monitor for `{name}`: {}",
                     e.message
                 )
             })?;
         let mfile = parser::parse(&monitored)
-            .map_err(|e| format!("parsing the monitored BTOR2 for `{sym}`: {}", e.message))?;
+            .map_err(|e| format!("parsing the monitored BTOR2 for `{name}`: {}", e.message))?;
         let outcome = decide_reach_portfolio(&mfile);
 
         out.push(FsmFinding {
-            register: sym.clone(),
+            register: name.clone(),
             legal_encodings: legal_vec,
             verdict: PropertyVerdict::from(outcome.verdict),
         });
@@ -150,19 +149,32 @@ pub fn fsm_encoding_scan(btor2: &str, max_width: u32) -> Result<Vec<FsmFinding>,
     Ok(out)
 }
 
-/// The legal encodings of a state register: every constant its own logic compares it
-/// against (via `eq` over a value-alias of the cell), plus its reset/init value.
+/// The legal encodings of a state register — an over-approximation, so that only a
+/// genuinely *computed* out-of-enum value (arithmetic / concat / decode) is ever
+/// flagged illegal (biasing to zero false positives). It is the union of:
+///
+/// - the register's reset/init value;
+/// - constants it is **compared** against (`eq` over a value-alias of the cell) — the
+///   enum values the case/if logic recognizes;
+/// - constants it is **assigned** (constant `ite`-branch leaves in its next-state cone)
+///   — the enum values transitions write, including states a `case` folds into
+///   `default` and so never compares against.
 fn legal_encodings(
     file: &Btor2File,
     state_nid: Nid,
     symbols: &HashMap<Nid, String>,
 ) -> BTreeSet<u64> {
     let aliases = value_alias_nids(file, state_nid);
+    let cell_sort = match file.lookup(state_nid).map(|l| &l.node) {
+        Some(Node::State { sort, .. }) => *sort,
+        _ => return BTreeSet::new(),
+    };
     let mut legal = BTreeSet::new();
 
     if let Some(v) = derive_idle(file, state_nid, symbols) {
         legal.insert(v);
     }
+    // Compared constants (eq over a value-alias of the cell).
     for line in &file.lines {
         let Node::Op {
             op: Op::Eq, args, ..
@@ -173,7 +185,6 @@ fn legal_encodings(
         if args.len() != 2 {
             continue;
         }
-        // The constant operand, when the other operand is a value-alias of the register.
         let (a, b) = (args[0].nid(), args[1].nid());
         let konst = if aliases.contains(&a) {
             resolve_btor2_constant(file, b)
@@ -186,7 +197,69 @@ fn legal_encodings(
             legal.insert(c);
         }
     }
+    // Assigned constants (constant `ite`-branch leaves in the next-state cone).
+    if let Some(next_val) = file.lines.iter().find_map(|l| match &l.node {
+        Node::Next { state, value, .. } if *state == state_nid => Some(*value),
+        _ => None,
+    }) {
+        collect_assigned_consts(
+            file,
+            next_val.nid(),
+            cell_sort,
+            &mut legal,
+            &mut HashSet::new(),
+        );
+    }
     legal
+}
+
+/// From a **value position** in the register's next-state expression, insert into
+/// `legal` every constant of `cell_sort` assigned to the register. Recurses only
+/// through value-carrying structure — `ite` branches (not the boolean condition) and
+/// `uext`/`sext` renames — and treats any *computed* op (arithmetic, concat, decode) as
+/// opaque: its result is the potential illegal value, and its operands are inputs, not
+/// assigned enum constants. This keeps a stray addend/comparison constant out of the
+/// legal set.
+fn collect_assigned_consts(
+    file: &Btor2File,
+    nid: Nid,
+    cell_sort: Nid,
+    legal: &mut BTreeSet<u64>,
+    visited: &mut HashSet<Nid>,
+) {
+    if !visited.insert(nid) {
+        return;
+    }
+    let Some(line) = file.lookup(nid) else {
+        return;
+    };
+    match &line.node {
+        // A constant of the register's sort reached as a value is a legal encoding.
+        Node::Const { sort, .. } if *sort == cell_sort => {
+            if let Some(v) = resolve_btor2_constant(file, nid) {
+                legal.insert(v);
+            }
+        }
+        // `ite(cond, then, else)`: the branches are assigned values; the condition is a
+        // boolean, not a value — skip it.
+        Node::Op {
+            op: Op::Ite, args, ..
+        } if args.len() == 3 => {
+            collect_assigned_consts(file, args[1].nid(), cell_sort, legal, visited);
+            collect_assigned_consts(file, args[2].nid(), cell_sort, legal, visited);
+        }
+        // `uext`/`sext`: a pure width-adjust rename — the value passes through.
+        Node::Op {
+            op: Op::Uext | Op::Sext,
+            args,
+            ..
+        } if !args.is_empty() => {
+            collect_assigned_consts(file, args[0].nid(), cell_sort, legal, visited);
+        }
+        // The register itself, or a computed op: opaque (its result is not a fresh enum
+        // constant, and may be the illegal value we are hunting).
+        _ => {}
+    }
 }
 
 /// The set of NIDs value-identical to `state_nid` — the cell itself plus every
@@ -350,28 +423,31 @@ mod tests {
 18 next 1 3 17
 ";
 
-    // The same FSM with a bug: from `req` (st==1), input `go` drives st to 3 — a value
-    // the case logic never compares against (an illegal encoding, an out-of-enum
-    // transition). 3 is reachable 0 →go 1 →go 3 ⇒ AG (st ∈ {0,1,2}) VIOLATED.
+    // A 3-bit sparse FSM (enum Idle=1, Busy=2, Done=4) with a COMPUTED illegal-encoding
+    // bug: from Busy, `go` assigns `st + 3` (= 2 + 3 = 5 = 3'b101), a value outside the
+    // enum. 5 is reachable Idle →go Busy →go 5 ⇒ AG (st ∈ {1,2,4}) VIOLATED. (A *computed*
+    // out-of-enum value is what the scan detects; a constant-assigned wrong value is
+    // indistinguishable from a legal encoding at the BTOR2 level — see legal_encodings.)
     const ILLEGAL_FSM: &str = "\
-1 sort bitvec 2
+1 sort bitvec 3
 2 sort bitvec 1
 3 state 1 st
-4 zero 1
+4 constd 1 1
 5 init 1 3 4
 6 input 2 go
-7 one 1
-8 constd 1 2
+7 constd 1 2
+8 constd 1 4
 9 constd 1 3
 10 eq 2 3 4
 11 eq 2 3 7
 12 eq 2 3 8
-13 ite 1 6 9 8
-14 ite 1 6 7 4
-15 ite 1 12 4 4
-16 ite 1 11 13 15
-17 ite 1 10 14 16
-18 next 1 3 17
+13 add 1 3 9
+14 ite 1 6 13 8
+15 ite 1 6 7 4
+16 ite 1 12 4 4
+17 ite 1 11 14 16
+18 ite 1 10 15 17
+19 next 1 3 18
 ";
 
     #[test]
@@ -381,7 +457,7 @@ mod tests {
             .iter()
             .find(|f| f.register == "st")
             .expect("st scanned");
-        // Legal set = {0,1,2} (compared against + init 0); 3 is illegal but unreachable.
+        // Legal set = {0,1,2} (compared + assigned + init 0); 3 is illegal but unreachable.
         assert_eq!(st.legal_encodings, vec![0, 1, 2]);
         assert_eq!(
             st.verdict,
@@ -398,15 +474,12 @@ mod tests {
             .iter()
             .find(|f| f.register == "st")
             .expect("st scanned");
-        assert!(
-            !st.legal_encodings.contains(&3),
-            "3 is not a legal encoding: {:?}",
-            st.legal_encodings
-        );
+        // Legal = {1,2,4}: Idle/Busy/Done. The computed `st + 3` (= 5) is not among them.
+        assert_eq!(st.legal_encodings, vec![1, 2, 4]);
         assert_eq!(
             st.verdict,
             PropertyVerdict::Violated,
-            "the bug drives st to the illegal value 3"
+            "the bug computes st + 3 = 5, an illegal encoding"
         );
         assert!(st.is_finding(), "a reachable illegal encoding is a finding");
     }

--- a/crates/mununu-core/src/adapter/fsm_scan.rs
+++ b/crates/mununu-core/src/adapter/fsm_scan.rs
@@ -1,112 +1,110 @@
-//! P1 — automatic FSM recoverability scan (no user input).
+//! P1 — automatic FSM illegal-encoding scan (no user input).
 //!
-//! Discovers the FSM-like state registers of a BTOR2 design, derives each one's
-//! idle/reset target from the design (its `init` value, or the reset-mux constant of an
-//! init-less yosys lift — spike-validated on the real OpenTitan `csrng_main_sm`), and
-//! checks recoverability `AG EF (reg == idle)` with the reset left **free**.
+//! Discovers the FSM-like state registers of a BTOR2 design, derives each one's set of
+//! **legal encodings** from the design (the constants its own logic compares it
+//! against, plus its reset value), and checks — starting from the real reset state —
+//! whether any **illegal** encoding (a value outside that set) is reachable. A
+//! reachable illegal encoding is an unambiguous defect: some input drives the FSM to a
+//! value it never legally holds (an incomplete `case`, a missing `default`, a decoder
+//! that can emit an out-of-range code).
 //!
-//! # Why reset-free is the intended-vs-unintended filter
+//! # Why this is a clean auto bug-finder (unlike recoverability)
 //!
-//! A `VIOLATED` verdict means: a reachable state exists from which the FSM can never
-//! get back to its reset state — **even with reset available**. That is a genuine
-//! *unrecoverable trap*, a real finding. A design's *intended* reset-dependence (the
-//! FSM recovers only when reset is asserted, e.g. an error state cleared by reset)
-//! still `HOLDS` here precisely because reset is free — so intended terminals do not
-//! show up as findings. This is the automatic bug-finder for the branching property
-//! SVA cannot express, on the small FSM cone where mununu is strongest and needs no
-//! predicates.
+//! Recoverability `AG EF idle` is *tautological* on a reset-carrying design: with reset
+//! free the environment can always assert reset to reach idle, so it can never see a
+//! trap; with reset held it flags every reset-recoverable-only state, including
+//! *intended* error states — neither is a zero-touch bug signal. Illegal-encoding
+//! reachability asks a question reset cannot paper over and design intent cannot
+//! excuse: **can the next-state logic, for some input, corrupt the register past its
+//! enum?** If yes it is a real bug, full stop. It is a *safety* property, decided by the
+//! word-level reachability portfolio ([`decide_reach_portfolio`], no bit cap), so it
+//! scales past the exact engine's cone.
 //!
-//! # Idle derivation (two sources — spike-validated 2026-07-08)
+//! # Starting from a legal state
 //!
-//! The idle/reset target is derived from the design, in order:
+//! Reachability must start from a LEGAL encoding. yosys-lifted RTL carries no `init`
+//! line (reset is an explicit signal), so [`inject_reset_init`] derives the post-reset
+//! state (one held-reset cycle) and seeds `init` lines, and the recognized reset inputs
+//! are pinned inactive ([`pin_inputs_to_constants`]) — the same "verified out of reset"
+//! discipline verify-auto uses. Without this the init-less power-on default 0 is itself
+//! an illegal sparse encoding and the scan would trivially "find" it. Hand-written
+//! BTOR2 that already carries `init` lines is left as-is.
 //!
-//! 1. **BTOR2 `init` value.** Hand-written / HWMCC-style / mununu-abstraction BTOR2
-//!    declares the reset state with an `init` line.
-//! 2. **Reset-mux constant.** yosys-lifted RTL (sv2v → yosys → BTOR2) models reset as an
-//!    *explicit signal* and carries **no `init` lines**; instead the register's `next`
-//!    is a top-level `ite(reset_input, normal_logic, RESET_CONST)`. The constant branch
-//!    of that reset mux is the reset state ([`derive_reset_idle`]). This is exactly how
-//!    the real OpenTitan `csrng_main_sm` encodes `MainSmIdle = 55` — so the scan works
-//!    end-to-end on real RTL with no user input.
+//! # Scope
 //!
-//! A register with neither an init nor a recognizable reset mux is skipped (not wrong).
-//!
-//! # Scope (honest limits)
-//!
-//! - **Named state.** A register is scanned if a symbol names it — directly on the
-//!   `state` cell or via a `uext`/reset-mux alias ([`parser::resolve_state_alias`]),
-//!   which is how yosys surfaces `state_q`. Unnamed internal flops are not scanned.
-//! - **Reset-free framing.** With reset left free, asserting reset forces a well-formed
-//!   FSM back to idle, so recoverability `HOLDS` for any register whose reset
-//!   unconditionally restores idle. A `VIOLATED` verdict therefore isolates the genuine
-//!   bug class: a reachable state from which the FSM cannot reach idle **even with reset
-//!   available** — a gated/ineffective reset, a wrong idle encoding, or an upstream trap.
-//!   Intended reset-*dependence* (recovers only when reset is asserted) still `HOLDS`.
-//! - Each check runs the exact 3-valued engine over the whole design; on a design
-//!   whose *total* state exceeds the engine's cone cap the verdict is `Unknown`
-//!   (skipped, not wrong). Routing the over-cap case to the cube + `smt-hyper-must`
-//!   path is a P0.2 follow-up.
-//! - `max_width` filters which registers count as "FSM-like" (narrow enum state, not a
-//!   wide datapath / counter — recoverability of a counter to 0 is not a meaningful
-//!   bug).
+//! - **Named, FSM-width state.** A register is scanned if a symbol names it (directly or
+//!   via a `uext`/reset-mux alias, [`parser::resolve_state_alias`]) and it is at most
+//!   `max_width` bits wide. A wider register is a datapath / counter, skipped.
+//! - **Non-trivial enum only.** A register whose legal set has fewer than 2 values, or
+//!   already covers every value of its width (`|L| ≥ 2^width`), has no illegal encoding
+//!   to reach and is skipped.
+//! - The reach portfolio abstains (`Unknown`) when no member decides (e.g. over every
+//!   engine's ceiling); a definite `Holds` / `Violated` is sound.
 
 use crate::adapter::btor2::ast::{Btor2File, Nid, Node, Op};
+use crate::adapter::btor2::bad_monitor::emit_ag_state_in_set_monitor;
 use crate::adapter::btor2::bit_blast::resolve_btor2_constant;
 use crate::adapter::btor2::parser;
-use crate::adapter::recoverability::verify_recoverability;
+use crate::adapter::btor2::pin::pin_inputs_to_constants;
+use crate::adapter::btor2::reset_init::inject_reset_init;
+use crate::adapter::reach_portfolio::decide_reach_portfolio;
 use crate::verdict::PropertyVerdict;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 /// The default "FSM-like" width bound: a state register wider than this is treated as
 /// a datapath / counter and skipped (256 encodings is a generous enum ceiling).
 pub const DEFAULT_FSM_MAX_WIDTH: u32 = 8;
 
-/// One register's recoverability result.
+/// One register's illegal-encoding result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FsmFinding {
     /// The state register's symbol.
     pub register: String,
-    /// The idle/reset value recoverability targets (the register's init or reset-mux
-    /// constant).
-    pub idle_value: u64,
-    /// `Holds` = always recoverable to idle; `Violated` = an **unrecoverable trap**
-    /// (a finding); `Unknown` = over the exact engine's cap (skipped).
+    /// The legal encodings the register's own logic recognizes (sorted).
+    pub legal_encodings: Vec<u64>,
+    /// `Holds` = the register provably stays within its legal encodings; `Violated` =
+    /// an illegal encoding is **reachable** (a finding); `Unknown` = the portfolio
+    /// could not decide.
     pub verdict: PropertyVerdict,
 }
 
 impl FsmFinding {
-    /// A `Violated` verdict is a real finding (an unrecoverable trap).
+    /// A `Violated` verdict is a real finding (a reachable illegal encoding).
     pub fn is_finding(&self) -> bool {
         self.verdict == PropertyVerdict::Violated
     }
 }
 
-/// Scan `btor2` for FSM-like state registers and check recoverability-to-init of each
-/// with reset free. Returns one [`FsmFinding`] per checked register (init-less or
-/// too-wide registers are skipped silently). See the module docs.
-pub fn fsm_recoverability_scan(btor2: &str, max_width: u32) -> Result<Vec<FsmFinding>, String> {
+/// Scan `btor2` for FSM-like state registers and check, from the reset state, that no
+/// illegal encoding is reachable for each. Returns one [`FsmFinding`] per checked
+/// register (registers without a non-trivial legal set are skipped). See the module
+/// docs.
+pub fn fsm_encoding_scan(btor2: &str, max_width: u32) -> Result<Vec<FsmFinding>, String> {
     let file = parser::parse(btor2).map_err(|e| format!("parsing BTOR2: {}", e.message))?;
     let symbols = parser::collect_symbols(&file);
 
-    // Enumerate NAMED signals and resolve each to its underlying state cell — directly
-    // (the symbol is on the `state` node) or via a `uext`/reset-mux alias (the symbol is
-    // on an `Op`/`Output`, as yosys surfaces `state_q`). Dedup by the resolved cell so an
-    // alias plus its own cell aren't scanned twice. Deterministic order by symbol nid.
+    // Establish a legal start: seed `init` at the post-reset state and pin the resets
+    // inactive (no-op for a design that already carries `init` lines / has no reset).
+    let resets = detect_resets(&file, &symbols);
+    let mut seeded = inject_reset_init(btor2, &resets)
+        .map_err(|e| format!("seeding reset init: {}", e.message))?;
+    let (pinned, _) = pin_inputs_to_constants(&seeded, &resets);
+    seeded = pinned;
+
+    // Enumerate NAMED signals and resolve each to its underlying state cell (directly
+    // or via a `uext`/reset-mux alias). Dedup by the resolved cell. Deterministic order.
     let mut named: Vec<(&Nid, &String)> = symbols.iter().collect();
     named.sort_by_key(|(nid, _)| **nid);
 
     let mut seen_cells: HashSet<Nid> = HashSet::new();
     let mut out = Vec::new();
     for (_, sym) in named {
-        // `allow_reset_mux = true`: yosys surfaces `state_q` as `uext(ite(rst, cell,
-        // reset_const))`, so the name resolves to its cell only through the reset mux.
         let Some(state_nid) = parser::resolve_state_alias(&file, sym, true) else {
             continue;
         };
         if !seen_cells.insert(state_nid) {
             continue;
         }
-        // The resolved cell must be an FSM-width state.
         let Some(Node::State { sort, .. }) = file.lookup(state_nid).map(|l| &l.node) else {
             continue;
         };
@@ -116,54 +114,160 @@ pub fn fsm_recoverability_scan(btor2: &str, max_width: u32) -> Result<Vec<FsmFin
         if width == 0 || width > max_width {
             continue;
         }
-        // idle = the register's init value if present, else the reset-mux constant of an
-        // init-less yosys lift; skip a register whose idle we can't pin down.
-        let Some(idle) = derive_idle(&file, state_nid, &symbols) else {
-            continue;
-        };
 
-        // AG EF (reg == idle) with reset FREE (reset_pinned = false inside).
-        let verdict = verify_recoverability(btor2, &format!("{sym} == {idle}"))?;
+        // Legal encodings = the constants the register's logic compares it against, plus
+        // its reset/init value. Skip a register with no non-trivial enum: fewer than two
+        // legal values, or a legal set already covering every value of its width.
+        let legal = legal_encodings(&file, state_nid, &symbols);
+        if legal.len() < 2 {
+            continue;
+        }
+        let total: u128 = 1u128 << width;
+        if legal.len() as u128 >= total {
+            continue;
+        }
+        let legal_vec: Vec<u64> = legal.into_iter().collect();
+
+        // bad = (reg ∉ legal); reachable from the (reset) start ⇒ an illegal encoding
+        // is reachable (a bug). Decided by the word-level safety portfolio.
+        let monitored =
+            emit_ag_state_in_set_monitor(&seeded, sym, &legal_vec, true).map_err(|e| {
+                format!(
+                    "building the illegal-encoding monitor for `{sym}`: {}",
+                    e.message
+                )
+            })?;
+        let mfile = parser::parse(&monitored)
+            .map_err(|e| format!("parsing the monitored BTOR2 for `{sym}`: {}", e.message))?;
+        let outcome = decide_reach_portfolio(&mfile);
+
         out.push(FsmFinding {
             register: sym.clone(),
-            idle_value: idle,
-            verdict,
+            legal_encodings: legal_vec,
+            verdict: PropertyVerdict::from(outcome.verdict),
         });
     }
     Ok(out)
 }
 
-/// Derive a state register's idle/reset value: its BTOR2 `init` value if present, else
-/// the constant branch of its reset mux (init-less yosys lifts). `None` if neither.
-fn derive_idle(file: &Btor2File, state_nid: Nid, symbols: &HashMap<Nid, String>) -> Option<u64> {
-    // 1. An explicit `init` constant.
-    let init = file.lines.iter().find_map(|l| match &l.node {
-        Node::Init { state, value, .. } if *state == state_nid => Some(*value),
-        _ => None,
-    });
-    if let Some(v) = init.and_then(|op| resolve_btor2_constant(file, op.nid())) {
-        return Some(v);
-    }
-    // 2. The reset-mux constant of an init-less register.
-    derive_reset_idle(file, state_nid, symbols)
-}
-
-/// Derive the reset value of an init-less state cell whose `next` is a top-level reset
-/// mux `ite(reset_input, normal_logic, RESET_CONST)`. yosys `async2sync` lowers an RTL
-/// reset to exactly this shape. Returns the constant branch when the condition is a
-/// reset-named input and exactly one branch is a constant (the other being the normal
-/// next-state logic, which is never a bare constant). Polarity-independent.
-fn derive_reset_idle(
+/// The legal encodings of a state register: every constant its own logic compares it
+/// against (via `eq` over a value-alias of the cell), plus its reset/init value.
+fn legal_encodings(
     file: &Btor2File,
     state_nid: Nid,
     symbols: &HashMap<Nid, String>,
-) -> Option<u64> {
-    // The register's `next` value node.
+) -> BTreeSet<u64> {
+    let aliases = value_alias_nids(file, state_nid);
+    let mut legal = BTreeSet::new();
+
+    if let Some(v) = derive_idle(file, state_nid, symbols) {
+        legal.insert(v);
+    }
+    for line in &file.lines {
+        let Node::Op {
+            op: Op::Eq, args, ..
+        } = &line.node
+        else {
+            continue;
+        };
+        if args.len() != 2 {
+            continue;
+        }
+        // The constant operand, when the other operand is a value-alias of the register.
+        let (a, b) = (args[0].nid(), args[1].nid());
+        let konst = if aliases.contains(&a) {
+            resolve_btor2_constant(file, b)
+        } else if aliases.contains(&b) {
+            resolve_btor2_constant(file, a)
+        } else {
+            None
+        };
+        if let Some(c) = konst {
+            legal.insert(c);
+        }
+    }
+    legal
+}
+
+/// The set of NIDs value-identical to `state_nid` — the cell itself plus every
+/// `uext`/`sext`-0 rename and async-reset-mux passthrough of it (how yosys surfaces the
+/// register's current value, e.g. `state_q`). The design's `eq` comparisons target
+/// these nids, not the raw cell.
+fn value_alias_nids(file: &Btor2File, state_nid: Nid) -> HashSet<Nid> {
+    let mut set: HashSet<Nid> = HashSet::from([state_nid]);
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for line in &file.lines {
+            if set.contains(&line.nid) {
+                continue;
+            }
+            let is_alias = match &line.node {
+                // `uext`/`sext` by 0 = a pure rename (same value).
+                Node::Op {
+                    op: Op::Uext | Op::Sext,
+                    args,
+                    ..
+                } if args.len() == 1
+                    && line.immediates.first() == Some(&0)
+                    && set.contains(&args[0].nid()) =>
+                {
+                    true
+                }
+                // Async-reset mux `ite(rst, then, else)`: one branch passes the state
+                // through, the other is the reset constant.
+                Node::Op {
+                    op: Op::Ite, args, ..
+                } if args.len() == 3 => {
+                    let (then_nid, else_nid) = (args[1].nid(), args[2].nid());
+                    (set.contains(&then_nid) && resolve_btor2_constant(file, else_nid).is_some())
+                        || (set.contains(&else_nid)
+                            && resolve_btor2_constant(file, then_nid).is_some())
+                }
+                _ => false,
+            };
+            if is_alias {
+                set.insert(line.nid);
+                changed = true;
+            }
+        }
+    }
+    set
+}
+
+/// Detect the design's reset inputs as `(name, inactive_value)` from each state cell's
+/// reset mux — the set [`inject_reset_init`] / [`pin_inputs_to_constants`] consume.
+fn detect_resets(file: &Btor2File, symbols: &HashMap<Nid, String>) -> Vec<(String, u64)> {
+    let mut resets: BTreeSet<(String, u64)> = BTreeSet::new();
+    for line in &file.lines {
+        if !matches!(&line.node, Node::State { .. }) {
+            continue;
+        }
+        if let Some(mux) = analyze_reset_mux(file, line.nid, symbols) {
+            resets.insert((mux.reset_name, mux.inactive_value));
+        }
+    }
+    resets.into_iter().collect()
+}
+
+/// The reset mux of a state cell: its `next` value is a top-level
+/// `ite(reset_input, normal_logic, RESET_CONST)` (how yosys `async2sync` lowers an RTL
+/// reset). Returns the reset input name, its inactive level, and the reset constant.
+struct ResetMux {
+    reset_name: String,
+    inactive_value: u64,
+    reset_value: u64,
+}
+
+fn analyze_reset_mux(
+    file: &Btor2File,
+    state_nid: Nid,
+    symbols: &HashMap<Nid, String>,
+) -> Option<ResetMux> {
     let next_val = file.lines.iter().find_map(|l| match &l.node {
         Node::Next { state, value, .. } if *state == state_nid => Some(*value),
         _ => None,
     })?;
-    // It must be a top-level `ite(cond, then, else)`.
     let Node::Op {
         op: Op::Ite, args, ..
     } = &file.lookup(next_val.nid())?.node
@@ -173,19 +277,44 @@ fn derive_reset_idle(
     let [cond, then_op, else_op] = args[..] else {
         return None;
     };
-    // The condition must reference a reset-named input (guards against picking up a
-    // normal FSM transition `ite(go, SOME_STATE_const, stay)` as if it were a reset).
-    if !symbols.get(&cond.nid()).is_some_and(|s| is_reset_name(s)) {
-        return None;
-    }
-    // The reset value is the constant branch; the normal-logic branch is not a constant.
+    let reset_name = symbols
+        .get(&cond.nid())
+        .filter(|s| is_reset_name(s))?
+        .clone();
+
+    // The reset value is the constant branch; polarity follows which branch it is.
+    // `ite(cond, then, else)`: reset in the `else` branch ⇒ applied when cond is 0
+    // (active-low, inactive = 1); reset in `then` ⇒ applied when cond is 1
+    // (active-high, inactive = 0).
     match (
         resolve_btor2_constant(file, then_op.nid()),
         resolve_btor2_constant(file, else_op.nid()),
     ) {
-        (Some(c), None) | (None, Some(c)) => Some(c),
-        _ => None, // both-const / neither-const is ambiguous — skip
+        (None, Some(reset_value)) => Some(ResetMux {
+            reset_name,
+            inactive_value: 1,
+            reset_value,
+        }),
+        (Some(reset_value), None) => Some(ResetMux {
+            reset_name,
+            inactive_value: 0,
+            reset_value,
+        }),
+        _ => None, // both-const / neither-const is ambiguous
     }
+}
+
+/// Derive a state register's reset/init value: its BTOR2 `init` value if present, else
+/// the constant branch of its reset mux (init-less yosys lifts). `None` if neither.
+fn derive_idle(file: &Btor2File, state_nid: Nid, symbols: &HashMap<Nid, String>) -> Option<u64> {
+    let init = file.lines.iter().find_map(|l| match &l.node {
+        Node::Init { state, value, .. } if *state == state_nid => Some(*value),
+        _ => None,
+    });
+    if let Some(v) = init.and_then(|op| resolve_btor2_constant(file, op.nid())) {
+        return Some(v);
+    }
+    analyze_reset_mux(file, state_nid, symbols).map(|m| m.reset_value)
 }
 
 /// Heuristic: does this signal name a reset input? Matches `rst` / `reset` roots with
@@ -199,9 +328,10 @@ fn is_reset_name(sym: &str) -> bool {
 mod tests {
     use super::*;
 
-    // A 3-state responder FSM: st 0=idle,1=req,2=grant; always returns to idle.
-    // AG EF (st == 0) HOLDS ⇒ no finding.
-    const RESPONDER: &str = "\
+    // A 3-state responder FSM (2-bit `st`, values 0..3). Case arms compare st against
+    // 0/1/2 (the recognized enum); transitions cycle 0 →go 1 → 2 → 0. The 4th encoding
+    // 3 is never reached ⇒ AG (st ∈ {0,1,2}) HOLDS ⇒ no finding.
+    const LEGAL_FSM: &str = "\
 1 sort bitvec 2
 2 sort bitvec 1
 3 state 1 st
@@ -210,17 +340,20 @@ mod tests {
 6 input 2 go
 7 one 1
 8 constd 1 2
-9 eq 2 3 4
-10 eq 2 3 7
-11 ite 1 6 7 4
-12 ite 1 10 8 4
-13 ite 1 9 11 12
-14 next 1 3 13
+10 eq 2 3 4
+11 eq 2 3 7
+12 eq 2 3 8
+14 ite 1 6 7 4
+15 ite 1 12 4 4
+16 ite 1 11 8 15
+17 ite 1 10 14 16
+18 next 1 3 17
 ";
 
-    // A 4-state staller: st 0=idle,1=req,3=stuck (absorbing); 2=grant unreachable.
-    // From `stuck` it can NEVER get back to idle ⇒ AG EF (st == 0) VIOLATED ⇒ a finding.
-    const STALLER: &str = "\
+    // The same FSM with a bug: from `req` (st==1), input `go` drives st to 3 — a value
+    // the case logic never compares against (an illegal encoding, an out-of-enum
+    // transition). 3 is reachable 0 →go 1 →go 3 ⇒ AG (st ∈ {0,1,2}) VIOLATED.
+    const ILLEGAL_FSM: &str = "\
 1 sort bitvec 2
 2 sort bitvec 1
 3 state 1 st
@@ -232,88 +365,60 @@ mod tests {
 9 constd 1 3
 10 eq 2 3 4
 11 eq 2 3 7
-12 ite 1 6 7 4
-13 ite 1 11 9 3
-14 ite 1 10 12 13
-15 next 1 3 14
+12 eq 2 3 8
+13 ite 1 6 9 8
+14 ite 1 6 7 4
+15 ite 1 12 4 4
+16 ite 1 11 13 15
+17 ite 1 10 14 16
+18 next 1 3 17
 ";
 
     #[test]
-    fn responder_scan_finds_no_trap() {
-        let findings = fsm_recoverability_scan(RESPONDER, DEFAULT_FSM_MAX_WIDTH).expect("scan");
-        assert_eq!(findings.len(), 1, "one FSM register (st)");
-        assert_eq!(findings[0].register, "st");
-        assert_eq!(findings[0].idle_value, 0);
-        assert_eq!(findings[0].verdict, PropertyVerdict::Holds);
-        assert!(
-            !findings[0].is_finding(),
-            "responder always recovers to idle"
-        );
-    }
-
-    #[test]
-    fn staller_scan_finds_the_unrecoverable_trap() {
-        let findings = fsm_recoverability_scan(STALLER, DEFAULT_FSM_MAX_WIDTH).expect("scan");
+    fn legal_fsm_finds_no_illegal_encoding() {
+        let findings = fsm_encoding_scan(LEGAL_FSM, DEFAULT_FSM_MAX_WIDTH).expect("scan");
         let st = findings
             .iter()
             .find(|f| f.register == "st")
-            .expect("st register scanned");
-        assert_eq!(
-            st.verdict,
-            PropertyVerdict::Violated,
-            "stuck state is a trap"
-        );
-        assert!(st.is_finding(), "the absorbing trap is a real finding");
-    }
-
-    // An init-LESS FSM whose reset is an explicit active-low `rst_ni`, lowered to a
-    // top-level reset mux `next = rst_ni ? normal : IDLE_CONST` exactly as yosys
-    // `async2sync` emits. idle=5 must be recovered from the mux constant (no init line).
-    // Normal logic cycles 5→1→0→5, so AG EF (st == 5) HOLDS ⇒ no finding.
-    const RESET_MUX: &str = "\
-1 sort bitvec 1
-2 sort bitvec 3
-3 state 2 st
-4 input 1 rst_ni
-5 constd 2 5
-6 constd 2 1
-7 zero 2
-8 eq 1 3 5
-9 eq 1 3 6
-10 ite 2 9 7 5
-11 ite 2 8 6 10
-12 ite 2 4 11 5
-13 next 2 3 12
-";
-
-    #[test]
-    fn reset_mux_idle_is_recovered_without_an_init_line() {
-        let findings = fsm_recoverability_scan(RESET_MUX, DEFAULT_FSM_MAX_WIDTH).expect("scan");
-        let st = findings
-            .iter()
-            .find(|f| f.register == "st")
-            .expect("st register scanned (idle derived from the reset mux)");
-        assert_eq!(
-            st.idle_value, 5,
-            "idle = the reset-mux constant, not an init"
-        );
+            .expect("st scanned");
+        // Legal set = {0,1,2} (compared against + init 0); 3 is illegal but unreachable.
+        assert_eq!(st.legal_encodings, vec![0, 1, 2]);
         assert_eq!(
             st.verdict,
             PropertyVerdict::Holds,
-            "the FSM cycles back to idle"
+            "st stays within its enum"
         );
         assert!(!st.is_finding());
     }
 
     #[test]
-    fn wide_registers_are_skipped() {
-        // A 16-bit datapath register (init 0, holds): too wide to be FSM-like.
-        const WIDE: &str =
-            "1 sort bitvec 16\n2 state 1 data\n3 zero 1\n4 init 1 2 3\n5 next 1 2 2\n";
-        let findings = fsm_recoverability_scan(WIDE, DEFAULT_FSM_MAX_WIDTH).expect("scan");
+    fn illegal_fsm_reaches_the_illegal_encoding() {
+        let findings = fsm_encoding_scan(ILLEGAL_FSM, DEFAULT_FSM_MAX_WIDTH).expect("scan");
+        let st = findings
+            .iter()
+            .find(|f| f.register == "st")
+            .expect("st scanned");
         assert!(
-            findings.is_empty(),
-            "a 16-bit datapath register is not FSM-like (max_width=8)"
+            !st.legal_encodings.contains(&3),
+            "3 is not a legal encoding: {:?}",
+            st.legal_encodings
+        );
+        assert_eq!(
+            st.verdict,
+            PropertyVerdict::Violated,
+            "the bug drives st to the illegal value 3"
+        );
+        assert!(st.is_finding(), "a reachable illegal encoding is a finding");
+    }
+
+    #[test]
+    fn full_coverage_register_is_skipped() {
+        // A 1-bit register that legally takes both 0 and 1 (|L| = 2^1): no illegal value.
+        const FULL: &str = "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 one 1\n5 init 1 2 3\n6 eq 1 2 3\n7 eq 1 2 4\n8 next 1 2 4\n";
+        let findings = fsm_encoding_scan(FULL, DEFAULT_FSM_MAX_WIDTH).expect("scan");
+        assert!(
+            findings.iter().all(|f| f.register != "flag"),
+            "a fully-covered 1-bit register has no illegal encoding to check"
         );
     }
 }

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -89,6 +89,16 @@ pub fn sv_verify_recoverability(lift: &SvLift, target: &str) -> Result<PropertyV
     verify_recoverability(&btor2, target)
 }
 
+/// `sv check-fsm` — lift SV and auto-scan every FSM-like state register for a reachable
+/// illegal encoding (no user input). The SV-direct peer of `btor2 check-fsm`.
+pub fn sv_check_fsm(
+    lift: &SvLift,
+    max_width: u32,
+) -> Result<Vec<crate::adapter::fsm_scan::FsmFinding>, String> {
+    let btor2 = lift.lift()?;
+    crate::adapter::fsm_scan::fsm_encoding_scan(&btor2, max_width)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -722,39 +722,38 @@ pub async fn btor2_verify_recoverability_handler(
     }))
 }
 
-/// Auto-scan every FSM-like state register for an unrecoverable trap
+/// Auto-scan every FSM-like state register for a reachable illegal encoding
 /// (`POST /api/v1/btor2/check-fsm`) — no user input. Surface peer of the CLI
-/// `mununu btor2 check-fsm`: derives each narrow state register's idle/reset value
-/// (init or reset-mux constant) and decides recoverability `AG EF (reg == idle)` with
-/// reset free; a `"violated"` register is an unrecoverable trap. A malformed BTOR2
-/// source is a `BadRequest`.
+/// `mununu btor2 check-fsm`: derives each narrow state register's legal encoding set
+/// from the design and checks, from the reset state, whether any illegal encoding is
+/// reachable via the word-level portfolio; a `"violated"` register has a reachable
+/// illegal encoding (a bug). A malformed BTOR2 source is a `BadRequest`.
 pub async fn btor2_check_fsm_handler(
     Json(request): Json<Btor2CheckFsmRequest>,
 ) -> ApiResult<Json<Btor2CheckFsmResponse>> {
-    use crate::adapter::fsm_scan::fsm_recoverability_scan;
+    use crate::adapter::fsm_scan::fsm_encoding_scan;
 
-    let findings =
-        fsm_recoverability_scan(&request.content, request.max_width).map_err(|message| {
-            ApiError::BadRequest {
-                message,
-                details: None,
-            }
-        })?;
+    let findings = fsm_encoding_scan(&request.content, request.max_width).map_err(|message| {
+        ApiError::BadRequest {
+            message,
+            details: None,
+        }
+    })?;
 
-    let traps_found = findings.iter().filter(|f| f.is_finding()).count();
+    let illegal_encodings_found = findings.iter().filter(|f| f.is_finding()).count();
     let registers = findings
         .iter()
         .map(|f| FsmRegisterFinding {
             register: f.register.clone(),
-            idle_value: f.idle_value,
+            legal_encodings: f.legal_encodings.clone(),
             verdict: f.verdict.as_str().to_string(),
-            unrecoverable_trap: f.is_finding(),
+            illegal_encoding_reachable: f.is_finding(),
         })
         .collect();
 
     Ok(Json(Btor2CheckFsmResponse {
         fsm_registers_checked: findings.len(),
-        traps_found,
+        illegal_encodings_found,
         registers,
     }))
 }
@@ -4154,24 +4153,46 @@ members = ["x"]
         assert!(matches!(err, ApiError::BadRequest { .. }));
     }
 
-    // The auto-scan discovers `st` (init 0), derives idle=0, and reports the absorbing
-    // trap as an unrecoverable finding — no user input.
+    // A 2-bit FSM (values 0..3) whose case logic recognizes 0/1/2 but a bug drives it
+    // to the illegal encoding 3. The auto-scan discovers `st`, derives legal {0,1,2},
+    // and reports the reachable illegal encoding — no user input.
+    const ILLEGAL_ENCODING_FSM: &str = "\
+1 sort bitvec 2
+2 sort bitvec 1
+3 state 1 st
+4 zero 1
+5 init 1 3 4
+6 input 2 go
+7 one 1
+8 constd 1 2
+9 constd 1 3
+10 eq 2 3 4
+11 eq 2 3 7
+12 eq 2 3 8
+13 ite 1 6 9 8
+14 ite 1 6 7 4
+15 ite 1 12 4 4
+16 ite 1 11 13 15
+17 ite 1 10 14 16
+18 next 1 3 17
+";
+
     #[tokio::test]
-    async fn btor2_check_fsm_handler_reports_the_trap() {
+    async fn btor2_check_fsm_handler_reports_the_illegal_encoding() {
         let request = Btor2CheckFsmRequest {
-            content: LIVENESS_STALLER.to_string(),
+            content: ILLEGAL_ENCODING_FSM.to_string(),
             max_width: crate::adapter::fsm_scan::DEFAULT_FSM_MAX_WIDTH,
         };
         let Json(out) = btor2_check_fsm_handler(Json(request))
             .await
             .expect("check-fsm runs");
         assert_eq!(out.fsm_registers_checked, 1, "response: {out:?}");
-        assert_eq!(out.traps_found, 1);
+        assert_eq!(out.illegal_encodings_found, 1);
         let st = &out.registers[0];
         assert_eq!(st.register, "st");
-        assert_eq!(st.idle_value, 0);
+        assert_eq!(st.legal_encodings, vec![0, 1, 2]);
         assert_eq!(st.verdict, "violated");
-        assert!(st.unrecoverable_trap);
+        assert!(st.illegal_encoding_reachable);
     }
 
     #[tokio::test]

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -867,6 +867,48 @@ pub async fn sv_verify_recoverability_handler(
     }))
 }
 
+/// `POST /api/v1/sv/check-fsm` — lift SV and auto-scan every FSM register for a
+/// reachable illegal encoding. Surface peer of the CLI `sv check-fsm`; returns the same
+/// [`Btor2CheckFsmResponse`] as the BTOR2-direct verb.
+pub async fn sv_check_fsm_handler(
+    Json(request): Json<SvCheckFsmRequest>,
+) -> ApiResult<Json<Btor2CheckFsmResponse>> {
+    use crate::adapter::sv_verify::{SvLift, sv_check_fsm};
+
+    let lift = SvLift {
+        source: request.source,
+        additional_sources: request
+            .additional_sources
+            .into_iter()
+            .map(|f| (f.name, f.content))
+            .collect(),
+        top: request.top,
+        use_sv2v: request.use_sv2v,
+    };
+    let findings =
+        sv_check_fsm(&lift, request.max_width).map_err(|message| ApiError::BadRequest {
+            message,
+            details: None,
+        })?;
+
+    let illegal_encodings_found = findings.iter().filter(|f| f.is_finding()).count();
+    let registers = findings
+        .iter()
+        .map(|f| FsmRegisterFinding {
+            register: f.register.clone(),
+            legal_encodings: f.legal_encodings.clone(),
+            verdict: f.verdict.as_str().to_string(),
+            illegal_encoding_reachable: f.is_finding(),
+        })
+        .collect();
+
+    Ok(Json(Btor2CheckFsmResponse {
+        fsm_registers_checked: findings.len(),
+        illegal_encodings_found,
+        registers,
+    }))
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — SV-direct CEGAR in one call.
 ///
 /// Lifts SystemVerilog to a single flattened BTOR2 (sv2v + Yosys, the
@@ -4153,28 +4195,30 @@ members = ["x"]
         assert!(matches!(err, ApiError::BadRequest { .. }));
     }
 
-    // A 2-bit FSM (values 0..3) whose case logic recognizes 0/1/2 but a bug drives it
-    // to the illegal encoding 3. The auto-scan discovers `st`, derives legal {0,1,2},
-    // and reports the reachable illegal encoding — no user input.
+    // A 3-bit sparse FSM (enum Idle=1, Busy=2, Done=4) with a COMPUTED illegal-encoding
+    // bug: from Busy, `go` assigns `st + 3` (= 5 = 3'b101), outside the enum. The
+    // auto-scan discovers `st`, derives legal {1,2,4}, and reports the reachable illegal
+    // encoding 5 — no user input.
     const ILLEGAL_ENCODING_FSM: &str = "\
-1 sort bitvec 2
+1 sort bitvec 3
 2 sort bitvec 1
 3 state 1 st
-4 zero 1
+4 constd 1 1
 5 init 1 3 4
 6 input 2 go
-7 one 1
-8 constd 1 2
+7 constd 1 2
+8 constd 1 4
 9 constd 1 3
 10 eq 2 3 4
 11 eq 2 3 7
 12 eq 2 3 8
-13 ite 1 6 9 8
-14 ite 1 6 7 4
-15 ite 1 12 4 4
-16 ite 1 11 13 15
-17 ite 1 10 14 16
-18 next 1 3 17
+13 add 1 3 9
+14 ite 1 6 13 8
+15 ite 1 6 7 4
+16 ite 1 12 4 4
+17 ite 1 11 14 16
+18 ite 1 10 15 17
+19 next 1 3 18
 ";
 
     #[tokio::test]
@@ -4190,7 +4234,7 @@ members = ["x"]
         assert_eq!(out.illegal_encodings_found, 1);
         let st = &out.registers[0];
         assert_eq!(st.register, "st");
-        assert_eq!(st.legal_encodings, vec![0, 1, 2]);
+        assert_eq!(st.legal_encodings, vec![1, 2, 4]);
         assert_eq!(st.verdict, "violated");
         assert!(st.illegal_encoding_reachable);
     }

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1065,6 +1065,27 @@ pub struct SvVerifyRecoverabilityRequest {
     pub target: String,
 }
 
+/// Request for `POST /api/v1/sv/check-fsm` — the SV lift fields plus the FSM width
+/// bound. Lifts the module and auto-scans every FSM register for a reachable illegal
+/// encoding (no property to name). Returns a [`Btor2CheckFsmResponse`].
+#[derive(Debug, Deserialize)]
+pub struct SvCheckFsmRequest {
+    /// SystemVerilog primary source content.
+    pub source: String,
+    /// Additional SV sources (packages / includes).
+    #[serde(default)]
+    pub additional_sources: Vec<FileContent>,
+    /// Top module for the lift (auto-detect when omitted).
+    #[serde(default)]
+    pub top: Option<String>,
+    /// Run sv2v before Yosys. Default `false`.
+    #[serde(default)]
+    pub use_sv2v: bool,
+    /// Max state-register width treated as an FSM (wider = datapath/counter, skipped).
+    #[serde(default = "default_fsm_max_width")]
+    pub max_width: u32,
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — request for the SV-direct
 /// CEGAR endpoint (`POST /api/v1/sv/cegar`). Mirrors the CLI
 /// `mununu sv cegar`: lifts SystemVerilog to a single flattened BTOR2

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -963,11 +963,11 @@ pub struct Btor2VerifyRecoverabilityResponse {
     pub property: String,
 }
 
-/// Request for the auto FSM-recoverability scan
+/// Request for the auto FSM illegal-encoding scan
 /// (`POST /api/v1/btor2/check-fsm`). Mirrors the CLI `mununu btor2 check-fsm`:
-/// auto-discovers the FSM-like state registers and decides recoverability of each to
-/// its idle/reset value with **no user input** (idle derived from the register's init
-/// or reset-mux constant).
+/// auto-discovers the FSM-like state registers and checks, from the reset state,
+/// whether any illegal encoding (a value outside the register's legal set) is
+/// reachable — with **no user input** (the legal set is derived from the design).
 #[derive(Debug, Deserialize)]
 pub struct Btor2CheckFsmRequest {
     /// BTOR2 source content.
@@ -981,18 +981,18 @@ fn default_fsm_max_width() -> u32 {
     crate::adapter::fsm_scan::DEFAULT_FSM_MAX_WIDTH
 }
 
-/// One state register's recoverability result in a [`Btor2CheckFsmResponse`].
+/// One state register's illegal-encoding result in a [`Btor2CheckFsmResponse`].
 #[derive(Debug, Serialize)]
 pub struct FsmRegisterFinding {
     /// The state register's symbol.
     pub register: String,
-    /// The idle/reset value recoverability targets.
-    pub idle_value: u64,
-    /// Canonical verdict — `"holds"` | `"violated"` (an unrecoverable trap) |
-    /// `"unknown"` (over the exact engine's cap).
+    /// The legal encodings the register's own logic recognizes (sorted).
+    pub legal_encodings: Vec<u64>,
+    /// Canonical verdict — `"holds"` (stays within its encoding) | `"violated"` (an
+    /// illegal encoding is reachable) | `"unknown"` (the portfolio could not decide).
     pub verdict: String,
-    /// `true` when the register is an unrecoverable trap (a finding).
-    pub unrecoverable_trap: bool,
+    /// `true` when an illegal encoding is reachable (a finding).
+    pub illegal_encoding_reachable: bool,
 }
 
 /// Response for `POST /api/v1/btor2/check-fsm`.
@@ -1000,8 +1000,8 @@ pub struct FsmRegisterFinding {
 pub struct Btor2CheckFsmResponse {
     /// Number of FSM-like state registers scanned.
     pub fsm_registers_checked: usize,
-    /// Number of unrecoverable traps found (`verdict == "violated"`).
-    pub traps_found: usize,
+    /// Number of registers with a reachable illegal encoding (`verdict == "violated"`).
+    pub illegal_encodings_found: usize,
     /// Per-register results.
     pub registers: Vec<FsmRegisterFinding>,
 }

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -162,6 +162,9 @@ fn create_router() -> Router {
             "/api/v1/sv/verify-recoverability",
             post(handlers::sv_verify_recoverability_handler),
         )
+        // SV-direct auto FSM illegal-encoding scan (lift + scan, one call). Surface peer
+        // of the CLI `sv check-fsm` and the BTOR2-direct `/api/v1/btor2/check-fsm`.
+        .route("/api/v1/sv/check-fsm", post(handlers::sv_check_fsm_handler))
         .route(
             "/api/v1/verify/memory-check",
             post(handlers::memory_check_handler),

--- a/docs/design/engine-routing.md
+++ b/docs/design/engine-routing.md
@@ -25,7 +25,7 @@ branching (νμ) properties can only go through the 3-valued engines.
 | `btor2/sv verify` (safety) | `decide_reach_portfolio` → **reach portfolio** | none |
 | `btor2/sv verify-liveness` (`AG(a→AF b)`) | Biere l2s → `bad`-monitor → **reach portfolio** | none |
 | `btor2/sv verify-recoverability` (`AG EF good`) | `exact_symbolic_verdict` → **exact-symbolic** | **none** |
-| `btor2 check-fsm` (auto `AG EF (reg==idle)` per FSM reg) | `fsm_recoverability_scan` → **exact-symbolic** per register | **none** (idle auto-derived from init / reset-mux) |
+| `btor2 check-fsm` (auto illegal-encoding per FSM reg) | `fsm_encoding_scan` → **reach portfolio** per register | **none** (legal set auto-derived from the design) |
 | `sv verify-auto` (default `portfolio-sequential`) | **exact-symbolic → symbolic → explicit**, early-exit | exact leg none; cube legs **auto-seeded** |
 | `sv verify-auto` safety ⊥ | escalate → reduce → **reach portfolio** | none |
 | `btor2 cegar` (explicit) | `cegar_refine_loop` → **cube** | hand-`--predicate` unless auto-seeded upstream |
@@ -42,7 +42,8 @@ So: **hand-written predicates are already the exception, not the rule** — the 
 
 ## Defensibility (which paths to lead with)
 
-- **`AG EF` recoverability via exact-symbolic / cube+hyper-must — DEFENSIBLE.** A branching νμ property SVA/LTL cannot express, decided soundly, on real RTL, with no predicates at FSM scale. No mainstream tool offers it. **This is the wedge — invest here (P1).** The first P1 slice ships `btor2 check-fsm` — the zero-input auto-scan that discovers FSM registers, derives idle from init / reset-mux, and reports unrecoverable traps (validated end-to-end on the real csrng `state_q`, idle=55 auto-derived).
+- **`AG EF` recoverability via exact-symbolic / cube+hyper-must — DEFENSIBLE as a *named* property.** A branching νμ property SVA/LTL cannot express, decided soundly, on real RTL, with no predicates at FSM scale. No mainstream tool offers it. Keep the `verify-recoverability` verb (the user names a meaningful target). **Do not auto-scan it**: reset-free recoverability-to-the-reset-value is *tautological* on a reset-carrying design (reset always provides an escape → `holds` everywhere), and reset-held flags every intended reset-recoverable error — neither is a zero-touch bug signal (soundness finding, 2026-07-08).
+- **Illegal-encoding reachability via the reach portfolio — the zero-touch auto bug-finder (P1).** The first P1 slice ships `btor2 check-fsm` (`fsm_encoding_scan`): discover FSM registers, derive each one's legal encoding set from the design (compared constants + reset value), and check from the reset state whether any illegal encoding is reachable. Reset cannot paper it over and design intent cannot excuse it — a reachable out-of-enum value is an unambiguous bug. A *safety* property, so it rides the word-level portfolio (no bit cap). Validated on the real csrng `state_q` (8 legal sparse encodings auto-derived, `holds`).
 - **Response-liveness via l2s — partly defensible.** Sound concrete reduction, but liveness-to-safety is known art; keep, don't lead.
 - **Safety via the reach portfolio — TABLE-STAKES.** SymbiYosys/commercial do BMC/PDR safety at scale, often better. Keep for completeness + the ⊥ escalation; don't position as the differentiator.
 

--- a/wiki/CI-and-Agent-Integration.md
+++ b/wiki/CI-and-Agent-Integration.md
@@ -54,25 +54,25 @@ jobs:
 
 ### The zero-input FSM auto-scan (`check-fsm`)
 
-> **Source of truth:** [`fsm_recoverability_scan`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/fsm_scan.rs) + `btor2 check-fsm` / `POST /api/v1/btor2/check-fsm` — surface: CLI+API+UI.
+> **Source of truth:** [`fsm_encoding_scan`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/fsm_scan.rs) + `btor2 check-fsm` / `POST /api/v1/btor2/check-fsm` — surface: CLI+API+UI.
 
-Every verb above needs a property or a target atom. **`btor2 check-fsm` needs neither.** It discovers every FSM-like state register, derives each one's idle/reset value from the design itself (the register's `init` value, or the reset-mux constant of an init-less yosys lift), and decides recoverability `AG EF (reg == idle)` with reset **free** — reporting any **unrecoverable trap** (`verdict: violated`) as a finding. A trap is a reachable state the FSM can never get back to idle from *even with reset available* — the branching bug SVA cannot state, found with zero input.
+Every verb above needs a property or a target atom. **`btor2 check-fsm` needs neither.** It discovers every FSM-like state register, derives each one's set of **legal encodings** from the design itself (the constants its own logic compares it against, plus its reset value), and checks — starting from the real reset state — whether any **illegal encoding** (a value outside that set) is reachable. A reachable illegal encoding (`verdict: violated`) is an unambiguous bug: some input drives the FSM past its enum (an incomplete `case`, a missing `default`, a decoder that emits an out-of-range code).
 
 ```bash
-# Lift the module once, then auto-scan its FSMs. Exit 2 on any unrecoverable trap.
+# Lift the module once, then auto-scan its FSMs. Exit 2 on any reachable illegal encoding.
 mununu --quiet sv emit-btor2 rtl/fsm.sv --preprocess-sv2v -o fsm.btor2
 mununu --quiet btor2 check-fsm fsm.btor2         # --fail-on / --quiet / exit codes as above
 ```
 
-The reset-free framing is the intended-vs-unintended-trap filter: a design's *intended* reset-dependence (recovers only when reset is asserted) still `holds`; only a genuine unrecoverable trap — a gated/ineffective reset, a wrong idle encoding, or an upstream trap — comes back `violated`. Output is JSON:
+Why this and not recoverability? Because reset makes recoverability tautological — with reset free the environment can always assert it to get back to idle, so an FSM trap is invisible; with reset held, every intended reset-recoverable error looks like a trap. Illegal-encoding reachability asks a question reset cannot paper over and design intent cannot excuse: *can the next-state logic, for some input, corrupt the register past its enum?* It is a **safety** property, decided by the word-level reachability portfolio (no bit cap), so it scales past the exact engine. Output is JSON:
 
 ```jsonc
-{ "file": "fsm.btor2", "fsm_registers_checked": 1, "traps_found": 0,
-  "registers": [ { "register": "state_q", "idle_value": 55,
-                   "verdict": "holds", "unrecoverable_trap": false } ] }
+{ "file": "fsm.btor2", "fsm_registers_checked": 1, "illegal_encodings_found": 0,
+  "registers": [ { "register": "state_q", "legal_encodings": [3,14,16,29,36,41,55,58],
+                   "verdict": "holds", "illegal_encoding_reachable": false } ] }
 ```
 
-`--max-width <bits>` (default `8`) bounds which registers count as "FSM-like" — a wider register is a datapath / counter and is skipped. Each register runs the exact 3-valued engine; a register whose cone exceeds the cap comes back `unknown` (skipped), never wrong.
+A `holds` register provably stays within its encoding (validated on the real OpenTitan csrng: `state_q`'s 8 sparse encodings auto-derived, no illegal value reachable). `--max-width <bits>` (default `8`) bounds which registers count as "FSM-like" — a wider register is a datapath / counter and is skipped. A register whose legal set is fewer than 2 values, or already covers every value of its width, has no illegal encoding to reach and is skipped; the portfolio abstains (`unknown`) only when no engine decides.
 
 ---
 
@@ -109,7 +109,7 @@ POST /api/v1/sv/verify-recoverability
 
 `POST /api/v1/sv/verify` (safety of the module's assertions) and `/api/v1/sv/verify-liveness` (`{request, grant}`) round out the trio. All return the canonical `verdict`, so the agent gates on `verdict === "violated"`.
 
-**No property to name?** `POST /api/v1/btor2/check-fsm { "content": "<btor2>", "max_width": 8 }` auto-scans every FSM register for an unrecoverable trap and returns `{ fsm_registers_checked, traps_found, registers: [{ register, idle_value, verdict, unrecoverable_trap }] }` — the agent gates on `traps_found > 0`. Lift the module with `sv emit-btor2` first (or post pre-lifted BTOR2).
+**No property to name?** `POST /api/v1/btor2/check-fsm { "content": "<btor2>", "max_width": 8 }` auto-scans every FSM register for a reachable illegal encoding and returns `{ fsm_registers_checked, illegal_encodings_found, registers: [{ register, legal_encodings, verdict, illegal_encoding_reachable }] }` — the agent gates on `illegal_encodings_found > 0`. Lift the module with `sv emit-btor2` first (or post pre-lifted BTOR2).
 
 The agent can skip the SV lift entirely and post pre-lifted BTOR2 to `/api/v1/btor2/verify{,-liveness,-recoverability}` — same responses.
 

--- a/wiki/CI-and-Agent-Integration.md
+++ b/wiki/CI-and-Agent-Integration.md
@@ -59,9 +59,11 @@ jobs:
 Every verb above needs a property or a target atom. **`btor2 check-fsm` needs neither.** It discovers every FSM-like state register, derives each one's set of **legal encodings** from the design itself (the constants its own logic compares it against, plus its reset value), and checks — starting from the real reset state — whether any **illegal encoding** (a value outside that set) is reachable. A reachable illegal encoding (`verdict: violated`) is an unambiguous bug: some input drives the FSM past its enum (an incomplete `case`, a missing `default`, a decoder that emits an out-of-range code).
 
 ```bash
-# Lift the module once, then auto-scan its FSMs. Exit 2 on any reachable illegal encoding.
-mununu --quiet sv emit-btor2 rtl/fsm.sv --preprocess-sv2v -o fsm.btor2
-mununu --quiet btor2 check-fsm fsm.btor2         # --fail-on / --quiet / exit codes as above
+# SV-direct: lift + auto-scan in one call. Exit 2 on any reachable illegal encoding.
+mununu --quiet sv check-fsm rtl/fsm.sv --preprocess-sv2v   # --fail-on / --quiet / exit codes as above
+
+# Or on a BTOR2 you already have (or lifted with `sv emit-btor2-per-module`):
+mununu --quiet btor2 check-fsm fsm.btor2
 ```
 
 Why this and not recoverability? Because reset makes recoverability tautological — with reset free the environment can always assert it to get back to idle, so an FSM trap is invisible; with reset held, every intended reset-recoverable error looks like a trap. Illegal-encoding reachability asks a question reset cannot paper over and design intent cannot excuse: *can the next-state logic, for some input, corrupt the register past its enum?* It is a **safety** property, decided by the word-level reachability portfolio (no bit cap), so it scales past the exact engine. Output is JSON:
@@ -109,7 +111,7 @@ POST /api/v1/sv/verify-recoverability
 
 `POST /api/v1/sv/verify` (safety of the module's assertions) and `/api/v1/sv/verify-liveness` (`{request, grant}`) round out the trio. All return the canonical `verdict`, so the agent gates on `verdict === "violated"`.
 
-**No property to name?** `POST /api/v1/btor2/check-fsm { "content": "<btor2>", "max_width": 8 }` auto-scans every FSM register for a reachable illegal encoding and returns `{ fsm_registers_checked, illegal_encodings_found, registers: [{ register, legal_encodings, verdict, illegal_encoding_reachable }] }` — the agent gates on `illegal_encodings_found > 0`. Lift the module with `sv emit-btor2` first (or post pre-lifted BTOR2).
+**No property to name?** `POST /api/v1/sv/check-fsm { "source": "<sv>", "use_sv2v": true }` lifts the module and auto-scans every FSM register for a reachable illegal encoding, returning `{ fsm_registers_checked, illegal_encodings_found, registers: [{ register, legal_encodings, verdict, illegal_encoding_reachable }] }` — the agent gates on `illegal_encodings_found > 0`. The BTOR2-direct peer is `POST /api/v1/btor2/check-fsm { "content": "<btor2>" }`.
 
 The agent can skip the SV lift entirely and post pre-lifted BTOR2 to `/api/v1/btor2/verify{,-liveness,-recoverability}` — same responses.
 


### PR DESCRIPTION
## Why this exists

#280 **auto-merged prematurely at its pre-pivot commit** (`e645c84`, the recoverability version) when that commit's CI passed — before the illegal-encoding pivot was pushed. So `main` currently ships the **tautological recoverability** check-fsm and the pre-pivot API shape, while **mununu-ui main already has the illegal-encoding client** (#45/#46) — the two repos are mismatched. This PR lands the pivot commits (`a19f6a9` + `05d56d7`) and reconciles them.

## What lands

- **check-fsm now scans for reachable illegal FSM encodings**, not recoverability. Recoverability `AG EF idle` is tautological on a reset-carrying design (reset always provides an escape) — kept only as the *named* `verify-recoverability` verb, not an auto-scan. Illegal-encoding reachability is a *safety* property reset cannot paper over: derive each register's legal set from the design (assigned ∪ compared ∪ reset constants), then check via the word-level reach portfolio whether a *computed* out-of-enum value is reachable.
- API/CLI response reshaped to `{legal_encodings, illegal_encoding_reachable}` / `illegal_encodings_found` — matches the merged UI client.
- Adds **`sv check-fsm`** (SV-direct one-liner) across CLI + API; fixes the wiki (which named a non-existent `sv emit-btor2`).
- Robustness fixes (discovery via `collect_symbols` cell mapping; over-approx legal set to avoid false positives on `default`-folded states).

## Validation

Real OpenTitan csrng `state_q` → `holds` (8 sparse encodings auto-derived); a lifted buggy SV FSM (`state + 3` from Busy → 5) → `violated`, exit 2. Unit + API handler tests updated to computed-illegal fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)