### PR TITLE
feat(P2): recoverability (AG EF / νμ) decides at scale via cube+smt-hyper-must

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -580,6 +580,12 @@ struct Btor2VerifyRecoverabilityArgs {
     /// The `good` atom to recover to — a register comparison, e.g. `"state_q == 3"`.
     #[arg(long, value_name = "ATOM")]
     target: String,
+    /// Extra abstraction predicate(s) for the cube-path escalation,
+    /// `NAME:REGISTER=VALUE` (repeatable, like `btor2 cegar`). Used only when the exact
+    /// engine abstains (over the ~40-bit cone cap); the escalation is automatic even
+    /// with none.
+    #[arg(long = "predicate", value_name = "NAME:REG=VALUE")]
+    predicate: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -1548,6 +1554,11 @@ struct SvVerifyRecoverabilityArgs {
     /// The `good` atom to recover to — a register comparison, e.g. `"state_q == 3"`.
     #[arg(long, value_name = "ATOM")]
     target: String,
+    /// Extra abstraction predicate(s) for the cube-path escalation,
+    /// `NAME:REGISTER=VALUE` (repeatable). Used only when the exact engine abstains; the
+    /// escalation is automatic even with none.
+    #[arg(long = "predicate", value_name = "NAME:REG=VALUE")]
+    predicate: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2367,12 +2378,17 @@ fn btor2_check_fsm(args: Btor2CheckFsmArgs) -> Result<(), String> {
 /// `POST /api/v1/btor2/verify-recoverability`.
 fn btor2_verify_recoverability(args: Btor2VerifyRecoverabilityArgs) -> Result<(), String> {
     use mununu_core::adapter::recoverability::{
-        recoverability_property_str, verify_recoverability,
+        parse_extra_predicate, recoverability_property_str, verify_recoverability_with_predicates,
     };
 
     let content = std::fs::read_to_string(&args.file)
         .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
-    let verdict = verify_recoverability(&content, &args.target)?;
+    let extra = args
+        .predicate
+        .iter()
+        .map(|s| parse_extra_predicate(s))
+        .collect::<Result<Vec<_>, _>>()?;
+    let verdict = verify_recoverability_with_predicates(&content, &args.target, &extra)?;
 
     let summary = serde_json::json!({
         "file": args.file.display().to_string(),
@@ -4677,11 +4693,19 @@ fn sv_verify_liveness(args: SvVerifyLivenessArgs) -> Result<(), String> {
 
 /// `mununu sv verify-recoverability` — lift SV and decide `AG EF good`.
 fn sv_verify_recoverability(args: SvVerifyRecoverabilityArgs) -> Result<(), String> {
-    use mununu_core::adapter::recoverability::recoverability_property_str;
-    use mununu_core::adapter::sv_verify::sv_verify_recoverability as core_sv_verify_recoverability;
+    use mununu_core::adapter::recoverability::{
+        parse_extra_predicate, recoverability_property_str,
+    };
+    use mununu_core::adapter::sv_verify::sv_verify_recoverability_with_predicates;
 
     let file = args.lift.file.display().to_string();
-    let verdict = core_sv_verify_recoverability(&read_sv_lift(&args.lift)?, &args.target)?;
+    let extra = args
+        .predicate
+        .iter()
+        .map(|s| parse_extra_predicate(s))
+        .collect::<Result<Vec<_>, _>>()?;
+    let verdict =
+        sv_verify_recoverability_with_predicates(&read_sv_lift(&args.lift)?, &args.target, &extra)?;
     let summary = serde_json::json!({
         "file": file,
         "property": recoverability_property_str(&args.target),

--- a/crates/mununu-core/src/adapter/btor2/concrete_oracle.rs
+++ b/crates/mununu-core/src/adapter/btor2/concrete_oracle.rs
@@ -60,7 +60,10 @@ pub enum AgOracle {
 
 /// Init value of each state cell (from BTOR2 `init` lines, default 0 — the
 /// `setundef -zero` power-up).
-fn init_valuation(file: &Btor2File) -> BTreeMap<String, u128> {
+///
+/// `pub(crate)` (P2 Slice 1): the recoverability cube path reuses it to build the
+/// initial-cube pin (`config_values`) so the lift's initial cube is the reset state.
+pub(crate) fn init_valuation(file: &Btor2File) -> BTreeMap<String, u128> {
     let symbols = parser::collect_symbols(file);
     let mut init_of: HashMap<crate::adapter::btor2::ast::Nid, u128> = HashMap::new();
     for line in &file.lines {

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -27,38 +27,253 @@
 //! For designs wider than the exact cap, the **predicate-cube + `smt-hyper-must`**
 //! path (`mununu btor2 cegar --formula … --must-edge-inference smt-hyper-must`)
 //! decides the same formula via abstraction — the path the V.7-c OpenTitan `csrng`
-//! recoverability showcase uses. This ergonomic command does not replace that path;
-//! it makes the small/medium case a one-liner and is the surface peer of the safety
-//! (`btor2 verify`) and response-liveness (`btor2 verify-liveness`) commands.
+//! recoverability showcase uses.
+//!
+//! P2 Slice 1 wires that path in **automatically**: [`verify_recoverability`] tries
+//! the exact engine first and, when it abstains (over the ~40-bit cone cap or an
+//! unsupported construct), escalates to [`verify_recoverability_scalable`] — the
+//! predicate-cube `smt-hyper-must` reduction — so the νμ property decides beyond 40
+//! bits. The escalation mirrors the verify-auto safety-⊥ `reach_rescue` escalation.
+//! Every scalable verdict is cross-checked against the exact engine on the small
+//! fixtures (the differential-oracle soundness gate; see the module tests).
 
-use crate::adapter::btor2::predicate_expr::parse_predicate_expr;
+use std::collections::BTreeMap;
+
+use crate::adapter::AdapterOptions;
+use crate::adapter::btor2::cegar::{
+    CegarOptions, LiftStrategy, PredicateSource, cegar_refine_loop, config_values_to_sidecar_json,
+};
+use crate::adapter::btor2::kmts_lift::{MayEdgeInference, MustEdgeInference, PredicateSpec};
+use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr, parse_predicate_expr};
 use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
+use crate::mu_calculus::Environment;
 use crate::mu_calculus::parser as mu_parser;
+use crate::mu_calculus::trit::Trit;
 use crate::verdict::PropertyVerdict;
+
+/// Max CEGAR refinement iterations for the scalable recoverability path — a sensible
+/// default: a pure state-atom `AG EF` target either decides at the seed abstraction or
+/// after a few weakest-precondition splits.
+const RECOVERABILITY_MAX_ITERATIONS: usize = 8;
 
 /// Decide recoverability `AG EF (good)` of `btor2_content`, where `good` is a single
 /// register-comparison atom string (`"state_q == 3"`).
 ///
 /// Returns the canonical [`PropertyVerdict`]: `Holds` (every reachable state can
-/// reach `good`), `Violated` (a reachable trap cannot), or `Unknown` (the design is
-/// over the exact engine's cap or uses an unsupported construct — try the cube +
-/// `smt-hyper-must` path for scale). Errors only when `good` is not a parseable atom.
+/// reach `good`), `Violated` (a reachable trap cannot), or `Unknown` (neither the
+/// exact engine nor the cube + `smt-hyper-must` escalation could decide). Errors only
+/// when `good` is not a parseable atom.
+///
+/// P2 Slice 1 — the exact engine is tried first; on a definite verdict it is returned
+/// as before. When the exact engine abstains (over the ~40-bit cone cap or an
+/// unsupported construct), the property is **escalated** to
+/// [`verify_recoverability_scalable`] (the cube + `smt-hyper-must` reduction), so the
+/// νμ recoverability property decides beyond 40 bits. The public signature is
+/// unchanged; callers that want extra abstraction predicates use
+/// [`verify_recoverability_with_predicates`].
 pub fn verify_recoverability(btor2_content: &str, good: &str) -> Result<PropertyVerdict, String> {
+    verify_recoverability_with_predicates(btor2_content, good, &[])
+}
+
+/// [`verify_recoverability`] with optional extra abstraction predicates for the
+/// cube-path escalation. `extra_predicates` refine the predicate-cube abstraction (they
+/// help the `smt-hyper-must` path decide) but do NOT appear in the `AG EF good` formula
+/// — only `good` does. When `extra_predicates` is empty this is exactly
+/// [`verify_recoverability`]. The exact engine (tried first) ignores the extras; they
+/// matter only if it abstains and the cube path runs.
+pub fn verify_recoverability_with_predicates(
+    btor2_content: &str,
+    good: &str,
+    extra_predicates: &[PredicateSpec],
+) -> Result<PropertyVerdict, String> {
     // Validate the atom up front for a target-specific error message (the µ-parser
     // would otherwise report it as a formula-syntax error).
     parse_predicate_expr(good).map_err(|e| {
         format!("recoverability target `{good}` is not a register-comparison atom (`REG op VALUE`): {e:?}")
     })?;
 
-    // AG EF good = nu Y. ((mu X. (good || <> X)) && [] Y).
+    // AG EF good = nu Y. ((mu X. (good || <> X)) && [] Y). The exact engine reads the
+    // raw `REG == VALUE` atom directly.
     let formula_str = format!("nu Y. ((mu X. (({good}) || <> X)) && [] Y)");
     let formula = mu_parser::parse(&formula_str)
         .map_err(|e| format!("building the AG EF formula for `{good}`: {e:?}"))?;
 
-    Ok(match exact_symbolic_verdict(btor2_content, &formula) {
-        Ok(v) => PropertyVerdict::from(v),
-        // Over the 40-bit cone cap or an unsupported construct: a sound abstention.
-        Err(_) => PropertyVerdict::Unknown,
+    match exact_symbolic_verdict(btor2_content, &formula) {
+        // The exact engine decided (definite at every alternation depth per
+        // Bruns–Godefroid) — return it unchanged; the exact-only behaviour is
+        // preserved when the exact engine gives a definite verdict.
+        Ok(v) => Ok(PropertyVerdict::from(v)),
+        // Over the ~40-bit cone cap or an unsupported construct: escalate to the
+        // cube + `smt-hyper-must` path so the property still decides at scale
+        // (slice-5b safety-⊥ escalation mirror). The scalable path itself abstains
+        // (Unknown) if it cannot decide, so this is never less sound than the old
+        // `Err(_) => Unknown` abstention.
+        Err(_) => verify_recoverability_scalable(btor2_content, good, extra_predicates),
+    }
+}
+
+/// P2 Slice 1 — decide recoverability `AG EF good` via the **predicate-cube +
+/// `smt-hyper-must`** path, so the νμ property decides beyond the exact engine's
+/// ~40-bit cone cap.
+///
+/// `good` must be a `REG == VALUE` equality atom; any other comparison (`<`, `>=`, …)
+/// returns `Ok(Unknown)` (an honest abstain — the auto-seed pins/enumerates only `==`
+/// targets). `extra_predicates` are additional abstraction predicates that refine the
+/// cube (they do not enter the formula). Returns the canonical verdict at the design's
+/// reset cube, or `Ok(Unknown)` when the abstraction cannot decide or the CEGAR loop
+/// errors (a sound abstain — never a fabricated definite verdict).
+pub fn verify_recoverability_scalable(
+    btor2_content: &str,
+    good: &str,
+    extra_predicates: &[PredicateSpec],
+) -> Result<PropertyVerdict, String> {
+    // Parse `good` and require a `REG == VALUE` equality atom.
+    let good_expr = parse_predicate_expr(good).map_err(|e| {
+        format!("recoverability target `{good}` is not a register-comparison atom (`REG op VALUE`): {e:?}")
+    })?;
+    let (good_register, good_value) = match good_expr {
+        PredicateExpr::Cmp {
+            register,
+            op: CmpOp::Eq,
+            value,
+        } => (register, value),
+        // SOUNDNESS: the cube auto-seed pins each predicate register to its reset value
+        // and reads the reset cube; that construction is only well-defined for an
+        // equality (`==`) target. A non-equality `good` (e.g. `st < 3`) is an honest
+        // abstain (Unknown), never a fabricated definite verdict.
+        _ => return Ok(PropertyVerdict::Unknown),
+    };
+
+    // Seed predicates = [good] ++ extra. The `good` predicate is named `good` so the
+    // formula atom resolves to it via the cube labelling; the extras carry their own
+    // names and only refine the abstraction (they are not referenced by the formula).
+    let good_spec = PredicateSpec {
+        name: "good".to_string(),
+        register: good_register,
+        value: good_value,
+    };
+    let mut specs: Vec<PredicateSpec> = Vec::with_capacity(1 + extra_predicates.len());
+    specs.push(good_spec);
+    specs.extend(extra_predicates.iter().cloned());
+
+    // AG EF good, over the PREDICATE-NAME atom (the cube path resolves `good` to the
+    // `good` predicate's 3-valued label, not a raw register comparison).
+    let formula = mu_parser::parse("nu Y. ((mu X. (good || <> X)) && [] Y)")
+        .map_err(|e| format!("building the AG EF cube formula: {e:?}"))?;
+
+    // Reset valuation of the BTOR2 (init lines, default 0).
+    let file = crate::adapter::btor2::parser::parse(btor2_content)
+        .map_err(|e| format!("recoverability cube path: parsing BTOR2: {}", e.message))?;
+    let init_values: BTreeMap<String, u128> =
+        crate::adapter::btor2::concrete_oracle::init_valuation(&file);
+
+    // SOUNDNESS: pin each predicate's register to its BTOR2 reset value via
+    // `config_values`, so the cube lift's initial cube is the design's reset state.
+    // WITHOUT this pin the lift defaults its initial cube to all-false, which is NOT
+    // the reset state and can falsely report VIOLATED — the pin is mandatory. A
+    // predicate whose register has no `init_values` entry (e.g. a free input) is
+    // silently skipped, which is correct (a free input has no reset value to pin).
+    let config_entries: Vec<String> = specs
+        .iter()
+        .filter_map(|s| {
+            init_values
+                .get(&s.register)
+                .map(|v| format!("{}={}", s.register, v))
+        })
+        .collect();
+    let sidecar_json = config_values_to_sidecar_json(&config_entries)
+        .map_err(|e| format!("recoverability cube path: building the config-values pin: {e}"))?;
+    let adapter_options = AdapterOptions {
+        sidecar_json,
+        ..Default::default()
+    };
+
+    // Cube + smt-hyper-must, matching the verify_auto CegarOptions shape.
+    let cegar_opts = CegarOptions {
+        max_iterations: RECOVERABILITY_MAX_ITERATIONS,
+        predicate_source: PredicateSource::WeakestPrecondition,
+        max_cube_count: 1024,
+        capture_approximants: false,
+        enable_approximant_reuse: false,
+        smart_uf_cap: true,
+        lift_strategy: LiftStrategy::Eager,
+        // The sound νμ hyper-must (GKMTS ∀∃ over the may-successor set) — definite
+        // recoverability verdicts transfer to the concrete design (Bruns–Godefroid /
+        // Shoham–Grumberg).
+        must_edge_inference: MustEdgeInference::SmtHyperMust,
+        // The sound all-pairs SMT may-relation (over-approximation).
+        may_edge_inference: MayEdgeInference::SmtAllPairs,
+        emit_ctxdsl: false,
+    };
+    let env = Environment::new(1usize << specs.len());
+
+    let trace = match cegar_refine_loop(
+        &formula,
+        btor2_content,
+        specs.clone(),
+        &env,
+        &adapter_options,
+        &cegar_opts,
+    ) {
+        Ok(t) => t,
+        // SOUNDNESS: a CEGAR error (SMT failure, cube-cap overflow, …) is an honest
+        // abstain — never a fabricated verdict, matching the exact verb's
+        // abstain-on-error posture.
+        Err(_) => return Ok(PropertyVerdict::Unknown),
+    };
+
+    // SOUNDNESS: the reset cube is well-defined only if EVERY final predicate's register
+    // has a known reset value (is a pinned state cell). WeakestPrecondition refinement can
+    // append a predicate over a free INPUT — e.g. `WP(st==0)` through `st' = ite(go,1,0)`
+    // is `go==0` — whose reset truth is not fixed (the input is free at cycle 0). Reading a
+    // single init-cube bit for such a predicate would silently pick one input flavour and
+    // could return a wrong DEFINITE verdict, and at scale the exact engine abstains so
+    // there is no cross-check to catch it. Rather than under-read (unsound) we ABSTAIN
+    // (sound). Fully enumerating free-input initial flavours conjunctively (à la
+    // verify_auto's `free_input_init_cubes`) is a completeness follow-up.
+    if !trace
+        .final_predicates
+        .iter()
+        .all(|spec| init_values.contains_key(&spec.register))
+    {
+        return Ok(PropertyVerdict::Unknown);
+    }
+
+    // The design's initial cube: evaluate every FINAL predicate at the reset valuation,
+    // in the lift's cube-bit order (`final_predicates[i]` ↔ bit `i`). Every final predicate
+    // is now a pinned `register == value` state atom (guarded above), so its reset truth is
+    // `init_values[register] == value` and the reset cube is input-independent.
+    let mut init_cube = 0usize;
+    for (i, spec) in trace.final_predicates.iter().enumerate() {
+        if init_values.get(&spec.register).copied() == Some(spec.value as u128) {
+            init_cube |= 1 << i;
+        }
+    }
+
+    Ok(match trace.final_verdict.verdict_at(init_cube) {
+        Trit::False => PropertyVerdict::Violated,
+        Trit::Unknown => PropertyVerdict::Unknown,
+        Trit::True => PropertyVerdict::Holds,
+    })
+}
+
+/// Parse an extra-abstraction-predicate triple `NAME:REGISTER=VALUE` (the surface
+/// syntax shared by `btor2 verify-recoverability --predicate` and the API
+/// `predicates` field) into a [`PredicateSpec`]. Same shape as `btor2 cegar`.
+pub fn parse_extra_predicate(raw: &str) -> Result<PredicateSpec, String> {
+    let (name, rest) = raw.split_once(':').ok_or_else(|| {
+        format!("predicate spec '{raw}' missing ':' separator (expected NAME:REGISTER=VALUE)")
+    })?;
+    let (register, value_str) = rest.split_once('=').ok_or_else(|| {
+        format!("predicate spec '{raw}' missing '=' separator (expected NAME:REGISTER=VALUE)")
+    })?;
+    let value: u64 = value_str
+        .parse()
+        .map_err(|e| format!("predicate spec '{raw}' has non-numeric value: {e}"))?;
+    Ok(PredicateSpec {
+        name: name.to_string(),
+        register: register.to_string(),
+        value,
     })
 }
 
@@ -136,5 +351,205 @@ mod tests {
     #[test]
     fn property_string_echoes_the_target() {
         assert_eq!(recoverability_property_str("st == 0"), "AG EF (st == 0)");
+    }
+
+    // A ≥48-bit free-running counter (over the exact ~40-bit cone cap) whose value
+    // gates a small 2-state FSM (`st`: 0=idle, 1=busy). The counter feeds st's
+    // next-state (idle advances to busy only when `cnt == 0`), so the counter is IN
+    // st's cone-of-influence → the exact engine over-caps. busy ALWAYS returns to idle,
+    // so every reachable state can reach idle ⇒ AG EF (st==0) HOLDS.
+    const WIDE_RECOVERABLE: &str = "\
+1 sort bitvec 48
+2 sort bitvec 2
+3 sort bitvec 1
+4 state 1 cnt
+5 zero 1
+6 init 1 4 5
+7 inc 1 4
+8 next 1 4 7
+9 state 2 st
+10 zero 2
+11 init 2 9 10
+12 one 2
+13 eq 3 9 10
+14 eq 3 4 5
+15 ite 2 14 12 10
+16 ite 2 13 15 10
+17 next 2 9 16
+";
+
+    // Same 48-bit counter (over the exact cap) but st's next-state is `stuck (2)`
+    // UNCONDITIONALLY — the `ite(cnt==0, 2, 2)` keeps the counter syntactically in st's
+    // cone (so the exact engine over-caps) while every state moves to the absorbing
+    // trap. From `stuck`, idle is unreachable ⇒ AG EF (st==0) VIOLATED.
+    const WIDE_TRAP: &str = "\
+1 sort bitvec 48
+2 sort bitvec 2
+3 sort bitvec 1
+4 state 1 cnt
+5 zero 1
+6 init 1 4 5
+7 inc 1 4
+8 next 1 4 7
+9 state 2 st
+10 zero 2
+11 init 2 9 10
+12 constd 2 2
+13 eq 3 4 5
+14 ite 2 13 12 12
+15 next 2 9 14
+";
+
+    /// The **exact-engine-only** verdict (no cube escalation) — the differential
+    /// oracle. `Unknown` means the exact engine abstained (over-cap / unsupported).
+    fn exact_verdict(btor2: &str, good: &str) -> PropertyVerdict {
+        let formula_str = format!("nu Y. ((mu X. (({good}) || <> X)) && [] Y)");
+        let formula = mu_parser::parse(&formula_str).expect("AG EF formula parses");
+        match exact_symbolic_verdict(btor2, &formula) {
+            Ok(v) => PropertyVerdict::from(v),
+            Err(_) => PropertyVerdict::Unknown,
+        }
+    }
+
+    // === P2 Slice 1 — the MANDATORY differential soundness gate ==================
+    // The scalable cube + smt-hyper-must verdict MUST equal the exact-engine verdict
+    // on the small fixtures the exact engine decides, in BOTH polarities. This is the
+    // non-negotiable soundness assertion (the L5 differential-oracle rule).
+
+    #[test]
+    fn scalable_matches_exact_holds_polarity() {
+        // RESPONDER: every reachable state can reach idle ⇒ Holds, both engines.
+        let exact = exact_verdict(RESPONDER, "st == 0");
+        let scalable = verify_recoverability_scalable(RESPONDER, "st == 0", &[]).expect("decides");
+        assert_eq!(
+            exact,
+            PropertyVerdict::Holds,
+            "exact decides RESPONDER Holds"
+        );
+        assert_eq!(
+            scalable, exact,
+            "cube path must AGREE with the exact engine on RESPONDER (Holds)"
+        );
+    }
+
+    #[test]
+    fn scalable_matches_exact_violated_polarity() {
+        // STALLER: the reachable `stuck` state cannot get back to idle ⇒ Violated,
+        // both engines.
+        let exact = exact_verdict(STALLER, "st == 0");
+        let scalable = verify_recoverability_scalable(STALLER, "st == 0", &[]).expect("decides");
+        assert_eq!(
+            exact,
+            PropertyVerdict::Violated,
+            "exact decides STALLER Violated"
+        );
+        assert_eq!(
+            scalable, exact,
+            "cube path must AGREE with the exact engine on STALLER (Violated)"
+        );
+    }
+
+    // === The proof the slice decides AT SCALE ==================================
+    // On a design whose cone exceeds the exact ~40-bit cap, the exact engine ABSTAINS
+    // (Unknown) while the cube path DECIDES — in both polarities.
+
+    #[test]
+    fn wide_design_exact_abstains_but_cube_decides_holds() {
+        // The 48-bit counter feeds st's cone ⇒ the exact engine over-caps (Unknown),
+        // but the cube abstraction (which drops the counter) decides Holds.
+        assert_eq!(
+            exact_verdict(WIDE_RECOVERABLE, "st == 0"),
+            PropertyVerdict::Unknown,
+            "the exact engine must ABSTAIN on the wide (over-cap) design"
+        );
+        assert_eq!(
+            verify_recoverability_scalable(WIDE_RECOVERABLE, "st == 0", &[]).expect("decides"),
+            PropertyVerdict::Holds,
+            "the cube path must DECIDE Holds where the exact engine abstains"
+        );
+    }
+
+    #[test]
+    fn wide_design_exact_abstains_but_cube_decides_violated() {
+        assert_eq!(
+            exact_verdict(WIDE_TRAP, "st == 0"),
+            PropertyVerdict::Unknown,
+            "the exact engine must ABSTAIN on the wide (over-cap) trap design"
+        );
+        assert_eq!(
+            verify_recoverability_scalable(WIDE_TRAP, "st == 0", &[]).expect("decides"),
+            PropertyVerdict::Violated,
+            "the cube path must DECIDE Violated where the exact engine abstains"
+        );
+    }
+
+    // === Auto-escalation: the public verb transparently uses the cube path ======
+
+    #[test]
+    fn verify_recoverability_auto_escalates_on_wide_design() {
+        // The public `verify_recoverability` tries exact first; on the over-cap wide
+        // designs it escalates to the cube path and returns the definite verdict.
+        assert_eq!(
+            verify_recoverability(WIDE_RECOVERABLE, "st == 0").expect("decides"),
+            PropertyVerdict::Holds,
+            "auto-escalation must yield the cube-decided Holds on the wide design"
+        );
+        assert_eq!(
+            verify_recoverability(WIDE_TRAP, "st == 0").expect("decides"),
+            PropertyVerdict::Violated,
+            "auto-escalation must yield the cube-decided Violated on the wide trap"
+        );
+    }
+
+    #[test]
+    fn verify_recoverability_keeps_exact_verdict_when_exact_decides() {
+        // When the exact engine decides (small fixtures), the escalation is a no-op —
+        // the exact verdict is returned unchanged.
+        assert_eq!(
+            verify_recoverability(RESPONDER, "st == 0").expect("decides"),
+            PropertyVerdict::Holds
+        );
+        assert_eq!(
+            verify_recoverability(STALLER, "st == 0").expect("decides"),
+            PropertyVerdict::Violated
+        );
+    }
+
+    // === Abstains + surface plumbing ===========================================
+
+    #[test]
+    fn scalable_non_equality_target_abstains() {
+        // A non-`==` good atom is an honest Unknown (the cube auto-seed only pins `==`
+        // targets), never a fabricated definite verdict.
+        assert_eq!(
+            verify_recoverability_scalable(RESPONDER, "st < 3", &[]).expect("abstains cleanly"),
+            PropertyVerdict::Unknown
+        );
+    }
+
+    #[test]
+    fn scalable_honors_extra_predicates() {
+        // Extra abstraction predicates refine the cube without changing the (sound)
+        // verdict on a design the seed already decides.
+        let extra = vec![parse_extra_predicate("busy:st=1").expect("parses")];
+        assert_eq!(
+            verify_recoverability_scalable(RESPONDER, "st == 0", &extra).expect("decides"),
+            PropertyVerdict::Holds
+        );
+    }
+
+    #[test]
+    fn parse_extra_predicate_parses_and_rejects() {
+        assert_eq!(
+            parse_extra_predicate("idle:state_q=3").expect("parses"),
+            PredicateSpec {
+                name: "idle".into(),
+                register: "state_q".into(),
+                value: 3,
+            }
+        );
+        assert!(parse_extra_predicate("no_colon").is_err());
+        assert!(parse_extra_predicate("n:reg").is_err());
+        assert!(parse_extra_predicate("n:reg=notanumber").is_err());
     }
 }

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -17,13 +17,14 @@
 //! reset-dependent (see `docs/design/recoverability-vs-sva.md` §3.2). Reset-gating
 //! (as `sv verify-auto` offers) is a future option.
 
+use crate::adapter::btor2::kmts_lift::PredicateSpec;
 use crate::adapter::btor2::parser;
 use crate::adapter::btor2::predicate_expr::parse_predicate_expr;
 use crate::adapter::liveness_rescue::{
     Atom, LivenessVerdict, parse_response_atom, response_liveness_rescue_atoms,
 };
 use crate::adapter::reach_portfolio::{ReachOutcome, decide_reach_portfolio_parallel};
-use crate::adapter::recoverability::verify_recoverability;
+use crate::adapter::recoverability::verify_recoverability_with_predicates;
 use crate::adapter::yosys::{YosysOptions, sv_to_btor2};
 use crate::verdict::PropertyVerdict;
 
@@ -82,11 +83,22 @@ pub fn sv_verify_liveness(
 /// `sv verify-recoverability` — lift SV and decide `AG EF target`. The target atom is
 /// validated before the lift.
 pub fn sv_verify_recoverability(lift: &SvLift, target: &str) -> Result<PropertyVerdict, String> {
+    sv_verify_recoverability_with_predicates(lift, target, &[])
+}
+
+/// [`sv_verify_recoverability`] with optional extra abstraction predicates for the
+/// cube-path escalation (P2 Slice 1). The target atom is validated before the
+/// (toolchain-gated) lift; the extras only refine the cube if the exact engine abstains.
+pub fn sv_verify_recoverability_with_predicates(
+    lift: &SvLift,
+    target: &str,
+    extra_predicates: &[PredicateSpec],
+) -> Result<PropertyVerdict, String> {
     parse_predicate_expr(target).map_err(|e| {
         format!("recoverability target `{target}` is not a register-comparison atom: {e:?}")
     })?;
     let btor2 = lift.lift()?;
-    verify_recoverability(&btor2, target)
+    verify_recoverability_with_predicates(&btor2, target, extra_predicates)
 }
 
 /// `sv check-fsm` — lift SV and auto-scan every FSM-like state register for a reachable

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -745,14 +745,24 @@ pub async fn btor2_verify_liveness_handler(
 pub async fn btor2_verify_recoverability_handler(
     Json(request): Json<Btor2VerifyRecoverabilityRequest>,
 ) -> ApiResult<Json<Btor2VerifyRecoverabilityResponse>> {
-    use crate::adapter::recoverability::{recoverability_property_str, verify_recoverability};
+    use crate::adapter::recoverability::{
+        parse_extra_predicate, recoverability_property_str, verify_recoverability_with_predicates,
+    };
 
-    let verdict = verify_recoverability(&request.content, &request.target).map_err(|message| {
-        ApiError::BadRequest {
+    let extra = request
+        .predicates
+        .iter()
+        .map(|s| parse_extra_predicate(s))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|message| ApiError::BadRequest {
             message,
             details: None,
-        }
-    })?;
+        })?;
+    let verdict = verify_recoverability_with_predicates(&request.content, &request.target, &extra)
+        .map_err(|message| ApiError::BadRequest {
+            message,
+            details: None,
+        })?;
 
     Ok(Json(Btor2VerifyRecoverabilityResponse {
         verdict: verdict.as_str().to_string(),
@@ -879,10 +889,19 @@ pub async fn sv_verify_liveness_handler(
 pub async fn sv_verify_recoverability_handler(
     Json(request): Json<SvVerifyRecoverabilityRequest>,
 ) -> ApiResult<Json<Btor2VerifyRecoverabilityResponse>> {
-    use crate::adapter::recoverability::recoverability_property_str;
-    use crate::adapter::sv_verify::{SvLift, sv_verify_recoverability};
+    use crate::adapter::recoverability::{parse_extra_predicate, recoverability_property_str};
+    use crate::adapter::sv_verify::{SvLift, sv_verify_recoverability_with_predicates};
 
     let property = recoverability_property_str(&request.target);
+    let extra = request
+        .predicates
+        .iter()
+        .map(|s| parse_extra_predicate(s))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|message| ApiError::BadRequest {
+            message,
+            details: None,
+        })?;
     let lift = SvLift {
         source: request.source,
         additional_sources: request
@@ -893,12 +912,11 @@ pub async fn sv_verify_recoverability_handler(
         top: request.top,
         use_sv2v: request.use_sv2v,
     };
-    let verdict = sv_verify_recoverability(&lift, &request.target).map_err(|message| {
-        ApiError::BadRequest {
+    let verdict = sv_verify_recoverability_with_predicates(&lift, &request.target, &extra)
+        .map_err(|message| ApiError::BadRequest {
             message,
             details: None,
-        }
-    })?;
+        })?;
     Ok(Json(Btor2VerifyRecoverabilityResponse {
         verdict: verdict.as_str().to_string(),
         property,
@@ -4234,6 +4252,7 @@ members = ["x"]
         let request = Btor2VerifyRecoverabilityRequest {
             content: LIVENESS_STALLER.to_string(),
             target: "st == 0".to_string(),
+            predicates: Vec::new(),
         };
         let Json(out) = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4247,6 +4266,7 @@ members = ["x"]
         let request = Btor2VerifyRecoverabilityRequest {
             content: LIVENESS_STALLER.to_string(),
             target: "definitely not an atom".to_string(),
+            predicates: Vec::new(),
         };
         let err = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4337,6 +4357,7 @@ members = ["x"]
             top: None,
             use_sv2v: false,
             target: "not an atom !!".to_string(),
+            predicates: Vec::new(),
         };
         let err = sv_verify_recoverability_handler(Json(request))
             .await

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -981,6 +981,11 @@ pub struct Btor2VerifyRecoverabilityRequest {
     pub content: String,
     /// The `good` atom to recover to (`"REG op VALUE"`).
     pub target: String,
+    /// Extra abstraction predicate(s) for the cube-path escalation, each
+    /// `"NAME:REGISTER=VALUE"` (P2 Slice 1). Used only when the exact engine abstains
+    /// (over the ~40-bit cone cap); the escalation is automatic even with none.
+    #[serde(default)]
+    pub predicates: Vec<String>,
 }
 
 /// Response for `POST /api/v1/btor2/verify-recoverability`.
@@ -1095,6 +1100,10 @@ pub struct SvVerifyRecoverabilityRequest {
     pub use_sv2v: bool,
     /// The `good` atom to recover to (`"REG op VALUE"`).
     pub target: String,
+    /// Extra abstraction predicate(s) for the cube-path escalation, each
+    /// `"NAME:REGISTER=VALUE"` (P2 Slice 1). Used only when the exact engine abstains.
+    #[serde(default)]
+    pub predicates: Vec<String>,
 }
 
 /// Request for `POST /api/v1/sv/check-fsm` — the SV lift fields plus the FSM width


### PR DESCRIPTION
**P2 Slice 1.** The νμ recoverability verb (`AG EF good` — the branching property SVA cannot express) routed only to the exact 3-valued engine (~40-bit cone cap → `Unknown`). It now **auto-escalates** to the sound predicate-cube + `smt-hyper-must` path when the exact engine abstains, so recoverability decides **beyond 40 bits**.

## Core (`adapter/recoverability.rs`)
- `verify_recoverability_scalable` — seeds `[good]++extra`, pins each predicate register to its BTOR2 reset value via `config_values` (the load-bearing init-cube pin), runs `cegar_refine_loop` with `SmtHyperMust` + `SmtAllPairs`, reads the verdict at the reset cube.
- `verify_recoverability` — signature unchanged; auto-escalates on exact abstain. Non-`==` target / CEGAR error → sound `Unknown`.
- **SOUNDNESS guard:** abstain if any *final* predicate references an unpinnable register (WP refinement can append a free-input predicate whose reset truth isn't fixed → a single init-cube read could give a wrong definite verdict, uncaught at scale). Sound > complete; free-input enumeration is a follow-up.

## Surfaces (CLI + API + UI)
`--predicate NAME:REG=VALUE` (repeatable) on `btor2`/`sv verify-recoverability`; optional `predicates` on both API requests; UI request types (mununu-ui #48, merged).

## Differential-tested (the soundness gate)
`scalable == exact` on RESPONDER (Holds) and STALLER (Violated), both polarities; and on a 48-bit-counter design the **exact engine abstains while the cube path decides** — Holds (recoverable) and Violated (trap) — the actual proof it decides at scale. `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)