### PR TITLE
feat(P3): concrete witness for the safety ⊥-reduction (native BMC trace)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/native_bmc.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_bmc.rs
@@ -66,6 +66,19 @@ pub enum BmcOutcome {
     NoCexWithin { k: u32 },
 }
 
+/// A concrete `Init → bad` execution witness extracted from the BMC model
+/// ([`bmc_bad_reachable_witness`]). Each frame lists only the NAMED state cells /
+/// inputs (a BTOR2 line with a `symbol`), so it maps back onto the original
+/// design's registers without projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BmcTrace {
+    /// State-register valuations, frame 0 (reset) .. frame k (the bad state), each a
+    /// sorted `(symbol, value)` list (only named state cells).
+    pub states: Vec<Vec<(String, u64)>>,
+    /// Input valuations driving each transition, frame 0 .. frame k-1.
+    pub inputs: Vec<Vec<(String, u64)>>,
+}
+
 /// A complete safety verdict from the k-induction driver
 /// ([`decide_bad_safety`]) — BMC's bounded outcome plus a genuine SAFE proof.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,6 +130,30 @@ fn extract_props(file: &Btor2File) -> Props {
         }
     }
     (bad_ops, init_pairs, constraint_ops)
+}
+
+/// Build `Nid → symbol` maps for the NAMED state cells and inputs — the cells the
+/// witness trace ([`BmcTrace`]) reports. An anonymous state/input (no `symbol`) is
+/// not surfaced in the trace.
+fn symbol_maps(file: &Btor2File) -> (HashMap<Nid, String>, HashMap<Nid, String>) {
+    let mut state_syms = HashMap::new();
+    let mut input_syms = HashMap::new();
+    for l in &file.lines {
+        match &l.node {
+            Node::State {
+                symbol: Some(s), ..
+            } => {
+                state_syms.insert(l.nid, s.clone());
+            }
+            Node::Input {
+                symbol: Some(s), ..
+            } => {
+                input_syms.insert(l.nid, s.clone());
+            }
+            _ => {}
+        }
+    }
+    (state_syms, input_syms)
 }
 
 /// The shared unrolling machinery: fresh per-frame state/input Z3 variables and
@@ -233,6 +270,40 @@ impl<'a> Unroller<'a> {
             }
         }
     }
+
+    /// Extract the concrete `Init → bad` witness from a SAT `model` whose `bad`
+    /// fired at frame `k`: per-frame state (frames `0..=k`) and input (frames
+    /// `0..k`) valuations for the NAMED cells, each a sorted `(symbol, value)` list.
+    /// `model_completion` is on, so a free (init-less / unconstrained-input) cell
+    /// gets a concrete value — the trace is a full assignment of a real model run.
+    fn extract_trace(
+        &self,
+        model: &z3::Model,
+        k: usize,
+        state_syms: &HashMap<Nid, String>,
+        input_syms: &HashMap<Nid, String>,
+    ) -> BmcTrace {
+        let eval_frame =
+            |frame: &HashMap<Nid, BV>, syms: &HashMap<Nid, String>| -> Vec<(String, u64)> {
+                let mut out: Vec<(String, u64)> = frame
+                    .iter()
+                    .filter_map(|(nid, bv)| {
+                        let sym = syms.get(nid)?;
+                        let val = model.eval(bv, true)?.as_u64()?;
+                        Some((sym.clone(), val))
+                    })
+                    .collect();
+                out.sort();
+                out
+            };
+        let states = (0..=k)
+            .map(|j| eval_frame(&self.frame_state[j], state_syms))
+            .collect();
+        let inputs = (0..k)
+            .map(|j| eval_frame(&self.frame_input[j], input_syms))
+            .collect();
+        BmcTrace { states, inputs }
+    }
 }
 
 /// Bounded model check: is a `bad` reachable within `max_k` steps of the BTOR2
