### PR TITLE
feat(reach): Phase-2 unification core — shared refinement primitive + predicate-abstraction safety driver

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/abs_safety.rs
+++ b/crates/mununu-core/src/adapter/btor2/abs_safety.rs
@@ -1,0 +1,612 @@
+//! Phase 2 · P2.2 — the safety driver of the shared lazy-refinement core (plan
+//! `cube-ic3ia-invariant-discovery.md` §9).
+//!
+//! Decides `AG ¬bad` by **predicate-abstraction forward reachability with
+//! interpolation refinement**, over the shared core: a predicate set `P` induces a
+//! finite abstraction (cubes = predicate valuations); the forward may-reachable
+//! cube set over-approximates the reachable states; if it excludes every `bad`
+//! cube, the design is safe. When the abstraction is too coarse (a `bad` cube is
+//! may-reachable but no concrete counterexample exists), the shared refinement
+//! primitive ([`super::refine::synthesize_refinement_predicate`]) — and, for
+//! reachability spuriousness, the interpolation engine
+//! ([`super::native_interp`]) — synthesise a new predicate and the pass restarts.
+//!
+//! **Soundness is structural, not search-dependent.** Every verdict is
+//! independently re-verified before it is returned. `Safe` only when the
+//! may-reachable set `R#` is a *checked* inductive invariant over the EXACT
+//! transition — `Init ⟹ R#`, `R# ∧ T ⟹ R#'`, `R# ⟹ ¬bad` — so a bug in the
+//! abstraction/BFS can at worst make it abstain, never wrongly prove. `Unsafe`
+//! only when [`super::native_bmc::bmc_bad_reachable`] exhibits a concrete
+//! counterexample. Everything else is `Unknown` — the driver never guesses.
+//!
+//! The IC3-frame incremental optimisation (block CTIs without enumerating the
+//! reachable cube set — the scalability half of §9's safety driver) is **P2.2b**;
+//! this first increment establishes the sound refinement-driven skeleton the frame
+//! ladder will slot into.
+
+use std::collections::{BTreeSet, HashMap, VecDeque};
+
+use z3::ast::{Ast, BV, Bool};
+
+use crate::adapter::btor2::ast::{Btor2File, ConstValue, Nid, Node};
+use crate::adapter::btor2::native_bmc::{BmcOutcome, bmc_bad_reachable};
+use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
+use crate::adapter::btor2::refine::{RefineOutcome, synthesize_refinement_predicate};
+use crate::adapter::sidecar::predicate_image::btor2_encode::{SignalKind, encode_design};
+
+/// Verdict of the predicate-abstraction safety driver.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AbsVerdict {
+    /// `AG ¬bad` — the may-reachable abstraction is a *verified* inductive invariant
+    /// excluding `bad`. `predicates` is how many were in `P` at convergence.
+    Safe { predicates: usize },
+    /// `bad` is reachable — `depth` from `bmc_bad_reachable`.
+    Unsafe { depth: u32 },
+    /// Abstained: refinement stalled (a needed predicate is outside the parseable
+    /// grammar), the abstraction blew up, cvc5 was absent, or a solver timed out.
+    Unknown { reason: String },
+}
+
+/// A cube = a full valuation of the predicate set (indexed by predicate position).
+type Cube = Vec<bool>;
+
+/// P2.2 — decide `AG ¬bad` by predicate-abstraction reachability + refinement.
+/// `max_refine` bounds the refinement loop; `max_cubes` caps the reachable-set
+/// enumeration (abstain if exceeded); `timeout_ms` bounds each solver query.
+pub fn verify_safety_abs(
+    file: &Btor2File,
+    max_refine: u32,
+    max_cubes: usize,
+    timeout_ms: u32,
+) -> AbsVerdict {
+    // Seed predicates from the `bad` cone's comparison atoms + the reset values of
+    // the named state cells — the cheap, always-available starting abstraction.
+    let mut preds = seed_predicates(file);
+
+    for _round in 0..max_refine {
+        match one_pass(file, &preds, max_cubes, timeout_ms) {
+            PassResult::Safe => {
+                return AbsVerdict::Safe {
+                    predicates: preds.len(),
+                };
+            }
+            PassResult::Unsafe { depth } => return AbsVerdict::Unsafe { depth },
+            PassResult::Refine(p) => {
+                if preds.iter().any(|q| q == &p) {
+                    return AbsVerdict::Unknown {
+                        reason: "refinement produced an already-present predicate (stalled)".into(),
+                    };
+                }
+                preds.push(p);
+            }
+            PassResult::Unknown(reason) => return AbsVerdict::Unknown { reason },
+        }
+    }
+    AbsVerdict::Unknown {
+        reason: format!("no fixpoint within {max_refine} refinements"),
+    }
+}
+
+enum PassResult {
+    Safe,
+    Unsafe { depth: u32 },
+    Refine(PredicateExpr),
+    Unknown(String),
+}
+
+/// One abstraction pass at a fixed predicate set: build the may-reachable cube set;
+/// if it excludes `bad` → verify inductive → Safe; else classify the abstract
+/// counterexample (real → Unsafe; spurious → a refinement predicate).
+fn one_pass(
+    file: &Btor2File,
+    preds: &[PredicateExpr],
+    max_cubes: usize,
+    timeout_ms: u32,
+) -> PassResult {
+    let cfg = z3::Config::new();
+    z3::with_z3_config(&cfg, || {
+        let view = match encode_design(file) {
+            Ok(v) => v,
+            Err(e) => return PassResult::Unknown(format!("encode: {e:?}")),
+        };
+        // Named-state interface (cur / nx) + transition, mirroring `refine`.
+        let name_to_nid: HashMap<String, Nid> = view
+            .signals
+            .iter()
+            .filter(|s| s.kind == SignalKind::State)
+            .filter_map(|s| s.symbol.clone().map(|sym| (sym, s.nid)))
+            .collect();
+        let nid_to_name: HashMap<Nid, String> =
+            name_to_nid.iter().map(|(n, &d)| (d, n.clone())).collect();
+        let named = |suffix: &str| -> HashMap<Nid, BV> {
+            view.state_curr
+                .iter()
+                .filter_map(|(nid, bv)| {
+                    let sym = nid_to_name.get(nid)?;
+                    Some((*nid, BV::new_const(format!("{sym}{suffix}"), bv.get_size())))
+                })
+                .collect()
+        };
+        let cur = named("__c");
+        let nx = named("__n");
+        let inp: HashMap<Nid, BV> = view
+            .inputs
+            .iter()
+            .map(|(nid, bv)| (*nid, BV::new_const(format!("i{nid}__x"), bv.get_size())))
+            .collect();
+        let mut subs: Vec<(&BV, &BV)> = Vec::new();
+        for (nid, bv) in &view.state_curr {
+            if let Some(c) = cur.get(nid) {
+                subs.push((bv, c));
+            }
+        }
+        for (nid, bv) in &view.state_next {
+            if let Some(n) = nx.get(nid) {
+                subs.push((bv, n));
+            }
+        }
+        for (nid, bv) in &view.inputs {
+            if let Some(i) = inp.get(nid) {
+                subs.push((bv, i));
+            }
+        }
+        let transition = view.transition.substitute(&subs);
+
+        // Predicate z3 Bools over cur and nx.
+        let build_over = |frame: &HashMap<Nid, BV>, p: &PredicateExpr| -> Option<Bool> {
+            let lookup = |name: &str| {
+                name_to_nid
+                    .get(name)
+                    .and_then(|nid| frame.get(nid))
+                    .cloned()
+            };
+            p.build_constraint(&lookup)
+        };
+        let (pred_cur, pred_nx): (Vec<Bool>, Vec<Bool>) = {
+            let mut pc = Vec::new();
+            let mut pn = Vec::new();
+            for p in preds {
+                match (build_over(&cur, p), build_over(&nx, p)) {
+                    (Some(c), Some(n)) => {
+                        pc.push(c);
+                        pn.push(n);
+                    }
+                    _ => {
+                        return PassResult::Unknown("predicate references unknown register".into());
+                    }
+                }
+            }
+            (pc, pn)
+        };
+
+        // Init / bad over cur (+ bad over nx).
+        let props = extract_props(file);
+        let init_cur = init_bool(&view, &props, &cur, &nid_to_name);
+        let bad_cur = bad_bool(&view, &props, &cur);
+
+        let mk_solver = || {
+            let s = z3::Solver::new();
+            let mut pr = z3::Params::new();
+            pr.set_u32("timeout", timeout_ms);
+            s.set_params(&pr);
+            s
+        };
+        let cube_bool = |c: &Cube, frame_preds: &[Bool]| -> Bool {
+            let lits: Vec<Bool> = frame_preds
+                .iter()
+                .zip(c)
+                .map(|(p, &pos)| if pos { p.clone() } else { p.not() })
+                .collect();
+            if lits.is_empty() {
+                Bool::from_bool(true)
+            } else {
+                Bool::and(&lits.iter().collect::<Vec<_>>())
+            }
+        };
+        // All-SAT enumeration of the predicate valuations satisfying `phi`
+        // (`phi` is over `over_preds` — either cur or nx). Bounded by `max_cubes`.
+        let all_cubes = |phi: &Bool, over_preds: &[Bool]| -> Option<Vec<Cube>> {
+            let s = mk_solver();
+            s.assert(phi);
+            let mut out = Vec::new();
+            loop {
+                match s.check() {
+                    z3::SatResult::Sat => {}
+                    z3::SatResult::Unsat => break,
+                    z3::SatResult::Unknown => return None,
+                }
+                let model = s.get_model()?;
+                let cube: Cube = over_preds
+                    .iter()
+                    .map(|p| {
+                        model
+                            .eval(p, true)
+                            .and_then(|b| b.as_bool())
+                            .unwrap_or(false)
+                    })
+                    .collect();
+                // block this exact valuation
+                let block = cube_bool(&cube, over_preds).not();
+                s.assert(&block);
+                out.push(cube);
+                if out.len() > max_cubes {
+                    return None;
+                }
+            }
+            Some(out)
+        };
+
+        // Reset-initial cubes (predicate valuations consistent with Init).
+        let init_cubes = match all_cubes(&init_cur, &pred_cur) {
+            Some(v) => v,
+            None => return PassResult::Unknown("init cube enumeration blew up / timed out".into()),
+        };
+
+        // Forward BFS of may-reachable cubes; record a parent for path recovery.
+        let mut reachable: BTreeSet<Cube> = init_cubes.iter().cloned().collect();
+        let mut parent: HashMap<Cube, Cube> = HashMap::new();
+        let mut queue: VecDeque<Cube> = init_cubes.into_iter().collect();
+        while let Some(c) = queue.pop_front() {
+            // may-successors: predicate valuations of `cube(c) ∧ T` at next-state.
+            let src = Bool::and(&[&cube_bool(&c, &pred_cur), &transition]);
+            let succs = match all_cubes(&src, &pred_nx) {
+                Some(v) => v,
+                None => return PassResult::Unknown("post-image enumeration blew up".into()),
+            };
+            for d in succs {
+                if reachable.insert(d.clone()) {
+                    parent.insert(d.clone(), c.clone());
+                    queue.push_back(d);
+                    if reachable.len() > max_cubes {
+                        return PassResult::Unknown("reachable set exceeded cap".into());
+                    }
+                }
+            }
+        }
+
+        // A reachable cube that intersects `bad`?
+        let bad_reach: Option<Cube> = reachable
+            .iter()
+            .find(|c| {
+                let s = mk_solver();
+                s.assert(cube_bool(c, &pred_cur));
+                s.assert(&bad_cur);
+                s.check() == z3::SatResult::Sat
+            })
+            .cloned();
+
+        let Some(bad_cube) = bad_reach else {
+            // No bad cube may-reachable ⇒ candidate safe. VERIFY the invariant
+            // R# = ⋁ reachable cube (over cur) is genuinely inductive + bad-free.
+            let inv = {
+                let disj: Vec<Bool> = reachable.iter().map(|c| cube_bool(c, &pred_cur)).collect();
+                Bool::or(&disj.iter().collect::<Vec<_>>())
+            };
+            // Init ⟹ inv
+            if sat_of(&mk_solver, &[&init_cur, &inv.not()]) != z3::SatResult::Unsat {
+                return PassResult::Unknown("invariant verification: Init ⊄ R#".into());
+            }
+            // inv ⟹ ¬bad
+            if sat_of(&mk_solver, &[&inv, &bad_cur]) != z3::SatResult::Unsat {
+                return PassResult::Unknown("invariant verification: R# ∩ bad ≠ ∅".into());
+            }
+            // inv ∧ T ⟹ inv'  — need inv over nx.
+            let inv_nx = {
+                let disj: Vec<Bool> = reachable.iter().map(|c| cube_bool(c, &pred_nx)).collect();
+                Bool::or(&disj.iter().collect::<Vec<_>>())
+            };
+            if sat_of(&mk_solver, &[&inv, &transition, &inv_nx.not()]) != z3::SatResult::Unsat {
+                return PassResult::Unknown("invariant verification: R# not closed under T".into());
+            }
+            return PassResult::Safe;
+        };
+
+        // A bad cube is may-reachable. Is there a CONCRETE counterexample? (Sound
+        // Unsafe gate.) Bound the depth by the abstract path length.
+        let path_len = recover_path_len(&bad_cube, &parent);
+        match bmc_bad_reachable(file, (path_len + 2).max(4)) {
+            Ok(BmcOutcome::Violated { depth }) => return PassResult::Unsafe { depth },
+            Ok(BmcOutcome::NoCexWithin { .. }) => {} // spurious → refine
+            Err(_) => {}                             // fall through to refinement
+        }
+
+        // Spurious abstract counterexample → refine. First try the shared
+        // single-step primitive on a spurious edge of the abstract path; that
+        // handles locally-impossible steps. (Reachability-spurious cases — where
+        // every edge is realizable but the composed path is not — need the
+        // interpolation engine's frame refinement; P2.2b.)
+        let path = recover_path(&bad_cube, &parent);
+        for w in path.windows(2) {
+            let (src, dst) = (&w[0], &w[1]);
+            let source = cube_to_predicates(src, preds);
+            let target = cube_to_predicates(dst, preds);
+            match synthesize_refinement_predicate(file, &source, &target, timeout_ms) {
+                RefineOutcome::Predicate(p) => return PassResult::Refine(p),
+                RefineOutcome::Realizable => continue,
+                RefineOutcome::Unavailable(_) => continue,
+            }
+        }
+        PassResult::Unknown(
+            "spurious abstract CEX with no single-step-refinable edge (needs frame/path \
+             interpolation — P2.2b)"
+                .into(),
+        )
+    })
+}
+
+/// SAT of the conjunction of `terms` under a timeout-bounded solver.
+fn sat_of(mk: &dyn Fn() -> z3::Solver, terms: &[&Bool]) -> z3::SatResult {
+    let s = mk();
+    for &t in terms {
+        s.assert(t);
+    }
+    s.check()
+}
+
+fn recover_path(target: &Cube, parent: &HashMap<Cube, Cube>) -> Vec<Cube> {
+    let mut path = vec![target.clone()];
+    let mut cur = target;
+    while let Some(p) = parent.get(cur) {
+        path.push(p.clone());
+        cur = p;
+    }
+    path.reverse();
+    path
+}
+
+fn recover_path_len(target: &Cube, parent: &HashMap<Cube, Cube>) -> u32 {
+    (recover_path(target, parent).len() as u32).saturating_sub(1)
+}
+
+/// A cube's positive literals as `register == value` predicates is NOT recoverable
+/// (a cube is a valuation of *derived* predicates, not registers); instead the
+/// source/target regions handed to the refinement primitive are the cube's
+/// predicates themselves at their valuation.
+fn cube_to_predicates(cube: &Cube, preds: &[PredicateExpr]) -> Vec<PredicateExpr> {
+    preds
+        .iter()
+        .zip(cube)
+        .map(|(p, &pos)| {
+            if pos {
+                p.clone()
+            } else {
+                PredicateExpr::Not(Box::new(p.clone()))
+            }
+        })
+        .collect()
+}
+
+// ---- shared small helpers (mirrors of native_interp's, kept local so this module
+//      does not depend on native_interp's private internals) ----
+
+struct Props {
+    bad: Vec<Nid>,
+    init: Vec<(Nid, Nid)>,
+}
+
+fn extract_props(file: &Btor2File) -> Props {
+    let mut p = Props {
+        bad: Vec::new(),
+        init: Vec::new(),
+    };
+    for l in &file.lines {
+        match &l.node {
+            Node::Bad { signal } => p.bad.push(signal.nid()),
+            Node::Init { state, value, .. } => p.init.push((*state, value.nid())),
+            _ => {}
+        }
+    }
+    p
+}
+
+fn curr_bv<'a>(
+    view: &'a crate::adapter::sidecar::predicate_image::btor2_encode::Btor2SmtView,
+    nid: &Nid,
+) -> Option<&'a BV> {
+    view.signal_bvs
+        .get(nid)
+        .or_else(|| view.state_curr.get(nid))
+        .or_else(|| view.inputs.get(nid))
+}
+
+fn bad_bool(
+    view: &crate::adapter::sidecar::predicate_image::btor2_encode::Btor2SmtView,
+    props: &Props,
+    frame: &HashMap<Nid, BV>,
+) -> Bool {
+    // Substitute state_curr → frame in each bad operand's BV.
+    let one1 = BV::from_u64(1, 1);
+    let subs: Vec<(&BV, &BV)> = view
+        .state_curr
+        .iter()
+        .filter_map(|(nid, bv)| frame.get(nid).map(|f| (bv, f)))
+        .collect();
+    let disj: Vec<Bool> = props
+        .bad
+        .iter()
+        .filter_map(|op| curr_bv(view, op).map(|bv| bv.substitute(&subs).eq(&one1)))
+        .collect();
+    if disj.is_empty() {
+        Bool::from_bool(false)
+    } else {
+        Bool::or(&disj.iter().collect::<Vec<_>>())
+    }
+}
+
+fn init_bool(
+    view: &crate::adapter::sidecar::predicate_image::btor2_encode::Btor2SmtView,
+    props: &Props,
+    cur: &HashMap<Nid, BV>,
+    _nid_to_name: &HashMap<Nid, String>,
+) -> Bool {
+    let subs: Vec<(&BV, &BV)> = view
+        .state_curr
+        .iter()
+        .filter_map(|(nid, bv)| cur.get(nid).map(|c| (bv, c)))
+        .collect();
+    let conj: Vec<Bool> = props
+        .init
+        .iter()
+        .filter_map(|(state, value_nid)| {
+            let c = cur.get(state)?;
+            let vbv = curr_bv(view, value_nid)?.substitute(&subs);
+            Some(c.eq(&vbv))
+        })
+        .collect();
+    if conj.is_empty() {
+        Bool::from_bool(true)
+    } else {
+        Bool::and(&conj.iter().collect::<Vec<_>>())
+    }
+}
+
+/// Seed predicates: the `register == reset_value` atom of each named state cell
+/// whose init is a constant (the reachability-constraining atoms), plus a
+/// `register == 0` fallback. Cheap and always available; refinement adds the rest.
+fn seed_predicates(file: &Btor2File) -> Vec<PredicateExpr> {
+    let mut const_vals: HashMap<Nid, u64> = HashMap::new();
+    let mut sym: HashMap<Nid, String> = HashMap::new();
+    for l in &file.lines {
+        match &l.node {
+            Node::State {
+                symbol: Some(s), ..
+            } => {
+                sym.insert(l.nid, s.clone());
+            }
+            Node::Const { value, .. } => {
+                let v: Option<u64> = match value {
+                    ConstValue::Zero => Some(0),
+                    ConstValue::One => Some(1),
+                    ConstValue::Dec(d) => u64::try_from(*d).ok(),
+                    ConstValue::Bin(s) => u64::from_str_radix(s, 2).ok(),
+                    ConstValue::Hex(s) => u64::from_str_radix(s, 16).ok(),
+                    ConstValue::Ones => None, // width-dependent; skip
+                };
+                if let Some(v) = v {
+                    const_vals.insert(l.nid, v);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut preds: Vec<PredicateExpr> = Vec::new();
+    let mut push = |name: &str, v: u64| {
+        let p = PredicateExpr::Cmp {
+            register: name.to_string(),
+            op: CmpOp::Eq,
+            value: v,
+        };
+        if !preds.contains(&p) {
+            preds.push(p);
+        }
+    };
+    // (1) reset-value atoms — `register == init_value`.
+    for l in &file.lines {
+        if let Node::Init { state, value, .. } = &l.node
+            && let (Some(name), Some(v)) = (sym.get(state), const_vals.get(&value.nid()))
+        {
+            push(name, *v);
+        }
+    }
+    // (2) comparison atoms in the design — any `eq(state_register, const)` (the
+    // control's decision conditions, incl. the `bad` cone). Cheap, sound, and it
+    // makes the abstraction distinguish the states the property cares about.
+    for l in &file.lines {
+        if let Node::Op {
+            op: crate::adapter::btor2::ast::Op::Eq,
+            args,
+            ..
+        } = &l.node
+            && args.len() == 2
+        {
+            let (n0, n1) = (args[0].nid(), args[1].nid());
+            if let (Some(name), Some(v)) = (sym.get(&n0), const_vals.get(&n1)) {
+                push(name, *v);
+            } else if let (Some(name), Some(v)) = (sym.get(&n1), const_vals.get(&n0)) {
+                push(name, *v);
+            }
+        }
+    }
+    preds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::parser;
+
+    /// Trivially safe: `x` holds at 0, `bad = (x == 3)`. R# = {x==0} excludes bad
+    /// and is inductive — Safe with no refinement.
+    #[test]
+    fn abs_proves_constant_hold_safe() {
+        const HOLD: &str = "1 sort bitvec 2\n2 zero 1\n3 state 1 x\n4 init 1 3 2\n5 next 1 3 3\n\
+                            6 constd 1 3\n7 sort bitvec 1\n8 eq 7 3 6\n9 bad 8\n";
+        let file = parser::parse(HOLD).expect("parse");
+        match verify_safety_abs(&file, 8, 4096, 5_000) {
+            AbsVerdict::Safe { .. } => {}
+            AbsVerdict::Unknown { reason }
+                if reason.contains("cvc5") || reason.contains("timeout") =>
+            {
+                eprintln!("SKIP: {reason}")
+            }
+            other => panic!("expected Safe, got {other:?}"),
+        }
+    }
+
+    /// A NON-1-inductive safe design decided by the abstraction: `a` holds at 0,
+    /// `b = a + 1`, `bad = (b == 2)`. `b` reaches only 1 (since `a` stays 0), never
+    /// 2 — but `¬(b==2)` is not 1-inductive (from a free `a==1`, `b'=2`). The
+    /// `a==0` reset atom + the `b==2` bad atom give an abstraction whose
+    /// may-reachable set excludes bad → verified Safe. This is the case native
+    /// k-induction abstains on that the predicate abstraction gets.
+    #[test]
+    fn abs_proves_non_inductive_safe_via_abstraction() {
+        // a: hold at 0; b: next = a + 1; bad = (b == 2).
+        const D: &str = "1 sort bitvec 2\n2 zero 1\n3 state 1 a\n4 init 1 3 2\n5 next 1 3 3\n\
+                         6 state 1 b\n7 init 1 6 2\n8 one 1\n9 add 1 3 8\n10 next 1 6 9\n\
+                         11 constd 1 2\n12 sort bitvec 1\n13 eq 12 6 11\n14 bad 13\n";
+        let file = parser::parse(D).expect("parse");
+        match verify_safety_abs(&file, 8, 4096, 5_000) {
+            AbsVerdict::Safe { .. } => {}
+            AbsVerdict::Unknown { reason }
+                if reason.contains("cvc5") || reason.contains("timeout") =>
+            {
+                eprintln!("SKIP: {reason}")
+            }
+            // NEVER Unsafe (b never reaches 2).
+            other => panic!("expected Safe via abstraction, got {other:?}"),
+        }
+    }
+
+    /// Genuinely reachable `bad` must be `Unsafe` (via the concrete-BMC gate).
+    #[test]
+    fn abs_refutes_reachable_bad() {
+        // x init 0; next x = x + 1 (2-bit); bad = (x == 3). Reachable at depth 3.
+        const REACH: &str = "1 sort bitvec 2\n2 zero 1\n3 state 1 x\n4 init 1 3 2\n5 one 1\n\
+                             6 add 1 3 5\n7 next 1 3 6\n8 constd 1 3\n9 sort bitvec 1\n\
+                             10 eq 9 3 8\n11 bad 10\n";
+        let file = parser::parse(REACH).expect("parse");
+        match verify_safety_abs(&file, 8, 4096, 5_000) {
+            AbsVerdict::Unsafe { .. } => {}
+            AbsVerdict::Unknown { reason } if reason.contains("cvc5") => {
+                eprintln!("SKIP: {reason}")
+            }
+            other => panic!("expected Unsafe, got {other:?}"),
+        }
+    }
+
+    /// `bad` at init ⇒ Unsafe depth 0.
+    #[test]
+    fn abs_detects_initial_violation() {
+        const INIT_BAD: &str =
+            "1 sort bitvec 1\n2 one 1\n3 state 1 x\n4 init 1 3 2\n5 next 1 3 2\n6 bad 3\n";
+        let file = parser::parse(INIT_BAD).expect("parse");
+        match verify_safety_abs(&file, 8, 4096, 5_000) {
+            AbsVerdict::Unsafe { depth } => assert_eq!(depth, 0),
+            AbsVerdict::Unknown { reason } if reason.contains("cvc5") => {
+                eprintln!("SKIP: {reason}")
+            }
+            other => panic!("expected Unsafe depth 0, got {other:?}"),
+        }
+    }
+}

--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -19,6 +19,7 @@
 //! - Overflow detectors (`saddo`, `uaddo`, `smulo`, ...).
 //! - Multi-clock designs.
 
+pub mod abs_safety;
 pub mod ast;
 pub mod bad_monitor;
 pub mod bit_blast;
@@ -36,6 +37,7 @@ pub mod parser;
 pub mod pin;
 pub mod predicate_expr;
 pub mod r_s8_encoder;
+pub mod refine;
 pub mod reset_init;
 pub mod shadow;
 pub mod smt_must_edge;

--- a/crates/mununu-core/src/adapter/btor2/native_interp.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_interp.rs
@@ -205,7 +205,7 @@ fn init_bool(view: &Btor2SmtView, props: &Props, iface: &Interface) -> Bool {
 /// via [`z3::Solver::to_smt2`]. Because the interface vars were built with
 /// [`BV::new_const`], the rendered names are the controlled `mc_*` names — stable
 /// across `A` and `B`, so their shared vocabulary lines up in the cvc5 query.
-fn serialize_term(b: &Bool) -> Option<(Vec<String>, String)> {
+pub(crate) fn serialize_term(b: &Bool) -> Option<(Vec<String>, String)> {
     let solver = z3::Solver::new();
     solver.assert(b);
     let smt2 = solver.to_smt2();
@@ -709,7 +709,7 @@ fn interpolate_bool(a: &Bool, b: &Bool, shared: &BTreeMap<Nid, BV>, timeout_ms: 
 }
 
 /// Run cvc5 on an interpolation query, returning raw stdout.
-fn run_cvc5_raw(query: &str, timeout_ms: u32) -> Result<String, String> {
+pub(crate) fn run_cvc5_raw(query: &str, timeout_ms: u32) -> Result<String, String> {
     use std::io::{Read, Write};
     use std::process::{Command, Stdio};
     use std::time::{Duration, Instant};
@@ -765,7 +765,7 @@ fn run_cvc5_raw(query: &str, timeout_ms: u32) -> Result<String, String> {
 /// Extract the interpolant term from cvc5's `(define-fun I () Bool <body>)` reply
 /// (cvc5 ≥ 1.x). Falls back to a bare top-level s-expression if `define-fun` is
 /// absent.
-fn extract_interpolant_body(stdout: &str) -> Option<String> {
+pub(crate) fn extract_interpolant_body(stdout: &str) -> Option<String> {
     if let Some(p) = stdout.find("(define-fun I () Bool") {
         let after = &stdout[p + "(define-fun I () Bool".len()..];
         return balanced_prefix(after.trim_start()).map(|s| s.to_string());

--- a/crates/mununu-core/src/adapter/btor2/refine.rs
+++ b/crates/mununu-core/src/adapter/btor2/refine.rs
@@ -1,0 +1,263 @@
+//! Phase 2 · P2.1 — the **shared lazy-refinement core**'s refinement primitive.
+//!
+//! This is the ONE capability that unifies KMTS-based verification (plan
+//! `cube-ic3ia-invariant-discovery.md` §9): given a spurious abstract step — a
+//! source region that the abstraction lets reach a target region, but the EXACT
+//! transition forbids — synthesise a new predicate that separates them. Both
+//! Phase-2 drivers call it: the safety IC3ia frame-ladder (block a spurious CTI)
+//! and the 3-valued μ-calculus evaluator (refine a spurious `⊥` obligation),
+//! replacing the eager-cube + CEGAR-predicate-split with lazy, interpolation-driven
+//! discovery.
+//!
+//! **Mechanism.** Build `A = source(cur) ∧ T(cur→nx)` and `B = ¬target(nx)` over
+//! the *exact* transition ([`encode_design`]). If the step is realizable
+//! (`A ∧ target(nx)` SAT) there is nothing to refine. Otherwise cvc5's
+//! `get-interpolant` (convention `A ⟹ I ⟹ B`) yields `I(nx)` — an
+//! over-approximation of the concrete image of `source` that excludes `target`.
+//! The next-state variables are named by their **register name** (current-state
+//! ones get a `__cur` suffix), so `I` comes back over register names and parses
+//! directly to a [`PredicateExpr`] (via `#318`) — a ready cube dimension.
+//!
+//! **Soundness.** The returned predicate is only a *candidate cube dimension*.
+//! Adding any well-formed predicate refines the abstraction monotonically
+//! (Shoham–Grumberg) and can never flip a definite verdict — so a weak/mis-parsed
+//! interpolant costs refinement power, never soundness.
+
+use std::collections::{BTreeSet, HashMap};
+
+use z3::ast::{Ast, BV, Bool};
+
+use crate::adapter::btor2::ast::{Btor2File, Nid};
+use crate::adapter::btor2::native_interp::{
+    extract_interpolant_body, run_cvc5_raw, serialize_term,
+};
+use crate::adapter::btor2::predicate_expr::PredicateExpr;
+use crate::adapter::cvc5::parse_interpolant_to_predicate_expr;
+use crate::adapter::sidecar::predicate_image::btor2_encode::{SignalKind, encode_design};
+
+/// Outcome of a refinement query.
+#[derive(Debug)]
+pub enum RefineOutcome {
+    /// The abstract step is spurious; this predicate separates it — a new cube
+    /// dimension for the abstraction.
+    Predicate(PredicateExpr),
+    /// The step is concretely realizable under the exact transition — not
+    /// spurious, so no refinement is needed (the driver must look elsewhere).
+    Realizable,
+    /// cvc5 absent / timed out / produced an interpolant outside the parseable
+    /// grammar, encode failed, or a predicate referenced an unknown register.
+    /// The caller falls back (a different predicate source, or abstains).
+    Unavailable(String),
+}
+
+/// P2.1 — synthesise a separating predicate for a (possibly spurious) one-step
+/// abstract transition `source(cur) → target(nx)` over the exact transition of
+/// `file`. See the module docs.
+pub fn synthesize_refinement_predicate(
+    file: &Btor2File,
+    source: &[PredicateExpr],
+    target: &[PredicateExpr],
+    timeout_ms: u32,
+) -> RefineOutcome {
+    let cfg = z3::Config::new();
+    z3::with_z3_config(&cfg, || {
+        let view = match encode_design(file) {
+            Ok(v) => v,
+            Err(e) => return RefineOutcome::Unavailable(format!("encode: {e:?}")),
+        };
+
+        // Register symbol → NID (only named state cells are addressable predicates).
+        let name_to_nid: HashMap<String, Nid> = view
+            .signals
+            .iter()
+            .filter(|s| s.kind == SignalKind::State)
+            .filter_map(|s| s.symbol.clone().map(|sym| (sym, s.nid)))
+            .collect();
+        let nid_to_name: HashMap<Nid, String> =
+            name_to_nid.iter().map(|(n, &d)| (d, n.clone())).collect();
+
+        // Controlled-name interface: next-state cells keep the register NAME (so the
+        // interpolant, over the shared vocabulary, parses straight to a PredicateExpr);
+        // current-state cells get a `__cur` suffix; inputs an `__in` suffix.
+        let named = |suffix: &str| -> HashMap<Nid, BV> {
+            view.state_curr
+                .iter()
+                .filter_map(|(nid, bv)| {
+                    let sym = nid_to_name.get(nid)?;
+                    Some((*nid, BV::new_const(format!("{sym}{suffix}"), bv.get_size())))
+                })
+                .collect()
+        };
+        let cur = named("__cur");
+        let nx = named("");
+        let inp: HashMap<Nid, BV> = view
+            .inputs
+            .iter()
+            .map(|(nid, bv)| (*nid, BV::new_const(format!("in{nid}__in"), bv.get_size())))
+            .collect();
+
+        // Instantiate the transition over the interface names.
+        let mut subs: Vec<(&BV, &BV)> = Vec::new();
+        for (nid, bv) in &view.state_curr {
+            if let Some(c) = cur.get(nid) {
+                subs.push((bv, c));
+            }
+        }
+        for (nid, bv) in &view.state_next {
+            if let Some(n) = nx.get(nid) {
+                subs.push((bv, n));
+            }
+        }
+        for (nid, bv) in &view.inputs {
+            if let Some(i) = inp.get(nid) {
+                subs.push((bv, i));
+            }
+        }
+        let transition = view.transition.substitute(&subs);
+
+        // Build the source region over `cur` and the target region over `nx`.
+        let build = |ps: &[PredicateExpr], frame: &HashMap<Nid, BV>| -> Option<Bool> {
+            let lookup = |name: &str| -> Option<BV> {
+                name_to_nid
+                    .get(name)
+                    .and_then(|nid| frame.get(nid))
+                    .cloned()
+            };
+            let mut conj = Vec::new();
+            for p in ps {
+                conj.push(p.build_constraint(&lookup)?);
+            }
+            Some(if conj.is_empty() {
+                Bool::from_bool(true)
+            } else {
+                Bool::and(&conj.iter().collect::<Vec<_>>())
+            })
+        };
+        let source_bool = match build(source, &cur) {
+            Some(b) => b,
+            None => {
+                return RefineOutcome::Unavailable("source references an unknown register".into());
+            }
+        };
+        let target_bool = match build(target, &nx) {
+            Some(b) => b,
+            None => {
+                return RefineOutcome::Unavailable("target references an unknown register".into());
+            }
+        };
+
+        let mk_solver = || {
+            let s = z3::Solver::new();
+            let mut p = z3::Params::new();
+            p.set_u32("timeout", timeout_ms);
+            s.set_params(&p);
+            s
+        };
+
+        // A = source(cur) ∧ T. Realizable ⇔ A ∧ target(nx) SAT.
+        let a = Bool::and(&[&source_bool, &transition]);
+        {
+            let s = mk_solver();
+            s.assert(&a);
+            s.assert(&target_bool);
+            match s.check() {
+                z3::SatResult::Sat => return RefineOutcome::Realizable,
+                z3::SatResult::Unknown => {
+                    return RefineOutcome::Unavailable("solver timeout on realizability".into());
+                }
+                z3::SatResult::Unsat => {} // spurious → interpolate
+            }
+        }
+
+        // Spurious: interpolate A vs B = ¬target(nx). Shared vocabulary = the
+        // next-state register names ⇒ I is a state predicate over them.
+        let b = target_bool.not();
+        let (a_decls, a_body) = match serialize_term(&a) {
+            Some(x) => x,
+            None => return RefineOutcome::Unavailable("serialize A".into()),
+        };
+        let (b_decls, b_body) = match serialize_term(&b) {
+            Some(x) => x,
+            None => return RefineOutcome::Unavailable("serialize B".into()),
+        };
+        let mut decls: BTreeSet<String> = BTreeSet::new();
+        decls.extend(a_decls);
+        decls.extend(b_decls);
+        let mut query =
+            String::from("(set-logic QF_BV)\n(set-option :produce-interpolants true)\n");
+        for d in &decls {
+            query.push_str(d);
+            query.push('\n');
+        }
+        query.push_str(&format!(
+            "(assert {a_body})\n(get-interpolant I {b_body})\n(exit)\n"
+        ));
+
+        let stdout = match run_cvc5_raw(&query, timeout_ms) {
+            Ok(s) => s,
+            Err(e) => return RefineOutcome::Unavailable(e),
+        };
+        if stdout.trim().is_empty()
+            || stdout.contains("(error")
+            || stdout
+                .lines()
+                .any(|l| l.trim() == "fail" || l.trim() == "none")
+        {
+            return RefineOutcome::Unavailable("cvc5 produced no interpolant".into());
+        }
+        match parse_interpolant_to_predicate_expr(&stdout) {
+            Some(pe) => RefineOutcome::Predicate(pe),
+            None => RefineOutcome::Unavailable(format!(
+                "interpolant outside the parseable grammar: {:?}",
+                extract_interpolant_body(&stdout)
+            )),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::parser;
+    use crate::adapter::btor2::predicate_expr::CmpOp;
+
+    // 2-bit `x` counter: init 0, next x = x + 1. No `bad` needed — refinement is
+    // about a source→target STEP, not reachability.
+    const COUNTER: &str = "1 sort bitvec 2\n2 zero 1\n3 state 1 x\n4 init 1 3 2\n\
+                           5 one 1\n6 add 1 3 5\n7 next 1 3 6\n";
+
+    fn cmp(reg: &str, value: u64) -> PredicateExpr {
+        PredicateExpr::Cmp {
+            register: reg.to_string(),
+            op: CmpOp::Eq,
+            value,
+        }
+    }
+
+    /// A spurious step (`x==0 → x==2` is impossible: `0+1=1≠2`) must yield a
+    /// separating predicate over `x`.
+    #[test]
+    fn spurious_step_yields_separating_predicate() {
+        let file = parser::parse(COUNTER).expect("parse");
+        match synthesize_refinement_predicate(&file, &[cmp("x", 0)], &[cmp("x", 2)], 5_000) {
+            RefineOutcome::Predicate(pe) => {
+                let s = format!("{pe:?}");
+                assert!(s.contains('x'), "predicate should mention x: {s}");
+            }
+            RefineOutcome::Realizable => panic!("x==0 → x==2 is NOT realizable (0+1=1)"),
+            RefineOutcome::Unavailable(w) => eprintln!("SKIP (cvc5/grammar): {w}"),
+        }
+    }
+
+    /// A realizable step (`x==0 → x==1`: `0+1=1`) must report `Realizable`, never a
+    /// spurious predicate.
+    #[test]
+    fn realizable_step_needs_no_refinement() {
+        let file = parser::parse(COUNTER).expect("parse");
+        match synthesize_refinement_predicate(&file, &[cmp("x", 0)], &[cmp("x", 1)], 5_000) {
+            RefineOutcome::Realizable => {}
+            RefineOutcome::Predicate(pe) => panic!("x==0 → x==1 IS realizable, got {pe:?}"),
+            RefineOutcome::Unavailable(w) => eprintln!("SKIP: {w}"),
+        }
+    }
+}


### PR DESCRIPTION
## Phase-2 unification core — shared refinement primitive + predicate-abstraction safety driver

Phase 2 of the IC3ia invariant-discovery track, architected to **unify** KMTS-based
verification around one shared lazy-refinement core (design: `cube-ic3ia-invariant-discovery.md`
§9) — not a third refinement loop.

### P2.1 — the shared refinement primitive (`refine.rs`)
`synthesize_refinement_predicate`: given a spurious abstract step `source(cur) → target(nx)`,
interpolate over the **exact** transition (`A ⟹ I ⟹ ¬target`) and parse `I` to a `PredicateExpr`
(#318). The one capability **both** Phase-2 drivers call (safety frame-ladder + the 3-valued
μ-calculus evaluator). Next-state vars are named by register, so the interpolant comes back as a
ready cube predicate.

### P2.2 — the safety driver (`abs_safety.rs`)
`verify_safety_abs`: predicate-abstraction forward reachability + refinement, **sound by
independent verdict verification**:
- `Safe` only when the may-reachable set `R#` is a *re-checked* inductive invariant
  (`Init⟹R#`, `R#∧T⟹R#'`, `R#⟹¬bad`) over the exact transition — a search bug can only make it
  abstain, never wrongly prove.
- `Unsafe` only when `bmc_bad_reachable` exhibits a concrete counterexample.

Seeds init + `bad`-cone `eq` atoms; refines spurious single-step edges via P2.1. **Decides a
non-1-inductive safe design that native k-induction abstains on** — via the abstraction.

### Scope
- **P2.2b (follow-up):** the IC3-frame incremental optimisation (block CTIs without enumerating
  the reachable cube set — the scalability half) + reachability-spurious refinement via path
  interpolation (the completeness half). This PR is the sound refinement-driven skeleton those
  slot into.
- Not yet wired into a surface — driver validation first.
- 6 tests (2 refine + 4 abs_safety). cvc5 (subprocess) required for the interpolation refinement;
  the driver abstains soundly when it is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
