### PR TITLE
feat(verify): surface IC3ia (verify-safety --engine) + opt-in safety-cube orchestrator pass

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -328,6 +328,28 @@ enum MayEdgeInferenceArg {
     SmtAllPairs,
 }
 
+/// Safety engine selector for `mununu btor2 verify-safety`.
+///
+/// surface: CLI-only — the `ic3` engine (IC3ia predicate abstraction,
+/// [`mununu_core::adapter::btor2::abs_safety::verify_safety_ic3`]) is an experimental,
+/// guarded foundation: on real designs its backward refinement stalls and it abstains
+/// (the P2.3b make-or-break finding). It is surfaced for evaluation, NOT production
+/// routing — the production safety path is `cube`. No API/UI surface until it decides
+/// real cases competitively with the cube + `native_interp`.
+#[derive(Clone, Debug, Copy, clap::ValueEnum, Default)]
+enum SafetyEngineArg {
+    /// The KMTS 3-valued cube (default) — [`verify_safety_scalable`]. Enumeration +
+    /// emergent-K interpolation discovery; the production safety path.
+    ///
+    /// [`verify_safety_scalable`]: mununu_core::adapter::recoverability::verify_safety_scalable
+    #[default]
+    Cube,
+    /// Experimental IC3ia predicate-abstraction frame ladder — `verify_safety_ic3`.
+    /// Guarded foundation; abstains where refinement stalls. Uses cvc5 for refinement
+    /// (abstains when cvc5 is absent).
+    Ic3,
+}
+
 /// R-F5.4.2b (2026-07-03) — which predicate-cube engine evaluates the
 /// property. Mirrors the two edge-construction strategies.
 #[derive(Clone, Debug, Copy, clap::ValueEnum, Default, PartialEq, Eq)]
@@ -630,6 +652,11 @@ struct Btor2VerifySafetyArgs {
     /// Path to the BTOR2 input file.
     #[arg(value_name = "BTOR2_FILE")]
     file: PathBuf,
+    /// Safety engine (default `cube`). `ic3` selects the experimental IC3ia
+    /// predicate-abstraction frame ladder — a guarded foundation for evaluation only;
+    /// it abstains where refinement stalls (see `SafetyEngineArg`).
+    #[arg(long, value_enum, default_value_t = SafetyEngineArg::Cube)]
+    engine: SafetyEngineArg,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2225,6 +2252,20 @@ fn handle_verify(args: VerifyArgs) -> Result<(), String> {
                 println!("        ({term})");
             }
         }
