### PR TITLE
docs(demo): M4 — wire the sv verify-auto headline verb into the demo

### DIFF
--- a/examples/agentic_rtl_loop/README.md
+++ b/examples/agentic_rtl_loop/README.md
@@ -94,6 +94,25 @@ no-starvation guarantees). `mununu … --controller-mode gr1` synthesizes it (a
 3-way mutual exclusion** (k-induction) with no starvation counterexample for any
 client. Nothing about the pipeline is specific to two clients.
 
+## The productized verb
+
+`run.sh` uses `btormc` directly (a mununu engine) so it can check *every* property
+— including the combinational grants and the liveness monitors — in one place.
+The headline no-sidecar verb, `mununu sv verify-auto`, is also wired:
+
+```bash
+./verify_auto.sh
+#   verify-auto: 1 property verified, 0 unsupported assertion(s)
+#     model: 6 state register(s)
+#     [assert] system_checked_sva_0: HOLDS
+```
+
+`system_checked.sv` writes the arbiter's mutual-exclusion guarantee as an SVA over
+*registered* grants, so verify-auto's predicate-abstraction path binds it and
+proves it **HOLDS** (a definite, sound verdict) on the assembled design. (verify-auto's
+cube path only binds *state* atoms, which is why the full-coverage `run.sh` uses
+explicit state monitors for the combinational/liveness properties.)
+
 ## Honest scope
 
 - This is a **constructed demo system**, not a finding about a real chip.

--- a/examples/agentic_rtl_loop/system_checked.sv
+++ b/examples/agentic_rtl_loop/system_checked.sv
@@ -1,0 +1,17 @@
+// Same assembled system as system.sv, but the arbiter's mutual-exclusion
+// guarantee is written as an SVA over registered (state) grants so the
+// productized verb `mununu sv verify-auto` binds and checks it. Uses `master`
+// (master.sv) and `gr1_controller` (synthesized).
+module system_checked (input logic clk, input logic want_0, input logic want_1,
+                       output logic grant_0_q, output logic grant_1_q);
+  logic req_0, req_1, grant_0, grant_1;
+  master m0 (.clk(clk), .want(want_0), .grant(grant_0), .req(req_0));
+  master m1 (.clk(clk), .want(want_1), .grant(grant_1), .req(req_1));
+  gr1_controller arb (.clk(clk), .req_0(req_0), .req_1(req_1),
+                      .grant_0(grant_0), .grant_1(grant_1));
+  always_ff @(posedge clk) begin
+    grant_0_q <= grant_0;
+    grant_1_q <= grant_1;
+  end
+  p_mutex: assert property (@(posedge clk) !(grant_0_q && grant_1_q));
+endmodule

--- a/examples/agentic_rtl_loop/verify_auto.sh
+++ b/examples/agentic_rtl_loop/verify_auto.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# The productized no-sidecar verb: `mununu sv verify-auto` extracts the design's
+# own SVA and checks it. Here it proves the arbiter's mutual-exclusion guarantee
+# on the assembled system. Requires a `mununu` binary + slang/sv2v/yosys — this
+# runs it from the mununu-sva image's built binary (build once:
+#   docker run --rm -v "$PWD/../..":/work -v mununu-target:/cargo-target \
+#     -e CARGO_TARGET_DIR=/cargo-target mununu-sva cargo build -p mununu-cli).
+set -euo pipefail
+cd "$(dirname "$0")"
+cat master.sv system_checked.sv gr1_controller.sv > _checked.sv
+docker run --rm -v mununu-target:/cargo-target -v "$PWD":/demo mununu-sva \
+  /cargo-target/debug/mununu sv verify-auto /demo/_checked.sv --top system_checked --preprocess-sv2v \
+  2>&1 | grep -E 'verify-auto:|assert\]|HOLDS|VIOLATED|state register'
+rm -f _checked.sv


### PR DESCRIPTION
Completes the demo polish (M4). The demo now uses **real mununu verbs for both legs**: `context synth` (synthesize) + `sv verify-auto` (verify).

## `examples/agentic_rtl_loop/`
- **`system_checked.sv`** — the assembled system with the arbiter's mutual-exclusion guarantee as an **SVA over registered grants**, so the productized no-sidecar verb binds it.
- **`verify_auto.sh`** — runs `mununu sv verify-auto`; it extracts the SVA and reports **HOLDS** (definite, sound over-approximation) across 6 state registers.
- README: a "productized verb" section — verify-auto (headline, state-based mutex) vs `btormc` (full coverage: combinational + liveness).

The pitch narrative (10-beat slides/talk-track + refreshed honesty ledger reflecting B1/M2/M3 shipped) lives in `mununu-private/docs/business/`.

**The demo build (M0–M4) is complete.** No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)