### PR TITLE
feat(verify): route the sv-yosys safety-cube through the slang SVA front-end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,13 @@ docker run --rm -v "$(pwd)":/work -v mununu-target:/cargo-target \
 
 **Host caveat.** slang ships prebuilts only for `linux-x86_64` and `macos-arm64`. On an Intel (x86_64) macOS host there is no native slang binary, and the workspace's `z3-sys` link also differs from the dev image — so the Linux `mununu-sva` image (which runs natively on x86_64 hosts) is the supported way to run these tests there. The `e2e_csrng_real_sva_verdict_breakdown` test reads only vendored fixtures (`examples/verify/m2_opentitan_csrng_main_sm` + the standard prim_assert macros from `examples/verify/m0_opentitan_prim_arbiter`), so it is fully reproducible.
 
+**[RULE] Validate any slang / SVA-touching change in the `mununu-sva` image — never on the bare host (added 2026-07-13).** The dev host commonly has `sv2v` + `yosys` but **not** `slang`. That combination is a trap, not a convenience:
+
+- `mununu sv verify-auto` / `sv extract-sva` (and the correct SVA→cube path) locate slang via `locate_slang()`; with slang absent they cannot run, so a "green" host run has simply *skipped* the real path.
+- The **sv2v-only lift is worse than useless for SVA**: `sv2v` (0.0.13) silently **drops** `assert property (@…)` during conversion (both concurrent and immediate forms), so `sv_to_btor2` yields a BTOR2 with **0 `bad` nodes**. The plain `mununu sv verify` verb (sv2v+yosys, no slang) then reports a **VACUOUS `holds`** — the property was never checked. (2026-07-13 incident: an sv-yosys "safety-cube" wiring looked like it produced no result / a spurious `holds`; the whole chain was the sv2v drop, invisible without slang. Root-caused via `MUNUNU_KEEP_YOSYS_TMP=1` — `preprocessed.sv` had 0 asserts.)
+
+**How to comply.** Any change that exercises `adapter/slang/**`, `sv extract-sva`, `sv verify-auto`, or an SV→BTOR2 path that must preserve assertions is validated by running the relevant `#[ignore]`d `e2e_` tests **in the `mununu-sva` image** (command above), not by a host `cargo test`. Pure-Rust / `btor2` / non-slang paths may still be validated on the host. When a host run of an SV path returns `holds` with no counterexample, treat it as *unverified* until reproduced under `mununu-sva` — a bare-host `holds` on SVA is presumed vacuous. slang honours `MUNUNU_SLANG_PATH`; the image provides a pinned build.
+
 ### Pre-push workspace check (added 2026-06-08)
 
 **Rule.** Before `git push`, when a commit touches a field of a struct with multiple construction sites (`OriginalTransition`, `TransitionSpec`, `SignalAnnotation`, `CegarOptions`, `PredicateCubeLiftOptions`, `TransitionDecl`, etc.), run the CI-equivalent workspace check:

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2258,9 +2258,12 @@ fn handle_verify(args: VerifyArgs) -> Result<(), String> {
                 report.safety_cube_results.len()
             );
             for r in &report.safety_cube_results {
+                let label = match &r.property {
+                    Some(p) => format!("{}::{p}", r.source_id),
+                    None => r.source_id.clone(),
+                };
                 println!(
-                    "    {src}: {verdict} [{file}]",
-                    src = r.source_id,
+                    "    {label}: {verdict} [{file}]",
                     verdict = r.verdict,
                     file = r.file,
                 );

--- a/crates/mununu-core/src/verify/orchestrator.rs
+++ b/crates/mununu-core/src/verify/orchestrator.rs
@@ -355,42 +355,118 @@ pub fn verify_project(config: &VerifyConfig, base_dir: &Path) -> Result<VerifyRe
     })
 }
 
-/// The opt-in `safety_cube` pass — run the KMTS 3-valued safety cube
-/// ([`crate::adapter::recoverability::verify_safety_scalable`]: `AG ¬bad`, enumeration +
-/// emergent-K interpolation discovery) on every `btor2`-adapter source that carries a
-/// `bad` obligation. Best-effort and side-channel to property evaluation: a source with
-/// no `bad` node (the cube returns `Err`), an unreadable file, or a parse failure is
-/// silently skipped, so the pass never aborts the run. Parameterised sources
-/// (`count >= 2`) are not expanded here — the cube reads each declared file directly.
+/// The opt-in `safety_cube` pass — run the KMTS 3-valued safety cube (`AG ¬bad`) on every
+/// source that carries a safety obligation:
 ///
