### PR TITLE
fix(evaluator): multi-target MustHyperOnly ◇ is universal, not existential (soundness)

### DIFF
--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -435,7 +435,17 @@ mod tests {
 
     #[test]
     fn scalable_matches_exact_holds_polarity() {
-        // RESPONDER: every reachable state can reach idle ⇒ Holds, both engines.
+        // Differential SOUNDNESS gate: the cube path must never CONTRADICT the exact engine — it
+        // either agrees or soundly abstains (`Unknown`). It must never emit the OPPOSITE definite
+        // verdict. (Soundness ≠ completeness: requiring an exact match would demand the cube be as
+        // *precise* as exact, which is not a soundness property.)
+        //
+        // RESPONDER: exact decides Holds. Post the universal-hyper-must-◇ fix (2026-07-11) the cube
+        // ABSTAINS here: the coarse hyper-must target set (the full may-successor set — a documented
+        // imprecision, `SmtEncode::hyper_must_edges`) combined with the now-SOUND universal ◇
+        // over-abstains where the old (unsound) existential ◇ decided. Sound — the auto verb returns
+        // exact's Holds for small designs regardless; recovering cube-alone precision needs
+        // tightening the hyper-must target set (follow-up).
         let exact = exact_verdict(RESPONDER, "st == 0");
         let scalable = verify_recoverability_scalable(RESPONDER, "st == 0", &[]).expect("decides");
         assert_eq!(
@@ -443,9 +453,9 @@ mod tests {
             PropertyVerdict::Holds,
             "exact decides RESPONDER Holds"
         );
-        assert_eq!(
-            scalable, exact,
-            "cube path must AGREE with the exact engine on RESPONDER (Holds)"
+        assert!(
+            scalable == exact || scalable == PropertyVerdict::Unknown,
+            "cube must agree with exact or soundly abstain — never contradict (got {scalable:?}, exact {exact:?})"
         );
     }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -2379,7 +2379,14 @@ fn escalate_bottom(
                                 prop.outcome = VerifyOutcome::Violated { false_cells: 0 };
                                 notes.push(recoverability_rescue_note(&prop.name, "VIOLATED"));
                             }
-                            PropertyVerdict::Unknown | PropertyVerdict::Skipped => {}
+                            PropertyVerdict::Unknown => {
+                                // Provenance: the recoverability rescue RAN but the cube +
+                                // smt-hyper-must abstained (sound — never a fabricated verdict;
+                                // precision follow-up = tighter hyper-must target sets). Recorded
+                                // so a ⊥ that reached the rescue is explained, not silent.
+                                notes.push(recoverability_rescue_note(&prop.name, "UNKNOWN"));
+                            }
+                            PropertyVerdict::Skipped => {}
                         }
                     }
                 }
@@ -2736,10 +2743,19 @@ mod tests {
             false,
             &VerifyAutoOptions::default(),
         );
+        // SOUNDNESS gate (2026-07-11): the router must dispatch the νμ ⊥ to the cube +
+        // smt-hyper-must path and get a SOUND verdict — `Holds` or (soundly) `Unknown`, never a
+        // contradiction. Post the universal-hyper-must-◇ fix the cube ABSTAINS here (Holds→Unknown):
+        // the coarse hyper-must target set (full may-successor set) + the now-sound universal ◇
+        // over-abstains. Precision is restored by tightening the target set (follow-up "B"), after
+        // which this becomes `Holds` again. The band-aid #301 aside, the verdict is never unsound.
         assert!(
-            matches!(report.properties[0].outcome, VerifyOutcome::Holds),
-            "the ⊥ νμ recoverability property should be rescued to HOLDS by the cube + \
-             smt-hyper-must path, got {:?}",
+            matches!(
+                report.properties[0].outcome,
+                VerifyOutcome::Holds | VerifyOutcome::Unknown { .. }
+            ),
+            "the ⊥ νμ recoverability property must be dispatched to the cube path and get a sound \
+             verdict (Holds, or a sound Unknown pending target-set tightening), got {:?}",
             report.properties[0].outcome
         );
         assert!(

--- a/crates/mununu-core/src/mu_calculus/evaluator.rs
+++ b/crates/mununu-core/src/mu_calculus/evaluator.rs
@@ -1824,11 +1824,26 @@ where
         // already uses plain ∀ for `Control::All`, so only the diamond was
         // affected.
         if guard.control == Control::All {
+            // SOUNDNESS (2026-07-11) — a multi-target `MustHyperOnly` edge guarantees reaching the
+            // target *set* but not *which* member, so its hyper-target coverage keys on the BOUND,
+            // not the ◇ modality: the definite-true (`must_bits`) pass reaches φ only if ALL
+            // hyper-targets do (ALL-coverage), while the not-false (`may_bits`) pass reaches φ if
+            // ANY hyper-target might (ANY-coverage). The bound is carried by `modality_filter`: for
+            // Diamond, `must_bits` is computed with `MustOnly`, `may_bits` with `All`. Keying
+            // coverage on the modality (pre-fix, always ANY) made ◇'s must-bits existential —
+            // unsound: a hyper-must claimed ◇φ definite-true when only SOME target satisfied φ.
+            // Singleton/Sharp/MayOnly edges read identically under both, so only multi-target
+            // hyper-must changes.
+            let all_coverage = matches!(modality_filter, TransitionModalityFilter::MustOnly);
             return outgoing.iter().any(|t| {
                 modality_filter.allows(t)
                     && self.guard_matches(state, t, guard)
                     && guard_parts.is_none_or(|p| p.matches_next(t.target().index()))
-                    && transition_target_in_set_diamond(t, targets)
+                    && if all_coverage {
+                        transition_target_in_set_box(t, targets)
+                    } else {
+                        transition_target_in_set_diamond(t, targets)
+                    }
             });
         }
 
@@ -3251,14 +3266,19 @@ where
         } else {
             None
         };
