### PR TITLE
docs: reclassify native_spacer as external algorithm (Z3 SPACER) + HWMCC owned-engine gap analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ flowchart TD
   C -->|"νμ box-AF → Response-liveness<br/>(AG(req → AF grant))"| L2S["Liveness-to-safety + portfolio"]
   C -->|"νμ diamond → Recoverability<br/>(AG EF good) — SVA/LTL can't state"| CUBE["KMTS 3-valued branching cube"]
 
-  SAFE --> PORT["exact BDD · native BMC/k-induction ·<br/>native SPACER · native interp (cvc5) ·<br/>btormc* · Pono*  →  differential-oracle merge"]
+  SAFE --> PORT["exact BDD · native BMC/k-induction · native interp (cvc5) ·<br/>Z3 SPACER (CHC)* · btormc* · Pono*  →  differential-oracle merge"]
   CUBE --> BR["exact 3-valued BDD (≤40b) →<br/>predicate-cube + SMT hyper-must →<br/>Podelski–Rybalchenko ranking cert"]
 
   PORT --> V["True / False / ⊥"]
@@ -214,14 +214,25 @@ runs several sound members under a *differential-oracle* merge: the first defini
 wins, and two disagreeing definite verdicts raise a `Contradiction` alarm rather than
 guessing. Any timeout / absent tool / inconclusive is a sound `⊥`.
 
