### PR TITLE
feat(synth): preserve state valuations onto synthesized controllers

### DIFF
--- a/crates/mununu-core/src/adapter/systemverilog/emit_controller.rs
+++ b/crates/mununu-core/src/adapter/systemverilog/emit_controller.rs
@@ -347,4 +347,50 @@ mod tests {
                 .all(|c| c.is_ascii_alphanumeric() || c == '_')
         );
     }
+
+    #[test]
+    fn synthesis_preserves_state_valuations_for_moore_outputs() {
+        // The RTL emitter derives Moore outputs from state valuations, so synthesis must
+        // carry them onto the controller state (context::mod copies `state_valuation`
+        // alongside `state_variables`). Without that copy the controller would have no
+        // valuations and the emitter could not tell which output is high in which state.
+        let ctxdsl = r#"
+        context t {
+            alphabet { label go; }
+            automata {
+                automaton M {
+                    controllable { label go; }
+                    states {
+                        state A initial { valuations { phase = 1; } };
+                        state B { valuations { phase = 2; } };
+                    }
+                    transitions {
+                        transition A -> B on label go;
+                        transition B -> A on label go;
+                    }
+                }
+            }
+            mu_formulas { formula safe { over M; body = nu X. ([] X); } }
+            controllers { controller c { source M; satisfying safe; } }
+        }
+        "#;
+        let doc = crate::context_dsl::parse(ctxdsl).unwrap();
+        let realized = crate::context_dsl::realize_context(&doc, &[]).unwrap();
+        let formula = realized.formulas.get("safe").unwrap();
+        let env = realized.environment_for("M");
+        let synth = realized
+            .context
+            .synthesise_controller("M", &formula.formula, &env, None)
+            .unwrap();
+        assert!(synth.realizable);
+        let ctrl = &synth.controller;
+        let a = ctrl
+            .states()
+            .find(|&s| ctrl.state_name(s) == Some("A"))
+            .expect("controller has state A");
+        let val = ctrl
+            .state_valuation(a)
+            .expect("state A's valuation was preserved onto the controller");
+        assert_eq!(val.get("phase"), Some(&"1".to_string()));
+    }
 }

--- a/crates/mununu-core/src/context/mod.rs
+++ b/crates/mununu-core/src/context/mod.rs
@@ -762,6 +762,13 @@ impl Context {
             let vars = clts.state_variables(state);
             builder.with_variables_for_state(new_state, vars.iter().map(|s| s.as_str()));
 
+            // Preserve structured signal valuations (e.g. `grant0 = 1`) onto the
+            // controller state — the RTL emitter derives Moore outputs from them, and
+            // counterexample/counterstrategy traces read them.
+            if let Some(valuation) = clts.state_valuation(state) {
+                builder.with_valuation_for_state(new_state, valuation.clone());
+            }
+
             mapping.insert(state, new_state);
         }
 


### PR DESCRIPTION
Second step of the synthesis→RTL emitter work (after #282's valid identifiers).

Controller synthesis copied `state_variables` onto each controller state but **dropped `state_valuation`** — the structured signal values (`grant0 = 1`) that the RTL emitter needs to derive Moore outputs (and that counterexample traces read). Without them, the synthesized controller can't say which output is high in which state.

Copy `state_valuation` alongside `state_variables` in the controller builder.

**Validation:** `synthesis_preserves_state_valuations_for_moore_outputs` synthesizes an automaton with `valuations { phase = 1; }` and asserts the controller state carries it. Checked *programmatically* via `state_valuation` because the emit-DSL / print-structure don't render valuations (a display gap, not a model gap — `realize.rs` `merged_state_valuation` does parse them into the plant CLTS).

Next (plan: synthesis-for-rtl): the input-guarded Moore emitter reads these valuations to emit real I/O-driven RTL, then the independent `btormc`/`sby` oracle loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)