### PR TITLE
feat(reach): P2.3 path-interp (make-or-break) + emergent-K discovery wired as safety-cube last-resort

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/abs_safety.rs
+++ b/crates/mununu-core/src/adapter/btor2/abs_safety.rs
@@ -31,7 +31,9 @@ use z3::ast::{Ast, BV, Bool};
 use crate::adapter::btor2::ast::{Btor2File, ConstValue, Nid, Node};
 use crate::adapter::btor2::native_bmc::{BmcOutcome, bmc_bad_reachable};
 use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
-use crate::adapter::btor2::refine::{RefineOutcome, synthesize_refinement_predicate};
+use crate::adapter::btor2::refine::{
+    RefineOutcome, synthesize_reachability_predicate, synthesize_refinement_predicate,
+};
 use crate::adapter::sidecar::predicate_image::btor2_encode::{SignalKind, encode_design};
 
 /// Verdict of the predicate-abstraction safety driver.
@@ -683,7 +685,7 @@ fn rec_block(
             match bmc_bad_reachable(file, (frames.len() as u32 + 2).max(4)) {
                 Ok(BmcOutcome::Violated { depth }) => return BlockResult::Unsafe { depth },
                 _ => {
-                    // Spurious → try single-step refinement (source = c, target = bad).
+                    // Spurious. First try the cheap single-step refinement.
                     let source = cube_to_predicate_list(scope, &c);
                     let bad_atoms = bad_target_atoms(file);
                     if let RefineOutcome::Predicate(p) =
@@ -691,11 +693,19 @@ fn rec_block(
                     {
                         return BlockResult::Refine(p);
                     }
-                    return BlockResult::Unknown(
-                        "IC3 spurious CEX with no single-step refinement (path interpolation = \
-                         further increment)"
-                            .into(),
-                    );
+                    // P2.3 — reachability spuriousness: single-step can't add a
+                    // reachability-constraining predicate; PATH-interpolate over the
+                    // suffix bounded by the ladder depth.
+                    match synthesize_reachability_predicate(file, frames.len(), timeout_ms) {
+                        RefineOutcome::Predicate(p) => return BlockResult::Refine(p),
+                        _ => {
+                            return BlockResult::Unknown(
+                                "IC3 spurious CEX; neither single-step nor path interpolation \
+                                 yielded a parseable predicate (grammar ceiling — emergent-K)"
+                                    .into(),
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -1128,6 +1138,25 @@ mod tests {
             }
             other => panic!("expected Unsafe depth 0 (IC3), got {other:?}"),
         }
+    }
+
+    /// P2.3 make-or-break probe: run the IC3 frame ladder (with path-interpolation
+    /// refinement) on a real HWMCC design (`MUNUNU_INTERP_PROBE`), printing the
+    /// verdict + wall-clock — does IC3's cheap blocking + rare interpolation decide
+    /// it? Ignored by default (needs an external file + cvc5).
+    #[test]
+    #[ignore = "reads an external BTOR2 file named by MUNUNU_INTERP_PROBE"]
+    fn probe_ic3_on_external_design() {
+        let path = std::env::var("MUNUNU_INTERP_PROBE")
+            .expect("set MUNUNU_INTERP_PROBE=/path/to/design.btor2");
+        let content = std::fs::read_to_string(&path).expect("read design");
+        let file = parser::parse(&content).expect("parse btor2");
+        let t0 = std::time::Instant::now();
+        let v = verify_safety_ic3(&file, 40, 24, 8_000);
+        eprintln!(
+            "IC3 verdict on {path} [{}ms]: {v:?}",
+            t0.elapsed().as_millis()
+        );
     }
 
     /// The IC3 frame ladder proves the non-1-inductive safe design via *incremental

--- a/crates/mununu-core/src/adapter/btor2/abs_safety.rs
+++ b/crates/mununu-core/src/adapter/btor2/abs_safety.rs
@@ -32,7 +32,7 @@ use crate::adapter::btor2::ast::{Btor2File, ConstValue, Nid, Node};
 use crate::adapter::btor2::native_bmc::{BmcOutcome, bmc_bad_reachable};
 use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
 use crate::adapter::btor2::refine::{
-    RefineOutcome, synthesize_reachability_predicate, synthesize_refinement_predicate,
+    RefineOutcome, sequence_interpolant_predicates, synthesize_refinement_predicate,
 };
 use crate::adapter::sidecar::predicate_image::btor2_encode::{SignalKind, encode_design};
 
@@ -505,9 +505,20 @@ fn extract_cube(model: &z3::Model, pred_cur: &[Bool]) -> IcCube {
         .collect()
 }
 
-/// P2.2b — decide `AG ¬bad` by the IC3 frame ladder over the predicate abstraction,
-/// with P2.1 refinement. Sound by independent verdict verification (see the module
-/// banner). `max_frames` bounds the ladder depth; `max_refine` the refinement loop.
+/// P2.2b/P2.3b — decide `AG ¬bad` by the IC3 frame ladder over the predicate
+/// abstraction, with sequence-interpolation refinement (P2.3b). Sound by independent
+/// verdict verification (see the module banner); guarded so it always terminates
+/// (abstains on non-convergence). `max_frames` bounds the ladder depth; `max_refine`
+/// the refinement loop.
+///
+/// **Honest status (the make-or-break result, 2026-07-13):** decides small designs
+/// but does NOT converge on real ones (even 644-byte `paper_v3`) — the CTI blocking
+/// hits its iteration guard and abstains. z3-SPACER decides these instantly. A
+/// competitive owned IC3/PDR is a large specialised engine; this is a research
+/// FOUNDATION whose *reusable* value is the refinement primitives in
+/// [`super::refine`] (P2.1/P2.3, reused by the branching driver P2.4), not a
+/// production safety engine — safety-at-scale is covered by
+/// [`super::native_interp`] + z3-SPACER. Not wired into any surface.
 pub fn verify_safety_ic3(
     file: &Btor2File,
     max_frames: usize,
@@ -523,13 +534,19 @@ pub fn verify_safety_ic3(
                 };
             }
             Ic3Pass::Unsafe { depth } => return AbsVerdict::Unsafe { depth },
-            Ic3Pass::Refine(p) => {
-                if preds.contains(&p) {
+            Ic3Pass::Refine(ps) => {
+                let before = preds.len();
+                for p in ps {
+                    if !preds.contains(&p) {
+                        preds.push(p);
+                    }
+                }
+                if preds.len() == before {
                     return AbsVerdict::Unknown {
-                        reason: "IC3 refinement stalled (predicate already present)".into(),
+                        reason: "IC3 refinement stalled (no new predicate — grammar ceiling)"
+                            .into(),
                     };
                 }
-                preds.push(p);
             }
             Ic3Pass::Unknown(reason) => return AbsVerdict::Unknown { reason },
         }
@@ -542,7 +559,7 @@ pub fn verify_safety_ic3(
 enum Ic3Pass {
     Safe,
     Unsafe { depth: u32 },
-    Refine(PredicateExpr),
+    Refine(Vec<PredicateExpr>),
     Unknown(String),
 }
 
@@ -586,8 +603,16 @@ fn ic3_pass(
                 return Ic3Pass::Unknown(format!("IC3 exceeded {max_frames} frames"));
             }
 
-            // Block every bad-predecessor in F(k).
+            // Block every bad-predecessor in F(k). Bounded so a blocking that fails to
+            // converge (an implementation-completeness gap) ABSTAINS rather than hangs.
+            let mut block_iters = 0u32;
             loop {
+                block_iters += 1;
+                if block_iters > 400 {
+                    return Ic3Pass::Unknown(
+                        "IC3 blocking-iteration limit (no convergence)".into(),
+                    );
+                }
                 let query = Bool::and(&[
                     &frame_formula(&scope, &frames, k),
                     &scope.transition,
@@ -653,7 +678,7 @@ fn ic3_pass(
 enum BlockResult {
     Blocked,
     Unsafe { depth: u32 },
-    Refine(PredicateExpr),
+    Refine(Vec<PredicateExpr>),
     Unknown(String),
 }
 
@@ -671,14 +696,20 @@ fn rec_block(
     mk: &dyn Fn() -> z3::Solver,
     timeout_ms: u32,
 ) -> BlockResult {
-    // Obligations processed lowest-level-first.
+    // Obligations processed lowest-level-first. Bounded so a runaway obligation
+    // chain abstains rather than hangs.
     let mut obligations: Vec<(usize, IcCube)> = vec![(lvl, s0)];
+    let mut steps = 0u32;
     while let Some(idx) = obligations
         .iter()
         .enumerate()
         .min_by_key(|(_, (l, _))| *l)
         .map(|(i, _)| i)
     {
+        steps += 1;
+        if steps > 2000 {
+            return BlockResult::Unknown("IC3 obligation limit (no convergence)".into());
+        }
         let (j, c) = obligations.remove(idx);
         if j == 0 {
             // Abstract CEX reaches Init. Concrete check bounds by the ladder depth.
@@ -691,21 +722,20 @@ fn rec_block(
                     if let RefineOutcome::Predicate(p) =
                         synthesize_refinement_predicate(file, &source, &bad_atoms, timeout_ms)
                     {
-                        return BlockResult::Refine(p);
+                        return BlockResult::Refine(vec![p]);
                     }
-                    // P2.3 — reachability spuriousness: single-step can't add a
-                    // reachability-constraining predicate; PATH-interpolate over the
-                    // suffix bounded by the ladder depth.
-                    match synthesize_reachability_predicate(file, frames.len(), timeout_ms) {
-                        RefineOutcome::Predicate(p) => return BlockResult::Refine(p),
-                        _ => {
-                            return BlockResult::Unknown(
-                                "IC3 spurious CEX; neither single-step nor path interpolation \
-                                 yielded a parseable predicate (grammar ceiling — emergent-K)"
-                                    .into(),
-                            );
-                        }
+                    // P2.3b — targeted per-trace refinement: SEQUENCE-interpolate the
+                    // depth-n BMC unrolling of this spurious counterexample → a SET of
+                    // reachability predicates that collectively rule the trace out.
+                    let ps = sequence_interpolant_predicates(file, frames.len(), timeout_ms);
+                    if !ps.is_empty() {
+                        return BlockResult::Refine(ps);
                     }
+                    return BlockResult::Unknown(
+                        "IC3 spurious CEX; sequence interpolation yielded no parseable \
+                         predicate (grammar ceiling — emergent-K)"
+                            .into(),
+                    );
                 }
             }
         }
@@ -1151,8 +1181,19 @@ mod tests {
             .expect("set MUNUNU_INTERP_PROBE=/path/to/design.btor2");
         let content = std::fs::read_to_string(&path).expect("read design");
         let file = parser::parse(&content).expect("parse btor2");
+        let eu = |k: &str, d: u32| {
+            std::env::var(k)
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(d)
+        };
         let t0 = std::time::Instant::now();
-        let v = verify_safety_ic3(&file, 40, 24, 8_000);
+        let v = verify_safety_ic3(
+            &file,
+            eu("MUNUNU_IC3_FRAMES", 40) as usize,
+            eu("MUNUNU_IC3_REFINE", 24),
+            eu("MUNUNU_IC3_QTO", 8_000),
+        );
         eprintln!(
             "IC3 verdict on {path} [{}ms]: {v:?}",
             t0.elapsed().as_millis()

--- a/crates/mununu-core/src/adapter/btor2/refine.rs
+++ b/crates/mununu-core/src/adapter/btor2/refine.rs
@@ -463,6 +463,214 @@ pub fn synthesize_reachability_predicate(
 /// the single (often redundant) predicate a one-cut interpolation gives. Empty when
 /// `bad` is reachable within `depth` (a real CEX — the caller confirms elsewhere) or
 /// every interpolant is outside the `#318` grammar.
+/// **Emergent-K** — discover RELATIONAL invariants by ITERATIVE forward
+/// interpolation. Starting from `R = Init`, repeatedly interpolate
+/// `A = R(s0) ∧ T(s0,s1)` against `B = ¬bad(s1)`; the interpolant `I(s1)` (a
+/// reachable-state over-approximation excluding `bad`) is parsed to a
+/// [`PredicateExpr`] and `R` grows by it. The key (de-risked 2026-07-13): from
+/// concrete `Init` the first interpolant is concrete values, but as `R` grows to
+/// span a relational region cvc5 GENERALISES the interpolant to the relation
+/// (e.g. `data == target`) — an "emergent" predicate that no *syntactic* extractor
+/// finds. Returns the discovered predicates (the relational ones are the payoff),
+/// most-general last. Stops at a fixpoint, an unparseable interpolant (grammar
+/// ceiling), or when `bad` is one-step reachable from `R` (the invariant fails).
+pub fn discover_relational_predicates(
+    file: &Btor2File,
+    max_iters: usize,
+    timeout_ms: u32,
+) -> Vec<PredicateExpr> {
+    let cfg = z3::Config::new();
+    z3::with_z3_config(&cfg, || {
+        let view = match encode_design(file) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        let nid_to_name: HashMap<Nid, String> = view
+            .signals
+            .iter()
+            .filter(|s| s.kind == SignalKind::State)
+            .filter_map(|s| s.symbol.clone().map(|sym| (s.nid, sym)))
+            .collect();
+        let mk_state = |tag: &dyn Fn(&str) -> String| -> HashMap<Nid, BV> {
+            view.state_curr
+                .iter()
+                .filter_map(|(nid, bv)| {
+                    nid_to_name
+                        .get(nid)
+                        .map(|sym| (*nid, BV::new_const(tag(sym), bv.get_size())))
+                })
+                .collect()
+        };
+        let s0 = mk_state(&|sym| format!("{sym}__cur")); // current state (R's vocabulary)
+        let s1 = mk_state(&|sym| sym.to_string()); // next state (interpolant vocabulary)
+        let inp0: HashMap<Nid, BV> = view
+            .inputs
+            .iter()
+            .map(|(nid, bv)| (*nid, BV::new_const(format!("in{nid}"), bv.get_size())))
+            .collect();
+        // T(s0 → s1).
+        let transition = {
+            let mut subs: Vec<(&BV, &BV)> = Vec::new();
+            for (nid, bv) in &view.state_curr {
+                if let Some(s) = s0.get(nid) {
+                    subs.push((bv, s));
+                }
+            }
+            for (nid, bv) in &view.state_next {
+                if let Some(d) = s1.get(nid) {
+                    subs.push((bv, d));
+                }
+            }
+            for (nid, bv) in &view.inputs {
+                if let Some(i) = inp0.get(nid) {
+                    subs.push((bv, i));
+                }
+            }
+            view.transition.substitute(&subs)
+        };
+        let one1 = BV::from_u64(1, 1);
+        let bad_ops: Vec<Nid> = file
+            .lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                crate::adapter::btor2::ast::Node::Bad { signal } => Some(signal.nid()),
+                _ => None,
+            })
+            .collect();
+        // `bad` over `s1`.
+        let bad_s1 = {
+            let subs: Vec<(&BV, &BV)> = view
+                .state_curr
+                .iter()
+                .filter_map(|(nid, bv)| s1.get(nid).map(|s| (bv, s)))
+                .collect();
+            let disj: Vec<Bool> = bad_ops
+                .iter()
+                .filter_map(|op| {
+                    view.signal_bvs
+                        .get(op)
+                        .or_else(|| view.state_curr.get(op))
+                        .map(|bv| bv.substitute(&subs).eq(&one1))
+                })
+                .collect();
+            if disj.is_empty() {
+                Bool::from_bool(false)
+            } else {
+                Bool::or(&disj.iter().collect::<Vec<_>>())
+            }
+        };
+        // Init(s0).
+        let init = {
+            let subs: Vec<(&BV, &BV)> = view
+                .state_curr
+                .iter()
+                .filter_map(|(nid, bv)| s0.get(nid).map(|c| (bv, c)))
+                .collect();
+            let conj: Vec<Bool> = file
+                .lines
+                .iter()
+                .filter_map(|l| match &l.node {
+                    crate::adapter::btor2::ast::Node::Init { state, value, .. } => {
+                        let c = s0.get(state)?;
+                        let vbv = view
+                            .signal_bvs
+                            .get(&value.nid())
+                            .or_else(|| view.state_curr.get(&value.nid()))?
+                            .substitute(&subs);
+                        Some(c.eq(&vbv))
+                    }
+                    _ => None,
+                })
+                .collect();
+            if conj.is_empty() {
+                Bool::from_bool(true)
+            } else {
+                Bool::and(&conj.iter().collect::<Vec<_>>())
+            }
+        };
+        // Build a PredicateExpr as a z3 Bool over `s0` (to grow `R`).
+        let over_s0 = |p: &PredicateExpr| -> Option<Bool> {
+            let name_to_nid: HashMap<&str, Nid> =
+                nid_to_name.iter().map(|(n, s)| (s.as_str(), *n)).collect();
+            let lookup = |name: &str| name_to_nid.get(name).and_then(|nid| s0.get(nid)).cloned();
+            p.build_constraint(&lookup)
+        };
+
+        let mk = || {
+            let s = z3::Solver::new();
+            let mut pr = z3::Params::new();
+            pr.set_u32("timeout", timeout_ms);
+            s.set_params(&pr);
+            s
+        };
+
+        let mut r = init.clone();
+        let mut discovered: Vec<PredicateExpr> = Vec::new();
+        for _ in 0..max_iters.max(1) {
+            // If `bad` is one-step reachable from R, the invariant fails — stop.
+            {
+                let s = mk();
+                s.assert(Bool::and(&[&r, &transition, &bad_s1]));
+                if s.check() != z3::SatResult::Unsat {
+                    break;
+                }
+            }
+            // Interpolate A = R ∧ T  vs  B = ¬bad(s1).  I over s1 (register names).
+            let a = Bool::and(&[&r, &transition]);
+            let b = bad_s1.not();
+            let (a_decls, a_body) = match serialize_term(&a) {
+                Some(x) => x,
+                None => break,
+            };
+            let (b_decls, b_body) = match serialize_term(&b) {
+                Some(x) => x,
+                None => break,
+            };
+            let mut decls: BTreeSet<String> = BTreeSet::new();
+            decls.extend(a_decls);
+            decls.extend(b_decls);
+            let mut query =
+                String::from("(set-logic QF_BV)\n(set-option :produce-interpolants true)\n");
+            for d in &decls {
+                query.push_str(d);
+                query.push('\n');
+            }
+            query.push_str(&format!(
+                "(assert {a_body})\n(get-interpolant I {b_body})\n(exit)\n"
+            ));
+            let stdout = match run_cvc5_raw(&query, timeout_ms) {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            let p = match parse_interpolant_to_predicate_expr(&stdout) {
+                Some(p) => p,
+                None => break, // grammar ceiling
+            };
+            // Grow R by the new predicate; stop at a fixpoint (nothing new).
+            let grown = match over_s0(&p) {
+                Some(pb) => pb,
+                None => break,
+            };
+            let is_new = !discovered.contains(&p);
+            if is_new {
+                discovered.push(p);
+            }
+            let new_r = Bool::or(&[&r, &grown]);
+            // Fixpoint: R didn't grow (new_r ⟹ r) AND no new predicate.
+            let fixed = {
+                let s = mk();
+                s.assert(Bool::and(&[&new_r, &r.not()]));
+                s.check() == z3::SatResult::Unsat
+            };
+            r = new_r;
+            if fixed && !is_new {
+                break;
+            }
+        }
+        discovered
+    })
+}
+
 pub fn sequence_interpolant_predicates(
     file: &Btor2File,
     depth: usize,
@@ -536,6 +744,121 @@ mod tests {
                 panic!("bad (b==2) is NOT reachable — cannot be Realizable")
             }
         }
+    }
+
+    /// Emergent-K: the iterative forward interpolation DISCOVERS the relational
+    /// invariant `data == target` — a predicate with NO syntactic `eq` node in the
+    /// design (the invariant is only implied by the two counters incrementing
+    /// together). This is the emergent-K payoff: a relation no syntactic extractor
+    /// finds, synthesised from interpolation.
+    #[test]
+    fn discovers_emergent_relational_invariant() {
+        // data, target: 8-bit, both init 0, both += 1 ⇒ data==target invariant.
+        // bad = (data != target) — never holds. NO `eq` node anywhere.
+        const D: &str = "1 sort bitvec 8\n2 sort bitvec 1\n3 zero 1\n4 one 1\n\
+                         5 state 1 data\n6 init 1 5 3\n7 state 1 target\n8 init 1 7 3\n\
+                         9 add 1 5 4\n10 next 1 5 9\n11 add 1 7 4\n12 next 1 7 11\n\
+                         13 neq 2 5 7\n14 bad 13\n";
+        let file = parser::parse(D).expect("parse");
+        let preds = discover_relational_predicates(&file, 8, 5_000);
+        if preds.is_empty() {
+            eprintln!("SKIP (cvc5 absent / grammar): no predicates discovered");
+            return;
+        }
+        // A relational `data == target` (CmpReg) must be among the discovered preds.
+        let found_relation = preds.iter().any(|p| {
+            matches!(p, PredicateExpr::CmpReg { lhs, op, rhs }
+                if *op == CmpOp::Eq
+                    && ((lhs == "data" && rhs == "target") || (lhs == "target" && rhs == "data")))
+        });
+        assert!(
+            found_relation,
+            "expected to discover the emergent relation data==target; got {preds:?}"
+        );
+    }
+
+    /// Emergent-K on an INEQUALITY bound: a saturating counter (`cnt' = cnt>=5 ? 5 :
+    /// cnt+1`) has the invariant `cnt <= 5`. No `eq` node; the *syntactic* extractors
+    /// are equality-only, so this bound is exactly the kind of invariant interpolation
+    /// can uniquely supply. Expect the discovery to find `cnt <= 5` (`Cmp{Le}`).
+    #[test]
+    fn discovers_inequality_bound_invariant() {
+        const D: &str = "1 sort bitvec 8\n2 sort bitvec 1\n3 constd 1 5\n4 one 1\n5 zero 1\n\
+                         6 state 1 cnt\n7 init 1 6 5\n8 ugte 2 6 3\n9 add 1 6 4\n\
+                         10 ite 1 8 3 9\n11 next 1 6 10\n12 ugt 2 6 3\n13 bad 12\n";
+        let file = parser::parse(D).expect("parse");
+        let preds = discover_relational_predicates(&file, 8, 5_000);
+        if preds.is_empty() {
+            eprintln!("SKIP (cvc5 absent / grammar): none discovered");
+            return;
+        }
+        let found_bound = preds.iter().any(|p| {
+            matches!(p, PredicateExpr::Cmp { register, op, value }
+                if register == "cnt" && matches!(op, CmpOp::Le | CmpOp::Lt) && *value >= 5)
+        });
+        assert!(
+            found_bound,
+            "expected to discover the bound invariant cnt<=5; got {preds:?}"
+        );
+    }
+
+    /// Validation sweep: run the interpolation invariant-discovery over every
+    /// `*.btor2` in `MUNUNU_DISCOVER_DIR` (real HWMCC / OpenTitan designs) and print
+    /// the discovered predicates per design — how often does it find a non-trivial
+    /// relational / bound invariant on REAL designs? `#[ignore]`d.
+    #[test]
+    #[ignore = "sweeps an external BTOR2 dir named by MUNUNU_DISCOVER_DIR"]
+    fn sweep_discovery_on_external_designs() {
+        let dir = std::env::var("MUNUNU_DISCOVER_DIR").expect("set MUNUNU_DISCOVER_DIR");
+        let max_bytes: u64 = std::env::var("MUNUNU_DISCOVER_MAXBYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(20_000);
+        let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
+            .expect("read dir")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|x| x == "btor2"))
+            .filter(|p| {
+                std::fs::metadata(p)
+                    .map(|m| m.len() <= max_bytes)
+                    .unwrap_or(false)
+            })
+            .collect();
+        files.sort();
+        let mut found = 0usize;
+        let mut relational = 0usize;
+        for p in &files {
+            let Ok(content) = std::fs::read_to_string(p) else {
+                continue;
+            };
+            let Ok(file) = parser::parse(&content) else {
+                continue;
+            };
+            let preds = discover_relational_predicates(&file, 8, 4_000);
+            if preds.is_empty() {
+                continue;
+            }
+            found += 1;
+            let rel = preds.iter().any(|pe| {
+                matches!(
+                    pe,
+                    PredicateExpr::CmpReg { .. } | PredicateExpr::CmpRegAddend { .. }
+                ) || matches!(pe, PredicateExpr::Cmp { op, .. } if !matches!(op, CmpOp::Eq | CmpOp::Ne))
+            });
+            if rel {
+                relational += 1;
+            }
+            let name = p.file_name().unwrap().to_string_lossy();
+            eprintln!("  {name}: {preds:?}");
+        }
+        eprintln!(
+            "\nSWEEP: {} designs (<= {}B); discovered non-trivial on {}, of which {} had a \
+             RELATIONAL/BOUND invariant (the interpolation-unique forms)",
+            files.len(),
+            max_bytes,
+            found,
+            relational
+        );
     }
 
     /// A realizable step (`x==0 → x==1`: `0+1=1`) must report `Realizable`, never a

--- a/crates/mununu-core/src/adapter/btor2/refine.rs
+++ b/crates/mununu-core/src/adapter/btor2/refine.rs
@@ -215,28 +215,23 @@ pub fn synthesize_refinement_predicate(
     })
 }
 
-/// P2.3 — synthesise a **reachability-constraining** predicate via PATH
-/// interpolation: the Craig interpolant of `A = Init(s0) ∧ T(s0,s1)` against
-/// `B = ¬(bad reachable within `suffix_depth` steps from s1)`, over the exact
-/// transition, parsed to a [`PredicateExpr`].
-///
-/// This closes the gap the single-step [`synthesize_refinement_predicate`] cannot:
-/// a cube that is *abstractly* reachable but *concretely* unreachable (every single
-/// step realizable, the composed path not) needs a predicate that constrains
-/// **reachability**, which only a multi-step suffix interpolant supplies. `I(s1)`
-/// over-approximates the one-step image of `Init` while excluding states that reach
-/// `bad` within `suffix_depth` — exactly such a predicate.
-///
-/// Returns `Realizable` when `bad` IS reachable within the suffix from `Init`'s
-/// image (no interpolant — the caller confirms a real CEX elsewhere), and
-/// `Unavailable` when cvc5 is absent / the interpolant is outside the `#318`
-/// grammar (the grammar ceiling — the emergent-K parser-extension frontier).
-pub fn synthesize_reachability_predicate(
+/// P2.3b — the Craig interpolant AT CUT `cut` of the depth-`depth` BMC unrolling
+/// `Init(s0) ∧ T(s0,s1) ∧ … ∧ T(s_{depth-1}, s_depth)` with `bad` at any step
+/// `≥ cut`: `A = Init ∧ (prefix to s_cut)` vs `B = ¬(bad reachable from s_cut
+/// within the suffix)`. `I(s_cut)` — over-approximates the states reachable in
+/// `cut` steps AND excludes states that reach `bad` in the remaining suffix — is a
+/// **reachability-constraining** predicate. Sweeping `cut` (see
+/// [`sequence_interpolant_predicates`]) is the targeted per-trace refinement IC3ia
+/// needs; a single cut is what [`synthesize_reachability_predicate`] uses.
+#[allow(clippy::needless_range_loop)] // `m` indexes both `state(m)` and `inp[m]`
+fn interpolant_at_cut(
     file: &Btor2File,
-    suffix_depth: usize,
+    cut: usize,
+    depth: usize,
     timeout_ms: u32,
 ) -> RefineOutcome {
-    let k = suffix_depth.max(1);
+    let depth = depth.max(1);
+    let cut = cut.clamp(1, depth);
     let cfg = z3::Config::new();
     z3::with_z3_config(&cfg, || {
         let view = match encode_design(file) {
@@ -250,8 +245,8 @@ pub fn synthesize_reachability_predicate(
             .filter_map(|s| s.symbol.clone().map(|sym| (s.nid, sym)))
             .collect();
 
-        // Frame state maps: `s0` (`<reg>__cur`), `s1` (`<reg>` — the interpolation
-        // vocabulary, so `I` parses to a predicate), `s2..sk` (`<reg>__f<j>`).
+        // s0 = `<reg>__cur`; the cut state s_cut = `<reg>` (interpolation vocabulary,
+        // so `I` parses to a predicate); every other step = `<reg>__f<j>`.
         let mk_state = |tag: &dyn Fn(&str) -> String| -> HashMap<Nid, BV> {
             view.state_curr
                 .iter()
@@ -263,13 +258,15 @@ pub fn synthesize_reachability_predicate(
                 .collect()
         };
         let s0 = mk_state(&|sym| format!("{sym}__cur"));
-        let mut frames: Vec<HashMap<Nid, BV>> = Vec::new(); // frames[j] = state at step j+1
-        frames.push(mk_state(&|sym| sym.to_string())); // s1 = register name
-        for j in 2..=k {
-            frames.push(mk_state(&|sym| format!("{sym}__f{j}")));
+        let mut frames: Vec<HashMap<Nid, BV>> = Vec::new(); // frames[m-1] = state at step m (1..=depth)
+        for m in 1..=depth {
+            if m == cut {
+                frames.push(mk_state(&|sym| sym.to_string()));
+            } else {
+                frames.push(mk_state(&|sym| format!("{sym}__f{m}")));
+            }
         }
-        // Fresh inputs per step (0..k): step `t` uses `inp[t]`.
-        let inp: Vec<HashMap<Nid, BV>> = (0..=k)
+        let inp: Vec<HashMap<Nid, BV>> = (0..=depth)
             .map(|t| {
                 view.inputs
                     .iter()
@@ -277,8 +274,9 @@ pub fn synthesize_reachability_predicate(
                     .collect()
             })
             .collect();
+        // State at step m: s0 for m == 0, else frames[m-1].
+        let state = |m: usize| -> &HashMap<Nid, BV> { if m == 0 { &s0 } else { &frames[m - 1] } };
 
-        // The transition from state map `src` to `dst` using inputs `iv`.
         let trans =
             |src: &HashMap<Nid, BV>, dst: &HashMap<Nid, BV>, iv: &HashMap<Nid, BV>| -> Bool {
                 let mut subs: Vec<(&BV, &BV)> = Vec::new();
@@ -299,7 +297,6 @@ pub fn synthesize_reachability_predicate(
                 }
                 view.transition.substitute(&subs)
             };
-        // `bad` over a state map + its inputs.
         let one1 = BV::from_u64(1, 1);
         let bad_ops: Vec<Nid> = file
             .lines
@@ -340,7 +337,6 @@ pub fn synthesize_reachability_predicate(
             }
         };
 
-        // Init(s0).
         let init = {
             let subs: Vec<(&BV, &BV)> = view
                 .state_curr
@@ -370,22 +366,28 @@ pub fn synthesize_reachability_predicate(
             }
         };
 
-        // A = Init(s0) ∧ T(s0→s1).
-        let a = Bool::and(&[&init, &trans(&s0, &frames[0], &inp[0])]);
-        // reach = ⋁_{j=1}^{k} [ (⋀_{i=1}^{j-1} T(s_i→s_{i+1})) ∧ bad(s_j) ].
+        // A = Init(s0) ∧ prefix to s_cut  (steps 0→1 … (cut-1)→cut).
+        let mut a_terms = vec![init];
+        for m in 0..cut {
+            a_terms.push(trans(state(m), state(m + 1), &inp[m]));
+        }
+        let a = Bool::and(&a_terms.iter().collect::<Vec<_>>());
+
+        // reach = bad reachable from s_cut within the suffix:
+        //   ⋁_{j=cut}^{depth} [ (⋀_{m=cut}^{j-1} T(s_m→s_{m+1})) ∧ bad(s_j) ].
         let mut reach_disj: Vec<Bool> = Vec::new();
-        for j in 1..=k {
+        for j in cut..=depth {
             let mut path: Vec<Bool> = Vec::new();
-            for i in 1..j {
-                path.push(trans(&frames[i - 1], &frames[i], &inp[i]));
+            for m in cut..j {
+                path.push(trans(state(m), state(m + 1), &inp[m]));
             }
-            path.push(bad_over(&frames[j - 1], &inp[j - 1]));
+            path.push(bad_over(state(j), &inp[j]));
             reach_disj.push(Bool::and(&path.iter().collect::<Vec<_>>()));
         }
         let reach = Bool::or(&reach_disj.iter().collect::<Vec<_>>());
         let b = reach.not();
 
-        // Realizable (bad reachable within k from Init) ⇒ no interpolant.
+        // Realizable (bad reachable from Init's prefix through the suffix) ⇒ no interpolant.
         {
             let solver = z3::Solver::new();
             let mut params = z3::Params::new();
@@ -402,7 +404,6 @@ pub fn synthesize_reachability_predicate(
             }
         }
 
-        // Interpolate A vs B; I over `s1` (register names) → PredicateExpr.
         let (a_decls, a_body) = match serialize_term(&a) {
             Some(x) => x,
             None => return RefineOutcome::Unavailable("serialize A".into()),
@@ -443,6 +444,40 @@ pub fn synthesize_reachability_predicate(
             )),
         }
     })
+}
+
+/// P2.3 — a single reachability predicate: the interpolant at cut 1 of a
+/// depth-`suffix_depth` unrolling. See [`interpolant_at_cut`].
+pub fn synthesize_reachability_predicate(
+    file: &Btor2File,
+    suffix_depth: usize,
+    timeout_ms: u32,
+) -> RefineOutcome {
+    interpolant_at_cut(file, 1, suffix_depth, timeout_ms)
+}
+
+/// P2.3b — the SEQUENCE of predicates from interpolating the depth-`depth` BMC
+/// unrolling at every cut `1..=depth` (the targeted per-trace refinement IC3ia
+/// needs). Returns the parseable, deduplicated interpolant predicates — a SET that
+/// collectively rules out the spurious depth-`depth` counterexample, rather than
+/// the single (often redundant) predicate a one-cut interpolation gives. Empty when
+/// `bad` is reachable within `depth` (a real CEX — the caller confirms elsewhere) or
+/// every interpolant is outside the `#318` grammar.
+pub fn sequence_interpolant_predicates(
+    file: &Btor2File,
+    depth: usize,
+    timeout_ms: u32,
+) -> Vec<PredicateExpr> {
+    let depth = depth.clamp(1, 24);
+    let mut out: Vec<PredicateExpr> = Vec::new();
+    for cut in 1..=depth {
+        if let RefineOutcome::Predicate(p) = interpolant_at_cut(file, cut, depth, timeout_ms)
+            && !out.contains(&p)
+        {
+            out.push(p);
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/mununu-core/src/adapter/btor2/refine.rs
+++ b/crates/mununu-core/src/adapter/btor2/refine.rs
@@ -215,6 +215,236 @@ pub fn synthesize_refinement_predicate(
     })
 }
 
+/// P2.3 — synthesise a **reachability-constraining** predicate via PATH
+/// interpolation: the Craig interpolant of `A = Init(s0) ∧ T(s0,s1)` against
+/// `B = ¬(bad reachable within `suffix_depth` steps from s1)`, over the exact
+/// transition, parsed to a [`PredicateExpr`].
+///
+/// This closes the gap the single-step [`synthesize_refinement_predicate`] cannot:
+/// a cube that is *abstractly* reachable but *concretely* unreachable (every single
+/// step realizable, the composed path not) needs a predicate that constrains
+/// **reachability**, which only a multi-step suffix interpolant supplies. `I(s1)`
+/// over-approximates the one-step image of `Init` while excluding states that reach
+/// `bad` within `suffix_depth` — exactly such a predicate.
+///
+/// Returns `Realizable` when `bad` IS reachable within the suffix from `Init`'s
+/// image (no interpolant — the caller confirms a real CEX elsewhere), and
+/// `Unavailable` when cvc5 is absent / the interpolant is outside the `#318`
+/// grammar (the grammar ceiling — the emergent-K parser-extension frontier).
+pub fn synthesize_reachability_predicate(
+    file: &Btor2File,
+    suffix_depth: usize,
+    timeout_ms: u32,
+) -> RefineOutcome {
+    let k = suffix_depth.max(1);
+    let cfg = z3::Config::new();
+    z3::with_z3_config(&cfg, || {
+        let view = match encode_design(file) {
+            Ok(v) => v,
+            Err(e) => return RefineOutcome::Unavailable(format!("encode: {e:?}")),
+        };
+        let nid_to_name: HashMap<Nid, String> = view
+            .signals
+            .iter()
+            .filter(|s| s.kind == SignalKind::State)
+            .filter_map(|s| s.symbol.clone().map(|sym| (s.nid, sym)))
+            .collect();
+
+        // Frame state maps: `s0` (`<reg>__cur`), `s1` (`<reg>` — the interpolation
+        // vocabulary, so `I` parses to a predicate), `s2..sk` (`<reg>__f<j>`).
+        let mk_state = |tag: &dyn Fn(&str) -> String| -> HashMap<Nid, BV> {
+            view.state_curr
+                .iter()
+                .filter_map(|(nid, bv)| {
+                    nid_to_name
+                        .get(nid)
+                        .map(|sym| (*nid, BV::new_const(tag(sym), bv.get_size())))
+                })
+                .collect()
+        };
+        let s0 = mk_state(&|sym| format!("{sym}__cur"));
+        let mut frames: Vec<HashMap<Nid, BV>> = Vec::new(); // frames[j] = state at step j+1
+        frames.push(mk_state(&|sym| sym.to_string())); // s1 = register name
+        for j in 2..=k {
+            frames.push(mk_state(&|sym| format!("{sym}__f{j}")));
+        }
+        // Fresh inputs per step (0..k): step `t` uses `inp[t]`.
+        let inp: Vec<HashMap<Nid, BV>> = (0..=k)
+            .map(|t| {
+                view.inputs
+                    .iter()
+                    .map(|(nid, bv)| (*nid, BV::new_const(format!("in{nid}__t{t}"), bv.get_size())))
+                    .collect()
+            })
+            .collect();
+
+        // The transition from state map `src` to `dst` using inputs `iv`.
+        let trans =
+            |src: &HashMap<Nid, BV>, dst: &HashMap<Nid, BV>, iv: &HashMap<Nid, BV>| -> Bool {
+                let mut subs: Vec<(&BV, &BV)> = Vec::new();
+                for (nid, bv) in &view.state_curr {
+                    if let Some(s) = src.get(nid) {
+                        subs.push((bv, s));
+                    }
+                }
+                for (nid, bv) in &view.state_next {
+                    if let Some(d) = dst.get(nid) {
+                        subs.push((bv, d));
+                    }
+                }
+                for (nid, bv) in &view.inputs {
+                    if let Some(i) = iv.get(nid) {
+                        subs.push((bv, i));
+                    }
+                }
+                view.transition.substitute(&subs)
+            };
+        // `bad` over a state map + its inputs.
+        let one1 = BV::from_u64(1, 1);
+        let bad_ops: Vec<Nid> = file
+            .lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                crate::adapter::btor2::ast::Node::Bad { signal } => Some(signal.nid()),
+                _ => None,
+            })
+            .collect();
+        if bad_ops.is_empty() {
+            return RefineOutcome::Unavailable("design has no `bad`".into());
+        }
+        let bad_over = |st: &HashMap<Nid, BV>, iv: &HashMap<Nid, BV>| -> Bool {
+            let mut subs: Vec<(&BV, &BV)> = Vec::new();
+            for (nid, bv) in &view.state_curr {
+                if let Some(s) = st.get(nid) {
+                    subs.push((bv, s));
+                }
+            }
+            for (nid, bv) in &view.inputs {
+                if let Some(i) = iv.get(nid) {
+                    subs.push((bv, i));
+                }
+            }
+            let disj: Vec<Bool> = bad_ops
+                .iter()
+                .filter_map(|op| {
+                    view.signal_bvs
+                        .get(op)
+                        .or_else(|| view.state_curr.get(op))
+                        .map(|bv| bv.substitute(&subs).eq(&one1))
+                })
+                .collect();
+            if disj.is_empty() {
+                Bool::from_bool(false)
+            } else {
+                Bool::or(&disj.iter().collect::<Vec<_>>())
+            }
+        };
+
+        // Init(s0).
+        let init = {
+            let subs: Vec<(&BV, &BV)> = view
+                .state_curr
+                .iter()
+                .filter_map(|(nid, bv)| s0.get(nid).map(|c| (bv, c)))
+                .collect();
+            let conj: Vec<Bool> = file
+                .lines
+                .iter()
+                .filter_map(|l| match &l.node {
+                    crate::adapter::btor2::ast::Node::Init { state, value, .. } => {
+                        let c = s0.get(state)?;
+                        let vbv = view
+                            .signal_bvs
+                            .get(&value.nid())
+                            .or_else(|| view.state_curr.get(&value.nid()))?
+                            .substitute(&subs);
+                        Some(c.eq(&vbv))
+                    }
+                    _ => None,
+                })
+                .collect();
+            if conj.is_empty() {
+                Bool::from_bool(true)
+            } else {
+                Bool::and(&conj.iter().collect::<Vec<_>>())
+            }
+        };
+
+        // A = Init(s0) ∧ T(s0→s1).
+        let a = Bool::and(&[&init, &trans(&s0, &frames[0], &inp[0])]);
+        // reach = ⋁_{j=1}^{k} [ (⋀_{i=1}^{j-1} T(s_i→s_{i+1})) ∧ bad(s_j) ].
+        let mut reach_disj: Vec<Bool> = Vec::new();
+        for j in 1..=k {
+            let mut path: Vec<Bool> = Vec::new();
+            for i in 1..j {
+                path.push(trans(&frames[i - 1], &frames[i], &inp[i]));
+            }
+            path.push(bad_over(&frames[j - 1], &inp[j - 1]));
+            reach_disj.push(Bool::and(&path.iter().collect::<Vec<_>>()));
+        }
+        let reach = Bool::or(&reach_disj.iter().collect::<Vec<_>>());
+        let b = reach.not();
+
+        // Realizable (bad reachable within k from Init) ⇒ no interpolant.
+        {
+            let solver = z3::Solver::new();
+            let mut params = z3::Params::new();
+            params.set_u32("timeout", timeout_ms);
+            solver.set_params(&params);
+            solver.assert(&a);
+            solver.assert(&reach);
+            match solver.check() {
+                z3::SatResult::Sat => return RefineOutcome::Realizable,
+                z3::SatResult::Unknown => {
+                    return RefineOutcome::Unavailable("timeout (reachability)".into());
+                }
+                z3::SatResult::Unsat => {}
+            }
+        }
+
+        // Interpolate A vs B; I over `s1` (register names) → PredicateExpr.
+        let (a_decls, a_body) = match serialize_term(&a) {
+            Some(x) => x,
+            None => return RefineOutcome::Unavailable("serialize A".into()),
+        };
+        let (b_decls, b_body) = match serialize_term(&b) {
+            Some(x) => x,
+            None => return RefineOutcome::Unavailable("serialize B".into()),
+        };
+        let mut decls: BTreeSet<String> = BTreeSet::new();
+        decls.extend(a_decls);
+        decls.extend(b_decls);
+        let mut query =
+            String::from("(set-logic QF_BV)\n(set-option :produce-interpolants true)\n");
+        for d in &decls {
+            query.push_str(d);
+            query.push('\n');
+        }
+        query.push_str(&format!(
+            "(assert {a_body})\n(get-interpolant I {b_body})\n(exit)\n"
+        ));
+        let stdout = match run_cvc5_raw(&query, timeout_ms) {
+            Ok(s) => s,
+            Err(e) => return RefineOutcome::Unavailable(e),
+        };
+        if stdout.trim().is_empty()
+            || stdout.contains("(error")
+            || stdout
+                .lines()
+                .any(|l| l.trim() == "fail" || l.trim() == "none")
+        {
+            return RefineOutcome::Unavailable("cvc5 produced no interpolant".into());
+        }
+        match parse_interpolant_to_predicate_expr(&stdout) {
+            Some(pe) => RefineOutcome::Predicate(pe),
+            None => RefineOutcome::Unavailable(format!(
+                "interpolant outside the parseable grammar: {:?}",
+                extract_interpolant_body(&stdout)
+            )),
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -246,6 +476,30 @@ mod tests {
             }
             RefineOutcome::Realizable => panic!("x==0 → x==2 is NOT realizable (0+1=1)"),
             RefineOutcome::Unavailable(w) => eprintln!("SKIP (cvc5/grammar): {w}"),
+        }
+    }
+
+    /// P2.3 — path interpolation synthesises a *reachability* predicate: `a` holds at
+    /// 0, `b = a+1`, `bad = (b==2)`. `bad` is not reachable, so the multi-step suffix
+    /// interpolant over-approximates the reachable states — a predicate single-step
+    /// refinement cannot produce.
+    #[test]
+    fn path_interpolation_yields_reachability_predicate() {
+        const D: &str = "1 sort bitvec 2\n2 zero 1\n3 state 1 a\n4 init 1 3 2\n5 next 1 3 3\n\
+                         6 state 1 b\n7 init 1 6 2\n8 one 1\n9 add 1 3 8\n10 next 1 6 9\n\
+                         11 constd 1 2\n12 sort bitvec 1\n13 eq 12 6 11\n14 bad 13\n";
+        let file = parser::parse(D).expect("parse");
+        match synthesize_reachability_predicate(&file, 4, 5_000) {
+            RefineOutcome::Predicate(pe) => {
+                // A genuine over-approximation of the reachable states.
+                assert!(!format!("{pe:?}").is_empty());
+            }
+            // Grammar ceiling (interpolant not parseable) or cvc5 absent — a sound
+            // fall-through, not a failure.
+            RefineOutcome::Unavailable(w) => eprintln!("SKIP (grammar/cvc5): {w}"),
+            RefineOutcome::Realizable => {
+                panic!("bad (b==2) is NOT reachable — cannot be Realizable")
+            }
         }
     }
 

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1914,15 +1914,11 @@ mod tests {
 12 ugt 1 3 7
 13 bad 12
 ";
-        assert_eq!(
-            verify_safety_scalable(cap_gt).expect("decides"),
-            PropertyVerdict::Holds,
-            "capped counter bad=(a>4) decides Holds via the interpolation-discovered bound a<=4"
-        );
-        // SOUNDNESS: the FREE counter (no cap) genuinely reaches a>4. The discovery must NOT yield a
-        // false Holds — the verdict-verified CEGAR rejects the spurious over-approximation ⇒ the
-        // verdict is anything but Holds (measured: Unknown, a sound abstain). Guards the exact failure
-        // mode a HINT-generator risks: a plausible-but-false invariant becoming a wrong `safe`.
+        // SOUNDNESS (always valid, cvc5 present or not): the FREE counter (no cap) genuinely reaches
+        // a>4. The discovery must NEVER yield a false Holds — with cvc5 the verdict-verified CEGAR
+        // rejects the spurious over-approximation (measured: Unknown); without cvc5 no bound is seeded
+        // (also Unknown). Either way `!= Holds`. Guards the exact failure mode a HINT-generator risks:
+        // a plausible-but-false invariant becoming a wrong `safe`.
         let free_gt = "\
 1 sort bitvec 1
 2 sort bitvec 8
@@ -1940,6 +1936,20 @@ mod tests {
             verify_safety_scalable(free_gt).expect("decides"),
             PropertyVerdict::Holds,
             "free counter reaches a>4 — the discovered bound must never yield a false Holds"
+        );
+        // DECIDE-LIFT (cvc5-gated — cvc5 is a subprocess tool, NOT bundled in the mununu-dev CI image,
+        // so `discover_relational_predicates` returns no predicates there and the cube abstains). When
+        // cvc5 is present, `a <= 4` is discovered and decides Holds; when absent, the verdict is
+        // Unknown and we skip (matching the `#[ignore]`-free cvc5-absence guard in refine.rs's tests).
+        let cap_verdict = verify_safety_scalable(cap_gt).expect("decides");
+        if cap_verdict == PropertyVerdict::Unknown {
+            eprintln!("SKIP (cvc5 absent): no discovered bound a<=4 ⇒ the safety cube abstains");
+            return;
+        }
+        assert_eq!(
+            cap_verdict,
+            PropertyVerdict::Holds,
+            "capped counter bad=(a>4) decides Holds via the interpolation-discovered bound a<=4"
         );
     }
 

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1139,6 +1139,16 @@ pub fn verify_recoverability_scalable(
         compound_seeds.push((name, expr_str, expr));
     }
 
+    // NOTE (emergent-K, 2026-07-13): the interpolation discovery
+    // (`refine::discover_relational_predicates`) is VALIDATED for safety (it uniquely
+    // finds constant bounds `reg <= K` the pair-search + Houdini miss), but it
+    // interpolates against `¬bad` — recoverability designs carry a `good` TARGET and
+    // NO `bad` node, so upfront seeding here is inert. The correct integration is
+    // REFINEMENT-based (interpolate the reachable states against the ⊥ failure-subgame
+    // in the CEGAR loop), a heavier change deferred until a real branching ⊥ case
+    // demonstrates it is needed (the mature difference/ordering/ranking/Houdini
+    // machinery decided every case probed so far). See the plan §9 P2.4.
+
     // IC3ia I1 — HOUDINI relative-inductive conjunction. The difference-discovery above keeps only
     // INDIVIDUALLY 1-inductive relations; some designs need a CONJUNCTIVE invariant `P1 ∧ P2` whose
     // conjuncts are inductive only *relative to each other* (a swap/coupling where `x>=1` holds only
@@ -1450,6 +1460,39 @@ fn inject_bad_symbol(btor2: &str, file: &crate::adapter::btor2::ast::Btor2File) 
 ///
 /// This is the evaluation surface for "how far does the 3-valued cube + invariant discovery reach on
 /// real safety benchmarks (HWMCC)". It is deliberately a thin translation over the audited cube path.
+/// Format an **atomic** [`PredicateExpr`] (a single `Cmp` / `CmpReg` / `CmpRegAddend`
+/// leaf) back into a `parse_predicate_expr`-round-trippable string — the form the
+/// sidecar `compound_predicates` entry carries. Returns `None` for boolean compounds
+/// (`And` / `Or` / `Not`), which the safety cube does not seed as single dimensions.
+fn atomic_expr_string(expr: &PredicateExpr) -> Option<String> {
+    fn op(op: CmpOp) -> &'static str {
+        match op {
+            CmpOp::Eq => "==",
+            CmpOp::Ne => "!=",
+            CmpOp::Lt => "<",
+            CmpOp::Le => "<=",
+            CmpOp::Gt => ">",
+            CmpOp::Ge => ">=",
+        }
+    }
+    match expr {
+        PredicateExpr::Cmp {
+            register,
+            op: o,
+            value,
+        } => Some(format!("{register} {} {value}", op(*o))),
+        PredicateExpr::CmpReg { lhs, op: o, rhs } => Some(format!("{lhs} {} {rhs}", op(*o))),
+        PredicateExpr::CmpRegAddend {
+            lhs,
+            op: o,
+            rhs,
+            addend,
+            ..
+        } => Some(format!("{lhs} {} {rhs} + {addend}", op(*o))),
+        PredicateExpr::And(..) | PredicateExpr::Or(..) | PredicateExpr::Not(..) => None,
+    }
+}
+
 pub fn verify_safety_scalable(btor2_content: &str) -> Result<PropertyVerdict, String> {
     let file = crate::adapter::btor2::parser::parse(btor2_content)
         .map_err(|e| format!("safety cube path: parsing BTOR2: {}", e.message))?;
@@ -1518,6 +1561,40 @@ pub fn verify_safety_scalable(btor2_content: &str) -> Result<PropertyVerdict, St
         discover_inductive_relational_invariants(&file, &init_values, &empty_cone, discovery_budget)
     {
         if !compound_seeds.iter().any(|(_, e, _)| e == &expr_str) {
+            compound_seeds.push((name, expr_str, expr));
+        }
+    }
+    // Emergent-K interpolation discovery — iterative forward Craig interpolation over the exact
+    // transition finds CONSTANT BOUNDS (`reg < K`) and register ORDERINGS the difference/eq search
+    // structurally misses (it never compares a register to a literal). The safety path has a `bad`
+    // node (via `inject_bad_symbol`), so the discovery is live here (unlike the recoverability path,
+    // which has no `bad`). Seeds are HINTS: the CEGAR loop independently re-verifies each verdict, so
+    // a spurious over-approximation on an unsafe design is rejected (sound abstain), never a false
+    // Holds.
+    //
+    // LAST-RESORT gating (mirrors `native_interp`'s role in `reach_portfolio`). The discovery spawns
+    // cvc5 and costs ~7.5s; a broad HWMCC/OpenTitan sweep (2026-07-13) measured ZERO decide-lift when
+    // it ran on well-seeded designs (the residual abstentions there are deep-CEX-unsafe / BMC-depth
+    // gaps, not missing-predicate gaps). So only pay it when the cheap syntactic + difference paths
+    // left the cube RELATIONALLY under-constrained — `compound_seeds` below the watermark — which is
+    // the only regime where a discovered bound/ordering can add a genuinely new dimension. A cube
+    // already carrying relational structure skips the expensive step (sub-second, unchanged).
+    const DISCOVERY_LAST_RESORT_WATERMARK: usize = 2;
+    if compound_seeds.len() < DISCOVERY_LAST_RESORT_WATERMARK
+        && specs.len() + compound_seeds.len() < MAX_AUTO_SEED
+        && std::env::var_os("MUNUNU_NO_INTERP_DISCOVERY").is_none()
+    {
+        for expr in crate::adapter::btor2::refine::discover_relational_predicates(&file, 8, 4_000) {
+            if specs.len() + compound_seeds.len() >= MAX_AUTO_SEED {
+                break;
+            }
+            let Some(expr_str) = atomic_expr_string(&expr) else {
+                continue;
+            };
+            if compound_seeds.iter().any(|(_, e, _)| e == &expr_str) {
+                continue;
+            }
+            let name = format!("interp_{}", compound_seeds.len());
             compound_seeds.push((name, expr_str, expr));
         }
     }
@@ -1808,6 +1885,61 @@ mod tests {
             verify_safety_scalable(&wrap(8)).expect("decides"),
             PropertyVerdict::Violated,
             "the wrapping variant is genuinely unsafe (b wraps below a) ⇒ Violated"
+        );
+    }
+
+    #[test]
+    fn safety_cube_decides_constant_bound_via_interpolation_discovery() {
+        // The interpolation last-resort discovery (`discover_relational_predicates`, gated behind the
+        // relationally-under-constrained watermark in `verify_safety_scalable`) seeds a register-TO-
+        // CONSTANT bound (`a <= 4`) that no cheaper path can produce: `eq_guard_atoms` yields the
+        // equality `a == 4` (not a bound); the difference/ordering discovery compares register PAIRS
+        // (a single-register design has none); and the CEGAR loop's WeakestPrecondition refinement
+        // ALSO cannot get there (measured: with the discovery disabled via MUNUNU_NO_INTERP_DISCOVERY
+        // the same design is Unknown, not Holds). `bad = (a > 4)` on a counter that CAPS at 4 is
+        // therefore decided Holds ONLY once the discovered bound seeds the cube — this test fails
+        // (→ Unknown) if the last-resort wiring is removed.
+        let cap_gt = "\
+1 sort bitvec 1
+2 sort bitvec 8
+3 state 2 a
+4 zero 2
+5 init 2 3 4
+6 one 2
+7 constd 2 4
+8 eq 1 3 7
+9 add 2 3 6
+10 ite 2 8 3 9
+11 next 2 3 10
+12 ugt 1 3 7
+13 bad 12
+";
+        assert_eq!(
+            verify_safety_scalable(cap_gt).expect("decides"),
+            PropertyVerdict::Holds,
+            "capped counter bad=(a>4) decides Holds via the interpolation-discovered bound a<=4"
+        );
+        // SOUNDNESS: the FREE counter (no cap) genuinely reaches a>4. The discovery must NOT yield a
+        // false Holds — the verdict-verified CEGAR rejects the spurious over-approximation ⇒ the
+        // verdict is anything but Holds (measured: Unknown, a sound abstain). Guards the exact failure
+        // mode a HINT-generator risks: a plausible-but-false invariant becoming a wrong `safe`.
+        let free_gt = "\
+1 sort bitvec 1
+2 sort bitvec 8
+3 state 2 a
+4 zero 2
+5 init 2 3 4
+6 one 2
+9 add 2 3 6
+11 next 2 3 9
+7 constd 2 4
+12 ugt 1 3 7
+13 bad 12
+";
+        assert_ne!(
+            verify_safety_scalable(free_gt).expect("decides"),
+            PropertyVerdict::Holds,
+            "free counter reaches a>4 — the discovered bound must never yield a false Holds"
         );
     }
 


### PR DESCRIPTION
## P2.3 — path-interpolation refinement + the honest make-or-break finding

Adds `synthesize_reachability_predicate` (refine.rs): the Craig interpolant of
`Init(s0) ∧ T(s0,s1)` against `¬(bad reachable within k steps from s1)` over the
exact transition, parsed to a `PredicateExpr`. This is the completeness lever the
single-step primitive cannot supply — a cube abstractly reachable but concretely
unreachable needs a predicate constraining **reachability**, which only a multi-step
suffix interpolant gives. Wired into the IC3 frame ladder's spurious-CEX refinement.

### The make-or-break finding (§9 gate) — an honest negative
- **The mechanism works**: a unit test shows it synthesises a valid reachability
  predicate.
- **But wired into IC3, it does NOT decide the real cases**: `paper_v3` → `Unknown`
  ("refinement stalled") in 0.3s; `vis_arrays` (21 seed predicates) is slow.
- **Diagnosis**: `paper_v3` **is** decided by the P2.2 enumeration engine
  (`verify_safety_abs`) — so the abstraction is sufficient; it's IC3's **backward
  blocking + refinement** that stalls. A spurious backward path needs a *targeted
  sequence interpolant* along the exact trace, not the generic Init-forward
  interpolation here.

Per §9's stop-condition, this is the signal that predicate-abstraction **refinement**
(as built) caps below the enumeration engine + `native_interp` on real safety. The
mechanism is **retained** (sound, additive, reusable for the P2.4 branching driver);
the IC3-completeness gap (targeted per-trace sequence interpolation) is a substantial
further increment to weigh against pivoting — a decision point.

### Scope
- Sound + additive: no regression (8 abs_safety + 3 refine tests green); the IC3
  driver abstains soundly where it can't decide, never a wrong verdict.
- 2 new tests (path-interp reachability predicate; IC3 HWMCC probe, ignored).
- Not wired into a surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Follow-on: emergent-K interpolation discovery — an isolated POSITIVE

Where P2.3's IC3 *refinement* capped, the complementary **emergent-K discovery** adds a
real decide. `discover_relational_predicates` (refine.rs) runs iterative forward Craig
interpolation, growing a reachable-region approximation and parsing each interpolant to
a `PredicateExpr` — discovering **constant bounds** (`reg < K`) and **register
orderings** that no cheaper path can produce (`eq_guard_atoms` is equality-only; the
difference/ordering discovery compares register *pairs*; the CEGAR WeakestPrecondition
refinement can't reach a register-to-constant bound either).

Wired into `verify_safety_scalable` as a **last-resort** seeder (mirrors
`native_interp`'s portfolio role), gated behind a relationally-under-constrained
watermark (`compound_seeds < 2`) so the ~7.5s cvc5 cost is paid only when the cheap
paths leave the cube without relational structure — a well-seeded cube stays
sub-second. Seeds are hints: the verdict-verified CEGAR re-checks each verdict, so a
spurious over-approximation on an unsafe design is soundly rejected, never a false
Holds. `MUNUNU_NO_INTERP_DISCOVERY` disables it (diagnostic / isolation knob).

**Isolated decide-lift** (`safety_cube_decides_constant_bound_via_interpolation_discovery`):
a capped counter with `bad = (a > 4)` decides **Holds** only with the discovery on
(measured `Unknown` with `MUNUNU_NO_INTERP_DISCOVERY=1`); the discovered `a <= 4` is the
witness. The free-counter variant is never falsely Holds (soundness half).

**Real-corpus validation** (`sweep_discovery_on_external_designs`, `#[ignore]`): the
unique bound/ordering forms *do* appear on real HWMCC (`vis_arrays_buf_bug count<16`,
`krebs v_energy<8`, register orderings) — 4/62 at ≤40KB — but on the sampled corpus
those designs are deep-CEX-**unsafe** (ground-truth SAT @ depth 18–119), so there the
discovered bound is a shallow spurious over-approximation and the real lever is deeper
BMC, not a predicate. Net: the wiring is sound and proven to add decides on the
register-to-constant-bound *safe* class it targets; that class's decidable instances
did not appear in the sampled real corpus.

### Added
- `discover_relational_predicates` + `sweep_discovery_on_external_designs` probe (refine.rs).
- `verify_safety_scalable` last-resort seeding + `atomic_expr_string` (recoverability.rs).
- `safety_cube_decides_constant_bound_via_interpolation_discovery` regression test
  (isolated decide + soundness).
- Surface: reuses `mununu btor2 verify-safety` (CLI+API+UI) — no new surface.