-| Engine | Owner | Method |
+"Owner" is *whose model-checking algorithm runs the search*, not merely which library is
+linked — an important distinction. mununu-owned means mununu drives the search loop and uses
+z3/cvc5 only as per-query oracles; external means an outside model checker runs the whole
+search (whether linked in-process, like Z3's SPACER, or a subprocess, like btormc/Pono).
+
+| Engine | Algorithm owner | Method |
 |---|---|---|
-| Exact BDD reachability | mununu (OxiDD, in-process) | ≤40-bit exact; refuses an unsound "safe" on free init |
-| Native BMC + k-induction | mununu (z3 library, in-process) | word-level counterexample + inductive proof |
-| Native SPACER (IC3/PDR) | mununu (z3 Fixedpoint/CHC, in-process) | Horn-clause inductive invariant |
-| Native interpolation (McMillan) | mununu (cvc5 for interpolants) | last-resort; uniquely decides HWMCC `gen12/14/39` |
-| btormc | **external** subprocess | BMC + k-induction |
-| Pono | **external** subprocess | IC3/PDR (`ic3bits`) |
+| Exact BDD reachability | **mununu** (OxiDD, in-process) | ≤40-bit exact; refuses an unsound "safe" on free init |
+| Native BMC + k-induction | **mununu** (drives the unroll; z3 answers per-depth SAT) | word-level counterexample + inductive proof |
+| Native McMillan interpolation | **mununu** (drives the forward-reach k-schedule; cvc5 answers per-interpolant queries) | last-resort; uniquely decides HWMCC `gen12/14/39` |
+| SPACER (IC3/PDR) via CHC | **external algorithm — Z3's SPACER** (in-process); mununu owns only the btor2→CHC *encoding* | Z3 solves the Horn-clause problem end-to-end |
+| btormc | **external** (subprocess) | BMC + k-induction |
+| Pono | **external** (subprocess) | IC3/PDR (`ic3bits`) |
+
+So mununu-owned model-checking algorithms are the exact BDD engine, native BMC,
+native k-induction, and native McMillan interpolation; the `native_spacer` path is a **Z3
+SPACER frontend** — mununu builds the CHC encoding, Z3 runs the IC3/PDR search. (On the
+HWMCC run below, that means only 2 of the 41 decides come from a mununu-owned safety
+algorithm; the rest are Z3 SPACER, btormc, or Pono.)
 
 **KMTS 3-valued branching cube** — the differentiator: it decides *branching-time*
 μ-calculus that SVA and LTL **cannot state**, most notably recoverability `AG EF good`
@@ -244,11 +255,13 @@ are reported, never silently dropped.
 The IC3ia predicate-abstraction ladder
 ([`adapter/btor2/abs_safety.rs`](crates/mununu-core/src/adapter/btor2/abs_safety.rs)) is a
 guarded research foundation, **not** a production decider — it abstains on real designs.
-On the HWMCC bit-level suite the two external subprocess checkers (btormc, Pono) do most of
-the deciding; the mununu-owned engines contribute the unique and branching-time decides.
-The only external subprocess tools in the *verification* engines are `btormc`, `Pono`, and
-`cvc5` (interpolation); everything labelled z3/SPACER is the linked z3 **library**,
-in-process. `slang` / `sv2v` / `yosys` are SV *front-ends*, not solvers.
+On the HWMCC bit-level suite the external model checkers (Z3 SPACER, btormc, Pono) do the
+bulk of the deciding; the mununu-owned safety algorithms contribute a handful (and the
+branching-time decides that no bv tool can state). Deployment vs ownership are separate:
+`btormc` / `Pono` / `cvc5` are external **subprocesses**; Z3's SPACER is an external
+**algorithm** run in-process via the linked z3 library. z3-as-an-SMT-solver (per-query,
+inside native BMC/k-induction/interp) is mununu's search using z3 as an oracle — that part
+*is* mununu-owned. `slang` / `sv2v` / `yosys` are SV *front-ends*, not solvers.
 
 ### Surfaces — CLI · API · UI
 

--- a/crates/mununu-core/src/adapter/btor2/native_spacer.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_spacer.rs
@@ -1,12 +1,17 @@
-//! Native SPACER — in-house IC3/PDR + interpolation via Z3's **Fixedpoint (CHC)**
-//! engine.
+//! SPACER frontend — a btor2→CHC encoding decided by **Z3's SPACER**
+//! (Fixedpoint/IC3-PDR) engine.
 //!
-//! Slice 3 of P1's in-house scalable-safety back-end. It decides SAFE properties
-//! native k-induction ([`crate::adapter::btor2::native_bmc::decide_bad_safety`])
-//! leaves `Unknown` — the *non-k-inductive* ones that need an inductive-invariant
-//! search. Z3's **SPACER** does interpolation-based IC3 INTERNALLY, so this stays
-//! in-process: no cvc5 cross-solver bridge, no subprocess, commercially clean like
-//! the rest of the native engine.
+//! **Ownership note (do not overclaim):** the model-checking *algorithm* here is
+//! **Z3's**, not mununu's. Unlike native BMC / k-induction / McMillan interpolation —
+//! where mununu drives the search loop and calls z3/cvc5 only as per-query oracles —
+//! this module builds the Horn encoding and hands the *entire* IC3/PDR + interpolation
+//! search to `z3::Fixedpoint::query` (SPACER runs the frames, generalization, and proof
+//! obligations internally). So mununu owns the **encoding**, Z3 owns the **deciding**;
+//! for engine-provenance accounting this is an *external algorithm* run in-process (the
+//! same algorithm-ownership class as btormc/Pono, differing only in that Z3 is linked
+//! rather than forked as a subprocess). It decides SAFE properties native k-induction
+//! ([`crate::adapter::btor2::native_bmc::decide_bad_safety`]) leaves `Unknown` — the
+//! *non-k-inductive* ones needing an inductive-invariant search — with no subprocess.
 //!
 //! # The Horn encoding
 //!
@@ -56,10 +61,11 @@ fn and_all(cs: &[Bool]) -> Bool {
     }
 }
 
