### PR TITLE
example(v10): nested-counter recoverability on real prim_count — lexicographic ranking

### DIFF
--- a/examples/verify/v10_opentitan_nested_count_recoverability/README.md
+++ b/examples/verify/v10_opentitan_nested_count_recoverability/README.md
@@ -1,0 +1,55 @@
+# `v10_opentitan_nested_count_recoverability` — nested-counter recoverability (lexicographic ranking)
+
+> **Status: PASS.** A NESTED counter built from two real OpenTitan `prim_count`
+> instances (the prescaler+counter pattern): an inner counter down-counts each tick and
+> reloads at zero; when it reloads, the outer counter decrements. Asks whether the outer
+> counter can always get back to zero — `AG EF (outer == 0)` — and decides `Holds` at
+> 48 bits via the **lexicographic** ranking `(outer, inner)`, where a single-register
+> ranking, the predicate cube, and the exact BDD engine all give out. Completes the
+> real-RTL ranking trio: v8 (relational), v9 (single-register), v10 (lexicographic).
+> §Phase 10 V-track recoverability showcase.
+
+> Source of truth: [`verify_recoverability`](../../../crates/mununu-core/src/adapter/recoverability.rs) — surface: CLI (`mununu btor2 verify-recoverability --target 'outer == 0'`)
+
+> **Claims integrity.** `prim_count.sv` and `prim_count_pkg.sv` are real OpenTitan RTL
+> (Apache-2.0), pinned under [`source/`](source/) at the commit in
+> [`source/UPSTREAM_COMMIT.txt`](source/UPSTREAM_COMMIT.txt). `prim_flop.sv` is a minimal
+> register matching OpenTitan's abstract-prim flop interface; `count_nested_top.sv` is a
+> nested-counter harness of two real `prim_count` instances (the prescaler+counter usage
+> — a pattern real timers use). A property-class demonstration on real silicon.
+
+## Why a single-register ranking is not enough
+
+The outer counter decrements only when the inner counter reloads. So `outer` **holds**
+for a whole inner cycle before it steps — it does not strictly decrease every tick, and
+is therefore **not a valid ranking function** on its own. The property still holds (tick
+long enough and the outer counter reaches zero), but proving it needs a measure that
+decreases *every* tick.
+
+## What decides it — the lexicographic ranking
+
+mununu's ranking certificate generalizes past a single register difference to
+**lexicographic tuples**. It pairs the outer distance with the inner counter as a
+tiebreaker, `(outer, inner)`, which decreases on every tick:
+
+- inner tick (inner > 0): `(outer, inner−1)` — same outer, smaller inner;
+- inner reload (inner == 0): `(outer−1, INNER_MAX)` — smaller outer (dominates regardless of inner).
+
+Lex order on `(outer, inner)` is well-founded, so the descent reaches `outer == 0` — a
+*sound* `Holds`, decided over the exact transition in one SMT query per candidate tuple.
+
+| Setup | `always_recoverable` | How |
+|---|---|---|
+| **Small** (`OW=8`, ≤ ~40 bits) | **`Holds`** | exact 3-valued engine |
+| **Wide** (`OW=48`, beyond the exact cap) | **`Holds`** | the **lexicographic** ranking certificate |
+
+## Run it
+
+```bash
+LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli
+./examples/verify/v10_opentitan_nested_count_recoverability/validate.sh
+```
+
+Requires `sv2v`, `yosys`, and `python3` on `PATH` (the plain-SV → BTOR2 flow, as v7–v9).
+`validate.sh` names the outer counter (the state in `outer_o`'s cone) `outer` and targets
+`outer == 0`.

--- a/examples/verify/v10_opentitan_nested_count_recoverability/source/UPSTREAM_COMMIT.txt
+++ b/examples/verify/v10_opentitan_nested_count_recoverability/source/UPSTREAM_COMMIT.txt
@@ -1,0 +1,1 @@
+558921ccc8aeefab652b45c1402c10bceb63accc

--- a/examples/verify/v10_opentitan_nested_count_recoverability/source/count_nested_top.sv
+++ b/examples/verify/v10_opentitan_nested_count_recoverability/source/count_nested_top.sv
@@ -1,0 +1,30 @@
+// Nested-counter usage of real prim_count (the prescaler+counter pattern): the inner counter
+// down-counts on each tick and reloads to INNER_MAX at zero; when it reloads, the outer counter
+// decrements. AG EF (outer_o == 0): outer alone is not a ranking (it holds while inner runs down),
+// but the lexicographic (outer, inner) decreases every tick.
+module count_nested_top #(
+  parameter int OW = 48,
+  parameter int IW = 8,
+  parameter logic [IW-1:0] INNER_MAX = 8'd100,
+  parameter logic [OW-1:0] OUTER_INIT = 48'd1099511627776  // 2^40
+) (
+  input clk_i, input rst_ni,
+  input tick_i, input commit_i,
+  output logic [OW-1:0] outer_o,
+  output logic [IW-1:0] inner_o_p, output logic [OW-1:0] ic_p, oc_p, output logic ie_p, oe_p
+);
+  logic [IW-1:0] inner_o; assign inner_o_p = inner_o;
+  logic inner_zero; assign inner_zero = (inner_o == '0);
+  logic outer_zero; assign outer_zero = (outer_o == '0);
+    prim_count #(.Width(IW), .ResetValue(INNER_MAX)) u_inner (
+    .clk_i, .rst_ni, .clr_i(1'b0),
+    .set_i(tick_i & inner_zero), .set_cnt_i(INNER_MAX),
+    .incr_en_i(1'b0), .decr_en_i(tick_i & ~inner_zero), .step_i(IW'(1)),
+    .commit_i, .cnt_o(inner_o), .cnt_after_commit_o(ic_p), .err_o(ie_p)
+  );
+  prim_count #(.Width(OW), .ResetValue(OUTER_INIT)) u_outer (
+    .clk_i, .rst_ni, .clr_i(1'b0), .set_i(1'b0), .set_cnt_i('0),
+    .incr_en_i(1'b0), .decr_en_i(tick_i & inner_zero & ~outer_zero), .step_i(OW'(1)),
+    .commit_i, .cnt_o(outer_o), .cnt_after_commit_o(oc_p), .err_o(oe_p)
+  );
+endmodule

--- a/examples/verify/v10_opentitan_nested_count_recoverability/source/prim_assert.sv
+++ b/examples/verify/v10_opentitan_nested_count_recoverability/source/prim_assert.sv
@@ -1,0 +1,61 @@
+// Stub `prim_assert.sv` for sv2v + Yosys ingestion of OpenTitan RTL.
+//
+// All SVA macros expand to empty — synthesis-equivalent to
+// OpenTitan's `prim_assert_dummy_macros.svh` (Apache 2.0). This is
+// shared build infrastructure for the differential-oracle corpus:
+// every DUT and every package it imports is vendored BYTE-EXACT from
+// upstream; only this macro shim is local, and it is functionally
+// identical to upstream's own synthesis dummy-macros header.
+//
+// Also defines `PRIM_FLOP_SPARSE_FSM` as a plain `always_ff` register
+// (the upstream definition wraps a `prim_sparse_fsm_flop` submodule
+// for FPV / runtime-encoding hardening, neither of which matters for
+// the synthesised KMTS lift). The plain `always_ff` form preserves
+// the FSM's functional semantics — `state_q` updates to `state_d`
+// each clock unless reset is asserted, then `state_q` becomes the
+// reset value.
+//
+// SOUNDNESS: dropping the sparse-FSM hardening removes only the
+// runtime "alert if state_q is not one of the legal encodings"
+// behaviour; the recoverability / completion properties the corpus
+// verifies don't depend on the hardening — the FSM transitions
+// remain identical. Concurrent SVA (`ASSERT*`) is not the corpus's
+// verification target (mununu verifies the `@mununu_guarantee`
+// liveness formula the SVA fragment cannot express); expanding the
+// assertion macros to empty is sound for that target.
+
+`define ASSERT_I(__name, __prop)
+`define ASSERT_INIT(__name, __prop)
+`define ASSERT_INIT_NET(__name, __prop)
+`define ASSERT_FINAL(__name, __prop)
+`define ASSERT_AT_RESET(__name, __prop, __rst = 0)
+`define ASSERT_AT_RESET_AND_FINAL(__name, __prop, __rst = 0)
+`define ASSERT(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_NEVER(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_KNOWN(__name, __sig, __clk = 0, __rst = 0)
+`define COVER(__name, __prop, __clk = 0, __rst = 0)
+`define ASSUME(__name, __prop, __clk = 0, __rst = 0)
+`define ASSUME_I(__name, __prop)
+`define ASSERT_PULSE(__name, __prop, __clk = 0, __rst = 0)
+`define ASSERT_IF(__name, __prop, __enable, __clk = 0, __rst = 0)
+`define ASSERT_KNOWN_IF(__name, __sig, __enable, __clk = 0, __rst = 0)
+`define ASSERT_FPV_LINEAR_FSM(__name, __sig, __type, __clk = 0, __rst = 0)
+`define ASSERT_STATIC_IN_PACKAGE(__name, __prop)
+`define ASSERT_STATIC(__name, __prop)
+`define ASSERT_STATIC_LINT_ERROR(__name, __prop)
+`define CALIPTRA_ASSERT(__name, __prop, __clk = 0, __rst = 0)
+`define _SEC_CM_ALERT_MAX_CYC 30
+`define ASSERT_ERROR_TRIGGER_ALERT(__name, __hier, __alert, __gate = 0, __max = 0)
+`define ASSERT_ERROR_TRIGGER_ALERT_IN(__name, __hier, __alert, __gate = 0, __max = 0)
+`define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(__name, __hier, __alert, __gate = 0, __max = 0)
+`define ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT(__name, __hier, __alert, __gate = 0, __max = 0)
+`define ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(__name, __hier, __alert, __gate = 0, __max = 0)
+
+`define PRIM_FLOP_SPARSE_FSM(__name, __d, __q, __type, __resval = '0, __clk = clk_i, __rst_n = rst_ni, __alert_trigger_sva_en = 1) \
+  always_ff @(posedge __clk or negedge __rst_n) begin                                                                              \
+    if (!__rst_n) begin                                                                                                            \
+      __q <= __resval;                                                                                                             \
+    end else begin                                                                                                                 \
+      __q <= __d;                                                                                                                  \
+    end                                                                                                                            \
+  end

--- a/examples/verify/v10_opentitan_nested_count_recoverability/source/prim_count.sv
+++ b/examples/verify/v10_opentitan_nested_count_recoverability/source/prim_count.sv
@@ -1,0 +1,313 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Hardened counter primitive:
+//
+// This internally uses a cross counter scheme with primary and a secondary counter, where the
+// secondary counter counts in reverse direction. The sum of both counters must remain constant and
+// equal to 2**Width-1 or otherwise an err_o will be asserted.
+//
+// This counter supports a generic clear / set / increment / decrement interface:
+//
+// clr_i: This clears the primary counter to ResetValue and adjusts the secondary counter to match
+//        (i.e. 2**Width-1-ResetValue). Clear has priority over set, increment and decrement.
+// set_i: This sets the primary counter to set_cnt_i and adjusts the secondary counter to match
+//        (i.e. 2**Width-1-set_cnt_i). Set has priority over increment and decrement.
+// incr_en_i: Increments the primary counter by step_i, and decrements the secondary by step_i.
+// decr_en_i: Decrements the primary counter by step_i, and increments the secondary by step_i.
+// commit_i: Counter changes only take effect when `commit_i` is set. This does not effect the
+//           `cnt_after_commit_o` output which gives the next counter state if the change is
+//           committed.
+//
+// Note that if both incr_en_i and decr_en_i are asserted at the same time, the counter remains
+// unchanged. The counter is also protected against under- and overflows.
+
+`include "prim_assert.sv"
+
+module prim_count
+  import prim_count_pkg::*;
+#(
+  parameter int               Width = 2,
+  // Can be used to reset the counter to a different value than 0, for example when
+  // the counter is used as a down-counter.
+  parameter logic [Width-1:0] ResetValue = '0,
+  // This should only be disabled in special circumstances, for example
+  // in non-comportable IPs where an error does not trigger an alert.
+  parameter bit               EnableAlertTriggerSVA = 1,
+
+  // We have some assertions below with preconditions that depend on particular input actions
+  // (clear, set, incr, decr). If the design has instantiated prim_count with one of these actions
+  // tied to zero, the preconditions for the associated assertions will not be satisfiable. The
+  // result is an unreachable item, which we treat as a failed assertion in the report.
+  //
+  // To avoid this, we the instantiation to specify the actions which might happen. If this is not
+  // '1, we will have an assertion which assert the corresponding action is never triggered. We can
+  // then use this to avoid the unreachable assertions.
+  parameter action_mask_t     PossibleActions = {$bits(action_mask_t){1'b1}}
+) (
+  input clk_i,
+  input rst_ni,
+  input clr_i,
+  input set_i,
+  input [Width-1:0] set_cnt_i,                 // Set value for the counter.
+  input incr_en_i,
+  input decr_en_i,
+  input [Width-1:0] step_i,                    // Increment/decrement step when enabled.
+  input commit_i,
+  output logic [Width-1:0] cnt_o,              // Current counter state
+  output logic [Width-1:0] cnt_after_commit_o, // Next counter state if committed
+  output logic err_o
+);
+
+  ///////////////////
+  // Counter logic //
+  ///////////////////
+
+  // Reset Values for primary and secondary counters.
+  localparam int NumCnt = 2;
+  localparam logic [NumCnt-1:0][Width-1:0] ResetValues = {{Width{1'b1}} - ResetValue, // secondary
+                                                          ResetValue};                // primary
+
+  logic [NumCnt-1:0][Width-1:0] cnt_d, cnt_d_committed, cnt_q;
+
+  // The fpv_force signal can be used in FPV runs to make the internal counters (cnt_q) jump
+  // unexpectedly. We only want to use this mechanism when we're doing FPV on prim_count itself. In
+  // that situation, we will have the PrimCountFpv define and wish to leave fpv_force undriven so
+  // that it becomes a free variable in FPV. In any other situation, we drive the signal with zero.
+  logic [NumCnt-1:0][Width-1:0] fpv_force;
+`ifndef PrimCountFpv
+  assign fpv_force = '0;
+`endif
+
+  for (genvar k = 0; k < NumCnt; k++) begin : gen_cnts
+    // Note that increments / decrements are reversed for the secondary counter.
+    logic incr_en, decr_en;
+    logic [Width-1:0] set_val;
+    if (k == 0) begin : gen_up_cnt
+      assign incr_en = incr_en_i;
+      assign decr_en = decr_en_i;
+      assign set_val = set_cnt_i;
+    end else begin : gen_dn_cnt
+      assign incr_en = decr_en_i;
+      assign decr_en = incr_en_i;
+      // The secondary value needs to be adjusted accordingly.
+      assign set_val = {Width{1'b1}} - set_cnt_i;
+    end
+
+    // Main counter logic
+    logic [Width:0] ext_cnt;
+    assign ext_cnt = (decr_en) ? {1'b0, cnt_q[k]} - {1'b0, step_i} :
+                     (incr_en) ? {1'b0, cnt_q[k]} + {1'b0, step_i} : {1'b0, cnt_q[k]};
+
+    // Saturation logic
+    logic uflow, oflow;
+    assign oflow = incr_en && ext_cnt[Width];
+    assign uflow = decr_en && ext_cnt[Width];
+    logic [Width-1:0] cnt_sat;
+    assign cnt_sat = (uflow) ? '0            :
+                     (oflow) ? {Width{1'b1}} : ext_cnt[Width-1:0];
+
+    // Clock gate flops when in saturation, and do not
+    // count if both incr_en and decr_en are asserted.
+    logic cnt_en;
+    assign cnt_en = (incr_en ^ decr_en) &&
+                    ((incr_en && !(&cnt_q[k])) ||
+                    (decr_en && !(cnt_q[k] == '0)));
+
+    // Counter muxes
+    assign cnt_d[k] = (clr_i)  ? ResetValues[k] :
+                      (set_i)  ? set_val        :
+                      (cnt_en) ? cnt_sat        : cnt_q[k];
+
+    assign cnt_d_committed[k] = commit_i ? cnt_d[k] : cnt_q[k];
+
+    logic [Width-1:0] cnt_unforced_q;
+    prim_flop #(
+      .Width(Width),
+      .ResetValue(ResetValues[k])
+    ) u_cnt_flop (
+      .clk_i,
+      .rst_ni,
+      .d_i(cnt_d_committed[k]),
+      .q_o(cnt_unforced_q)
+    );
+
+    // fpv_force is only used during FPV.
+    assign cnt_q[k] = fpv_force[k] + cnt_unforced_q;
+  end
+
+  // The sum of both counters must always equal the counter maximum.
+  logic [Width:0] sum;
+  assign sum = (cnt_q[0] + cnt_q[1]);
+
+  // Register the error signal to avoid potential CDC issues downstream.
+  logic err_d, err_q;
+  assign err_d = (sum != {1'b0, {Width{1'b1}}});
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      err_q <= 1'b0;
+    end else begin
+      err_q <= err_d;
+    end
+  end
+  assign err_o = err_q;
+
+  // Output count values
+  assign cnt_o              = cnt_q[0];
+  assign cnt_after_commit_o = cnt_d[0];
+
+  ////////////////
+  // Assertions //
+  ////////////////
+`ifdef INC_ASSERT
+  //VCS coverage off
+  // pragma coverage off
+
+  // We need to disable most assertions in that case using a helper signal.
+  // We can't rely on err_o since some error patterns cannot be detected (e.g. all error
+  // patterns that still fulfil the sum constraint).
+  logic fpv_err_present;
+  assign fpv_err_present = |fpv_force;
+
+  // Helper functions for assertions.
+  function automatic logic signed [Width+1:0] max(logic signed [Width+1:0] a,
+                                                  logic signed [Width+1:0] b);
+    return (a > b) ? a : b;
+  endfunction
+
+  function automatic logic signed [Width+1:0] min(logic signed [Width+1:0] a,
+                                                  logic signed [Width+1:0] b);
+    return (a < b) ? a : b;
+  endfunction
+  //VCS coverage on
+  // pragma coverage on
+
+  if (!(PossibleActions & Clr)) begin : g_check_no_clr
+    `ASSERT(ClrNeverTrue_A, clr_i !== 1'b1)
+  end
+  if (!(PossibleActions & Set)) begin : g_check_no_set
+    `ASSERT(SetNeverTrue_A, set_i !== 1'b1)
+  end
+  if (!(PossibleActions & Incr)) begin : g_check_no_incr
+    `ASSERT(IncrNeverTrue_A, incr_en_i !== 1'b1)
+  end
+  if (!(PossibleActions & Decr)) begin : g_check_no_decr
+    `ASSERT(DecrNeverTrue_A, decr_en_i !== 1'b1)
+  end
+
+  // Cnt next
+  `ASSERT(CntNext_A,
+      rst_ni
+      |=>
+      $past(!commit_i) || (cnt_o == $past(cnt_after_commit_o)),
+      clk_i, err_d || fpv_err_present || !rst_ni)
+
+  // Clear
+  if (PossibleActions & Clr) begin : g_check_clr_fwd_a
+    `ASSERT(ClrFwd_A,
+            rst_ni && commit_i && clr_i
+            |=>
+            (cnt_o == ResetValue) &&
+            (cnt_q[1] == ({Width{1'b1}} - ResetValue)),
+            clk_i, err_d || fpv_err_present || !rst_ni)
+  end
+
+  // Set
+  if (PossibleActions & Set) begin : g_check_set_fwd_a
+    `ASSERT(SetFwd_A,
+        rst_ni && commit_i && set_i && !clr_i
+        |=>
+        (cnt_o == $past(set_cnt_i)) &&
+        (cnt_q[1] == ({Width{1'b1}} - $past(set_cnt_i))),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+  end
+
+  // Do not count if both increment and decrement are asserted.
+  if ((PossibleActions & Incr) && (PossibleActions & Decr)) begin : g_check_inc_and_dec
+    `ASSERT(IncrDecrUpDnCnt_A,
+        rst_ni && incr_en_i && decr_en_i && !(clr_i || set_i)
+        |=>
+        $stable(cnt_o) && $stable(cnt_q[1]),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+  end
+
+  // Increment
+  if ((PossibleActions & Incr)) begin : g_check_incr
+    `ASSERT(IncrUpCnt_A,
+        rst_ni && incr_en_i && !(clr_i || set_i || decr_en_i) && commit_i
+        |=>
+        cnt_o == min($past(cnt_o) + $past({2'b0, step_i}), {2'b0, {Width{1'b1}}}),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+    `ASSERT(IncrDnCnt_A,
+        rst_ni && incr_en_i && !(clr_i || set_i || decr_en_i) && commit_i
+        |=>
+        cnt_q[1] == max($past(signed'({2'b0, cnt_q[1]})) - $past({2'b0, step_i}), '0),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+    `ASSERT(UpCntIncrStable_A,
+        incr_en_i && !(clr_i || set_i || decr_en_i) &&
+        cnt_o == {Width{1'b1}}
+        |=>
+        $stable(cnt_o),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+    `ASSERT(DnCntIncrStable_A,
+        rst_ni && incr_en_i && !(clr_i || set_i || decr_en_i) &&
+        cnt_q[1] == '0
+        |=>
+        $stable(cnt_q[1]),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+  end
+
+  // Decrement
+  if ((PossibleActions & Decr)) begin : g_check_decr
+    `ASSERT(DecrUpCnt_A,
+        rst_ni && decr_en_i && !(clr_i || set_i || incr_en_i) && commit_i
+        |=>
+        cnt_o == max($past(signed'({2'b0, cnt_o})) - $past({2'b0, step_i}), '0),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+    `ASSERT(DecrDnCnt_A,
+        rst_ni && decr_en_i && !(clr_i || set_i || incr_en_i) && commit_i
+        |=>
+        cnt_q[1] == min($past(cnt_q[1]) + $past({2'b0, step_i}), {2'b0, {Width{1'b1}}}),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+    `ASSERT(UpCntDecrStable_A,
+        decr_en_i && !(clr_i || set_i || incr_en_i) &&
+        cnt_o == '0
+        |=>
+        $stable(cnt_o),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+    `ASSERT(DnCntDecrStable_A,
+        rst_ni && decr_en_i && !(clr_i || set_i || incr_en_i) &&
+        cnt_q[1] == {Width{1'b1}}
+        |=>
+        $stable(cnt_q[1]),
+        clk_i, err_d || fpv_err_present || !rst_ni)
+  end
+
+  // A backwards check for count changes. This asserts that the count only changes if one of the
+  // inputs that should tell it to change (clear, set, increment, decrement) does so.
+  `ASSERT(ChangeBackward_A,
+          rst_ni ##1 $changed(cnt_o) && $changed(cnt_q[1])
+          |->
+          $past(clr_i || set_i || (commit_i && (incr_en_i || decr_en_i))),
+          clk_i, err_d || fpv_err_present || !rst_ni)
+
+  // Check that count errors are reported properly in err_o
+  //
+  // This is essentially a "|=> implication", but is structured in a way to avoid generating a cover
+  // property for the left hand side if PrimCountFpv is not defined (because we won't have a way to
+  // inject an error if not)
+  `ASSERT(CntErrReported_A, ##1 $past((cnt_q[1] + cnt_q[0]) != {Width{1'b1}}) == err_o)
+ `ifdef PrimCountFpv
+  `COVER(CntErr_C, err_o)
+ `endif
+
+  // This logic that will be assign to one, when user adds macro
+  // ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT to check the error with alert, in case that prim_count
+  // is used in design without adding this assertion check.
+  logic unused_assert_connected;
+
+  `ASSERT_INIT_NET(AssertConnected_A, unused_assert_connected === 1'b1 || !EnableAlertTriggerSVA)
+`endif
+
+endmodule // prim_count

--- a/examples/verify/v10_opentitan_nested_count_recoverability/source/prim_count_pkg.sv
+++ b/examples/verify/v10_opentitan_nested_count_recoverability/source/prim_count_pkg.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package prim_count_pkg;
+
+  // An enum that names the possible actions that the inputs might ask for. See the PossibleActions
+  // parameter in prim_count for how this is used.
+  typedef logic [3:0] action_mask_t;
+  typedef enum action_mask_t {Clr  = 4'h1,
+                              Set  = 4'h2,
+                              Incr = 4'h4,
+                              Decr = 4'h8} action_e;
+
+endpackage : prim_count_pkg

--- a/examples/verify/v10_opentitan_nested_count_recoverability/source/prim_flop.sv
+++ b/examples/verify/v10_opentitan_nested_count_recoverability/source/prim_flop.sv
@@ -1,0 +1,16 @@
+// Minimal prim_flop matching OpenTitan's abstract-prim register interface (resolves to a plain
+// reset flop, identical to prim_generic_flop). Stands in for the prim-abstraction selector.
+module prim_flop #(
+  parameter int Width = 1,
+  parameter logic [Width-1:0] ResetValue = '0
+) (
+  input clk_i,
+  input rst_ni,
+  input [Width-1:0] d_i,
+  output logic [Width-1:0] q_o
+);
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) q_o <= ResetValue;
+    else q_o <= d_i;
+  end
+endmodule

--- a/examples/verify/v10_opentitan_nested_count_recoverability/validate.sh
+++ b/examples/verify/v10_opentitan_nested_count_recoverability/validate.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# validate.sh — V.10 recoverability showcase: a NESTED counter built from real OpenTitan prim_count.
+#
+# The prescaler+counter pattern: an inner prim_count down-counts each tick and reloads to INNER_MAX at
+# zero; when it reloads, an outer prim_count decrements. Asks whether the outer counter can always get
+# back to zero — recoverability over a NESTED descent:
+#     always_recoverable = nu Y. ((mu X. (outer==0 || <> X)) && [] Y)   (AG EF outer==0)
+#
+# `outer` ALONE is not a ranking (it holds while `inner` runs down), so a single-register ranking
+# certificate fails. mununu's ranking certificate generalizes to LEXICOGRAPHIC measures: the tuple
+# (outer, inner) decreases every tick (inner down with outer fixed, or outer down when inner reloads),
+# and lex order on the tuple is well-founded — so `AG EF (outer == 0)` decides HOLDS on a 48-bit outer
+# counter, where a single-register ranking, the predicate cube, and the exact BDD engine all give out.
+#
+# Pedigree: prim_count.sv + prim_count_pkg.sv are real OpenTitan RTL (Apache-2.0), pinned under source/
+# at the commit in UPSTREAM_COMMIT.txt. prim_flop.sv is a minimal register matching OpenTitan's
+# abstract-prim flop interface; count_nested_top.sv is a nested-counter harness of two real prim_count
+# instances (the prescaler+counter usage). A property-class demonstration on real silicon.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+SRC="examples/verify/v10_opentitan_nested_count_recoverability/source"
+MUNUNU="${MUNUNU:-./target/debug/mununu}"
+export LIBRARY_PATH="${LIBRARY_PATH:-/usr/local/opt/z3/lib}"
+
+if [[ ! -x "${MUNUNU}" ]]; then
+  echo "validate.sh: mununu not found at ${MUNUNU} — build with: LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli" >&2
+  exit 2
+fi
+for tool in sv2v yosys python3; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "validate.sh: required tool '${tool}' not on PATH" >&2; exit 2; }
+done
+
+OUT="$(mktemp -d -t mununu-v10-XXXXXX)"
+sv2v -I"${SRC}" "${SRC}/prim_count_pkg.sv" "${SRC}/prim_flop.sv" "${SRC}/prim_count.sv" \
+     "${SRC}/count_nested_top.sv" > "${OUT}/top.v" 2>"${OUT}/sv2v.err"
+
+# Lift, then name the OUTER counter (the state cell in outer_o's cone) `outer` so the target resolves.
+lift() {
+  local ow="$1" iw="$2" imax="$3" oinit="$4" out="$5"
+  yosys -q -p "read_verilog -sv ${OUT}/top.v; hierarchy -check -top count_nested_top \
+                 -chparam OW ${ow} -chparam IW ${iw} -chparam INNER_MAX ${iw}'d${imax} -chparam OUTER_INIT ${ow}'d${oinit}; \
+               proc; flatten; opt -full; wreduce; opt -full -purge; async2sync; dffunmap; opt_clean -purge; \
+               write_btor ${out}" 2>"${OUT}/yosys.err"
+  python3 - "$out" <<'PY'
+import sys
+from collections import deque
+p=sys.argv[1]; L=open(p).read().splitlines(); lines={}; oo=None
+for ln in L:
+    t=ln.split()
+    if len(t)>=2 and t[0].isdigit(): lines[int(t[0])]=t
+    if len(t)>=4 and t[1]=="output" and t[3]=="outer_o": oo=int(t[2])
+seen=set(); q=deque([abs(oo)]); st=None
+while q:
+    n=q.popleft()
+    if n in seen: continue
+    seen.add(n); t=lines.get(n)
+    if not t: continue
+    if t[1]=="state": st=n; break
+    if t[1] not in ("input","sort","const","constd","zero","one","ones"):
+        for tok in t[2:]:
+            try: q.append(abs(int(tok)))
+            except: pass
+out=[]
+for ln in L:
+    t=ln.split()
+    if len(t)==3 and t[1]=="state" and int(t[0])==st: out.append(ln+" outer")
+    else: out.append(ln)
+open(p,"w").write("\n".join(out)+"\n")
+PY
+}
+
+echo "=== V.10 — nested-counter recoverability on real OpenTitan prim_count (AG EF outer==0) ==="
+echo
+echo "--- small (OW=8, exact engine) — expect HOLDS ---"
+lift 8 4 6 40 "${OUT}/small.btor2"
+"${MUNUNU}" btor2 verify-recoverability "${OUT}/small.btor2" --target 'outer == 0' 2>/dev/null | grep -iE '"verdict"'
+SMALL="$("${MUNUNU}" btor2 verify-recoverability "${OUT}/small.btor2" --target 'outer == 0' 2>/dev/null | grep -oiE 'holds|violated|unknown' | head -1)"
+echo
+echo "--- wide (OW=48, > exact cap) — expect HOLDS via the LEXICOGRAPHIC ranking ---"
+lift 48 8 100 1099511627776 "${OUT}/wide.btor2"
+"${MUNUNU}" btor2 verify-recoverability "${OUT}/wide.btor2" --target 'outer == 0' 2>/dev/null | grep -iE '"verdict"'
+WIDE="$("${MUNUNU}" btor2 verify-recoverability "${OUT}/wide.btor2" --target 'outer == 0' 2>/dev/null | grep -oiE 'holds|violated|unknown' | head -1)"
+echo
+
+ok=1
+[[ "${SMALL}" != "holds" ]] && { echo "FAIL: small expected holds, got ${SMALL}" >&2; ok=0; }
+[[ "${WIDE}"  != "holds" ]] && { echo "FAIL: wide expected holds (lexicographic ranking), got ${WIDE}" >&2; ok=0; }
+if [[ "${ok}" == "1" ]]; then
+  echo "PASS — nested-counter recoverability DECIDES HOLDS on real prim_count at OW=48 via the LEXICOGRAPHIC ranking, where a single-register ranking + the cube + exact BDD all give out."
+else
+  echo "FAILED"; exit 1
+fi


### PR DESCRIPTION
## Summary

Completes the real-RTL ranking trio. Two real OpenTitan `prim_count` instances (Apache-2.0, pinned) wired in the **prescaler+counter** pattern: the inner counter down-counts each tick and reloads at zero; when it reloads, the outer counter decrements. `AG EF (outer == 0)`.

`outer` alone is **not a ranking** (it holds for a whole inner cycle before it steps), so a single-register ranking certificate fails. The **lexicographic** `(outer, inner)` measure decreases every tick and is well-founded, so `AG EF (outer == 0)` decides **Holds at OW=48** — where a single-register ranking, the predicate cube, and the exact BDD engine all give out. Small (OW=8) decides via the exact engine (differential oracle); `validate.sh` reproduces both.

## The real-RTL ranking corpus now covers all three shapes on real OpenTitan silicon

| | Property | Ranking shape |
|---|---|---|
| v8 | `AG EF (wptr == rptr)` | relational (FIFO drain) |
| v9 | `AG EF (cnt == 0)` | single-register (down-counter) |
| **v10** | `AG EF (outer == 0)` | **lexicographic (nested counter)** |

Examples-only (the lexicographic ranking + COI-filter already shipped in #313–#315). Same extraction recipe as v9; the COI-filter keeps the enumeration narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)