+        if !report.safety_cube_results.is_empty() {
+            println!(
+                "  safety-cube AG !bad ({}):",
+                report.safety_cube_results.len()
+            );
+            for r in &report.safety_cube_results {
+                println!(
+                    "    {src}: {verdict} [{file}]",
+                    src = r.source_id,
+                    verdict = r.verdict,
+                    file = r.file,
+                );
+            }
+        }
     }
 
     if args.strict && report.property_verdicts.iter().any(|v| !v.satisfied) {
@@ -2475,14 +2516,32 @@ fn btor2_verify_recoverability(args: Btor2VerifyRecoverabilityArgs) -> Result<()
 /// obligation, complementing the bit-level `btor2 verify` portfolio.
 fn btor2_verify_safety(args: Btor2VerifySafetyArgs) -> Result<(), String> {
     use mununu_core::adapter::recoverability::verify_safety_scalable;
+    use mununu_core::verdict::PropertyVerdict;
 
     let content = std::fs::read_to_string(&args.file)
         .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
-    let verdict = verify_safety_scalable(&content)?;
+
+    let (verdict, engine) = match args.engine {
+        SafetyEngineArg::Cube => (verify_safety_scalable(&content)?, "cube"),
+        SafetyEngineArg::Ic3 => {
+            use mununu_core::adapter::btor2::abs_safety::{AbsVerdict, verify_safety_ic3};
+            let file = mununu_core::adapter::btor2::parser::parse(&content)
+                .map_err(|e| format!("verify-safety (ic3): parsing BTOR2: {}", e.message))?;
+            // Budgets mirror the abs_safety unit tests (32 frames, 8 refinements, 5 s/query),
+            // with a longer overall query timeout for the CLI's larger inputs.
+            let verdict = match verify_safety_ic3(&file, 32, 8, 10_000) {
+                AbsVerdict::Safe { .. } => PropertyVerdict::Holds,
+                AbsVerdict::Unsafe { .. } => PropertyVerdict::Violated,
+                AbsVerdict::Unknown { .. } => PropertyVerdict::Unknown,
+            };
+            (verdict, "ic3")
+        }
+    };
 
     let summary = serde_json::json!({
         "file": args.file.display().to_string(),
         "property": "AG !bad",
+        "engine": engine,
         "verdict": verdict.as_str(),
     });
     println!(

--- a/crates/mununu-core/src/verify/codesign_shorthand.rs
+++ b/crates/mununu-core/src/verify/codesign_shorthand.rs
@@ -70,6 +70,9 @@ pub fn codesign_to_verify(codesign: &CodesignProjectConfig) -> VerifyConfig {
     let project = ProjectSection {
         name: codesign.project.name.clone(),
         description: codesign.project.description.clone(),
+        // Codesign shorthand targets composed firmware+RTL properties, not raw btor2
+        // safety-cube passes; leave the opt-in cube off.
+        safety_cube: false,
     };
 
     // Sources: one for the firmware C, one for the RTL SV.

--- a/crates/mununu-core/src/verify/config.rs
+++ b/crates/mununu-core/src/verify/config.rs
@@ -105,6 +105,15 @@ pub struct ProjectSection {
     /// Optional human-readable description.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Opt-in (`[project] safety_cube = true`): also run the KMTS 3-valued safety cube
+    /// (`AG ¬bad`, [`crate::adapter::recoverability::verify_safety_scalable`] —
+    /// enumeration + the emergent-K interpolation discovery) on every `btor2`-adapter
+    /// source that carries a `bad` obligation, reporting the per-source verdict in
+    /// [`crate::verify::report::VerifyReport::safety_cube_results`] alongside the
+    /// mu-calculus property verdicts. Default `false`. A best-effort pass: a source with
+    /// no `bad` node (or a parse error) is silently skipped.
+    #[serde(default)]
+    pub safety_cube: bool,
 }
 
 /// One entry in the `[[sources]]` array.

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -63,8 +63,8 @@ use crate::verify::binding::{AlphabetBinding, apply_renamings_to_ctxdsl};
 use crate::verify::config::{PropertySection, VerifyConfig};
 use crate::verify::register_map_rewriter::derive_sv_renamings_from_register_map;
 use crate::verify::report::{
-    CompositionInfo, PropertyFormulaSource, PropertyVerdict, SourceSummary, TraceStep,
-    TraceTermination, TraceWitness, VerifyError, VerifyReport,
+    CompositionInfo, PropertyFormulaSource, PropertyVerdict, SafetyCubeResult, SourceSummary,
+    TraceStep, TraceTermination, TraceWitness, VerifyError, VerifyReport,
 };
 
 // ---------------------------------------------------------------------------
@@ -115,6 +115,18 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
     let mut source_ctxdsls: Vec<SourceCtxdsl> = Vec::with_capacity(config.sources.len());
     let mut source_summaries: Vec<SourceSummary> = Vec::with_capacity(config.sources.len());
     for source in &config.sources {
+        // btor2 sources are CUBE-ONLY when `safety_cube` is on: they carry a `bad`
+        // obligation for `run_safety_cube_pass` (step 9), not a composable automaton —
+        // the orchestrator has no btor2→automaton dispatch. Record a summary and skip.
+        if config.project.safety_cube && source.adapter == "btor2" {
+            source_summaries.push(SourceSummary {
+                id: source.id.clone(),
+                adapter: source.adapter.clone(),
+                automaton: None,
+                partition_summary: None,
+            });
+            continue;
+        }
         let primary_file = source
             .files
             .first()
@@ -179,6 +191,28 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
                 partition_summary,
             });
         }
+    }
+
+    // Cube-only project: every source was a btor2 safety-cube source (no composable
+    // automaton). Composition + property evaluation both require ≥1 automaton, so return
+    // the cube results directly instead of failing on an empty composition.
+    if source_ctxdsls.is_empty() {
+        let safety_cube_results = if config.project.safety_cube {
+            run_safety_cube_pass(config, base_dir)
+        } else {
+            Vec::new()
+        };
+        return Ok(VerifyReport {
+            project: config.project.name.clone(),
+            sources: source_summaries,
+            composition: CompositionInfo {
+                semantics: config.composition.semantics.clone(),
+                name: config.composition_name(),
+                members: Vec::new(),
+            },
+            property_verdicts: Vec::new(),
+            safety_cube_results,
+        });
     }
 
     // R46-3 (R.4.6 per-cluster verification) — collect the
@@ -304,12 +338,52 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
         property_verdicts.push(verdict);
     }
 