-/// Decide `bad`-reachability of `file` with Z3's SPACER (Fixedpoint/CHC) engine —
-/// an in-house IC3/PDR + interpolation model checker. See the module docs for the
-/// Horn encoding and verdict semantics. `timeout_ms` bounds the SPACER solve (a
-/// timeout returns [`SafetyVerdict::Unknown`] — never a wrong verdict).
+/// Decide `bad`-reachability of `file` with **Z3's SPACER** (Fixedpoint/CHC) engine.
+/// mununu owns the btor2→CHC encoding; the IC3/PDR + interpolation model checking is
+/// Z3's (see the module docs — this is an external algorithm run in-process, not an
+/// in-house model checker). `timeout_ms` bounds the SPACER solve (a timeout returns
+/// [`SafetyVerdict::Unknown`] — never a wrong verdict).
 pub fn decide_bad_safety_spacer(
     file: &Btor2File,
     timeout_ms: Option<u32>,

--- a/measurements/hwmcc-owned-engine-gaps.md
+++ b/measurements/hwmcc-owned-engine-gaps.md
@@ -1,0 +1,156 @@
+# Where mununu's *owned* engines fail on HWMCC'20 bv — a categorized gap analysis
+
+> Grounded in the full-portfolio run (`~/hwmcc20-bench/results-full/FINAL.md`,
+> `verify-full.log`, 2026-07-11): `mununu btor2 verify` over all 136 HWMCC'20 bv
+> instances, 120 s outer timeout shared across 5 engines. **Owner note (by *algorithm*, not
+> deployment):** the exact (BDD), native word-level BMC/k-induction, and native McMillan
+> interpolation engines are **mununu-owned** (mununu drives the search; z3/cvc5 are per-query
+> oracles). **`native_spacer` is NOT** — it builds a btor2→CHC encoding and hands the whole
+> IC3/PDR search to **Z3's SPACER** (an external algorithm, run in-process via the linked z3
+> library), the same algorithm-ownership class as the two subprocess checkers **btormc** and
+> **Pono**.
+
+## The raw split
+
+| Decider | Count (of 41 decided) | Algorithm owner |
+|---|---|---|
+| Pono (safety proof) | 23 | **external** (subprocess) |
+| btormc (counterexample) | 17 | **external** (subprocess) |
+| Z3 SPACER (via mununu's CHC encoding) | 3 | **external algorithm** (Z3, in-process; mununu owns only the encoding) |
+| exact BDD | 1 | **mununu** |
+| native BMC/k-induction | 1 | **mununu** |
+
+**mununu-owned model-checking algorithms decide only 2/41** (exact 1, native BMC/k-ind 1);
+the other 39 are external algorithms — Z3 SPACER (3), btormc (17), Pono (23). ~88/136 are
+undecided by anything. So on this suite the mununu-owned engines are *not* the workhorse —
+they contribute the exact/soundness cross-check and, via native McMillan interpolation, a
+few unique decides (see the `gen12/14/39` note). (`native_spacer` is a **Z3 SPACER
+frontend**, not a mununu algorithm — mununu builds the btor2→CHC encoding, Z3 runs the
+IC3/PDR search; it is counted external here.)
+
+## First, the honest framing: HWMCC bv is uniformly one property class
+
+Every bv-track obligation is **bit-level safety** — `AG ¬bad` (is a `bad` node reachable?).
+So the owned-engine failures here are **not** by *property class*; they are by **model
+characteristic**. The property is always the same; what changes is the design's width,
+sequential depth, memory content, and datapath arithmetic. The categories below are those
+characteristics. (The property-class gap — liveness / branching — is a separate axis the bv
+suite does not exercise; see the last section.)
+
+## The categories owned engines fail on, and why
+
+### A. State space ≫ 40 bits → the exact engine is structurally excluded
+
+mununu's flagship **exact** 3-valued BDD engine is hard-capped at 40 register+input bits
+(`MAX_BITBLAST_BITS`, `symbolic_bitblast.rs`) and `Skip`s above it. HWMCC designs are not
+close to that ceiling:
+
+| Instance | Total state bits |
+|---|---|
+| `arbitrated_top_n2_w8_d16_e0` (the *narrowest*) | **313** |
+| `arbitrated_top_n2_w64_d64_e0` | 8,323 |
+| `arbitrated_top_n2_w128_d32_e0` | 8,378 |
+
+Even the "w8" arbiter is 313 bits — ~8× the cap. The exact engine's only bv decide
+(`paper_v3`) is a 644-byte toy. **Why it fails:** BDD reachability is exponential in the
+BDD size, which explodes on hundreds-to-thousands of state bits; the cap is a deliberate
+abstain (sound) rather than an OOM. **Consequence:** the exact engine — the one that gives
+mununu its "definite verdict, sound at every alternation depth" guarantee — contributes
+essentially nothing on real bit-vector benchmarks. Above 40 bits you are on the abstraction
+cube or the external tools.
+
+### B. Non-trivially-inductive safety proofs → native k-induction + the Z3-SPACER-via-CHC path ≪ Pono's IC3/PDR
+
+Most safe HWMCC instances need an **auxiliary strengthening invariant** — the property is
+not k-inductive for small k. Generating that invariant *is* modern model checking.
+
+- **Examples (Pono proves safe, owned engines miss):** `cal159`, `cal161`, `cal162`,
+  `cal21`, `cal35`, `cal37`, `cal33`, `cal4`, `cal41`, `gen10/12/14/21/35/39`,
+  `elevator.4`. The `cal*` family (200+ instances) is almost entirely Pono-or-nothing.
+- **Examples (nobody decides):** the deep `arbitrated_top_*_d64/d128` proofs.
+
+**Why it fails:** the truly-owned **k-induction** only closes when the property is inductive
+at the tried depth — it does not synthesize the missing invariant. The `native_spacer` path
+(mununu's btor2→CHC encoding, decided by **Z3's SPACER** — not a mununu algorithm) encodes
+the design as a *single* `Inv` relation; run in-process on a shared budget it underperforms
+a dedicated **Pono** `ic3bits`, which does incremental inductive generalization (CTI blocking
++ MIC) tuned for bit-level transition systems. Note this gap is *not* fixed by any
+mununu-owned invariant discovery — mununu's own IC3ia foundation (`abs_safety.rs`) abstains
+on real designs for the same reason. **This is the single biggest gap on HWMCC:
+safe-instance proofs at scale need a strong external IC3/PDR (Z3 SPACER or Pono); mununu's
+owned safety algorithms do not synthesize the strengthening invariant.**
+
+### C. Deep counterexamples → btormc's optimized BMC out-reaches native BMC in budget
+
+For *violated* instances, native BMC is correct (it only ever claims `Violated`) but slow.
+
+- **Examples (btormc finds the CEX, owned miss):** `arbitrated_top_*_d16` (several),
+  `circular_pointer_top_w*_d*`, `brp2.3`, `at.6`, `anderson.3`.
+
+**Why it fails:** btormc/Boolector's BMC uses incremental SAT with a mature bit-vector
+encoding and reaches the violation depth quickly; mununu's native BMC (word-level, z3
+per-depth) is far less optimized and times out before the CEX depth within the shared 120 s.
+The gap is *engineering throughput on deep unrollings*, not a soundness or expressiveness
+gap — the owned BMC would find the same CEX given enough time.
+
+### D. Arrays / memories → BDD explodes *and* the CHC array encoding is unsound-suspect
+
+Array-backed designs (`vcegar_arrays_*`, `vis_arrays_*`) make each memory word part of the
+state, so the model is both wide (Category A) and semantically array-heavy.
+
+- **Example (the one confirmed defect):** `vcegar_arrays_itc99_b12_p2` — mununu's native
+  SPACER returned **`violated`** where the HWMCC ground truth is **safe** (`unsat`), and no
+  other engine (native BMC, btormc BMC to depth 200/300) could corroborate the claimed CEX.
+  Preponderance of evidence: a **spurious counterexample from mununu's btor2→CHC encoding**
+  (Z3's SPACER itself is sound; the suspect is the encoding). Flagged, not 100 % confirmed.
+
+**Why it fails:** BDDs for large memories blow the 40-bit cap immediately, and mununu's
+own array→CHC lowering is where the one soundness-bug candidate lives. External tools carry
+mature array theory; mununu's owned array handling is the weakest link — the *only*
+vs-ground-truth mismatch in the whole run (1/32 checked) is here. Notably, the inter-engine
+contradiction check **missed** it (only SPACER decided the instance), so this category is
+also where mununu's soundness *net* is thinnest.
+
+### E. Nonlinear datapath arithmetic (multipliers, `bvurem`/`bvmul`) → BDD + interpolation both choke
+
+- **Example (btormc+Pono find the CEX, owned miss):** `mul7`.
+- **Interpolation ceiling (measured elsewhere):** the `gen43`-class needs an interpolant of
+  the form `(or (= s32 s17) (= s19 (bvurem s19 s26)))`; cvc5's SyGuS `get-interpolant` search
+  took **105 s** to reach that `bvurem` grammar depth — past the per-query budget.
+
+**Why it fails:** BDD representations of multiplication are provably exponential, so the
+exact engine cannot build the relation; and mununu's McMillan interpolation engine
+(`native_interp`) is only as fast as cvc5's interpolant search, which explodes in
+grammar depth on nonlinear operators. Owned engines can decide *linear* datapath properties
+but wall on multiplier/modulo relations.
+
+## An important nuance: `gen12` / `gen14` / `gen39`
+
+In a *separate* single-engine eval, mununu's owned **McMillan `native_interp`** uniquely
+decides `gen12/14/39` — cases the whole rest of the portfolio (incl. in-process SPACER,
+btormc, Pono) left `unknown`. In *this* shared-budget portfolio run they show as
+`unreach=[pono]`, because `native_interp` is a **last-resort** member (it fires only when
+the other engines abstain) and here Pono decided them first inside the shared 120 s. So they
+are **not** a clean owned-engine failure — mununu *can* decide them; the budget order just
+let the external tool win. This is the one place the owned interpolation engine has a genuine
+*unique* edge on this suite.
+
+## The other axis: property class (not exercised by bv-track)
+
+The bv-track is 100 % safety, so it never tests the classes where the owned engines are
+strongest *or* weakest by *kind*:
+
+- **Response-liveness** `AG(req → AF grant)` — owned engines handle it only via the
+  liveness-to-safety (`l2s`) reduction, then the same safety portfolio; the Category A–E
+  limits apply to the reduced product.
+- **Branching-time recoverability** `AG EF good` — this is where the owned KMTS 3-valued
+  cube is the *only* decider (SVA/LTL and every external bv tool cannot even state it), but
+  it is decided on *abstracted* models, and above 40 bits it depends on the cube + ranking
+  certificate, not the exact engine.
+
+So a fair one-line summary: **on real bit-vector safety benchmarks, mununu's owned engines
+are gated by state-space size (exact engine, Cat A), inductive-invariant synthesis (proofs,
+Cat B), BMC throughput (deep CEX, Cat C), array theory (Cat D, + the one soundness bug), and
+nonlinear arithmetic (Cat E) — which is why external btormc/Pono carry the bulk. mununu's
+differentiated value is elsewhere: branching-time recoverability that no bv tool can state,
+and synthesis.**


### PR DESCRIPTION
**native_spacer is a Z3 SPACER wrapper, not a mununu algorithm** — it builds a btor2→CHC encoding and calls `z3::Fixedpoint::query`; Z3's SPACER runs the whole IC3/PDR search internally. mununu owns only the encoding. Distinct from native BMC / k-induction / McMillan interpolation, where mununu drives the search and uses z3/cvc5 as per-query oracles.

- `native_spacer.rs`: drop the misleading 'in-house IC3/PDR' doc claims (claims-integrity).
- README: owner column is now *by algorithm*; native_spacer → external (Z3 SPACER, in-process). Only 2/41 HWMCC decides are from a mununu-owned safety algorithm.
- `measurements/hwmcc-owned-engine-gaps.md` (new): categorized gap analysis (Cat A–E) with the array soundness-bug candidate attributed to mununu's CHC *encoding* feeding a sound Z3 SPACER.

🤖 Generated with [Claude Code](https://claude.com/claude-code)