@@ -242,10 +313,27 @@ impl<'a> Unroller<'a> {
 /// depth; the returned `Violated { depth }` is the SHALLOWEST counterexample
 /// (frames are checked in increasing order), which is the most useful witness.
 pub fn bmc_bad_reachable(file: &Btor2File, max_k: u32) -> Result<BmcOutcome, BmcError> {
+    bmc_bad_reachable_witness(file, max_k).map(|(outcome, _trace)| outcome)
+}
+
+/// As [`bmc_bad_reachable`], but on a `Violated` verdict also extracts the concrete
+/// `Init → bad` execution witness ([`BmcTrace`]) from the Z3 model.
+///
+/// The search loop is identical to [`bmc_bad_reachable`]'s; the only difference is
+/// that on SAT at frame `k` — before the `pop` that discards the model — the model
+/// is queried for every named per-frame state/input variable, giving the concrete
+/// counting/driving path that reaches `bad`. `NoCexWithin` carries no trace
+/// (`None`); a `Violated` carries `Some(trace)` unless the solver returned no model
+/// (also `None`, defensively — a SAT check always has a model here).
+pub fn bmc_bad_reachable_witness(
+    file: &Btor2File,
+    max_k: u32,
+) -> Result<(BmcOutcome, Option<BmcTrace>), BmcError> {
     let (bad_ops, init_pairs, constraint_ops) = extract_props(file);
     if bad_ops.is_empty() {
         return Err(BmcError::NoBadProperty);
     }
+    let (state_syms, input_syms) = symbol_maps(file);
     let n = max_k as usize;
     let cfg = z3::Config::new();
     z3::with_z3_config(&cfg, || {
@@ -262,10 +350,15 @@ pub fn bmc_bad_reachable(file: &Btor2File, max_k: u32) -> Result<BmcOutcome, Bmc
             solver.push();
             solver.assert(u.bad_at(k));
             let sat = matches!(solver.check(), z3::SatResult::Sat);
-            solver.pop(1);
             if sat {
-                return Ok(BmcOutcome::Violated { depth: k as u32 });
+                // Extract the concrete witness from the model BEFORE popping it.
+                let trace = solver
+                    .get_model()
+                    .map(|m| u.extract_trace(&m, k, &state_syms, &input_syms));
+                solver.pop(1);
+                return Ok((BmcOutcome::Violated { depth: k as u32 }, trace));
             }
+            solver.pop(1);
             if k < n {
                 solver.assert(u.transition_at(k));
                 for c in u.constraints_at(k + 1) {
@@ -273,7 +366,7 @@ pub fn bmc_bad_reachable(file: &Btor2File, max_k: u32) -> Result<BmcOutcome, Bmc
                 }
             }
         }
-        Ok(BmcOutcome::NoCexWithin { k: max_k })
+        Ok((BmcOutcome::NoCexWithin { k: max_k }, None))
     })
 }
 