-        // Kind-aware forcing-set reach.
-        let reaches = |transition: &Transition<S, L>, set: &BitVec<usize, Lsb0>| -> bool {
-            match kind {
-                ModalKind::Diamond => transition_target_in_set_diamond(transition, set),
-                ModalKind::Box => transition_target_in_set_box(transition, set),
-            }
-        };
-
+        // SOUNDNESS (2026-07-11) — the per-edge hyper-target coverage keys on the BOUND, not the
+        // modality. A `MustHyperOnly` edge guarantees reaching the target *set* but not *which*
+        // member, so:
+        //   - `reaches_must` (definite-true / lower bound): the edge reaches φ only if ALL
+        //     hyper-targets are definite-φ ⇒ ALL-coverage (`transition_target_in_set_box`).
+        //   - `reaches_may` (not-false / upper bound): the edge might reach φ if ANY hyper-target
+        //     is possible-φ ⇒ ANY-coverage (`transition_target_in_set_diamond`).
+        // The ◇/□ distinction is the OUTER quantifier in `modal_trit_core` (∃ over must-edges for
+        // ◇-True, ∀ over may-edges for □-True), NOT the per-edge coverage. Keying coverage on
+        // `kind` (pre-fix) made ◇'s `reaches_must` existential — unsound: a multi-target hyper-must
+        // could claim ◇φ definite-true when only SOME target satisfied φ (the concrete successor
+        // could be another). Singleton edges (Sharp / MayOnly / card-1 hyper) read identically
+        // under both helpers, so this changes only multi-target `MustHyperOnly` edges.
         let mut edges: Vec<EdgeFacts> = Vec::new();
         for state in self.clts.states() {
             edges.clear();
@@ -3277,8 +3297,8 @@ where
                         transition.modality(),
                         crate::clts::TransitionModality::MayOnly
                     ),
-                    reaches_must: reaches(transition, &must_set),
-                    reaches_may: reaches(transition, &may_set),
+                    reaches_must: transition_target_in_set_box(transition, &must_set), // ALL
+                    reaches_may: transition_target_in_set_diamond(transition, &may_set), // ANY
                 });
             }
             match modal_trit_core(kind, guard.control, &edges) {
@@ -5796,6 +5816,51 @@ mod modal_trit_draft_tests {
             &targets_empty
         ));
         assert!(!transition_target_in_set_box(hyper_trans, &targets_empty));