-/// Scope: `btor2` sources only. `sv-yosys` sources are NOT lifted here — the cube needs a
-/// BTOR2 whose SVA `assert property` survives as a `bad` node, and the available `sv2v`
-/// (0.0.13) drops the concurrent-assertion form during the flatten lift (`sv_to_btor2`
-/// yields 0 `bad` nodes), so the cube would have nothing to check. Verify SV safety with
-/// the standalone `mununu sv verify` portfolio verb; wiring the cube onto a reliably
-/// SVA-preserving SV→BTOR2 lift is a follow-up.
+/// - **`btor2`** sources — the file already *is* the BTOR2 (cube-only; skipped in
+///   dispatch). Run [`crate::adapter::recoverability::verify_safety_scalable`]
+///   (enumeration plus the emergent-K interpolation discovery) directly; one result per
+///   source (`property = None`). A source with no `bad` node returns `Err` → skipped.
+/// - **`sv-yosys`** (/ `yosys`) sources — route through [`verify_auto`], whose **slang**
+///   front-end parses each `assert property` into a cube obligation *independently of
+///   sv2v* (the sv2v flatten silently drops SVA — see the CLAUDE.md `mununu-sva` rule).
+///   One result **per SVA assertion** (its slang name in `property`). These sources ALSO
+///   compose normally — the cube is an additional per-assertion safety check.
+///   **Requires slang** (a subprocess tool absent on bare hosts): when slang is missing
+///   `verify_auto` errors and the source is silently skipped, so this path is validated in
+///   the `mununu-sva` image, never on the host.
+///
+/// Best-effort and side-channel to property evaluation: an unreadable file, an absent
+/// tool, a lift failure, or a `bad`-less design is silently skipped, so the pass never
+/// aborts the run. Parameterised sources (`count >= 2`) are not expanded here.
 fn run_safety_cube_pass(config: &VerifyConfig, base_dir: &Path) -> Vec<SafetyCubeResult> {
     let mut out = Vec::new();
     for src in &config.sources {
-        if src.adapter != "btor2" {
-            continue;
-        }
-        for file in &src.files {
-            let path = base_dir.join(file);
-            let Ok(content) = std::fs::read_to_string(&path) else {
-                continue;
-            };
-            // `Err` = no `bad` node / parse error → skip (opt-in best-effort).
-            if let Ok(verdict) = crate::adapter::recoverability::verify_safety_scalable(&content) {
-                out.push(SafetyCubeResult {
-                    source_id: src.id.clone(),
-                    file: file.display().to_string(),
-                    verdict: verdict.as_str().to_string(),
-                });
+        match src.adapter.as_str() {
+            "btor2" => {
+                for file in &src.files {
+                    let Ok(content) = std::fs::read_to_string(base_dir.join(file)) else {
+                        continue;
+                    };
+                    // `Err` = no `bad` node / parse error → skip (opt-in best-effort).
+                    if let Ok(verdict) =
+                        crate::adapter::recoverability::verify_safety_scalable(&content)
+                    {
+                        out.push(SafetyCubeResult {
+                            source_id: src.id.clone(),
+                            file: file.display().to_string(),
+                            property: None,
+                            verdict: verdict.as_str().to_string(),
+                        });
+                    }
+                }
             }
+            "sv-yosys" | "yosys" => {
+                out.extend(sv_safety_cube_results(src, base_dir));
+            }
+            _ => continue,
         }
     }
     out
+}
+
+/// Run the slang SVA front-end + cube ([`verify_auto`]) on one `sv-yosys` source and map
+/// its per-assertion outcomes to [`SafetyCubeResult`]s. Best-effort: an unreadable file or
+/// an absent/failed toolchain (slang / sv2v / yosys) yields an empty vec.
+fn sv_safety_cube_results(
+    src: &crate::verify::config::SourceSection,
+    base_dir: &Path,
+) -> Vec<SafetyCubeResult> {
+    use crate::adapter::slang::verify_auto::{VerifyAutoOptions, VerifyOutcome, verify_auto};
+
+    let Some(primary) = src.files.first() else {
+        return Vec::new();
+    };
+    // Stage every declared file as an in-memory SV source (name, content).
+    let mut sources: Vec<(String, String)> = Vec::with_capacity(src.files.len());
+    for f in &src.files {
+        let Ok(body) = std::fs::read_to_string(base_dir.join(f)) else {
+            return Vec::new();
+        };
+        let name = f
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("source.sv")
+            .to_string();
+        sources.push((name, body));
+    }
+    let additional_sources: Vec<(String, String)> = sources.iter().skip(1).cloned().collect();
+    let top = src
+        .options
+        .get("top")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let use_sv2v = src
+        .options
+        .get("use_sv2v")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let yopts = crate::adapter::yosys::YosysOptions {
+        top,
+        additional_sources,
+        use_sv2v,
+        ..Default::default()
+    };
+    // slang absent / lift failure / no SVA → Err or empty → skip.
+    let Ok(report) = verify_auto(&sources, &yopts, &VerifyAutoOptions::default()) else {
+        return Vec::new();
+    };
+    report
+        .properties
+        .iter()
+        .map(|p| SafetyCubeResult {
+            source_id: src.id.clone(),
+            file: primary.display().to_string(),
+            property: Some(p.name.clone()),
+            verdict: match p.outcome {
+                VerifyOutcome::Holds => "holds",
+                VerifyOutcome::Violated { .. } => "violated",
+                VerifyOutcome::Unknown { .. } => "unknown",
+                VerifyOutcome::Skipped { .. } => "skipped",
+            }
+            .to_string(),
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -1978,6 +2054,75 @@ name = "System"
         assert!(
             report.property_verdicts.is_empty(),
             "a cube-only project has no mu-calculus property verdicts"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires slang + sv2v + Yosys + z3 (use the mununu-sva docker image); run with --ignored"]
+    fn e2e_sv_safety_cube_reports_slang_sva_verdict() {
+        // `[project] safety_cube = true` routes an sv-yosys source through the slang SVA
+        // front-end (verify_auto), so each `assert property` becomes a cube obligation —
+        // independently of sv2v (which silently drops SVA). The one-hot state invariant
+        // `$onehot0(state_q)` HOLDS, and it is reported per-assertion in
+        // `safety_cube_results` (property = the slang assertion name).
+        const SV: &str = r#"module onehot_fsm (input logic clk, input logic rst_ni, input logic go_i);
+  localparam logic [2:0] S0 = 3'b001, S1 = 3'b010, S2 = 3'b100;
+  logic [2:0] state_q, state_d;
+  always_comb begin
+    state_d = state_q;
+    unique case (state_q)
+      S0: if (go_i) state_d = S1;
+      S1: state_d = S2;
+      S2: state_d = S0;
+      default: state_d = S0;
+    endcase
+  end
+  always_ff @(posedge clk or negedge rst_ni) begin
+    if (!rst_ni) state_q <= S0;
+    else         state_q <= state_d;
+  end
+  OneHotState_A: assert property (@(posedge clk) disable iff (!rst_ni) $onehot0(state_q));
+endmodule
+"#;
+        let temp = tempdir().unwrap();
+        std::fs::write(temp.path().join("onehot_fsm.sv"), SV).unwrap();
+        let toml_src = r#"
+[project]
+name = "SvSafetyCube"
+safety_cube = true
+
+[[sources]]
+id = "fsm"
+adapter = "sv-yosys"
+files = ["onehot_fsm.sv"]
+options = { top = "onehot_fsm", use_sv2v = true }
+
+[composition]
+semantics = "asynchronous"
+members = ["fsm"]
+name = "System"
+"#;
+        let config = VerifyConfig::from_toml(toml_src).unwrap();
+        let report = verify_project(&config, temp.path()).expect("verify_project succeeds");
+        // The design's single SVA assertion is reported per-property (slang names it
+        // `<module>_sva_<index>`, e.g. `onehot_fsm_sva_0`) and the one-hot invariant HOLDS.
+        let r = report
+            .safety_cube_results
+            .iter()
+            .find(|r| r.source_id == "fsm")
+            .unwrap_or_else(|| {
+                panic!(
+                    "the sv-yosys source's slang SVA assertion is reported; got {:?}",
+                    report.safety_cube_results
+                )
+            });
+        assert!(
+            r.property.is_some(),
+            "an sv-yosys safety-cube result carries the slang assertion name: {r:?}"
+        );
+        assert_eq!(
+            r.verdict, "holds",
+            "the one-hot state invariant HOLDS (slang SVA → cube): {r:?}"
         );
     }
 

--- a/crates/mununu-core/src/verify/report.rs
+++ b/crates/mununu-core/src/verify/report.rs
@@ -28,16 +28,25 @@ pub struct VerifyReport {
     pub safety_cube_results: Vec<SafetyCubeResult>,
 }
 
-/// One `btor2`-source safety-cube result from the opt-in `safety_cube` pass.
+/// One safety-cube result from the opt-in `safety_cube` pass.
+///
+/// A `btor2` source yields one result (its single `bad` obligation, `property = None`).
+/// An `sv-yosys` source yields one result **per SVA assertion** — its `property` is the
+/// slang-extracted assertion name — since the slang front-end parses each `assert
+/// property` into its own cube obligation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SafetyCubeResult {
     /// `[[sources]].id` the cube ran on.
     pub source_id: String,
-    /// The BTOR2 file (relative to the project base dir) the cube read.
+    /// The source file (relative to the project base dir) the cube read/lifted.
     pub file: String,
-    /// `AG ¬bad` verdict from `verify_safety_scalable` (cube + emergent-K discovery),
-    /// as the canonical [`crate::verdict::PropertyVerdict::as_str`] string —
-    /// `"holds"` | `"violated"` | `"unknown"`.
+    /// The SVA assertion name for an `sv-yosys` source; `None` for a `btor2` source
+    /// (a single anonymous `bad` obligation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub property: Option<String>,
+    /// The verdict string — `"holds"` | `"violated"` | `"unknown"` (a `btor2` source's
+    /// `verify_safety_scalable` verdict, or an `sv-yosys` property's `verify_auto`
+    /// outcome, which additionally uses `"skipped"` for a non-cube-bindable atom).
     pub verdict: String,
 }
 

--- a/wiki/Verify-Project-Flow.md
+++ b/wiki/Verify-Project-Flow.md
@@ -151,7 +151,12 @@ over = "System"
 
 > **Source of truth:** [`verify::config::ProjectSection::safety_cube`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/config.rs), [`verify::orchestrator::run_safety_cube_pass`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/orchestrator.rs) — surface: CLI+API+UI.
 
-Set `[project] safety_cube = true` to additionally run the KMTS 3-valued safety cube (`AG ¬bad` — enumeration + the **emergent-K** interpolation discovery of constant-bound / register-ordering invariants) on every `btor2`-adapter source that carries a `bad` obligation. Those sources are **cube-only**: the orchestrator has no `btor2`→automaton dispatch, so they are excluded from composition + property evaluation, and only the cube verdict is reported (in `safety_cube_results`). A best-effort pass — a `btor2` source with no `bad` node is silently skipped. Reuses [`recoverability::verify_safety_scalable`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/recoverability.rs) (also the standalone `mununu btor2 verify-safety` verb).
+Set `[project] safety_cube = true` to additionally run the KMTS 3-valued safety cube (`AG ¬bad`) on the project's sources, reporting per-source/per-assertion verdicts in `safety_cube_results`:
+
+- **`btor2` sources** — run [`recoverability::verify_safety_scalable`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/recoverability.rs) (enumeration + the **emergent-K** interpolation discovery of constant-bound / register-ordering invariants) on the source's `bad` obligation. These are **cube-only** (the orchestrator has no `btor2`→automaton dispatch): excluded from composition, one result (`property = None`).
+- **`sv-yosys` sources** — route through [`slang::verify_auto`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/slang/verify_auto.rs), whose **slang** front-end parses each `assert property` into a cube obligation *independently of sv2v* (the sv2v flatten silently drops SVA). One result **per SVA assertion** (its name in `property`). These sources still compose normally — the cube is an additional per-assertion check. **Requires slang** (a subprocess tool not on bare hosts; validate under the `mununu-sva` image).
+
+A best-effort pass — an unreadable file, an absent toolchain, or a design with no obligation is silently skipped.
 
 ```toml
 [project]
@@ -183,9 +188,10 @@ pub struct VerifyReport {
 }
 
 pub struct SafetyCubeResult {
-    pub source_id: String,                     // the btor2 source the cube ran on
+    pub source_id: String,                     // the source the cube ran on
     pub file: String,
-    pub verdict: String,                       // "holds" | "violated" | "unknown"
+    pub property: Option<String>,              // SVA assertion name (sv-yosys); None for btor2
+    pub verdict: String,                       // "holds" | "violated" | "unknown" | "skipped"
 }
 
 pub struct PropertyVerdict {


### PR DESCRIPTION
Follow-up to the emergent-K + safety-cube work: the opt-in `[project] safety_cube` pass now handles **sv-yosys** sources via `slang::verify_auto`, whose slang front-end parses each `assert property` into a cube obligation **independently of sv2v** (sv2v silently drops SVA → the earlier sv2v-lift attempt gave a vacuous `holds` and was reverted).

- `SafetyCubeResult` gains `property: Option<String>` — one result PER SVA assertion (slang name) for sv-yosys; `None` for btor2. CLI/UI/wiki updated.
- `run_safety_cube_pass` dispatches: btor2 → `verify_safety_scalable`; sv-yosys → `verify_auto`.
- **Validated in the `mununu-sva` image** (slang absent on bare hosts): `e2e_sv_safety_cube_reports_slang_sva_verdict` → `onehot_fsm_sva_0 = holds`. `#[ignore]`d.
- CLAUDE.md: `[RULE]` that slang/SVA changes are validated in `mununu-sva`, never the bare host (bare-host `holds` on SVA is presumed vacuous).

Companion UI PR: mununu-ui#51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)