### PR TITLE
perf(kmts): gate post-image may-edges to |P| >= 2 (scalable-KMTS follow-up A)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -2134,7 +2134,11 @@ pub fn predicate_cube_lift(
         // scalable-KMTS P1.4 — the may-relation via post-image (O(2^|P|·#succ)) instead of all-pairs
         // (O(2^{2|P|})). Both use `encode_design_for_lift`, so the edge set is IDENTICAL; a `None` (an
         // unresolvable register / cube-space over the bound) falls back to the all-pairs seam.
+        // GATE (follow-up A): only for |P| >= 2. At |P| == 1 all-pairs is 2 cubes / ~4 checks (trivial),
+        // and the post-image's fixed all-SAT overhead loses (measured 1.6s vs 0.13s); from |P| == 2 the
+        // post-image wins (and grows to 33-256x by |P| = 3-7).
         let may_edges: Vec<(usize, usize)> = if lift_opts.may_postimage
+            && predicates.len() >= 2
             && let Some(map) =
                 compute_all_may_edges_smt_postimage(&file, &predicates, &lift_opts.compound_exprs)
         {


### PR DESCRIPTION
Follow-up to the post-image wall fix (#324). At `|P| == 1` the all-pairs may-relation is 2
cubes / ~4 checks (trivial), and the post-image's fixed all-SAT overhead loses (measured 1.6s
vs 0.13s). From `|P| == 2` the post-image wins (0.13s vs 0.68s, growing to 33-256× by |P|=3-7).
So only take the post-image path for `|P| >= 2`. Verdict-equivalent;
`p1_postimage_lift_matches_all_pairs_lift` (2 predicates) still exercises the post-image path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)