### PR TITLE
feat(P2): verify_auto auto-escalates a box-AF liveness ⊥ via l2s

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1491,10 +1491,11 @@ struct SvVerifyAutoArgs {
     /// stubbed so its register survives the lift; pass this to leave it cut.
     #[arg(long = "no-auto-stub-flops")]
     no_auto_stub_flops: bool,
-    /// Disable the safety-⊥ escalation. By default, a *safety* property the cube
-    /// abstraction leaves ⊥ (and that is a reducible AG-invariant) is retried with the
-    /// multi-engine reachability portfolio (exact ⊕ native ⊕ spacer ⊕ btormc ⊕ Pono);
-    /// pass this to report the cube's ⊥ verdict unchanged.
+    /// Disable the ⊥ escalations. By default, a *safety* property the cube abstraction
+    /// leaves ⊥ (and that is a reducible AG-invariant) is retried with the multi-engine
+    /// reachability portfolio (exact ⊕ native ⊕ spacer ⊕ btormc ⊕ Pono), and a *box-AF
+    /// liveness* property left ⊥ is retried via the liveness-to-safety reduction; pass
+    /// this to report the cube's ⊥ verdict unchanged for both.
     #[arg(long = "no-rescue")]
     no_rescue: bool,
     /// H.J.b — config concretization: pin a wide config input to a constant so
@@ -2891,6 +2892,7 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
             _ => None,
         },
         rescue_bottom_safety: !args.no_rescue,
+        rescue_bottom_liveness: !args.no_rescue,
     };
 
     let report = verify_auto(&sources, &yopts, &opts)

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -559,6 +559,14 @@ pub struct VerifyAutoOptions {
     /// liveness / recoverability are untouched. Default `true`; the CLI `--no-rescue`
     /// / API `rescue_bottom_safety: false` opts out.
     pub rescue_bottom_safety: bool,
+    /// On a *box-response liveness* property `AG(a → AF b)` the cube portfolio leaves
+    /// `⊥`, escalate to the liveness-to-safety reduction + reachability portfolio
+    /// (reduce to a `bad`-monitor lasso and decide it symbolically). Only fires on `⊥`
+    /// reducible box-AF responses — the diamond-EF recoverability liveness (`AG(a → EF
+    /// b)`, νμ) is NOT l2s-able and stays on the exact / cube νμ path, so there is no
+    /// common-path cost and no mis-route. Default `true`; opts out with the same
+    /// `--no-rescue` / API `rescue_bottom_liveness: false`.
+    pub rescue_bottom_liveness: bool,
 }
 
 /// PORTFOLIO scheduling mode — the budget knob for the multi-engine default.
@@ -613,6 +621,7 @@ impl Default for VerifyAutoOptions {
             exact_symbolic: false,
             portfolio: None,
             rescue_bottom_safety: true,
+            rescue_bottom_liveness: true,
         }
     }
 }