+    }
+
+    /// SOUNDNESS regression (2026-07-11) — the multi-target `MustHyperOnly` ◇ must be UNIVERSAL,
+    /// not existential. A hyper-must edge `s0 ⤳ {s1,s2}` GUARANTEES reaching the SET {s1,s2} but
+    /// not WHICH member; so `◇p` is definite-true at `s0` ONLY if `p` holds at BOTH s1 and s2
+    /// (all-coverage). The pre-fix evaluator computed `reaches_must` with ANY-coverage (keyed on
+    /// the ◇ modality), so it wrongly returned `True` when only s1 ⊨ p — the exact mechanism behind
+    /// the recoverability cube path's unsound `holds` on a trap (`trap48`).
+    #[test]
+    fn hyper_must_diamond_is_universal_not_existential() {
+        use crate::mu_calculus::trit::Trit;
+        let clts = build_hyper_must_kmts(); // s0 ⤳ {s1,s2} (MustHyperOnly), label `act`
+        let s0 = clts.state_id("s0").expect("s0").index();
+        let s1 = clts.state_id("s1").expect("s1").index();
+        let s2 = clts.state_id("s2").expect("s2").index();
+        let formula = parser::parse("< labels = {act} > p").expect("parse");
+
+        // p at s1 ONLY: s2 ⊭ p ⇒ the hyper-must does NOT guarantee reaching p ⇒ ◇p is Unknown,
+        // NOT definite-true. (Pre-fix ANY-coverage wrongly gave True.)
+        let mut p_s1 = bv(&[false, false, false]);
+        p_s1.set(s1, true);
+        let env = Environment::new(clts.state_count()).with_predicate("p", p_s1);
+        let v = evaluate_tri_with_options(&formula, &clts, &env, &EvaluationOptions::default())
+            .expect("eval");
+        assert_eq!(
+            v.verdict_at(s0),
+            Trit::Unknown,
+            "◇p at s0 must be Unknown when only some hyper-target satisfies p (must-false: not \
+             guaranteed; may-true: might). Pre-fix any-coverage wrongly returned True."
+        );
+
+        // p at BOTH s1 and s2: the guarantee holds ⇒ ◇p is genuinely definite-true (all-coverage).
+        let mut p_both = bv(&[false, false, false]);
+        p_both.set(s1, true);
+        p_both.set(s2, true);
+        let env_both = Environment::new(clts.state_count()).with_predicate("p", p_both);
+        let v_both =
+            evaluate_tri_with_options(&formula, &clts, &env_both, &EvaluationOptions::default())
+                .expect("eval");
+        assert_eq!(
+            v_both.verdict_at(s0),
+            Trit::True,
+            "◇p at s0 must be definite-True when ALL hyper-targets satisfy p (the legitimate \
+             guarantee — the fix must not over-abstain)."
+        );
     }
 
     /// R.6.3 — dual fix on the Box side: `[]false` over a CLTS where


### PR DESCRIPTION
## Soundness fix — foundational

The 3-valued evaluator treated a multi-target `MustHyperOnly` edge `s0 ⤳ {t1,t2}` as `Sharp` for the ◇ modality, computing `reaches_must` with **any-coverage** (`∃ t∈T. t∈X`). A hyper-must edge **guarantees reaching the set T but not which member**, so `◇φ` is definite-true via it **only if all of T satisfy φ** (universal, `∀ t∈T. t∈X`). The existential reading let a hyper-must claim `◇φ` definite-true when only *some* target satisfied φ — **unsound**. It is the exact mechanism behind the recoverability cube path's spurious `holds` on a genuine trap (the `trap48` case); #301's abstain-on-UF-wrap was a band-aid that hid it by removing the inflated may-successor set.

### Root cause
Coverage was keyed on the **modality** (◇→any, □→all) instead of the **bound**. The correct rule, independent of ◇/□:
- `reaches_must` (definite / lower bound) → **all-coverage** (the guarantee)
- `reaches_may` (not-false / upper bound) → **any-coverage** (the possibility)

The ◇/□ distinction is the *outer* quantifier in `modal_trit_core` (∃ over must-edges for ◇-True, ∀ over may-edges for □-True), not the per-edge coverage.

### Fix
Keys coverage on the bound (carried by the modality filter):
- `modal_trit_from_target` (Controllable/Environment path)
- `modal_exists`'s `Control::All` branch (the recoverability path)

Singleton / `Sharp` / `MayOnly` edges read identically under both helpers, so **only multi-target hyper-must edges change**.

### Confirming oracle test
`hyper_must_diamond_is_universal_not_existential`: `◇p` over `s0 ⤳ {s1,s2}` with only `s1 ⊨ p` is now `Unknown` (was the unsound `True`); `True` when both satisfy `p`.

### Consequence (sound; precision follow-up)
The cube-scalable recoverability's precision partly relied on the unsound existential ◇. With the sound ◇ + the deliberately **coarse hyper-must target set** (the full may-successor set — a documented "tightening is future work"), it now **abstains** (`Unknown`) where it used to decide (RESPONDER cube-alone + the `escalate_bottom` router demo). Sound — never a wrong definite verdict; the auto verb returns exact's verdict for small designs. The differential gate is corrected from "matches exact" to **"agrees-or-abstains, never contradicts"** (the real soundness property). The router records a `recoverability-rescue` provenance note on the abstain case so a routed ⊥ is explained. **Restoring cube-alone precision via tight target sets is the immediate follow-up PR (B).**

### Validation
2214 lib tests pass (`make ci` green locally). Foundational for the incremental 3-valued engine (N1), whose lazy CPre-must emits exactly these multi-target ∀∃ hyper-edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)