+    // 9. Opt-in KMTS safety-cube pass (`safety_cube = true`): run `AG ¬bad` (cube +
+    //    emergent-K discovery) on each `btor2` source carrying a `bad` obligation.
+    let safety_cube_results = if config.project.safety_cube {
+        run_safety_cube_pass(config, base_dir)
+    } else {
+        Vec::new()
+    };
+
     Ok(VerifyReport {
         project: config.project.name.clone(),
         sources: source_summaries,
         composition: composition_info,
         property_verdicts,
+        safety_cube_results,
     })
+}
+
+/// The opt-in `safety_cube` pass — run the KMTS 3-valued safety cube
+/// ([`crate::adapter::recoverability::verify_safety_scalable`]: `AG ¬bad`, enumeration +
+/// emergent-K interpolation discovery) on every `btor2`-adapter source that carries a
+/// `bad` obligation. Best-effort and side-channel to property evaluation: a source with
+/// no `bad` node (the cube returns `Err`), an unreadable file, or a parse failure is
+/// silently skipped, so the pass never aborts the run. Parameterised sources
+/// (`count >= 2`) are not expanded here — the cube reads each declared file directly.
+fn run_safety_cube_pass(config: &VerifyConfig, base_dir: &Path) -> Vec<SafetyCubeResult> {
+    let mut out = Vec::new();
+    for src in &config.sources {
+        if src.adapter != "btor2" {
+            continue;
+        }
+        for file in &src.files {
+            let path = base_dir.join(file);
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            // `Err` = no `bad` node / parse error → skip (opt-in best-effort).
+            if let Ok(verdict) = crate::adapter::recoverability::verify_safety_scalable(&content) {
+                out.push(SafetyCubeResult {
+                    source_id: src.id.clone(),
+                    file: file.display().to_string(),
+                    verdict: verdict.as_str().to_string(),
+                });
+            }
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -1835,6 +1909,99 @@ formula = "true"
 over = "System"
 "#;
         VerifyConfig::from_toml(toml_src).unwrap()
+    }
+
+    /// Safe capped counter — `a` caps at 4, so `bad = (a==5)` is unreachable. The safety
+    /// cube decides Holds via the `{a==4, a==5}` eq-atoms alone (no cvc5 needed → the
+    /// emergent-K discovery never fires → CI-safe without the subprocess tool).
+    const CAPPED_SAFE_BTOR2: &str = "\
+1 sort bitvec 1
+2 sort bitvec 8
+3 state 2 a
+4 zero 2
+5 init 2 3 4
+6 one 2
+7 constd 2 4
+8 eq 1 3 7
+9 add 2 3 6
+10 ite 2 8 3 9
+11 next 2 3 10
+12 constd 2 5
+13 eq 1 3 12
+14 bad 13
+";
+
+    #[test]
+    fn safety_cube_pass_decides_btor2_source_when_enabled() {
+        let temp = tempdir().unwrap();
+        std::fs::write(temp.path().join("design.btor2"), CAPPED_SAFE_BTOR2).unwrap();
+        let toml_src = r#"
+[project]
+name = "CubeSmoke"
+safety_cube = true
+
+[[sources]]
+id = "design"
+adapter = "btor2"
+files = ["design.btor2"]
+
+[composition]
+semantics = "asynchronous"
+members = ["design"]
+name = "System"
+"#;
+        let config = VerifyConfig::from_toml(toml_src).unwrap();
+        assert!(
+            config.project.safety_cube,
+            "`[project] safety_cube = true` parses"
+        );
+        // End-to-end: `verify_project` treats the btor2 source as cube-only (not
+        // composable → members = []), runs the cube on it, and reports the verdict.
+        let report = verify_project(&config, temp.path()).expect("verify_project succeeds");
+        assert_eq!(
+            report.safety_cube_results.len(),
+            1,
+            "one btor2 source with a `bad` node ⇒ one cube result"
+        );
+        assert_eq!(report.safety_cube_results[0].source_id, "design");
+        assert_eq!(
+            report.safety_cube_results[0].verdict, "holds",
+            "capped counter: bad (a==5) unreachable ⇒ safe"
+        );
+        assert!(
+            report.property_verdicts.is_empty(),
+            "a cube-only project has no mu-calculus property verdicts"
+        );
+    }
+
+    #[test]
+    fn safety_cube_pass_skips_non_btor2_and_bad_less_sources() {
+        let temp = tempdir().unwrap();
+        // A non-`btor2` adapter is skipped; a `btor2` source with NO `bad` node returns
+        // `Err` from the cube and is silently skipped ⇒ zero results either way.
+        let no_bad = "1 sort bitvec 8\n2 state 1 a\n3 zero 1\n4 init 1 2 3\n5 next 1 2 2\n";
+        std::fs::write(temp.path().join("nobad.btor2"), no_bad).unwrap();
+        let toml_src = r#"
+[project]
+name = "CubeSkip"
+safety_cube = true
+
+[[sources]]
+id = "nobad"
+adapter = "btor2"
+files = ["nobad.btor2"]
+
+[composition]
+semantics = "asynchronous"
+members = ["nobad"]
+name = "System"
+"#;
+        let config = VerifyConfig::from_toml(toml_src).unwrap();
+        let results = run_safety_cube_pass(&config, temp.path());
+        assert!(
+            results.is_empty(),
+            "a btor2 source with no `bad` obligation is skipped"
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -362,6 +362,13 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
 /// no `bad` node (the cube returns `Err`), an unreadable file, or a parse failure is
 /// silently skipped, so the pass never aborts the run. Parameterised sources
 /// (`count >= 2`) are not expanded here — the cube reads each declared file directly.
+///
+/// Scope: `btor2` sources only. `sv-yosys` sources are NOT lifted here — the cube needs a
+/// BTOR2 whose SVA `assert property` survives as a `bad` node, and the available `sv2v`
+/// (0.0.13) drops the concurrent-assertion form during the flatten lift (`sv_to_btor2`
+/// yields 0 `bad` nodes), so the cube would have nothing to check. Verify SV safety with
+/// the standalone `mununu sv verify` portfolio verb; wiring the cube onto a reliably
+/// SVA-preserving SV→BTOR2 lift is a follow-up.
 fn run_safety_cube_pass(config: &VerifyConfig, base_dir: &Path) -> Vec<SafetyCubeResult> {
     let mut out = Vec::new();
     for src in &config.sources {

--- a/crates/mununu-core/src/verify/report.rs
+++ b/crates/mununu-core/src/verify/report.rs
@@ -21,6 +21,24 @@ pub struct VerifyReport {
     pub composition: CompositionInfo,
     /// One verdict per `[[properties]]` entry.
     pub property_verdicts: Vec<PropertyVerdict>,
+    /// Per-source KMTS safety-cube (`AG ¬bad`) verdicts — populated only when
+    /// `[project].safety_cube = true` (or the config field `safety_cube`). Empty
+    /// otherwise. See [`crate::verify::config::ProjectSection::safety_cube`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub safety_cube_results: Vec<SafetyCubeResult>,
+}
+
+/// One `btor2`-source safety-cube result from the opt-in `safety_cube` pass.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SafetyCubeResult {
+    /// `[[sources]].id` the cube ran on.
+    pub source_id: String,
+    /// The BTOR2 file (relative to the project base dir) the cube read.
+    pub file: String,
+    /// `AG ¬bad` verdict from `verify_safety_scalable` (cube + emergent-K discovery),
+    /// as the canonical [`crate::verdict::PropertyVerdict::as_str`] string —
+    /// `"holds"` | `"violated"` | `"unknown"`.
+    pub verdict: String,
 }
 
 /// Per-source diagnostic information.

--- a/wiki/Verify-Project-Flow.md
+++ b/wiki/Verify-Project-Flow.md
@@ -147,6 +147,28 @@ formula = "mu X. (Init || <> X)"
 over = "System"
 ```
 
+### Safety-cube pass (`[project] safety_cube`)
+
+> **Source of truth:** [`verify::config::ProjectSection::safety_cube`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/config.rs), [`verify::orchestrator::run_safety_cube_pass`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/orchestrator.rs) — surface: CLI+API+UI.
+
+Set `[project] safety_cube = true` to additionally run the KMTS 3-valued safety cube (`AG ¬bad` — enumeration + the **emergent-K** interpolation discovery of constant-bound / register-ordering invariants) on every `btor2`-adapter source that carries a `bad` obligation. Those sources are **cube-only**: the orchestrator has no `btor2`→automaton dispatch, so they are excluded from composition + property evaluation, and only the cube verdict is reported (in `safety_cube_results`). A best-effort pass — a `btor2` source with no `bad` node is silently skipped. Reuses [`recoverability::verify_safety_scalable`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/recoverability.rs) (also the standalone `mununu btor2 verify-safety` verb).
+
+```toml
+[project]
+name = "csrng_safety"
+safety_cube = true
+
+[[sources]]
+id = "design"
+adapter = "btor2"          # cube-only: carries a `bad` property, not composed
+files = ["design.btor2"]
+
+[composition]
+semantics = "asynchronous"
+members = ["design"]       # resolves to [] in the report — btor2 sources don't compose
+name = "System"
+```
+
 ## Report shape
 
 > **Source of truth:** [`verify::report::VerifyReport`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/report.rs) — surface: CLI+API+UI.
@@ -157,6 +179,13 @@ pub struct VerifyReport {
     pub sources: Vec<SourceSummary>,           // id, adapter, resolved automaton
     pub composition: CompositionInfo,          // semantics, name, resolved members
     pub property_verdicts: Vec<PropertyVerdict>,
+    pub safety_cube_results: Vec<SafetyCubeResult>, // opt-in `[project] safety_cube`; empty otherwise
+}
+
+pub struct SafetyCubeResult {
+    pub source_id: String,                     // the btor2 source the cube ran on
+    pub file: String,
+    pub verdict: String,                       // "holds" | "violated" | "unknown"
 }
 
 pub struct PropertyVerdict {


### PR DESCRIPTION
Two follow-ups to the merged emergent-K work (#329).

## Task 2 — IC3ia surfaced for evaluation
`mununu btor2 verify-safety --engine <cube|ic3>`. Default `cube` (`verify_safety_scalable`); `ic3` routes to the IC3ia predicate-abstraction frame ladder (`verify_safety_ic3`). **CLI-only** (declared inline on `SafetyEngineArg`): IC3ia is a guarded foundation that abstains where refinement stalls on real designs (the P2.3b make-or-break finding) — surfaced for evaluation, not production routing.

## Task 3 — safety-cube in the verify orchestrator (opt-in)
`[project] safety_cube = true` runs the KMTS 3-valued cube (`AG !bad`, enumeration + emergent-K discovery) on every `btor2` source carrying a `bad` obligation, reporting per-source verdicts in the new `VerifyReport.safety_cube_results`. btor2 sources are **cube-only** (the orchestrator has no btor2→automaton dispatch): skipped in dispatch, excluded from composition; a cube-only project returns cube verdicts with an empty composition.

### Surfaces (parity)
- **CLI**: `--engine` flag + `mununu verify` safety-cube section.
- **API**: `verify_project_handler` returns the new report field automatically (shared `VerifyConfig`/`VerifyReport`).
- **UI**: mununu-ui#50 (`VerifyReport.safety_cube_results`).
- **Wiki**: Verify-Project-Flow schema + report + safety-cube subsection.

### Tests
- `safety_cube_pass_decides_btor2_source_when_enabled` — end-to-end `verify_project` on a cube-only project → holds.
- `safety_cube_pass_skips_non_btor2_and_bad_less_sources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)