@@ -2221,11 +2230,19 @@ pub fn verify_auto(
     // rescue): reduce a reducible AG-invariant the cube left ⊥ to a `bad`-monitor and
     // decide it with the multi-engine reachability portfolio. Only fires on ⊥
     // reducible AG-invariants — no common-path cost.
-    let rescue_notes = if opts.rescue_bottom_safety {
+    let mut rescue_notes = if opts.rescue_bottom_safety {
         escalate_bottom_safety(&mut report, &btor2, reset_pinned)
     } else {
         Vec::new()
     };
+
+    // Liveness-⊥ escalation (P2): a box-response `AG(a → AF b)` the cube left ⊥ is
+    // reduced to a `bad`-monitor lasso (Biere–Artho–Schuppan l2s) and decided by the
+    // reachability portfolio. Only fires on ⊥ reducible box-AF responses — the
+    // diamond-EF recoverability liveness stays on the νμ path — no common-path cost.
+    if opts.rescue_bottom_liveness {
+        rescue_notes.extend(escalate_bottom_liveness(&mut report, &btor2, reset_pinned));
+    }
 
     // H.J — provenance notes: surface every abstraction/scoping decision this run
     // made (config concretizations, posture, reset-gating, flop stubs, cut
@@ -2321,6 +2338,86 @@ fn rescue_note(name: &str, verdict: &str, engines: &[&str]) -> VerificationNote 
                  multi-engine reachability portfolio (exact ⊕ native ⊕ spacer ⊕ btormc ⊕ Pono). \
                  Sound: every portfolio member is sound, and a disagreement would surface a \
                  contradiction alarm rather than a verdict."
+            .into(),
+        items: Vec::new(),
+    }
+}
+
+/// On each *box-response liveness* property `AG(a → AF b)` the cube portfolio left `⊥`,
+/// try the liveness-to-safety reduction
+/// ([`response_liveness_rescue`](crate::adapter::liveness_rescue::response_liveness_rescue)):
+/// reduce the property to a reachable-`b`-free-lasso `bad`-monitor over `design_btor2`
+/// and decide it with the reachability portfolio. Upgrades the property's outcome in
+/// place and returns a provenance note per rescue.
+///
+/// SOUNDNESS: `response_liveness_rescue` (via `reduce_response_af`) returns `None` for
+/// every shape other than the exact single-atom **box-AF** response with unconstrained
+/// boxes — so the **diamond-EF** recoverability liveness (`AG(a → EF b)`, a νμ property
+/// l2s does NOT decide) and every safety shape are left untouched (no mis-route, no
+/// common-path cost). The l2s reduction it does apply is sound + complete for the box-AF
+/// shape, cross-checked against the exact engine in the `liveness_rescue` module tests.
+/// Pure over `(report, design_btor2)`, so it is unit-testable on a BTOR2 fixture without
+/// the SV toolchain.
+fn escalate_bottom_liveness(
+    report: &mut AutoVerifyReport,
+    design_btor2: &str,
+    reset_pinned: bool,
+) -> Vec<VerificationNote> {
+    use crate::adapter::liveness_rescue::{LivenessVerdict, response_liveness_rescue};
+    use crate::mu_calculus::parser as mu_parser;
+
+    let mut notes = Vec::new();
+    for prop in report.properties.iter_mut() {
+        if !matches!(prop.outcome, VerifyOutcome::Unknown { .. }) {
+            continue;
+        }
+        let Ok(formula) = mu_parser::parse(&prop.formula) else {
+            continue;
+        };
+        let Some((verdict, reach)) = response_liveness_rescue(design_btor2, &formula, reset_pinned)
+        else {
+            continue;
+        };
+        let engines: Vec<&str> = reach
+            .reachable_by
+            .iter()
+            .chain(reach.unreachable_by.iter())
+            .copied()
+            .collect();
+        match verdict {
+            LivenessVerdict::Holds => {
+                prop.outcome = VerifyOutcome::Holds;
+                notes.push(liveness_rescue_note(&prop.name, "HOLDS", &engines));
+            }
+            LivenessVerdict::Violated => {
+                prop.outcome = VerifyOutcome::Violated { false_cells: 0 };
+                notes.push(liveness_rescue_note(&prop.name, "VIOLATED", &engines));
+            }
+            LivenessVerdict::Inconclusive => {}
+        }
+    }
+    notes
+}
+
+/// A provenance note for a box-AF liveness property the l2s reduction + reachability
+/// portfolio rescued from `⊥`.
+fn liveness_rescue_note(name: &str, verdict: &str, engines: &[&str]) -> VerificationNote {
+    VerificationNote {
+        kind: "liveness-rescue".into(),
+        level: NoteLevel::Info,
+        summary: format!(
+            "`{name}`: the cube abstraction left ⊥; the liveness-to-safety reduction + \
+             reachability portfolio decided it {verdict} (engine(s): {})",
+            if engines.is_empty() {
+                "—".to_string()
+            } else {
+                engines.join(", ")
+            }
+        ),
+        detail: "The box-response liveness ⊥ (`AG(a → AF b)`) was reduced to a reachable \
+                 `b`-free-lasso `bad`-monitor (Biere–Artho–Schuppan liveness-to-safety) and \
+                 decided symbolically by the reachability portfolio. Sound + complete for the \
+                 box-AF shape; the diamond-EF recoverability response is not reduced here."
             .into(),
         items: Vec::new(),
     }
@@ -2427,6 +2524,76 @@ mod tests {
             notes.is_empty(),
             "no rescue note for an un-reducible property"
         );
+    }
+
+    // 3-state responder: st 0=idle,1=req,2=grant; idle -go-> req; req -> grant; grant ->
+    // idle. AG((st==1) → AF (st==2)) HOLDS — the l2s reduction + portfolio decides it.
+    const RESPONDER_LIVE: &str = "\
+1 sort bitvec 2
+2 sort bitvec 1
+3 state 1 st
+4 zero 1
+5 init 1 3 4
+6 input 2 go
+7 one 1
+8 constd 1 2
+9 eq 2 3 4
+10 eq 2 3 7
+11 ite 1 6 7 4
+12 ite 1 10 8 4
+13 ite 1 9 11 12
+14 next 1 3 13
+";
+
+    // A box-response `AG(a → AF b)` the cube left ⊥ is rescued to a definite verdict by
+    // the liveness-to-safety reduction + reachability portfolio.
+    #[test]
+    fn escalate_bottom_liveness_rescues_a_box_response() {
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "req_grant".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                formula: "nu Z. ((!(st == 1) || mu Y. ((st == 2) || [] Y)) && [] Z)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let notes = escalate_bottom_liveness(&mut report, RESPONDER_LIVE, false);
+        assert!(
+            matches!(report.properties[0].outcome, VerifyOutcome::Holds),
+            "the ⊥ box-AF liveness property should be rescued to HOLDS, got {:?}",
+            report.properties[0].outcome
+        );
+        assert!(
+            notes.iter().any(|n| n.kind == "liveness-rescue"),
+            "a liveness-rescue provenance note should be recorded"
+        );
+    }
+
+    // SOUNDNESS: a diamond-EF recoverability liveness (`AG(a → EF b)`, νμ) is NOT the
+    // l2s-able box-AF shape, so the liveness escalation must leave it untouched — never
+    // route a νμ property through the 2-valued l2s.
+    #[test]
+    fn escalate_bottom_liveness_ignores_diamond_ef() {
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "recover".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                formula: "nu Z. ((!(st == 1) || mu Y. ((st == 2) || <> Y)) && [] Z)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let notes = escalate_bottom_liveness(&mut report, RESPONDER_LIVE, false);
+        assert!(
+            matches!(report.properties[0].outcome, VerifyOutcome::Unknown { .. }),
+            "a diamond-EF νμ ⊥ must be left untouched (l2s does not decide it)"
+        );
+        assert!(notes.is_empty(), "no rescue note for a non-box-AF property");
     }
 
     /// A cube engine's ⊥ (Unknown) is filled by a later engine's definite verdict, and the

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1232,6 +1232,7 @@ pub async fn sv_verify_auto_handler(
         exact_symbolic: engine_exact,
         portfolio: engine_portfolio,
         rescue_bottom_safety: request.rescue_bottom_safety.unwrap_or(true),
+        rescue_bottom_liveness: request.rescue_bottom_liveness.unwrap_or(true),
     };
 
     let report = verify_auto(&sources, &yopts, &opts).map_err(|e| ApiError::BadRequest {

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1342,6 +1342,12 @@ pub struct SvVerifyAutoRequest {
     /// cube's ⊥ unchanged. Only fires on ⊥ reducible AG-invariants.
     #[serde(default)]
     pub rescue_bottom_safety: Option<bool>,
+    /// Liveness-⊥ escalation (default `true`): a *box-AF* liveness property `AG(a → AF
+    /// b)` the cube leaves ⊥ is retried via the liveness-to-safety reduction + the
+    /// reachability portfolio. Set `false` to report the cube's ⊥ unchanged. Only fires
+    /// on the l2s-able box-AF shape (diamond-EF recoverability stays on the νμ path).
+    #[serde(default)]
+    pub rescue_bottom_liveness: Option<bool>,
 }
 
 /// Response for `/api/v1/sv/verify-auto`.


### PR DESCRIPTION
**P2 Slice 3.** verify_auto already escalates a *safety* ⊥ (a reducible AG-invariant) to the reachability portfolio (slice 5b). This adds the parallel *liveness* escalation: a box-response `AG(a → AF b)` the cube abstraction leaves ⊥ (over the ~40-bit cap) is reduced to a reachable-`b`-free-lasso `bad`-monitor (Biere–Artho–Schuppan l2s) and decided by the reachability portfolio — so the flagship agent-facing `sv verify-auto` decides response-liveness **at scale, automatically**.

## `escalate_bottom_liveness` (mirrors `escalate_bottom_safety`)
Upgrades each `Unknown` box-AF property in place + records a `liveness-rescue` note. Pure over `(report, design_btor2)` — unit-testable without the SV toolchain.

## SOUNDNESS
`response_liveness_rescue` (via `reduce_response_af`) returns `None` for every shape but the exact box-AF response — so the **diamond-EF** recoverability liveness (`AG(a → EF b)`, νμ, not l2s-able) and every safety shape are left untouched: **never a νμ property mis-routed through the 2-valued l2s.** Tested both ways (box-AF → HOLDS; diamond-EF → left ⊥).

Gated by `rescue_bottom_liveness` (default true); `--no-rescue` now opts out both escalations; API gains `rescue_bottom_liveness`. No UI change (backend-only flags, default on). `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)