@@ -402,6 +495,50 @@ mod tests {
     #[test]
     fn finds_shallowest_cex() {
         assert_eq!(bmc(REACH, 5), BmcOutcome::Violated { depth: 1 });
+    }
+
+    #[test]
+    fn witness_is_the_concrete_counting_path() {
+        // 2-bit up-counter: `cnt` init 0, `next = cnt + 1`, `bad = (cnt == 3)`.
+        // `bad` is reachable at depth 3 and `cnt` is fully determined by init +
+        // transition (no free input drives it), so the ONLY model run is the
+        // concrete 0→1→2→3 count — the extracted witness must be exactly that path,
+        // proving the trace is the real execution and not a fabricated one.
+        const COUNTER: &str = "1 sort bitvec 2\n2 zero 1\n3 one 1\n4 state 1 cnt\n5 init 1 4 2\n\
+                               6 add 1 4 3\n7 next 1 4 6\n8 constd 1 3\n9 sort bitvec 1\n\
+                               10 eq 9 4 8\n11 bad 10\n";
+        let file = parser::parse(COUNTER).expect("parse btor2");
+        let (outcome, trace) = bmc_bad_reachable_witness(&file, 5).expect("bmc runs");
+        assert_eq!(outcome, BmcOutcome::Violated { depth: 3 });
+        let trace = trace.expect("a Violated verdict carries the witness trace");
+        assert_eq!(
+            trace.states,
+            vec![
+                vec![("cnt".to_string(), 0)],
+                vec![("cnt".to_string(), 1)],
+                vec![("cnt".to_string(), 2)],
+                vec![("cnt".to_string(), 3)],
+            ],
+            "the extracted trace must be the concrete 0→3 counting path"
+        );
+        // The last state satisfies the `bad` condition (cnt == 3) — the trace really
+        // ends in a violating state.
+        assert_eq!(trace.states.last().unwrap(), &vec![("cnt".to_string(), 3)]);
+        // 3 transitions ⇒ 3 input frames; this design has no named inputs ⇒ empty.
+        assert_eq!(trace.inputs.len(), 3);
+        assert!(trace.inputs.iter().all(Vec::is_empty));
+    }
+
+    #[test]
+    fn no_witness_when_bounded_safe() {
+        // A bounded-safe design produces `NoCexWithin` and therefore no trace.
+        let file = parser::parse(SAFE).expect("parse btor2");
+        let (outcome, trace) = bmc_bad_reachable_witness(&file, 10).expect("bmc runs");
+        assert_eq!(outcome, BmcOutcome::NoCexWithin { k: 10 });
+        assert!(
+            trace.is_none(),
+            "a bounded-safe run carries no counterexample"
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -203,6 +203,29 @@ pub fn reach_portfolio_rescue(
     Some((verdict, outcome))
 }
 
+/// The concrete counterexample trace for an AG-invariant the reachability portfolio
+/// found VIOLATED: rebuild the same `bad`-monitor [`reach_portfolio_rescue`] uses and
+/// run native BMC to extract the `Init → ¬invariant` path. The bad-monitor adds no
+/// state, so the trace is over the ORIGINAL design's registers (no projection).
+/// Returns `None` if the formula is not a reducible AG-invariant or no bounded
+/// counterexample is found within `max_k`.
+pub fn ag_invariant_witness(
+    design_btor2: &str,
+    formula: &Formula,
+    reset_pinned: bool,
+    max_k: u32,
+) -> Option<crate::adapter::btor2::native_bmc::BmcTrace> {
+    let inv = reduce_ag_invariant(formula)?;
+    let monitored =
+        emit_ag_state_atom_monitor(design_btor2, &inv.signal, inv.op, inv.value, reset_pinned)
+            .ok()?;
+    let file = parser::parse(&monitored).ok()?;
+    match crate::adapter::btor2::native_bmc::bmc_bad_reachable_witness(&file, max_k).ok()? {
+        (crate::adapter::btor2::native_bmc::BmcOutcome::Violated { .. }, trace) => trace,
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -2318,6 +2318,22 @@ fn escalate_bottom(
                         }
                         RescueVerdict::Violated => {
                             prop.outcome = VerifyOutcome::Violated { false_cells: 0 };
+                            // P3 Update 2 — attach the concrete safety counterexample: native
+                            // BMC extracts the `Init → ¬invariant` path from the same bad-monitor.
+                            // A safety CEX is a finite path (empty `cycle`); the monitor adds no
+                            // state, so the trace is over the original design registers.
+                            if let Some(trace) = crate::adapter::reach_rescue::ag_invariant_witness(
+                                design_btor2,
+                                &formula,
+                                reset_pinned,
+                                60,
+                            ) {
+                                prop.counterexample = Some(ExactCounterexample {
+                                    prefix: trace.states,
+                                    cycle: Vec::new(),
+                                    inputs: trace.inputs,
+                                });
+                            }
                             notes.push(rescue_note(&prop.name, "VIOLATED", &engines));
                         }
                         RescueVerdict::Inconclusive => {}
@@ -2516,6 +2532,60 @@ mod tests {
             matches!(report.properties[0].outcome, VerifyOutcome::Holds),
             "the ⊥ safety property should be rescued to HOLDS, got {:?}",
             report.properties[0].outcome
+        );
+        assert!(
+            notes.iter().any(|n| n.kind == "portfolio-rescue"),
+            "a portfolio-rescue provenance note should be recorded"
+        );
+    }
+
+    // P3 Update 2 — a safety AG-invariant the cube left ⊥ that is actually VIOLATED is
+    // rescued to Violated AND carries the concrete native-BMC counterexample: a wrapping
+    // 2-bit counter `cnt` (0→1→2→3→0) violates `AG(cnt != 3)` at depth 3. The attached
+    // witness is a finite path (empty cycle) over the ORIGINAL design register `cnt`,
+    // ending in the violating state (cnt == 3).
+    #[test]
+    fn escalate_bottom_safety_attaches_violation_witness() {
+        const COUNTER: &str = "1 sort bitvec 2\n2 sort bitvec 1\n3 zero 1\n4 one 1\n\
+                               5 state 1 cnt\n6 init 1 5 3\n7 add 1 5 4\n8 next 1 5 7\n";
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "cnt_ne_3".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                formula: "nu X. ((cnt != 3) && [] X)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let notes = escalate_bottom(&mut report, COUNTER, false, &VerifyAutoOptions::default());
+        assert!(
+            matches!(report.properties[0].outcome, VerifyOutcome::Violated { .. }),
+            "the ⊥ safety property should be rescued to VIOLATED, got {:?}",
+            report.properties[0].outcome
+        );
+        let cx = report.properties[0]
+            .counterexample
+            .as_ref()
+            .expect("a VIOLATED safety rescue must attach the native-BMC counterexample");
+        assert!(
+            !cx.prefix.is_empty(),
+            "the safety CEX prefix (the finite Init→bad path) must be non-empty"
+        );
+        assert!(
+            cx.cycle.is_empty(),
+            "a safety counterexample is a finite path — no repeating cycle"
+        );
+        // The final state of the finite path satisfies the violation (cnt == 3).
+        assert!(
+            cx.prefix
+                .last()
+                .unwrap()
+                .iter()
+                .any(|(sig, v)| sig == "cnt" && *v == 3),
+            "the witness's final state must satisfy the violated bad condition (cnt == 3); got {:?}",
+            cx.prefix.last().unwrap()
         );
         assert!(
             notes.iter().any(|n| n.kind == "portfolio-rescue"),


### PR DESCRIPTION
**P3 Update 2, first increment** — witness unification for the SAFETY reduction. When the ⊥-escalation router (#299) rescues a safety AG-invariant to VIOLATED via the reachability portfolio, it now attaches a concrete counterexample in the same vocabulary (`ExactCounterexample`, a lasso) the exact engine fills — a reduced property no longer reports a bare verdict.

## What
- `native_bmc`: `BmcTrace` + `bmc_bad_reachable_witness` — the witness-returning BMC variant. On SAT at depth k it queries the Z3 model **while `bad_at(k)` is still asserted (before `pop`)**, so the trace necessarily satisfies `Init ∧ transitions ∧ bad(sᵏ)` — **sound by construction**. Validated: a 2-bit counter violating `cnt==3` yields the real `0→1→2→3` path. `bmc_bad_reachable` delegates (callers unchanged).
- `reach_rescue::ag_invariant_witness` — rebuilds the same bad-monitor the rescue uses (adds no state ⇒ trace is over the ORIGINAL registers, no projection) and extracts the path.
- `verify_auto`: the router's Safety→Violated arm attaches `ExactCounterexample { prefix, cycle: [], inputs }` (a safety CEX is a finite path). Tested end-to-end.

## Scope
Named state cells only (the `ExactCounterexample` convention). The **liveness** reduction witnesses (l2s-lasso projection, recoverability trap at scale, per-response) need this extractor plus a projection layer — folded into `.claude/plans/p3-updates.md` as scoped follow-ups; **not** blocking the HWMCC build (verdicts, not witnesses, drive adjudication — only the router #299 was foundational for it).

`make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)