### PR TITLE
feat(gr1): general TLSF-spec -> GR(1) game extraction

### DIFF
--- a/crates/mununu-core/src/mu_calculus/gr1_build.rs
+++ b/crates/mununu-core/src/mu_calculus/gr1_build.rs
@@ -1,0 +1,544 @@
+//! General TLSF-spec → GR(1) game construction.
+//!
+//! Turns a set of LTL assumptions/guarantees (plus the input/output signal
+//! lists) into the monitor-augmented two-player game that [`super::gr1`] solves.
+//! The base plant is memoryless — each round the environment picks an input
+//! valuation and the controller an output valuation — so the entire game state
+//! is the **monitor bits**:
+//!   - one `pre_prev` bit per transition-safety clause `G(pre → X post)`;
+//!   - one `pending` bit per response clause `G(trig → F resp)`.
+//!
+//! Supported GR(1) fragment (rejected clauses are reported, not silently
+//! dropped — the honest fragment boundary):
+//!   - invariant safety `G(prop)`
+//!   - transition safety `G(pre → X post)`  (`pre`, `post` propositional)
+//!   - input fairness `G F prop` / `GF prop` over inputs  → `env_fair`
+//!   - response `G(trig → F resp)`                         → `sys_fair` via `¬pending`
+//!
+//! `GF` guarantees over outputs, `U`/`R`/`W`, and `FG` are out of scope for now
+//! (would need extra monitor bits); they are returned as classification errors.
+
+use std::collections::HashMap;
+
+use bitvec::prelude::{Lsb0, bitvec};
+
+use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, LabelControllability};
+use crate::ltl::ast::LtlFormula;
+
+use super::gr1::StateSet;
+
+// ---------------------------------------------------------------------------
+// Propositional layer
+// ---------------------------------------------------------------------------
+
+/// True when `f` contains no temporal operator (pure Boolean over predicates).
+fn is_propositional(f: &LtlFormula) -> bool {
+    use LtlFormula::*;
+    match f {
+        True | False | Predicate(_) => true,
+        Not(a) => is_propositional(a),
+        And(a, b) | Or(a, b) | Implies(a, b) => is_propositional(a) && is_propositional(b),
+        _ => false,
+    }
+}
+
+/// Evaluate a propositional formula under a signal valuation (absent ⇒ false).
+fn eval_prop(f: &LtlFormula, val: &HashMap<String, bool>) -> bool {
+    use LtlFormula::*;
+    match f {
+        True => true,
+        False => false,
+        Predicate(p) => *val.get(p).unwrap_or(&false),
+        Not(a) => !eval_prop(a, val),
+        And(a, b) => eval_prop(a, val) && eval_prop(b, val),
+        Or(a, b) => eval_prop(a, val) || eval_prop(b, val),
+        Implies(a, b) => !eval_prop(a, val) || eval_prop(b, val),
+        // Non-propositional nodes never reach here after classification.
+        _ => false,
+    }
+}
+
+/// Collect the predicate names referenced by a formula.
+fn predicates_of(f: &LtlFormula, out: &mut Vec<String>) {
+    use LtlFormula::*;
+    match f {
+        Predicate(p) => {
+            if !out.contains(p) {
+                out.push(p.clone());
+            }
+        }
+        Not(a) => predicates_of(a, out),
+        And(a, b) | Or(a, b) | Implies(a, b) => {
+            predicates_of(a, out);
+            predicates_of(b, out);
+        }
+        Next(a) | Always(a) | Eventually(a) | Recurrence(a) | Stabilization(a) => {
+            predicates_of(a, out)
+        }
+        Until { left, right } | WeakUntil { left, right } | Release { left, right } => {
+            predicates_of(left, out);
+            predicates_of(right, out);
+        }
+        Response { trigger, response } => {
+            predicates_of(trigger, out);
+            predicates_of(response, out);
+        }
+        True | False => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+enum SafetyClause {
+    Invariant(LtlFormula),
+    Transition { pre: LtlFormula, post: LtlFormula },
+}
+
+struct ResponseClause {
+    trigger: LtlFormula,
+    response: LtlFormula,
+}
+
+/// A spec classified into GR(1) normal form.
+pub struct Gr1Spec {
+    inputs: Vec<String>,
+    outputs: Vec<String>,
+    safety: Vec<SafetyClause>,
+    responses: Vec<ResponseClause>,
+    /// Propositional recurrence sets from `GF` assumptions (over inputs).
+    env_fair: Vec<LtlFormula>,
+}
+
+impl Gr1Spec {
+    /// Classify LTL assumptions/guarantees into the GR(1) fragment, or return
+    /// the first clause that falls outside it.
+    pub fn classify(
+        assumptions: &[LtlFormula],
+        guarantees: &[LtlFormula],
+        inputs: &[String],
+        outputs: &[String],
+    ) -> Result<Gr1Spec, String> {
+        let mut spec = Gr1Spec {
+            inputs: inputs.to_vec(),
+            outputs: outputs.to_vec(),
+            safety: Vec::new(),
+            responses: Vec::new(),
+            env_fair: Vec::new(),
+        };
+        for a in assumptions {
+            spec.classify_one(a, false)?;
+        }
+        for g in guarantees {
+            spec.classify_one(g, true)?;
+        }
+        Ok(spec)
+    }
+
+    fn classify_one(&mut self, f: &LtlFormula, is_guarantee: bool) -> Result<(), String> {
+        use LtlFormula::*;
+        match f {
+            // GF prop
+            Recurrence(inner) if is_propositional(inner) => self.push_fair(inner, is_guarantee),
+            Always(inner) => self.classify_always(inner, is_guarantee),
+            // G(trig -> F resp)
+            Response { trigger, response }
+                if is_propositional(trigger) && is_propositional(response) =>
+            {
+                self.push_response(trigger, response, is_guarantee)
+            }
+            other => Err(format!("unsupported GR(1) clause: {other:?}")),
+        }
+    }
+
+    fn classify_always(&mut self, body: &LtlFormula, is_guarantee: bool) -> Result<(), String> {
+        use LtlFormula::*;
+        match body {
+            // G(F prop) or G(GF prop) → fairness
+            Eventually(inner) | Recurrence(inner) if is_propositional(inner) => {
+                self.push_fair(inner, is_guarantee)
+            }
+            // G(pre -> ...) → transition safety or response
+            Implies(pre, rhs) if is_propositional(pre) => match &**rhs {
+                Next(post) if is_propositional(post) => {
+                    self.safety.push(SafetyClause::Transition {
+                        pre: (**pre).clone(),
+                        post: (**post).clone(),
+                    });
+                    Ok(())
+                }
+                Eventually(resp) if is_propositional(resp) => {
+                    self.push_response(pre, resp, is_guarantee)
+                }
+                other => Err(format!("unsupported G(pre -> {other:?})")),
+            },
+            // G(prop) → invariant
+            p if is_propositional(p) => {
+                self.safety.push(SafetyClause::Invariant(p.clone()));
+                Ok(())
+            }
+            other => Err(format!("unsupported G({other:?})")),
+        }
+    }
+
+    fn push_fair(&mut self, prop: &LtlFormula, is_guarantee: bool) -> Result<(), String> {
+        if is_guarantee {
+            // A GF guarantee over outputs needs a last-output monitor bit (not
+            // yet built). Only reject if it actually mentions an output.
+            let mut ps = Vec::new();
+            predicates_of(prop, &mut ps);
+            if ps.iter().any(|p| self.outputs.contains(p)) {
+                return Err(format!(
+                    "GF guarantee over outputs not yet supported: {prop:?} \
+                     (needs a last-output monitor)"
+                ));
+            }
+            // GF over inputs as a *guarantee* is degenerate but harmless — treat
+            // like an env recurrence the controller cannot influence. Reject to
+            // stay honest.
+            return Err(format!("GF guarantee over non-output signals: {prop:?}"));
+        }
+        self.env_fair.push(prop.clone());
+        Ok(())
+    }
+
+    fn push_response(
+        &mut self,
+        trigger: &LtlFormula,
+        response: &LtlFormula,
+        is_guarantee: bool,
+    ) -> Result<(), String> {
+        if !is_guarantee {
+            return Err("response as an assumption is not supported".to_string());
+        }
+        if !is_propositional(trigger) || !is_propositional(response) {
+            return Err("response with temporal trigger/response is unsupported".to_string());
+        }
+        self.responses.push(ResponseClause {
+            trigger: trigger.clone(),
+            response: response.clone(),
+        });
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Game construction
+// ---------------------------------------------------------------------------
+
+/// The monitor-augmented GR(1) game built from a [`Gr1Spec`], plus the metadata
+/// needed to project a strategy back to a Mealy controller.
+pub struct Gr1Game {
+    pub clts: Clts<DefaultStateIdx, DefaultLabelIdx>,
+    pub safe: StateSet,
+    pub sys_fair: Vec<StateSet>,
+    pub env_fair: Vec<StateSet>,
+    pub init: usize,
+    /// For a ctrl-turn state index: `(monitor_bits, input_valuation)`.
+    pub ctrl_meta: HashMap<usize, (usize, u32)>,
+    /// For a ctrl transition target: the output valuation it commits.
+    pub move_output: HashMap<(usize, usize), u32>,
+    pub n_monitors: usize,
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+}
+
+impl Gr1Game {
+    /// Build the game. Monitor bit layout: `[0..n_ts)` = transition-safety
+    /// `pre_prev` bits, `[n_ts..n_ts+n_resp)` = response `pending` bits.
+    // `m` is the monitor bit-state (used in bit arithmetic throughout), not a
+    // mere collection index, so range loops over it are the correct form.
+    #[allow(clippy::needless_range_loop)]
+    pub fn build(spec: &Gr1Spec) -> Gr1Game {
+        let n_ts = spec
+            .safety
+            .iter()
+            .filter(|c| matches!(c, SafetyClause::Transition { .. }))
+            .count();
+        let n_resp = spec.responses.len();
+        let n_monitors = n_ts + n_resp;
+        let n_in = spec.inputs.len();
+        let n_out = spec.outputs.len();
+        let n_mon_states = 1usize << n_monitors;
+        let n_in_vals = 1u32 << n_in;
+        let n_out_vals = 1u32 << n_out;
+
+        // Index the transition-safety clauses (for pre_prev bit positions).
+        let ts_clauses: Vec<(&LtlFormula, &LtlFormula)> = spec
+            .safety
+            .iter()
+            .filter_map(|c| match c {
+                SafetyClause::Transition { pre, post } => Some((pre, post)),
+                _ => None,
+            })
+            .collect();
+        let inv_clauses: Vec<&LtlFormula> = spec
+            .safety
+            .iter()
+            .filter_map(|c| match c {
+                SafetyClause::Invariant(p) => Some(p),
+                _ => None,
+            })
+            .collect();
+
+        let mut b = Clts::builder();
+        // Labels: one env_{k} per input valuation, one ctrl_{k} per output valuation, plus bad.
+        let env_labels: Vec<_> = (0..n_in_vals)
+            .map(|k| {
+                let l = b.labels().intern([format!("env_{k}")]).unwrap();
+                b.set_label_controllability(l, LabelControllability::Uncontrollable);
+                l
+            })
+            .collect();
+        let ctrl_labels: Vec<_> = (0..n_out_vals)
+            .map(|k| {
+                let l = b.labels().intern([format!("ctrl_{k}")]).unwrap();
+                b.set_label_controllability(l, LabelControllability::Controllable);
+                l
+            })
+            .collect();
+        let bad_label = b.labels().intern(["bad"]).unwrap();
+        b.set_label_controllability(bad_label, LabelControllability::Uncontrollable);
+
+        // Allocate states.
+        let mut e_state = vec![None; n_mon_states];
+        let mut c_state: HashMap<(usize, u32), _> = HashMap::new();
+        for m in 0..n_mon_states {
+            e_state[m] = Some(b.state_with_name(format!("E{m}")).unwrap());
+        }
+        for m in 0..n_mon_states {
+            for iv in 0..n_in_vals {
+                c_state.insert((m, iv), b.state_with_name(format!("C{m}_{iv}")).unwrap());
+            }
+        }
+        let bad = b.state_with_name("BAD".into()).unwrap();
+        let init_state = e_state[0].unwrap(); // all monitors clear
+        b.initial_state_id(init_state);
+
+        // Signal valuation helper for a (input_val, output_val) pair.
+        let signal_val = |iv: u32, ov: u32| -> HashMap<String, bool> {
+            let mut val = HashMap::new();
+            for (bit, name) in spec.inputs.iter().enumerate() {
+                val.insert(name.clone(), (iv >> bit) & 1 == 1);
+            }
+            for (bit, name) in spec.outputs.iter().enumerate() {
+                val.insert(name.clone(), (ov >> bit) & 1 == 1);
+            }
+            val
+        };
+
+        let mut ctrl_meta = HashMap::new();
+        let mut move_output = HashMap::new();
+
+        // env moves: E[m] -env_iv-> C[m,iv]
+        for m in 0..n_mon_states {
+            let e = e_state[m].unwrap();
+            for iv in 0..n_in_vals {
+                let c = c_state[&(m, iv)];
+                b.transition_ids(e, &[env_labels[iv as usize]], c);
+                ctrl_meta.insert(c.index(), (m, iv));
+            }
+        }
+        // ctrl moves: C[m,iv] -ctrl_ov-> E[m'] or BAD
+        for m in 0..n_mon_states {
+            for iv in 0..n_in_vals {
+                let c = c_state[&(m, iv)];
+                for ov in 0..n_out_vals {
+                    let val = signal_val(iv, ov);
+                    // safety: invariants + transition safeties.
+                    let mut unsafe_move = inv_clauses.iter().any(|p| !eval_prop(p, &val));
+                    for (i, (pre, post)) in ts_clauses.iter().enumerate() {
+                        let pre_prev = (m >> i) & 1 == 1;
+                        if pre_prev && !eval_prop(post, &val) {
+                            unsafe_move = true;
+                        }
+                        let _ = pre; // used below for the next-state update
+                    }
+                    let target = if unsafe_move {
+                        bad
+                    } else {
+                        // next monitor bits
+                        let mut m2 = 0usize;
+                        for (i, (pre, _post)) in ts_clauses.iter().enumerate() {
+                            if eval_prop(pre, &val) {
+                                m2 |= 1 << i;
+                            }
+                        }
+                        for (j, resp) in spec.responses.iter().enumerate() {
+                            let pending = (m >> (n_ts + j)) & 1 == 1;
+                            let trig = eval_prop(&resp.trigger, &val);
+                            let done = eval_prop(&resp.response, &val);
+                            let pending2 = (pending || trig) && !done;
+                            if pending2 {
+                                m2 |= 1 << (n_ts + j);
+                            }
+                        }
+                        e_state[m2].unwrap()
+                    };
+                    b.transition_ids(c, &[ctrl_labels[ov as usize]], target);
+                    move_output.insert((c.index(), target.index()), ov);
+                }
+            }
+        }
+        // BAD self-loop.
+        b.transition_ids(bad, &[bad_label], bad);
+
+        let clts = b.build().unwrap();
+        let n = clts.state_count();
+        let mut safe = bitvec![usize, Lsb0; 1; n];
+        safe.set(bad.index(), false);
+
+        // env_fair: recurrence sets over inputs, observed at C states.
+        let env_fair: Vec<StateSet> = spec
+            .env_fair
+            .iter()
+            .map(|prop| {
+                let mut s = bitvec![usize, Lsb0; 0; n];
+                for m in 0..n_mon_states {
+                    for iv in 0..n_in_vals {
+                        // inputs only: output bits absent → treated as false.
+                        let val = signal_val(iv, 0);
+                        if eval_prop(prop, &val) {
+                            s.set(c_state[&(m, iv)].index(), true);
+                        }
+                    }
+                }
+                s
+            })
+            .collect();
+
+        // sys_fair: one recurrence set per response = { E[m] : pending_j == 0 }.
+        let sys_fair: Vec<StateSet> = (0..n_resp)
+            .map(|j| {
+                let mut s = bitvec![usize, Lsb0; 0; n];
+                for m in 0..n_mon_states {
+                    if (m >> (n_ts + j)) & 1 == 0 {
+                        s.set(e_state[m].unwrap().index(), true);
+                    }
+                }
+                s
+            })
+            .collect();
+
+        Gr1Game {
+            clts,
+            safe,
+            sys_fair,
+            env_fair,
+            init: init_state.index(),
+            ctrl_meta,
+            move_output,
+            n_monitors,
+            inputs: spec.inputs.clone(),
+            outputs: spec.outputs.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mu_calculus::gr1::{gr1_strategy_single, gr1_win};
+
+    fn pred(s: &str) -> LtlFormula {
+        LtlFormula::Predicate(s.to_string())
+    }
+
+    /// request_grant: assume GF req; guarantee G(req -> F grant) and G(grant -> X !grant).
+    fn request_grant_spec() -> Gr1Spec {
+        let assumptions = vec![LtlFormula::Recurrence(Box::new(pred("req")))];
+        let guarantees = vec![
+            LtlFormula::Response {
+                trigger: Box::new(pred("req")),
+                response: Box::new(pred("grant")),
+            },
+            LtlFormula::Always(Box::new(LtlFormula::Implies(
+                Box::new(pred("grant")),
+                Box::new(LtlFormula::Next(Box::new(LtlFormula::Not(Box::new(pred(
+                    "grant",
+                )))))),
+            ))),
+        ];
+        Gr1Spec::classify(
+            &assumptions,
+            &guarantees,
+            &["req".to_string()],
+            &["grant".to_string()],
+        )
+        .expect("request_grant is in the GR(1) fragment")
+    }
+
+    #[test]
+    fn classify_request_grant_shapes() {
+        let spec = request_grant_spec();
+        assert_eq!(spec.responses.len(), 1, "one response (req -> F grant)");
+        assert_eq!(
+            spec.safety
+                .iter()
+                .filter(|c| matches!(c, SafetyClause::Transition { .. }))
+                .count(),
+            1,
+            "one transition safety (grant -> X !grant)"
+        );
+        assert_eq!(spec.env_fair.len(), 1, "one input fairness (GF req)");
+    }
+
+    #[test]
+    fn built_request_grant_is_realizable_and_strategy_serves_safely() {
+        let spec = request_grant_spec();
+        let game = Gr1Game::build(&spec);
+        let z = gr1_win(&game.clts, &game.safe, &game.sys_fair, &game.env_fair);
+        assert!(z[game.init], "request_grant must be realizable from init");
+
+        // Decode the strategy into grant(pending, was_grant, req) and check it is
+        // SAFE (never grants when was_grant) and SERVING (grants pending+safe).
+        // Monitor bit layout: bit0 = was_grant (transition safety), bit1 = pending.
+        let strat = gr1_strategy_single(&game.clts, &z, &game.sys_fair[0]);
+        let grant_at = |pending: usize, was_grant: usize, req: u32| -> Option<bool> {
+            let m = (pending << 1) | was_grant;
+            // find the C state for (m, iv=req)
+            let c = game
+                .ctrl_meta
+                .iter()
+                .find(|(_, meta)| meta.0 == m && meta.1 == req)
+                .map(|(&c, _)| c)?;
+            if !z[c] {
+                return None;
+            }
+            let t = *strat.get(&c)?;
+            game.move_output.get(&(c, t)).map(|&ov| ov & 1 == 1)
+        };
+        for pending in 0..2 {
+            for req in 0..2 {
+                if let Some(g) = grant_at(pending, 1, req) {
+                    assert!(
+                        !g,
+                        "must not grant when was_grant (pending={pending}, req={req})"
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            grant_at(0, 0, 1),
+            Some(true),
+            "grant a fresh request when safe"
+        );
+        assert_eq!(
+            grant_at(1, 0, 0),
+            Some(true),
+            "grant a pending request when safe"
+        );
+    }
+
+    #[test]
+    fn out_of_fragment_clause_is_rejected() {
+        // An unbounded Until is outside the supported GR(1) fragment.
+        let g = vec![LtlFormula::Until {
+            left: Box::new(pred("a")),
+            right: Box::new(pred("b")),
+        }];
+        let r = Gr1Spec::classify(&[], &g, &["a".into()], &["b".into()]);
+        assert!(r.is_err(), "Until must be rejected as out-of-fragment");
+    }
+}

--- a/crates/mununu-core/src/mu_calculus/mod.rs
+++ b/crates/mununu-core/src/mu_calculus/mod.rs
@@ -8,6 +8,7 @@ use crate::clts::{Clts, IdStorage, StateId, Transition};
 
 pub mod evaluator;
 pub mod gr1;
+pub mod gr1_build;
 pub mod invert;
 mod memo;
 pub mod nnf;


### PR DESCRIPTION
Builds on #284 (sound GR(1) engine, merged). Adds `mu_calculus/gr1_build.rs` so GR(1) synthesis works on **arbitrary** specs, not the hand-built request_grant game.

## What

- `Gr1Spec::classify` — classifies LTL assumptions/guarantees into the GR(1) fragment:
  - invariant safety `G(prop)`
  - transition safety `G(pre → X post)` (adds a `pre_prev` monitor bit)
  - input fairness `GF prop` → `env_fair`
  - response `G(trig → F resp)` (adds a `pending` bit → `sys_fair` via `¬pending`)
  - out-of-fragment clauses (`U`/`R`/`W`, `FG`, GF-over-outputs) are **reported as errors**, not silently dropped.
- `Gr1Game::build` — builds the monitor-augmented two-player game from the classified spec. The game state is the monitor bits; each round env picks an input valuation and ctrl an output valuation, with safety violations routed to a `BAD` sink.

## Validation

`request_grant` reconstructed **from its LTL formulas** (`Recurrence(req)`, `Response{req,grant}`, `G(grant → X !grant)`) → `gr1_win` realizable, and the extracted strategy is safe (never grants when `was_grant`) and serving. Unbounded `Until` is rejected as out-of-fragment. 3 unit tests; clippy clean.

## Next (follow-up)

Mealy emit from the strategy over a `Gr1Game` → RTL/CLTS (oracle-validate per spec); `ControllerMode::Gr1` routing the TLSF structured spec through classify→build→emit across CLI+API+UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)