### PR TITLE
feat(recoverability): ASCENT ranking direction + v9 two-direction showcase

### DIFF
--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -362,8 +362,9 @@ fn inputs_in_next_cone(
 /// cube cannot capture. When `good` is reached by a monotone datapath descent (a down-counter to 0, a
 /// timer, a drain), no bounded predicate set represents the descent, so the cube abstains (`Unknown`) —
 /// yet the property HOLDS. This proves it directly over the EXACT transition (Podelski–Rybalchenko),
-/// sidestepping the cube. For a candidate ranking δ — `good = (r == V)` → δ = `r - V`; `good = (a == b)`
-/// → δ = `a - b` (unsigned BV difference) — it checks:
+/// sidestepping the cube. For a candidate ranking δ — `good = (r == V)` → δ = `r - V` (a DESCENT of r to
+/// V) or δ = `V - r` (an ASCENT of r to V); `good = (a == b)` → δ = `a - b` or `b - a` (unsigned BV
+/// difference; both directions are tried) — it checks:
 ///   (2) **`transition ∧ ¬good ∧ δ_next ≥ δ_curr` is UNSAT** — i.e. EVERY transition out of a non-good
 ///       state STRICTLY decreases δ; combined with (1) δ ≥ 0 (trivial for an unsigned BV), δ cannot
 ///       decrease forever, so every path reaches good.
@@ -398,15 +399,15 @@ fn ranking_certificate_holds(
         };
         let nid_map = crate::adapter::btor2::smt_must_edge::build_register_nid_map(&view);
         let mask = |w: u32| if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
-        // PRIMARY ranking component δ1 + the ¬good constraint, plus the good register NIDs (excluded from
-        // the lexicographic secondaries below).
-        let (d1_curr, d1_next, not_good, good_nids): (
-            z3::ast::BV,
-            z3::ast::BV,
+        // PRIMARY ranking components + the ¬good constraint + the good register NIDs. BOTH directions are
+        // tried: a DESCENT `δ = r - V` (r counts DOWN to V) and an ASCENT `δ = V - r` (r counts UP to V).
+        // Exactly one direction is a well-founded measure for a monotone move toward `good`; the other
+        // wraps and fails harmlessly. For a relational good `a == b`, the two are `a - b` and `b - a`.
+        let (primaries, not_good, good_nids): (
+            Vec<(z3::ast::BV, z3::ast::BV)>,
             z3::ast::Bool,
             Vec<i64>,
         ) = match good_value {
-            // Simple good `r == V`: δ1 = r - V.
             Some(v) => {
                 let [r] = good_registers else { return false };
                 let Some(&nid) = nid_map.get(r) else {
@@ -417,9 +418,15 @@ fn ranking_certificate_holds(
                 };
                 let w = rc.get_size();
                 let vbv = z3::ast::BV::from_u64(v & mask(w), w);
-                (rc.bvsub(&vbv), rn.bvsub(&vbv), rc.eq(&vbv).not(), vec![nid])
+                (
+                    vec![
+                        (rc.bvsub(&vbv), rn.bvsub(&vbv)), // descent δ = r - V
+                        (vbv.bvsub(rc), vbv.bvsub(rn)),   // ascent  δ = V - r
+                    ],
+                    rc.eq(&vbv).not(),
+                    vec![nid],
+                )
             }
-            // Relational good `a == b`: δ1 = a - b (same-width registers only).
             None => {
                 let [a, b] = good_registers else { return false };
                 let (Some(&na), Some(&nb)) = (nid_map.get(a), nid_map.get(b)) else {
@@ -436,7 +443,11 @@ fn ranking_certificate_holds(
                 if ac.get_size() != bc.get_size() {
                     return false;
                 }
-                (ac.bvsub(bc), an.bvsub(bn), ac.eq(bc).not(), vec![na, nb])
+                (
+                    vec![(ac.bvsub(bc), an.bvsub(bn)), (bc.bvsub(ac), bn.bvsub(an))],
+                    ac.eq(bc).not(),
+                    vec![na, nb],
+                )
             }
         };
 
@@ -542,22 +553,24 @@ fn ranking_certificate_holds(
         // tuple `(δ1, s1, …, sk)` over all secondaries in nid order — decides a k-LEVEL nested descent
         // (a 3-deep counter needs the 3-tuple; a 2-tuple over any single secondary fails). Lex order on
         // the tuple is well-founded, so the descent still reaches good (SOUND).
-        let d1 = (&d1_curr, &d1_next);
-        if certifies(&non_decrease(&[d1])) {
-            return true;
-        }
-        for (sc, sn) in &secondaries {
-            if certifies(&non_decrease(&[d1, (sc, sn)])) {
+        for (d1_curr, d1_next) in &primaries {
+            let d1 = (d1_curr, d1_next);
+            if certifies(&non_decrease(&[d1])) {
                 return true;
             }
-        }
-        if secondaries.len() >= 2 {
-            let mut full: Vec<(&z3::ast::BV, &z3::ast::BV)> = vec![d1];
             for (sc, sn) in &secondaries {
-                full.push((sc, sn));
+                if certifies(&non_decrease(&[d1, (sc, sn)])) {
+                    return true;
+                }
             }
-            if certifies(&non_decrease(&full)) {
-                return true;
+            if secondaries.len() >= 2 {
+                let mut full: Vec<(&z3::ast::BV, &z3::ast::BV)> = vec![d1];
+                for (sc, sn) in &secondaries {
+                    full.push((sc, sn));
+                }
+                if certifies(&non_decrease(&full)) {
+                    return true;
+                }
             }
         }
         false
@@ -1843,6 +1856,35 @@ mod tests {
             verify_recoverability(&dead_input_drain_w(8, 200), "cnt == 0").expect("exact decides"),
             PropertyVerdict::Holds,
             "8-bit exact oracle agrees"
+        );
+    }
+
+    // Ascent ranking — a saturating UP-counter to MAX = 2^W-1. `AG EF (cnt == MAX)` ("always able to fill
+    // up") HOLDS by an ASCENT, but the descent measure δ = cnt - MAX wraps; the ASCENT measure δ = MAX -
+    // cnt strictly decreases every step. The certificate tries both directions.
+    fn upcnt_w(width: u32) -> String {
+        format!(
+            "1 sort bitvec 1\n2 sort bitvec {width}\n3 state 2 cnt\n4 ones 2\n5 one 2\n6 zero 2\n\
+             7 init 2 3 6\n8 eq 1 3 4\n9 add 2 3 5\n10 ite 2 8 4 9\n11 next 2 3 10\n"
+        )
+    }
+
+    #[test]
+    fn ranking_certificate_decides_ascent_to_max() {
+        // 48-bit up-counter to MAX: decides Holds via the ascent (δ = V - r) direction, where the descent
+        // direction wraps, the cube abstains, and exact BDD walls.
+        let max48: u128 = (1u128 << 48) - 1;
+        assert_eq!(
+            verify_recoverability_scalable(&upcnt_w(48), &format!("cnt == {max48}"), &[])
+                .expect("decides"),
+            PropertyVerdict::Holds,
+            "48-bit up-counter to MAX decides Holds via the ascent ranking"
+        );
+        // DIFFERENTIAL ORACLE at 8-bit (exact BDD).
+        assert_eq!(
+            verify_recoverability(&upcnt_w(8), "cnt == 255").expect("exact decides"),
+            PropertyVerdict::Holds,
+            "8-bit exact oracle agrees with the 48-bit ascent ranking Holds"
         );
     }
 

--- a/examples/verify/v9_opentitan_count_recoverability/README.md
+++ b/examples/verify/v9_opentitan_count_recoverability/README.md
@@ -1,14 +1,16 @@
-# `v9_opentitan_count_recoverability` — down-counter recoverability of a real OpenTitan counter
+# `v9_opentitan_count_recoverability` — counter recoverability of a real OpenTitan counter (both directions)
 
-> **Status: PASS.** Asks whether OpenTitan's `prim_count`, wired as a down-counter,
-> can always get back to **zero** — a recoverability (`AG EF`) question over a datapath
-> **descent**. It decides `Holds` on both a small counter (exact) and a 48-bit counter
+> **Status: PASS.** Asks, in **both directions**, whether OpenTitan's `prim_count` can
+> always get back to a known state: down to **zero** (`AG EF cnt==0`, a datapath
+> **descent**) *and* up to **max credit** (`AG EF cnt==MAX`, a datapath **ascent**). It
+> decides `Holds` for both properties on a small counter (exact) and a 48-bit counter
 > (via the **ranking certificate**), where exact BDD walls and the predicate cube
-> abstains. A single-register ranking on a real hardened primitive — the companion
-> shape to [`../v8_opentitan_fifo_recoverability`](../v8_opentitan_fifo_recoverability)'s
-> relational FIFO drain. §Phase 9 V-track recoverability showcase.
+> abstains. A single-register ranking in two directions on a real hardened primitive — the
+> companion shape to
+> [`../v8_opentitan_fifo_recoverability`](../v8_opentitan_fifo_recoverability)'s relational
+> FIFO drain. §Phase 9 V-track recoverability showcase.
 
-> Source of truth: [`verify_recoverability`](../../../crates/mununu-core/src/adapter/recoverability.rs) — surface: CLI (`mununu btor2 verify-recoverability --target 'cnt == 0'`)
+> Source of truth: [`verify_recoverability`](../../../crates/mununu-core/src/adapter/recoverability.rs) — surface: CLI (`mununu btor2 verify-recoverability --target 'cnt == 0'` / `--target 'cnt == MAX'`)
 
 > **Claims integrity.** `prim_count.sv` and `prim_count_pkg.sv` are real OpenTitan RTL
 > (Apache-2.0), pinned under [`source/`](source/) at the commit in
@@ -18,34 +20,40 @@
 > configuration — `step = 1`, no clear/set). A property-class demonstration on real
 > silicon, not a vulnerability finding.
 
-## The question
+## The question — both directions
 
 A counter that must not wedge raises a branching-time question: from any value it can
-hold, can it always get back to a known state — here, **zero**? That is recoverability,
-`AG EF (cnt == 0)`:
+hold, can it always get back to a known state? `prim_count` answers **yes in both
+directions** — it can always drain back to **zero** *and* always fill up to **max
+credit** (`MAX = 2^Width − 1`). Both are recoverability, `AG EF (cnt == GOAL)`:
 
 ```
-recoverable        = mu X. (cnt == 0 || <> X)         # EF cnt==0 — zero reachable from here
-always_recoverable = nu Y. (recoverable && [] Y)      # AG EF cnt==0 — ...from every value
+recoverable        = mu X. (cnt == GOAL || <> X)      # EF cnt==GOAL — goal reachable from here
+always_recoverable = nu Y. (recoverable && [] Y)      # AG EF cnt==GOAL — ...from every value
 ```
 
-The `<>` inside the `[]` is the branching content a linear formalism (LTL / SVA) cannot
-state.
+with `GOAL ∈ {0, MAX}`. The `<>` inside the `[]` is the branching content a linear
+formalism (LTL / SVA) cannot state.
 
-## What decides it — the ranking certificate
+## What decides it — the ranking certificate (both measure directions)
 
-`prim_count` wired as a down-counter reaches zero by a **well-founded descent** (each
-decrement lowers the count, saturating at 0). No bounded predicate set captures a
-2^W-step descent, so the predicate cube abstains and — beyond ~40 bits — the exact BDD
-engine walls. mununu's **ranking certificate** decides it directly over the exact
-transition: for the ranking δ = `cnt`, from every non-zero state *some* input (decrement
-+ commit) strictly decreases δ; with δ bounded below by 0, that forces a descent to
-zero — so `AG EF (cnt == 0)` **Holds**, in ~1.4 s at Width = 48.
+Reaching either goal is a **well-founded descent of a measure** — but the two goals need
+measures pointing opposite ways:
 
-| Setup | `always_recoverable` | How |
-|---|---|---|
-| **Small** (`Width=8`, ≤ ~40 bits) | **`Holds`** | exact 3-valued engine |
-| **Wide** (`Width=48`, beyond the exact cap) | **`Holds`** | the ranking certificate (∃-input variant) |
+- **descent to 0** — measure δ = `cnt` (each decrement lowers it, bounded below by 0);
+- **ascent to MAX** — measure δ = `MAX − cnt` (each increment lowers it, bounded below by 0).
+
+No bounded predicate set captures a 2^W-step descent, so the predicate cube abstains and
+— beyond ~40 bits — the exact BDD engine walls. mununu's **ranking certificate** decides
+each directly over the exact transition: from every off-goal state *some* input strictly
+decreases the relevant δ, forcing a descent to the goal. The certificate **tries both
+measure directions**, so the same extraction decides both properties — each `Holds` at
+Width = 48.
+
+| Setup | `AG EF cnt==0` (descent) | `AG EF cnt==MAX` (ascent) | How |
+|---|---|---|---|
+| **Small** (`Width=8`, ≤ ~40 bits) | **`Holds`** | **`Holds`** | exact 3-valued engine |
+| **Wide** (`Width=48`, beyond the exact cap) | **`Holds`** | **`Holds`** | the ranking certificate (∃-input variant), δ = `cnt` / δ = `MAX−cnt` |
 
 ## A real-hardware wrinkle (and why the certificate is robust to it)
 
@@ -65,4 +73,4 @@ LIBRARY_PATH=/usr/local/opt/z3/lib cargo build -p mununu-cli
 
 Requires `sv2v`, `yosys`, and `python3` on `PATH` (the standard plain-SV → BTOR2 flow,
 same as v7/v8). `validate.sh` names the primary counter state (the one in `cnt_o`'s cone)
-`cnt` and targets `cnt == 0`.
+`cnt` and targets both `cnt == 0` (descent) and `cnt == MAX` (ascent) on one extraction.

--- a/examples/verify/v9_opentitan_count_recoverability/validate.sh
+++ b/examples/verify/v9_opentitan_count_recoverability/validate.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 # validate.sh — V.9 recoverability showcase on OpenTitan prim_count (a hardened counter).
 #
-# Asks a branching-time question SVA cannot state: "from any count value, can the counter
-# always get back to zero?" — recoverability over a datapath descent:
-#     always_recoverable = nu Y. ((mu X. (cnt==0 || <> X)) && [] Y)   (AG EF cnt==0)
-# The counter is a real OpenTitan `prim_count` wired as a down-counter (step=1, no clear/set,
-# see count_top.sv), so reaching zero is a well-founded DESCENT — the RANKING class, which no
-# bounded predicate set captures. mununu's RANKING CERTIFICATE decides it over the exact
-# transition: from every non-zero state SOME input (decrement + commit) strictly decreases the
-# count, which — bounded below by 0 — forces a descent to zero (∃-input variant, one relation).
+# Asks a branching-time question SVA cannot state, in BOTH directions on the SAME real primitive:
+#   (1) DESCENT  — "from any count, can the counter always get back to zero?"    (AG EF cnt==0)
+#   (2) ASCENT   — "from any count, can the counter always fill to max credit?"  (AG EF cnt==MAX)
+#     always_recoverable = nu Y. ((mu X. (cnt==GOAL || <> X)) && [] Y)
+# The counter is a real OpenTitan `prim_count` (step=1, no clear/set, see count_top.sv). Reaching
+# zero is a well-founded DESCENT; reaching MAX = 2^Width-1 is a well-founded ASCENT — both the
+# RANKING class, which no bounded predicate set captures. mununu's RANKING CERTIFICATE decides
+# each over the exact transition: from every off-goal state SOME input strictly moves a
+# well-founded measure toward the goal — δ = cnt for the descent (bounded below by 0), δ = MAX−cnt
+# for the ascent (bounded below by 0). The certificate tries BOTH measure directions, so one
+# extraction decides both properties (∃-input variant, one relation each).
 #
-# RESULT: `AG EF (cnt == 0)` decides HOLDS on a 48-bit prim_count in ~1.4 s, where the exact BDD
-# engine walls and the predicate cube abstains. This is a SINGLE-REGISTER ranking on a real
-# hardened primitive — a different shape from v8's relational FIFO drain.
+# RESULT: both `AG EF (cnt == 0)` and `AG EF (cnt == MAX)` decide HOLDS on a 48-bit prim_count,
+# where the exact BDD engine walls and the predicate cube abstains. A SINGLE-REGISTER ranking in
+# TWO directions on a real hardened primitive — a different shape from v8's relational FIFO drain.
 #
 # Note on the extraction: prim_count is HARDENED — it carries a redundant SECONDARY counter (for
 # fault detection) and an FPV backdoor. Those leave wide signals in the lifted BTOR2 that do not
@@ -79,24 +82,37 @@ open(p,"w").write("\n".join(out)+"\n")
 PY
 }
 
-echo "=== V.9 — recoverability of OpenTitan prim_count (AG EF cnt==0, a down-counter descent) ==="
+echo "=== V.9 — recoverability of OpenTitan prim_count, BOTH directions on one real primitive ==="
+echo "===        (1) AG EF cnt==0  descent      (2) AG EF cnt==MAX  ascent                    ==="
 echo
-echo "--- small counter (Width=8, exact engine) — expect HOLDS ---"
+
+# MAX credit for the ascent = 2^Width - 1.
+MAX8=255
+MAX48=281474976710655
+
+echo "--- small counter (Width=8, exact engine) — expect HOLDS both directions ---"
 lift 8 "${OUT}/w8.btor2"
-"${MUNUNU}" btor2 verify-recoverability "${OUT}/w8.btor2" --target 'cnt == 0' 2>/dev/null | grep -iE '"verdict"'
-SMALL="$("${MUNUNU}" btor2 verify-recoverability "${OUT}/w8.btor2" --target 'cnt == 0' 2>/dev/null | grep -oiE 'holds|violated|unknown' | head -1)"
+echo -n "  descent AG EF (cnt == 0):     "; "${MUNUNU}" btor2 verify-recoverability "${OUT}/w8.btor2" --target 'cnt == 0'        2>/dev/null | grep -oiE '"verdict": "[a-z]+"'
+echo -n "  ascent  AG EF (cnt == ${MAX8}):   "; "${MUNUNU}" btor2 verify-recoverability "${OUT}/w8.btor2" --target "cnt == ${MAX8}"  2>/dev/null | grep -oiE '"verdict": "[a-z]+"'
+S_DN="$("${MUNUNU}" btor2 verify-recoverability "${OUT}/w8.btor2" --target 'cnt == 0'       2>/dev/null | grep -oiE 'holds|violated|unknown' | head -1)"
+S_UP="$("${MUNUNU}" btor2 verify-recoverability "${OUT}/w8.btor2" --target "cnt == ${MAX8}" 2>/dev/null | grep -oiE 'holds|violated|unknown' | head -1)"
 echo
-echo "--- wide counter (Width=48, > exact cap) — expect HOLDS via the ranking certificate ---"
+echo "--- wide counter (Width=48, > exact cap) — expect HOLDS both directions via the ranking certificate ---"
 lift 48 "${OUT}/w48.btor2"
-"${MUNUNU}" btor2 verify-recoverability "${OUT}/w48.btor2" --target 'cnt == 0' 2>/dev/null | grep -iE '"verdict"'
-WIDE="$("${MUNUNU}" btor2 verify-recoverability "${OUT}/w48.btor2" --target 'cnt == 0' 2>/dev/null | grep -oiE 'holds|violated|unknown' | head -1)"
+echo -n "  descent AG EF (cnt == 0):                  "; "${MUNUNU}" btor2 verify-recoverability "${OUT}/w48.btor2" --target 'cnt == 0'         2>/dev/null | grep -oiE '"verdict": "[a-z]+"'
+echo -n "  ascent  AG EF (cnt == ${MAX48}):   "; "${MUNUNU}" btor2 verify-recoverability "${OUT}/w48.btor2" --target "cnt == ${MAX48}" 2>/dev/null | grep -oiE '"verdict": "[a-z]+"'
+W_DN="$("${MUNUNU}" btor2 verify-recoverability "${OUT}/w48.btor2" --target 'cnt == 0'          2>/dev/null | grep -oiE 'holds|violated|unknown' | head -1)"
+W_UP="$("${MUNUNU}" btor2 verify-recoverability "${OUT}/w48.btor2" --target "cnt == ${MAX48}" 2>/dev/null | grep -oiE 'holds|violated|unknown' | head -1)"
 echo
 
 ok=1
-[[ "${SMALL}" != "holds" ]] && { echo "FAIL: small counter expected holds, got ${SMALL}" >&2; ok=0; }
-[[ "${WIDE}"  != "holds" ]] && { echo "FAIL: wide counter expected holds (ranking certificate), got ${WIDE}" >&2; ok=0; }
+[[ "${S_DN}" != "holds" ]] && { echo "FAIL: small descent expected holds, got ${S_DN}" >&2; ok=0; }
+[[ "${S_UP}" != "holds" ]] && { echo "FAIL: small ascent expected holds, got ${S_UP}" >&2; ok=0; }
+[[ "${W_DN}" != "holds" ]] && { echo "FAIL: wide descent expected holds (ranking certificate), got ${W_DN}" >&2; ok=0; }
+[[ "${W_UP}" != "holds" ]] && { echo "FAIL: wide ascent expected holds (ranking certificate), got ${W_UP}" >&2; ok=0; }
 if [[ "${ok}" == "1" ]]; then
-  echo "PASS — down-counter recoverability DECIDES HOLDS on real prim_count at Width=48 (ranking certificate), where exact BDD walls and the predicate cube abstains."
+  echo "PASS — prim_count recoverability DECIDES HOLDS in BOTH directions at Width=48 (ranking certificate,"
+  echo "       δ=cnt for the descent, δ=MAX−cnt for the ascent), where exact BDD walls and the cube abstains."
 else
   echo "FAILED"; exit 1
 fi


### PR DESCRIPTION
## What

Extends the KMTS ranking certificate to prove goals reached by an **ascent** (a
saturating up-counter filling to `MAX = 2^W-1`), not only **descents** to a goal. The
primary measure is now a `Vec` of both directions — δ = `r−V` (descent) *and* δ = `V−r`
(ascent) for a `good = (r==V)` target; `(a−b)` and `(b−a)` for a relational `good =
(a==b)` target. The measure loop tries each; whichever yields an UNSAT all-path /
covered ∃-input certificate decides `Holds`.

**Same soundness theorem.** The ascent is just a different δ into the same well-order, so
L2.5 / L2.6 (δ into a well-order + strict decrease ⟹ `AG EF good`) cover it unchanged —
no proof-harness change.

## Why

`AG EF (cnt == MAX)` — "the counter can always fill to max credit" — is a natural
recoverability property, but the descent measure δ = `cnt − MAX` *wraps*, so the
certificate returned `Unknown` even though the property holds by the mirror measure
δ = `MAX − cnt`. This closes that gap and adds a new property **direction** to the
real-RTL ranking corpus.

## Results

- 48-bit saturating up-counter `AG EF (cnt == MAX)`: **Unknown → Holds**.
- Differential oracle at 8-bit (exact BDD) agrees, both directions.
- New unit test `ranking_certificate_decides_ascent_to_max` (+ `upcnt_w` generator).
- **v9 becomes a two-direction showcase** on one real OpenTitan `prim_count`: always
  drains to 0 (descent, δ=`cnt`) **and** always fills to MAX (ascent, δ=`MAX−cnt`). Both
  decide `Holds` at Width=48 end-to-end via `validate.sh`, where exact BDD walls and the
  predicate cube abstains. No redundant block — a new direction on the existing real
  primitive.
- 29 recoverability tests pass (was 28); 7 ranking tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)