### PR TITLE
feat(P2): multi-response (guarantee-conjunction) liveness verification

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -254,6 +254,15 @@ enum Btor2Command {
     /// prints the verdict (`holds` / `violated` / `unknown`). `--request`
     /// and `--grant` are single register-comparison atoms (`"st == 1"`).
     VerifyLiveness(Btor2VerifyLivenessArgs),
+    /// Decide a conjunction of response-liveness properties `⋀ᵢ AG(aᵢ → AF bᵢ)`.
+    ///
+    /// The multi-guarantee peer of `verify-liveness`: pass a repeatable
+    /// `--response "ANTE => CONS"` (each a request/grant pair of register-comparison
+    /// atoms). Every conjunct is reduced to its own `bad`-reachability query; the
+    /// combined verdict is `violated` if any conjunct is (a real ungranted-request
+    /// lasso), else `unknown` if any is, else `holds`. Surface peer of
+    /// `POST /api/v1/btor2/verify-liveness-all`.
+    VerifyLivenessAll(Btor2VerifyLivenessAllArgs),
     /// Decide recoverability `AG EF good` — the branching property SVA cannot state.
     ///
     /// "From every reachable state, can the design still get back to a `good`
@@ -567,6 +576,22 @@ struct Btor2VerifyLivenessArgs {
     /// The grant atom that must eventually follow on every path, e.g. `"st == 2"`.
     #[arg(long, value_name = "ATOM")]
     grant: String,
+    #[command(flatten)]
+    ci: CiArgs,
+}
+
+/// Arguments for `mununu btor2 verify-liveness-all` — a conjunction of
+/// response-liveness properties, each a repeatable `--response "ANTE => CONS"`.
+#[derive(Args, Debug)]
+struct Btor2VerifyLivenessAllArgs {
+    /// Path to the BTOR2 input file.
+    #[arg(value_name = "BTOR2_FILE")]
+    file: PathBuf,
+    /// A response pair `"ANTE => CONS"` — both sides register-comparison atoms
+    /// (`"req == 1 => grant == 1"`). Repeatable; the verdict is the conjunction
+    /// `⋀ AG(ANTE → AF CONS)`. At least one required.
+    #[arg(long = "response", value_name = "ANTE => CONS", required = true)]
+    responses: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -1224,6 +1249,11 @@ enum SvCommand {
     /// SV-direct peer of `btor2 verify-liveness`. `--request` / `--grant` are single
     /// register-comparison atoms. Surface peer of `POST /api/v1/sv/verify-liveness`.
     VerifyLiveness(SvVerifyLivenessArgs),
+    /// Lift SV and decide a conjunction of response-liveness properties
+    /// `⋀ᵢ AG(aᵢ → AF bᵢ)` from repeatable `--response "ANTE => CONS"` pairs — the
+    /// SV-direct peer of `btor2 verify-liveness-all`. Surface peer of
+    /// `POST /api/v1/sv/verify-liveness-all`.
+    VerifyLivenessAll(SvVerifyLivenessAllArgs),
     /// Lift SV and decide recoverability `AG EF good` — the branching property SVA
     /// cannot state, checked directly against raw SV in one call. `--target` is a
     /// single register-comparison atom. Surface peer of
@@ -1542,6 +1572,21 @@ struct SvVerifyLivenessArgs {
     /// The grant atom that must eventually follow on every path, e.g. `"st == 2"`.
     #[arg(long, value_name = "ATOM")]
     grant: String,
+    #[command(flatten)]
+    ci: CiArgs,
+}
+
+/// Arguments for `mununu sv verify-liveness-all` — SV-direct conjunction of
+/// response-liveness properties.
+#[derive(Args, Debug)]
+struct SvVerifyLivenessAllArgs {
+    #[command(flatten)]
+    lift: SvLiftArgs,
+    /// A response pair `"ANTE => CONS"` — both sides register-comparison atoms
+    /// (`"req == 1 => grant == 1"`). Repeatable; the verdict is the conjunction
+    /// `⋀ AG(ANTE → AF CONS)`. At least one required.
+    #[arg(long = "response", value_name = "ANTE => CONS", required = true)]
+    responses: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2332,6 +2377,7 @@ fn handle_btor2(command: Btor2Command) -> Result<(), String> {
         Btor2Command::Cegar(args) => btor2_cegar(args),
         Btor2Command::Verify(args) => btor2_verify(args),
         Btor2Command::VerifyLiveness(args) => btor2_verify_liveness(args),
+        Btor2Command::VerifyLivenessAll(args) => btor2_verify_liveness_all(args),
         Btor2Command::VerifyRecoverability(args) => btor2_verify_recoverability(args),
         Btor2Command::CheckFsm(args) => btor2_check_fsm(args),
     }
@@ -2440,6 +2486,62 @@ fn btor2_verify_liveness(args: Btor2VerifyLivenessArgs) -> Result<(), String> {
     );
     ci_gate_exit(PropertyVerdict::from(verdict).as_str(), args.ci.fail_on);
     Ok(())
+}
+
+/// `mununu btor2 verify-liveness-all` — decide the conjunction of response-liveness
+/// properties `⋀ᵢ AG(aᵢ → AF bᵢ)` from repeatable `--response "ANTE => CONS"` pairs,
+/// via the l2s reduction + the portfolio, printing the combined verdict + per-response
+/// `decided_by` as JSON. Surface peer of `POST /api/v1/btor2/verify-liveness-all`.
+fn btor2_verify_liveness_all(args: Btor2VerifyLivenessAllArgs) -> Result<(), String> {
+    use mununu_core::adapter::liveness_rescue::{
+        parse_response_pairs, response_conjunction_property, response_liveness_rescue_conjunction,
+    };
+    use mununu_core::verdict::PropertyVerdict;
+
+    let content = std::fs::read_to_string(&args.file)
+        .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
+    let pairs = parse_response_pairs(&args.responses)?;
+
+    let (verdict, outcomes) = response_liveness_rescue_conjunction(&content, &pairs, false)
+        .ok_or_else(|| {
+            format!(
+                "could not build the liveness monitor for '{}' — an atom likely binds no signal",
+                args.file.display()
+            )
+        })?;
+
+    let summary = serde_json::json!({
+        "file": args.file.display().to_string(),
+        "property": response_conjunction_property(&args.responses),
+        "verdict": PropertyVerdict::from(verdict).as_str(),
+        "responses": per_response_decided_by(&args.responses, &outcomes),
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&summary).map_err(|e| format!("serialize summary: {e}"))?
+    );
+    ci_gate_exit(PropertyVerdict::from(verdict).as_str(), args.ci.fail_on);
+    Ok(())
+}
+
+/// Build the per-response `[{ response, decided_by }]` JSON for the
+/// `verify-liveness-all` summaries (BTOR2- and SV-direct), pairing each `"ANTE => CONS"`
+/// input with the engines that decided its `bad`-reachability query.
+fn per_response_decided_by(
+    responses: &[String],
+    outcomes: &[mununu_core::adapter::reach_portfolio::ReachOutcome],
+) -> Vec<serde_json::Value> {
+    responses
+        .iter()
+        .zip(outcomes.iter())
+        .map(|(r, o)| {
+            serde_json::json!({
+                "response": r.trim(),
+                "decided_by": o.reachable_by.iter().chain(o.unreachable_by.iter())
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .collect()
 }
 
 /// `mununu btor2 verify` — decide `bad`-reachability with the multi-engine safety
@@ -4620,6 +4722,7 @@ fn handle_sv(command: SvCommand) -> Result<(), String> {
         SvCommand::VerifyAuto(args) => sv_verify_auto(args),
         SvCommand::Verify(args) => sv_verify(args),
         SvCommand::VerifyLiveness(args) => sv_verify_liveness(args),
+        SvCommand::VerifyLivenessAll(args) => sv_verify_liveness_all(args),
         SvCommand::VerifyRecoverability(args) => sv_verify_recoverability(args),
         SvCommand::CheckFsm(args) => sv_check_fsm(args),
     }
@@ -4685,6 +4788,28 @@ fn sv_verify_liveness(args: SvVerifyLivenessArgs) -> Result<(), String> {
         "verdict": PropertyVerdict::from(verdict).as_str(),
         "decided_by": outcome.reachable_by.iter().chain(outcome.unreachable_by.iter())
             .collect::<Vec<_>>(),
+    });
+    print_json_summary(&summary)?;
+    ci_gate_exit(PropertyVerdict::from(verdict).as_str(), args.ci.fail_on);
+    Ok(())
+}
+
+/// `mununu sv verify-liveness-all` — lift SV and decide the conjunction
+/// `⋀ᵢ AG(aᵢ → AF bᵢ)` from repeatable `--response "ANTE => CONS"` pairs. SV-direct
+/// peer of `btor2 verify-liveness-all`; same JSON summary + CI exit.
+fn sv_verify_liveness_all(args: SvVerifyLivenessAllArgs) -> Result<(), String> {
+    use mununu_core::adapter::liveness_rescue::response_conjunction_property;
+    use mununu_core::adapter::sv_verify::sv_verify_liveness_all as core_sv_verify_liveness_all;
+    use mununu_core::verdict::PropertyVerdict;
+
+    let file = args.lift.file.display().to_string();
+    let (verdict, outcomes) =
+        core_sv_verify_liveness_all(&read_sv_lift(&args.lift)?, &args.responses)?;
+    let summary = serde_json::json!({
+        "file": file,
+        "property": response_conjunction_property(&args.responses),
+        "verdict": PropertyVerdict::from(verdict).as_str(),
+        "responses": per_response_decided_by(&args.responses, &outcomes),
     });
     print_json_summary(&summary)?;
     ci_gate_exit(PropertyVerdict::from(verdict).as_str(), args.ci.fail_on);

--- a/crates/mununu-core/src/adapter/liveness_rescue.rs
+++ b/crates/mununu-core/src/adapter/liveness_rescue.rs
@@ -259,6 +259,62 @@ pub fn response_liveness_rescue_atoms(
     Some((verdict, outcome))
 }
 
+/// Decide a **conjunction** of response-liveness properties `⋀_i AG(a_i → AF b_i)`
+/// over one `design_btor2`, by deciding each response independently via
+/// [`response_liveness_rescue_atoms`] and combining the verdicts:
+///
+/// - **any `Violated` ⇒ `Violated`** — a real `b_i`-free lasso through a pending `a_i`
+///   is a genuine path violating the conjunction (the counterexample to conjunct `i`
+///   is a counterexample to `⋀`), so `Violated` dominates.
+/// - else **any `Inconclusive` ⇒ `Inconclusive`** — that conjunct might yet be
+///   violated, so the conjunction cannot be declared to hold.
+/// - else **all `Holds` ⇒ `Holds`**.
+///
+/// This is **correct by composition**: each single-response query is a sound + complete
+/// l2s reduction (see [`response_liveness_rescue`]), a conjunction violation is exactly
+/// *some* conjunct's violation (which its query finds), and each query still scales via
+/// the reachability portfolio. It is the closed-system shape — verifying a
+/// multi-guarantee controller (e.g. an arbiter's per-client no-starvation) in place,
+/// where the environment is concrete and any GR(1) assumptions are already discharged.
+/// The open-system Streett shape `(⋀ GF a_i) → (⋀ GF b_j)` — where live assumptions
+/// couple the guarantees, so this N-query decomposition does NOT hold — is a separate
+/// follow-up (the Emerson–Lei fair-cycle l2s).
+///
+/// Returns `None` (matching [`response_liveness_rescue_atoms`]) if `pairs` is empty or
+/// any monitor cannot be built (an atom binds no signal). On `Some`, the second
+/// component is the per-response [`ReachOutcome`] (same order as `pairs`) for diagnostics.
+pub fn response_liveness_rescue_conjunction(
+    design_btor2: &str,
+    pairs: &[(Atom, Atom)],
+    reset_pinned: bool,
+) -> Option<(LivenessVerdict, Vec<ReachOutcome>)> {
+    if pairs.is_empty() {
+        return None;
+    }
+    let mut outcomes = Vec::with_capacity(pairs.len());
+    let mut any_violated = false;
+    let mut any_inconclusive = false;
+    for (ante, cons) in pairs {
+        let (verdict, outcome) =
+            response_liveness_rescue_atoms(design_btor2, ante, cons, reset_pinned)?;
+        match verdict {
+            LivenessVerdict::Violated => any_violated = true,
+            LivenessVerdict::Inconclusive => any_inconclusive = true,
+            LivenessVerdict::Holds => {}
+        }
+        outcomes.push(outcome);
+    }
+    // Violated dominates Inconclusive dominates Holds (conjunction semantics).
+    let verdict = if any_violated {
+        LivenessVerdict::Violated
+    } else if any_inconclusive {
+        LivenessVerdict::Inconclusive
+    } else {
+        LivenessVerdict::Holds
+    };
+    Some((verdict, outcomes))
+}
+
 /// Parse a request/grant atom string (`"REG op VALUE"`, e.g. `"st == 2"`) into an
 /// [`Atom`], for the CLI / API `verify-liveness` surface. Reuses the same predicate
 /// grammar as the classifier, so a relational (`reg ⋈ reg`) or malformed atom is
@@ -280,6 +336,48 @@ pub fn parse_response_atom(s: &str) -> Result<Atom, String> {
         )),
         Err(e) => Err(format!("cannot parse response atom `{s}`: {e:?}")),
     }
+}
+
+/// Parse repeatable `"ANTE => CONS"` response strings (the `verify-liveness-all`
+/// surface) into `(ante, cons)` [`Atom`] pairs for
+/// [`response_liveness_rescue_conjunction`]. Each string is split on the first literal
+/// `=>`; both sides are trimmed and parsed with [`parse_response_atom`]. Errors if a
+/// string lacks `=>`, or either side is not a single register-comparison atom.
+///
+/// Reused by the CLI, HTTP API, and SV-direct surfaces so the `--response` grammar is
+/// identical everywhere.
+pub fn parse_response_pairs(responses: &[String]) -> Result<Vec<(Atom, Atom)>, String> {
+    responses
+        .iter()
+        .map(|r| {
+            let (ante, cons) = r.split_once("=>").ok_or_else(|| {
+                format!(
+                    "response `{r}` must contain `=>` separating the antecedent and consequent \
+                     (e.g. `\"req == 1 => grant == 1\"`)"
+                )
+            })?;
+            Ok((
+                parse_response_atom(ante.trim())?,
+                parse_response_atom(cons.trim())?,
+            ))
+        })
+        .collect()
+}
+
+/// Render a list of `"ANTE => CONS"` response strings as the display property
+/// `AG((a) -> AF (b)) && AG((c) -> AF (d))`, echoed for provenance across the
+/// `verify-liveness-all` surfaces. Splits each string on the first `=>` (falling back
+/// to the raw trimmed text when absent — a malformed entry is caught by
+/// [`parse_response_pairs`], so this is display-only).
+pub fn response_conjunction_property(responses: &[String]) -> String {
+    responses
+        .iter()
+        .map(|r| match r.split_once("=>") {
+            Some((ante, cons)) => format!("AG(({}) -> AF ({}))", ante.trim(), cons.trim()),
+            None => r.trim().to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(" && ")
 }
 
 // The surface verdict label comes from the canonical
@@ -442,6 +540,63 @@ mod tests {
         assert_eq!(v_r, LivenessVerdict::Holds);
         let (v_s, _) = response_liveness_rescue_atoms(STALLER, &ante, &cons, false).expect("ok");
         assert_eq!(v_s, LivenessVerdict::Violated);
+    }
+
+    // --- Multi-response conjunction (correct by composition) ---
+
+    // Two responses on RESPONDER, each individually Holds — req→grant and grant→idle —
+    // so the conjunction Holds, and the conjunction verdict matches the composition of
+    // the individual single-response verdicts.
+    #[test]
+    fn conjunction_all_hold_is_holds() {
+        let p1 = (
+            parse_response_atom("st == 1").unwrap(),
+            parse_response_atom("st == 2").unwrap(),
+        );
+        let p2 = (
+            parse_response_atom("st == 2").unwrap(),
+            parse_response_atom("st == 0").unwrap(),
+        );
+        let (v1, _) = response_liveness_rescue_atoms(RESPONDER, &p1.0, &p1.1, false).unwrap();
+        let (v2, _) = response_liveness_rescue_atoms(RESPONDER, &p2.0, &p2.1, false).unwrap();
+        assert_eq!(v1, LivenessVerdict::Holds, "req→grant holds");
+        assert_eq!(v2, LivenessVerdict::Holds, "grant→idle holds");
+        let (v, outs) =
+            response_liveness_rescue_conjunction(RESPONDER, &[p1, p2], false).expect("decides");
+        assert_eq!(v, LivenessVerdict::Holds, "both hold ⇒ conjunction holds");
+        assert_eq!(outs.len(), 2, "one outcome per response");
+    }
+
+    // On STALLER the req→grant response is Violated; conjoined with a trivially-holding
+    // response, the conjunction is Violated (Violated dominates).
+    #[test]
+    fn conjunction_one_violated_is_violated() {
+        let p_bad = (
+            parse_response_atom("st == 1").unwrap(),
+            parse_response_atom("st == 2").unwrap(),
+        );
+        let p_ok = (
+            parse_response_atom("st == 0").unwrap(),
+            parse_response_atom("st == 0").unwrap(),
+        );
+        let (vb, _) = response_liveness_rescue_atoms(STALLER, &p_bad.0, &p_bad.1, false).unwrap();
+        assert_eq!(
+            vb,
+            LivenessVerdict::Violated,
+            "req→grant violated on staller"
+        );
+        let (v, _) =
+            response_liveness_rescue_conjunction(STALLER, &[p_ok, p_bad], false).expect("decides");
+        assert_eq!(
+            v,
+            LivenessVerdict::Violated,
+            "one violated conjunct ⇒ conjunction violated"
+        );
+    }
+
+    #[test]
+    fn conjunction_empty_is_none() {
+        assert!(response_liveness_rescue_conjunction(RESPONDER, &[], false).is_none());
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -21,7 +21,8 @@ use crate::adapter::btor2::kmts_lift::PredicateSpec;
 use crate::adapter::btor2::parser;
 use crate::adapter::btor2::predicate_expr::parse_predicate_expr;
 use crate::adapter::liveness_rescue::{
-    Atom, LivenessVerdict, parse_response_atom, response_liveness_rescue_atoms,
+    Atom, LivenessVerdict, parse_response_atom, parse_response_pairs,
+    response_liveness_rescue_atoms, response_liveness_rescue_conjunction,
 };
 use crate::adapter::reach_portfolio::{ReachOutcome, decide_reach_portfolio_parallel};
 use crate::adapter::recoverability::verify_recoverability_with_predicates;
@@ -76,6 +77,27 @@ pub fn sv_verify_liveness(
     let btor2 = lift.lift()?;
     response_liveness_rescue_atoms(&btor2, &ante, &cons, false).ok_or_else(|| {
         "could not build the liveness monitor — an atom likely binds no signal in the design"
+            .to_string()
+    })
+}
+
+/// `sv verify-liveness-all` — lift SV and decide the **conjunction** of
+/// response-liveness properties `⋀ᵢ AG(aᵢ → AF bᵢ)` via the l2s reduction + the
+/// portfolio (one lift, one `bad`-reachability query per response). Each `responses`
+/// entry is a `"ANTE => CONS"` pair; every pair is parsed first, so a malformed
+/// response errors before the (toolchain-gated) lift — matching [`sv_verify_liveness`].
+///
+/// Returns the combined verdict + the per-response [`ReachOutcome`] (same order as
+/// `responses`), via [`response_liveness_rescue_conjunction`].
+pub fn sv_verify_liveness_all(
+    lift: &SvLift,
+    responses: &[String],
+) -> Result<(LivenessVerdict, Vec<ReachOutcome>), String> {
+    let pairs = parse_response_pairs(responses)?;
+    let btor2 = lift.lift()?;
+    response_liveness_rescue_conjunction(&btor2, &pairs, false).ok_or_else(|| {
+        "could not build a liveness monitor — an atom likely binds no signal in the design, \
+         or no responses were given"
             .to_string()
     })
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -736,6 +736,48 @@ pub async fn btor2_verify_liveness_handler(
     }))
 }
 
+/// Decide the conjunction of response-liveness properties `⋀ᵢ AG(aᵢ → AF bᵢ)`
+/// (`POST /api/v1/btor2/verify-liveness-all`). Surface peer of the CLI
+/// `mununu btor2 verify-liveness-all`: reduces each `"ANTE => CONS"` conjunct to its
+/// own `bad`-reachability query, returning the combined `"holds"` / `"violated"` /
+/// `"unknown"` verdict. A malformed response (missing `=>` or a non-atom side) or
+/// unparseable BTOR2 is a `BadRequest`.
+pub async fn btor2_verify_liveness_all_handler(
+    Json(request): Json<Btor2VerifyLivenessAllRequest>,
+) -> ApiResult<Json<Btor2VerifyLivenessResponse>> {
+    use crate::adapter::liveness_rescue::{
+        parse_response_pairs, response_conjunction_property, response_liveness_rescue_conjunction,
+    };
+
+    let bad_req = |message: String| ApiError::BadRequest {
+        message,
+        details: None,
+    };
+    let pairs = parse_response_pairs(&request.responses).map_err(bad_req)?;
+    let property = response_conjunction_property(&request.responses);
+
+    let (verdict, outcomes) = response_liveness_rescue_conjunction(&request.content, &pairs, false)
+        .ok_or_else(|| {
+            bad_req(
+                "could not build a liveness monitor — an atom likely binds no signal, or no \
+                 responses were given"
+                    .to_string(),
+            )
+        })?;
+
+    Ok(Json(Btor2VerifyLivenessResponse {
+        verdict: crate::verdict::PropertyVerdict::from(verdict)
+            .as_str()
+            .to_string(),
+        property,
+        decided_by: outcomes
+            .iter()
+            .flat_map(|o| o.reachable_by.iter().chain(o.unreachable_by.iter()))
+            .map(|s| s.to_string())
+            .collect(),
+    }))
+}
+
 /// Decide recoverability `AG EF target` (`POST /api/v1/btor2/verify-recoverability`)
 /// — "from every reachable state, can the design get back to `target`?", the
 /// branching property SVA cannot state. Surface peer of the CLI
@@ -880,6 +922,46 @@ pub async fn sv_verify_liveness_handler(
             .reachable_by
             .iter()
             .chain(outcome.unreachable_by.iter())
+            .map(|s| s.to_string())
+            .collect(),
+    }))
+}
+
+/// `POST /api/v1/sv/verify-liveness-all` — lift SV and decide the conjunction
+/// `⋀ᵢ AG(aᵢ → AF bᵢ)` from `"ANTE => CONS"` response pairs. SV-direct peer of the
+/// CLI `sv verify-liveness-all`; reuses the [`Btor2VerifyLivenessResponse`] shape.
+pub async fn sv_verify_liveness_all_handler(
+    Json(request): Json<SvVerifyLivenessAllRequest>,
+) -> ApiResult<Json<Btor2VerifyLivenessResponse>> {
+    use crate::adapter::liveness_rescue::response_conjunction_property;
+    use crate::adapter::sv_verify::{SvLift, sv_verify_liveness_all};
+
+    let property = response_conjunction_property(&request.responses);
+    let lift = SvLift {
+        source: request.source,
+        additional_sources: request
+            .additional_sources
+            .into_iter()
+            .map(|f| (f.name, f.content))
+            .collect(),
+        top: request.top,
+        use_sv2v: request.use_sv2v,
+    };
+    let (verdict, outcomes) =
+        sv_verify_liveness_all(&lift, &request.responses).map_err(|message| {
+            ApiError::BadRequest {
+                message,
+                details: None,
+            }
+        })?;
+    Ok(Json(Btor2VerifyLivenessResponse {
+        verdict: crate::verdict::PropertyVerdict::from(verdict)
+            .as_str()
+            .to_string(),
+        property,
+        decided_by: outcomes
+            .iter()
+            .flat_map(|o| o.reachable_by.iter().chain(o.unreachable_by.iter()))
             .map(|s| s.to_string())
             .collect(),
     }))
@@ -4242,6 +4324,36 @@ members = ["x"]
         let err = btor2_verify_liveness_handler(Json(request))
             .await
             .expect_err("relational atom must be rejected");
+        assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    #[tokio::test]
+    async fn btor2_verify_liveness_all_handler_decides_violated_conjunction() {
+        // The staller violates `st == 1 => st == 2`; a conjunction containing it is
+        // violated regardless of the second (trivially-holding) conjunct.
+        let request = Btor2VerifyLivenessAllRequest {
+            content: LIVENESS_STALLER.to_string(),
+            responses: vec![
+                "st == 1 => st == 2".to_string(),
+                "st == 0 => st == 0".to_string(),
+            ],
+        };
+        let Json(out) = btor2_verify_liveness_all_handler(Json(request))
+            .await
+            .expect("verify-liveness-all runs");
+        assert_eq!(out.verdict, "violated", "response: {out:?}");
+        assert!(out.property.contains("&&"), "conjunction echoed: {out:?}");
+    }
+
+    #[tokio::test]
+    async fn btor2_verify_liveness_all_handler_rejects_missing_arrow() {
+        let request = Btor2VerifyLivenessAllRequest {
+            content: LIVENESS_STALLER.to_string(),
+            responses: vec!["st == 1 st == 2".to_string()], // no `=>`
+        };
+        let err = btor2_verify_liveness_all_handler(Json(request))
+            .await
+            .expect_err("a response without `=>` must be rejected");
         assert!(matches!(err, ApiError::BadRequest { .. }));
     }
 

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -970,6 +970,19 @@ pub struct Btor2VerifyLivenessResponse {
     pub decided_by: Vec<String>,
 }
 
+/// Request for the conjunctive response-liveness endpoint
+/// (`POST /api/v1/btor2/verify-liveness-all`). Mirrors the CLI
+/// `mununu btor2 verify-liveness-all`: decides `⋀ᵢ AG(aᵢ → AF bᵢ)`. Each `responses`
+/// entry is a `"ANTE => CONS"` pair of register-comparison atoms. At least one
+/// required. Reuses [`Btor2VerifyLivenessResponse`] for the reply.
+#[derive(Debug, Deserialize)]
+pub struct Btor2VerifyLivenessAllRequest {
+    /// BTOR2 source content.
+    pub content: String,
+    /// The response pairs, each `"ANTE => CONS"`.
+    pub responses: Vec<String>,
+}
+
 /// Request for the recoverability endpoint
 /// (`POST /api/v1/btor2/verify-recoverability`). Mirrors the CLI
 /// `mununu btor2 verify-recoverability`: decides `AG EF target` — "from every
@@ -1081,6 +1094,26 @@ pub struct SvVerifyLivenessRequest {
     pub request: String,
     /// The grant atom that must eventually follow on every path.
     pub grant: String,
+}
+
+/// Request for `POST /api/v1/sv/verify-liveness-all` — the SV lift fields plus the
+/// conjunction's `"ANTE => CONS"` response pairs. Mirrors the CLI
+/// `mununu sv verify-liveness-all`; reuses [`Btor2VerifyLivenessResponse`].
+#[derive(Debug, Deserialize)]
+pub struct SvVerifyLivenessAllRequest {
+    /// SystemVerilog primary source content.
+    pub source: String,
+    /// Additional SV sources (packages / includes).
+    #[serde(default)]
+    pub additional_sources: Vec<FileContent>,
+    /// Top module for the lift (auto-detect when omitted).
+    #[serde(default)]
+    pub top: Option<String>,
+    /// Run sv2v before Yosys. Default `false`.
+    #[serde(default)]
+    pub use_sv2v: bool,
+    /// The response pairs, each `"ANTE => CONS"`. At least one required.
+    pub responses: Vec<String>,
 }
 
 /// Request for `POST /api/v1/sv/verify-recoverability` — the SV lift fields plus the

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -120,6 +120,12 @@ fn create_router() -> Router {
             "/api/v1/btor2/verify-liveness",
             post(handlers::btor2_verify_liveness_handler),
         )
+        // Conjunctive response-liveness — ⋀ᵢ AG(aᵢ → AF bᵢ) via N liveness-to-safety
+        // queries + the portfolio. Surface peer of `mununu btor2 verify-liveness-all`.
+        .route(
+            "/api/v1/btor2/verify-liveness-all",
+            post(handlers::btor2_verify_liveness_all_handler),
+        )
         // P2 recoverability — AG EF good ("can it always get back?"), the branching
         // property SVA cannot state. Surface peer of `mununu btor2 verify-recoverability`.
         .route(
@@ -158,6 +164,10 @@ fn create_router() -> Router {
         .route(
             "/api/v1/sv/verify-liveness",
             post(handlers::sv_verify_liveness_handler),
+        )
+        .route(
+            "/api/v1/sv/verify-liveness-all",
+            post(handlers::sv_verify_liveness_all_handler),
         )
         .route(
             "/api/v1/sv/verify-recoverability",


### PR DESCRIPTION
**P2 Slice 2.** A `verify-liveness-all` verb decides a **conjunction** of response properties `⋀_i AG(a_i → AF b_i)` over one design — the shape that verifies a multi-guarantee controller *in place* (an arbiter's per-client no-starvation; a multi-guarantee GR(1) controller whose environment is concrete).

## Core (`adapter/liveness_rescue.rs`)
`response_liveness_rescue_conjunction` decides each response via the existing, already-validated single-response l2s + portfolio and combines: any **Violated → Violated** (a real `b_i`-free lasso is a counterexample to the whole), else any Inconclusive → Inconclusive, else Holds. **Correct by composition** — zero new soundness surface, and each query still scales via the reachability portfolio. (The open-system Streett shape `⋀GF a → ⋀GF b`, coupled live assumptions, is a separate follow-up.)

## Differential-tested
RESPONDER: two individually-holding responses → conjunction Holds (== composition of the individual verdicts). STALLER: one violated conjunct → conjunction Violated. Empty → None.

## Surfaces (CLI+API+UI, btor2 + sv)
`btor2 verify-liveness-all --response "a => b"` (repeatable) + `sv verify-liveness-all`; `POST /api/v1/btor2/verify-liveness-all` + `/sv/verify-liveness-all`; UI clients (mununu-ui PR). `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)