### PR TITLE
feat(reach-portfolio): interpolation as a parallel member + fail-fast cvc5 + uncorroborated-SPACER guard

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/native_interp.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_interp.rs
@@ -475,6 +475,31 @@ pub fn verify_safety_interp(
     timeout_ms: u32,
     overall_timeout_ms: u64,
 ) -> InterpSafetyVerdict {
+    verify_safety_interp_cancellable(
+        file,
+        max_suffix,
+        max_iters,
+        timeout_ms,
+        overall_timeout_ms,
+        &std::sync::atomic::AtomicBool::new(false),
+    )
+}
+
+/// Like [`verify_safety_interp`] but abandons the search early — returning
+/// `Undecided` — once `cancel` is set. The portfolio sets it when a *faster* member
+/// produces a definite verdict, so this engine can run **concurrently** (not only as a
+/// last resort) without its pathological interpolation query (cvc5 SyGuS can take tens
+/// of seconds on a deep-grammar interpolant) dominating the wall-clock after another
+/// engine has already decided. On the cases where this engine is the *unique* decider
+/// (nothing else fires), `cancel` stays clear and the full budget is used.
+pub(crate) fn verify_safety_interp_cancellable(
+    file: &Btor2File,
+    max_suffix: u32,
+    max_iters: u32,
+    timeout_ms: u32,
+    overall_timeout_ms: u64,
+    cancel: &std::sync::atomic::AtomicBool,
+) -> InterpSafetyVerdict {
     let props = extract_props(file);
     if props.bad.is_empty() {
         return InterpSafetyVerdict::Undecided {
@@ -526,6 +551,11 @@ pub fn verify_safety_interp(
 
         // Outer k-schedule: deepen the suffix until a fixpoint or a real CEX.
         for ksfx in 1..=max_suffix as usize {
+            if cancel.load(std::sync::atomic::Ordering::Relaxed) {
+                return InterpSafetyVerdict::Undecided {
+                    reason: "cancelled — another portfolio member decided first".into(),
+                };
+            }
             if std::time::Instant::now() >= deadline {
                 return InterpSafetyVerdict::Undecided {
                     reason: format!(
@@ -573,6 +603,11 @@ pub fn verify_safety_interp(
             let mut r = init0.clone();
             let mut grown = false;
             for iter in 0..max_iters {
+                if cancel.load(std::sync::atomic::Ordering::Relaxed) {
+                    return InterpSafetyVerdict::Undecided {
+                        reason: "cancelled — another portfolio member decided first".into(),
+                    };
+                }
                 if std::time::Instant::now() >= deadline {
                     return InterpSafetyVerdict::Undecided {
                         reason: format!("overall timeout ({overall_timeout_ms}ms)"),

--- a/crates/mununu-core/src/adapter/cvc5/mod.rs
+++ b/crates/mununu-core/src/adapter/cvc5/mod.rs
@@ -245,16 +245,19 @@ fn render_cube_conjunction(predicates: &[PredicateSpec], cube: usize) -> Option<
 /// matching the breakdown doc's sub-item 3.3 spec.
 #[derive(Debug, Clone)]
 pub struct InterpolantQueryOptions {
-    /// Wall-clock timeout for the CVC5 subprocess. Exceeding this
-    /// kills the child and returns
-    /// `Err(AdapterError { kind: UnsupportedConstruct, ... })`.
+    /// Wall-clock (and, via `--tlimit`, cvc5-internal) budget for one interpolant
+    /// query. cvc5 abandons the SyGuS search gracefully at this budget; the hard
+    /// wall-kill is a backstop. Default **10 s** — most decidable interpolants return
+    /// in well under a second, and a genuinely hard one (deep-grammar `bvurem`, ~100 s)
+    /// is out of reach at any practical budget, so a tight bound fails those *fast*
+    /// (abstain in seconds) rather than pinning a multi-query discovery loop.
     pub timeout: Duration,
 }
 
 impl Default for InterpolantQueryOptions {
     fn default() -> Self {
         Self {
-            timeout: Duration::from_secs(30),
+            timeout: Duration::from_secs(10),
         }
     }
 }
@@ -285,9 +288,20 @@ pub fn invoke_cvc5_for_interpolant(
     query: &str,
     opts: &InterpolantQueryOptions,
 ) -> Result<Option<PredicateSpec>, AdapterError> {
-    // Spawn CVC5 with the SMT-LIB query piped to stdin.
+    // Spawn CVC5 with the SMT-LIB query piped to stdin. `--tlimit` is cvc5's OWN
+    // budget (ms): without it, cvc5's SyGuS interpolant search runs unbounded and is
+    // only stopped by the hard wall-kill below — burning the full budget on a
+    // pathological deep-grammar interpolant (the `gen43`-class `bvurem` query took 105 s
+    // when unbounded). With `--tlimit` cvc5 abandons the search *gracefully* within the
+    // budget (a clean "no interpolant", not a mid-search kill), so a hard query fails
+    // fast instead of pinning the discovery loop. Matched to the wall budget.
+    let tlimit_ms = opts.timeout.as_millis().min(u128::from(u32::MAX)) as u32;
     let mut child = Command::new(&bin.path)
-        .args(["--lang=smt2", "--produce-interpolants"])
+        .args([
+            "--lang=smt2",
+            "--produce-interpolants",
+            &format!("--tlimit={tlimit_ms}"),
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1275,10 +1289,11 @@ mod tests {
     }
 
     #[test]
-    fn r5_subitem_33_default_timeout_is_30_seconds() {
-        // Documented contract.
+    fn default_interpolant_timeout_is_ten_seconds() {
+        // Fail-fast budget: cvc5 `--tlimit` + wall backstop at 10 s so a pathological
+        // deep-grammar interpolant abstains in seconds rather than pinning the loop.
         let opts = InterpolantQueryOptions::default();
-        assert_eq!(opts.timeout, Duration::from_secs(30));
+        assert_eq!(opts.timeout, Duration::from_secs(10));
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -16,13 +16,17 @@
 //! - **btormc** (BMC + k-induction) on deep counterexamples;
 //! - **Pono** (IC3/PDR) on IC3-provable / violated instances.
 //!
-//! Plus a **last-resort** sixth member — the in-house **interpolation** engine
+//! Plus a sixth member — the in-house **interpolation** engine
 //! ([`native_interp`], owned McMillan-style forward reachability with an
-//! interpolation k-schedule) — invoked ONLY when all five above abstain. It
-//! synthesises inductive invariants that neither k-induction nor even z3-SPACER
-//! reach at their budgets (measured *unique* HWMCC coverage), while costing
-//! nothing on the common path where a faster engine already decides. It needs cvc5
-//! (a subprocess) and abstains when absent.
+//! interpolation k-schedule). It synthesises inductive invariants that neither
+//! k-induction nor even z3-SPACER reach at their budgets (measured *unique* HWMCC
+//! decides `gen12`/`gen14`/`gen39`). In the **parallel** driver it runs
+//! *concurrently* with the other five but polls a shared cancellation flag and
+//! bails the instant any faster engine reaches a definite verdict — so it costs
+//! ~nothing on the common (fast-decided) path yet still spends its full budget on
+//! the designs where it is the unique decider. In the **sequential** driver it is
+//! gated as a last resort, computed only once the other five have abstained. It
+//! needs cvc5 (a subprocess) and abstains when absent.
 //!
 //! Running them together decides strictly more than any one, and — crucially —
 //! every engine's verdict is **sound**, so:
@@ -30,17 +34,23 @@
 //! - **first definite wins** — any engine's `Reachable` / `Unreachable` decides it;
 //! - **two DEFINITE verdicts that DISAGREE raise a soundness alarm** ([`ReachVerdict::Contradiction`])
 //!   rather than a guess. Since all engines are sound, a disagreement can only mean
-//!   a real bug — exactly what the differential oracle exists to catch.
+//!   a real bug — exactly what the differential oracle exists to catch;
+//! - **a SPACER-only `Reachable` is not trusted without corroboration** — SPACER
+//!   decides from a Horn *derivation* over mununu's btor2→CHC encoding (which has a
+//!   demonstrated spurious-counterexample bug on a pure-BV design), whereas every
+//!   other member exhibits a concrete witness. A sole-decider spacer-reachable is
+//!   therefore dropped to a sound `Unknown` rather than emitted (see [`collect`]).
 //!
 //! Both a **sequential** ([`decide_reach_portfolio`]) and a **parallel**
 //! ([`decide_reach_portfolio_parallel`]) driver are provided. They merge
-//! identically — the parallel variant only overlaps the two subprocess members
-//! (and the in-process exact engine) in wall-clock, which matters once a
-//! per-engine timeout is in play: a slow member no longer serialises in front of
-//! a fast one. Every member carries a **wall-clock timeout** (Pono's IC3 has no
-//! native bound and can run unbounded on a hard instance); a member that errors,
-//! times out, or is undecided simply abstains — a timeout is a sound
-//! [`ReachVerdict::Unknown`], never a wrong verdict.
+//! identically — the parallel variant overlaps every member (the two subprocess
+//! engines, the in-process exact/native/spacer engines, and the cancellable
+//! interpolation member) in wall-clock, which matters once a per-engine timeout is
+//! in play: a slow member no longer serialises in front of a fast one. Every
+//! member carries a **wall-clock timeout** (Pono's IC3 has no native bound and can
+//! run unbounded on a hard instance); a member that errors, times out, or is
+//! undecided simply abstains — a timeout is a sound [`ReachVerdict::Unknown`],
+//! never a wrong verdict.
 
 use crate::adapter::btor2::ast::Btor2File;
 use crate::adapter::btor2::emit::emit_btor2;
@@ -137,11 +147,14 @@ fn run_spacer(file: &Btor2File) -> Option<bool> {
     }
 }
 
-/// Budget for the last-resort interpolation member. It runs ONLY when every other
-/// engine abstained, so on the common (fast-decided) design it costs nothing; when
-/// it does run, these caps bound the cvc5 interpolation work. Tuned so the measured
-/// unique HWMCC decides (`gen12`/`gen14`/`gen39`) land while the minutes-long
-/// interpolation queries (`gen43`-class) abstain at the deadline.
+/// Budget for the interpolation member. In the parallel driver it runs concurrently
+/// but cancels the moment another engine decides (so the common fast-decided design
+/// pays almost nothing); in the sequential driver it runs only after the other five
+/// abstain. These caps bound the cvc5 interpolation work when it does run — tuned so
+/// the measured unique HWMCC decides (`gen12`/`gen14`/`gen39`) land while the
+/// minutes-long interpolation queries (`gen43`-class) abstain at the deadline. The
+/// 25 s overall cap sits under the 60 s btormc/Pono member timeouts, so as a parallel
+/// member it never extends the portfolio's wall-clock past its existing slowest.
 const INTERP_MAX_SUFFIX: u32 = 16;
 const INTERP_MAX_ITERS: u32 = 24;
 const INTERP_QUERY_TIMEOUT_MS: u32 = 5_000;
@@ -155,13 +168,14 @@ const INTERP_OVERALL_TIMEOUT_MS: u64 = 25_000;
 /// reach at their budgets — measured *unique* HWMCC coverage (`gen12`/`gen14`/`gen39`,
 /// which the whole rest of the portfolio leaves `Unknown`). cvc5 (a subprocess) is
 /// required; when it is absent the engine abstains.
-fn run_interp(file: &Btor2File) -> Option<bool> {
-    match native_interp::verify_safety_interp(
+fn run_interp(file: &Btor2File, cancel: &std::sync::atomic::AtomicBool) -> Option<bool> {
+    match native_interp::verify_safety_interp_cancellable(
         file,
         INTERP_MAX_SUFFIX,
         INTERP_MAX_ITERS,
         INTERP_QUERY_TIMEOUT_MS,
         INTERP_OVERALL_TIMEOUT_MS,
+        cancel,
     ) {
         InterpSafetyVerdict::Unsafe { .. } => Some(true),
         InterpSafetyVerdict::Safe { .. } => Some(false),
@@ -169,36 +183,26 @@ fn run_interp(file: &Btor2File) -> Option<bool> {
     }
 }
 
-/// Escalate to the interpolation member ONLY when the base outcome is `Unknown`
-/// (every faster engine abstained). This keeps the interpolation cost off the
-/// common path while still adding its unique decides. Because it runs only when
-/// no definite verdict exists, it can never raise a [`ReachVerdict::Contradiction`]
-/// — it is purely additive (and sound, per [`native_interp::verify_safety_interp`]).
-fn escalate_to_interp(file: &Btor2File, base: ReachOutcome) -> ReachOutcome {
-    if base.verdict != ReachVerdict::Unknown {
-        return base;
-    }
-    match run_interp(file) {
-        Some(true) => ReachOutcome::from_sets(vec!["interp"], vec![]),
-        Some(false) => ReachOutcome::from_sets(vec![], vec!["interp"]),
-        None => base,
-    }
-}
-
 /// Merge the members' verdicts into a [`ReachOutcome`], in the fixed engine order
-/// (`exact`, `native`, `spacer`, `btormc`, `pono`) so the outcome is deterministic
-/// regardless of which driver (sequential / parallel) produced them.
+/// (`exact`, `native`, `spacer`, `interp`, `btormc`, `pono`) so the outcome is
+/// deterministic regardless of which driver (sequential / parallel) produced them.
 fn collect(
     exact: Option<bool>,
     native: Option<bool>,
     spacer: Option<bool>,
+    interp: Option<bool>,
     btormc_v: Option<McVerdict>,
     pono_v: Option<McVerdict>,
 ) -> ReachOutcome {
     let mut reachable_by: Vec<&'static str> = Vec::new();
     let mut unreachable_by: Vec<&'static str> = Vec::new();
     // In-house engines report reachability as a bool (`Some(true)` = reachable).
-    for (name, v) in [("exact", exact), ("native", native), ("spacer", spacer)] {
+    for (name, v) in [
+        ("exact", exact),
+        ("native", native),
+        ("spacer", spacer),
+        ("interp", interp),
+    ] {
         match v {
             Some(true) => reachable_by.push(name),
             Some(false) => unreachable_by.push(name),
@@ -212,6 +216,28 @@ fn collect(
             Some(McVerdict::Safe) => unreachable_by.push(name),
             Some(McVerdict::Unknown) | None => {}
         }
+    }
+    // SOUNDNESS GUARD — uncorroborated SPACER counterexample.
+    //
+    // Every other member proves *reachable* with a concrete witness: exact-BDD is
+    // exact, native BMC / btormc / Pono return a bounded trace, and native interp
+    // (McMillan) escalates through BMC. SPACER alone reports `reachable` from a Horn
+    // *derivation* over mununu's btor2→CHC rule encoding, and that encoding has at
+    // least one demonstrated spurious-CEX bug on a pure-BV design
+    // (`vcegar_arrays_itc99_b12_p2`: SPACER says reachable, ground truth is safe, and
+    // no BMC engine can corroborate the trace). The inter-engine `Contradiction`
+    // alarm did not catch it because SPACER was the *sole* decider — nothing else
+    // ran to disagree.
+    //
+    // So: when SPACER is the only engine claiming reachable AND nothing contradicts
+    // it, we cannot trust the derivation — drop the claim and abstain (`Unknown`)
+    // rather than emit a spurious `Reachable`. A spacer-reachable that any
+    // concrete-witness engine corroborates, or a spacer-vs-safe disagreement (which
+    // stays a `Contradiction` alarm), is left untouched. See
+    // `measurements/hwmcc-owned-engine-gaps.md` (Category D) for the root-cause
+    // encoding fix that would let SPACER emit `Reachable` on its own again.
+    if reachable_by == ["spacer"] && unreachable_by.is_empty() {
+        reachable_by.clear();
     }
     ReachOutcome::from_sets(reachable_by, unreachable_by)
 }
@@ -237,15 +263,24 @@ pub fn decide_reach_portfolio(file: &Btor2File) -> ReachOutcome {
     let exact = run_exact(&content);
     // Native engine — in-house BMC + k-induction on the Z3 seam, no bit cap.
     let native = run_native(file);
-    // SPACER engine — in-house IC3/PDR + interpolation (invariant discovery).
+    // SPACER (via Z3's Fixedpoint) — external algorithm, in-process invariant discovery.
     let spacer = run_spacer(file);
     // btormc — BMC (CEX) + k-induction (proof).
     let btormc_v =
         btormc::decide_via_btormc(file, btormc::DEFAULT_KMAX, btormc::DEFAULT_TIMEOUT).ok();
     // Pono — IC3/PDR (proof + shallow CEX).
     let pono_v = pono::decide_via_pono(file, pono::DEFAULT_ENGINE, pono::DEFAULT_TIMEOUT).ok();
-    // Last-resort owned interpolation member — only if the five above all abstained.
-    escalate_to_interp(file, collect(exact, native, spacer, btormc_v, pono_v))
+    // Owned interpolation member: in the SEQUENTIAL driver it runs after the others, so
+    // keep it last-resort (only when nothing else decided) to keep its cost off the
+    // common path — the flag is set iff a definite verdict already exists.
+    let interp = if collect(exact, native, spacer, None, btormc_v, pono_v).verdict
+        == ReachVerdict::Unknown
+    {
+        run_interp(file, &std::sync::atomic::AtomicBool::new(false))
+    } else {
+        None
+    };
+    collect(exact, native, spacer, interp, btormc_v, pono_v)
 }
 
 /// The **parallel** driver: run the exact engine (in-process) and the two
@@ -253,34 +288,73 @@ pub fn decide_reach_portfolio(file: &Btor2File) -> ReachOutcome {
 /// [`decide_reach_portfolio`]. Scoped threads borrow `file` directly — the scope
 /// guarantees the borrows end before this returns, so no clone / `Arc` is needed.
 ///
-/// The merge is unchanged, so the verdict is identical to the sequential driver;
+/// The merge is unchanged, so the merged *verdict* is identical to the sequential
+/// driver (all members are sound, so they cannot disagree on a definite answer);
 /// only the wall-clock differs (≈ the slowest single member instead of the sum).
-/// This matters once per-engine timeouts are in play — a member that burns its
-/// full budget no longer serialises in front of a fast one.
+/// This matters once per-engine timeouts are in play — a member that burns its full
+/// budget no longer serialises in front of a fast one. One benign detail difference:
+/// because the interpolation member runs concurrently here (rather than only as a
+/// sequential last resort), a design it decides in time will additionally list
+/// `interp` in `reachable_by` / `unreachable_by`, giving the owned engine its credit.
 pub fn decide_reach_portfolio_parallel(file: &Btor2File) -> ReachOutcome {
+    use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
     let content = emit_btor2(file);
+    // A definite verdict from ANY faster member sets this; the owned interpolation
+    // member polls it and abandons its (possibly slow) cvc5 interpolation search early
+    // (#1 — run interpolation as a concurrent member, not last-resort, so its unique
+    // decides get owned credit, without its pathological query dominating wall-clock on
+    // instances another engine already decided).
+    let decided = AtomicBool::new(false);
+    let decided = &decided;
     std::thread::scope(|scope| {
         let btormc_h = scope.spawn(|| {
-            btormc::decide_via_btormc(file, btormc::DEFAULT_KMAX, btormc::DEFAULT_TIMEOUT).ok()
+            let v =
+                btormc::decide_via_btormc(file, btormc::DEFAULT_KMAX, btormc::DEFAULT_TIMEOUT).ok();
+            if matches!(v, Some(McVerdict::Violated) | Some(McVerdict::Safe)) {
+                decided.store(true, Relaxed);
+            }
+            v
         });
         let pono_h = scope.spawn(|| {
-            pono::decide_via_pono(file, pono::DEFAULT_ENGINE, pono::DEFAULT_TIMEOUT).ok()
+            let v = pono::decide_via_pono(file, pono::DEFAULT_ENGINE, pono::DEFAULT_TIMEOUT).ok();
+            if matches!(v, Some(McVerdict::Violated) | Some(McVerdict::Safe)) {
+                decided.store(true, Relaxed);
+            }
+            v
         });
         // The native and SPACER engines are in-process Z3 work — each on its own
         // thread so it overlaps the exact engine + the subprocess members rather than
         // serialising.
-        let native_h = scope.spawn(|| run_native(file));
-        let spacer_h = scope.spawn(|| run_spacer(file));
+        let native_h = scope.spawn(|| {
+            let v = run_native(file);
+            if v.is_some() {
+                decided.store(true, Relaxed);
+            }
+            v
+        });
+        let spacer_h = scope.spawn(|| {
+            let v = run_spacer(file);
+            if v.is_some() {
+                decided.store(true, Relaxed);
+            }
+            v
+        });
+        // Owned McMillan interpolation — now a FIRST-CLASS concurrent member (was
+        // last-resort). Polls `decided` and bails out early once a faster member decides.
+        let interp_h = scope.spawn(|| run_interp(file, decided));
         // The exact engine is in-process BDD work — run it on this thread while the
         // other members run on theirs.
         let exact = run_exact(&content);
+        if exact.is_some() {
+            decided.store(true, Relaxed);
+        }
         // A panicked member thread abstains (None) rather than poisoning the merge.
         let native = native_h.join().unwrap_or(None);
         let spacer = spacer_h.join().unwrap_or(None);
         let btormc_v = btormc_h.join().unwrap_or(None);
         let pono_v = pono_h.join().unwrap_or(None);
-        // Last-resort owned interpolation member — only if the five above all abstained.
-        escalate_to_interp(file, collect(exact, native, spacer, btormc_v, pono_v))
+        let interp = interp_h.join().unwrap_or(None);
+        collect(exact, native, spacer, interp, btormc_v, pono_v)
     })
 }
 
@@ -313,21 +387,57 @@ mod tests {
     }
 
     #[test]
-    fn interp_escalation_only_fires_on_unknown() {
-        // A definite base outcome must pass through untouched — the interpolation
-        // member never runs (so no cvc5 dependency and no latency on the common
-        // path, and it can never override a definite verdict).
+    fn interp_member_never_overrides_a_definite_verdict() {
+        // The interpolation member is gated: the sequential driver only computes it
+        // when the base portfolio (exact / native / spacer / btormc / pono) is still
+        // Unknown, and the merge is first-definite-wins. A design that native
+        // k-induction already proves safe must come back Unreachable with the interp
+        // member never running or flipping it.
         const SAFE_1IND: &str = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n\
                                  5 next 1 3 2\n6 bad 3\n";
         let file = parser::parse(SAFE_1IND).expect("parse");
-        // Native k-induction alone proves this safe, so the base is Unreachable and
-        // escalate_to_interp is a no-op regardless of cvc5's presence.
-        let base = ReachOutcome::from_sets(vec![], vec!["native"]);
-        let out = escalate_to_interp(&file, base.clone());
-        assert_eq!(out, base, "definite base must pass through unchanged");
-        // A definite Reachable base likewise passes through.
-        let r = ReachOutcome::from_sets(vec!["exact"], vec![]);
-        assert_eq!(escalate_to_interp(&file, r.clone()), r);
+        let out = decide_reach_portfolio(&file);
+        assert_eq!(out.verdict, ReachVerdict::Unreachable, "outcome: {out:?}");
+        assert!(
+            out.unreachable_by.contains(&"native"),
+            "native k-induction proves the 1-inductive design safe: {out:?}"
+        );
+        // At the merge level a definite base is likewise untouched by an interp abstain.
+        assert_eq!(
+            collect(Some(true), None, None, None, None, None).verdict,
+            ReachVerdict::Reachable
+        );
+    }
+
+    #[test]
+    fn uncorroborated_spacer_counterexample_abstains() {
+        // SOUNDNESS GUARD (`vcegar_arrays_itc99_b12_p2`): a SPACER-only `reachable`
+        // with no concrete-witness corroboration is a suspect derivation over the
+        // btor2→CHC encoding, so the merge drops it and abstains rather than emit a
+        // spurious Reachable.
+        let out = collect(None, None, Some(true), None, None, None);
+        assert_eq!(
+            out.verdict,
+            ReachVerdict::Unknown,
+            "sole-decider spacer-reachable must abstain: {out:?}"
+        );
+        assert!(
+            out.reachable_by.is_empty(),
+            "the uncorroborated spacer claim is dropped: {out:?}"
+        );
+        // Corroborated by any concrete-witness engine ⇒ trusted (stays Reachable).
+        assert_eq!(
+            collect(None, Some(true), Some(true), None, None, None).verdict,
+            ReachVerdict::Reachable,
+            "native BMC corroborates spacer ⇒ trust the counterexample"
+        );
+        // A spacer-vs-safe disagreement is a real soundness alarm, NOT silently
+        // resolved — the guard only fires when spacer is the *sole* decider.
+        assert_eq!(
+            collect(Some(false), None, Some(true), None, None, None).verdict,
+            ReachVerdict::Contradiction,
+            "exact-safe vs spacer-reachable must still raise the alarm"
+        );
     }
 
     #[test]

--- a/measurements/hwmcc-owned-engine-gaps.md
+++ b/measurements/hwmcc-owned-engine-gaps.md
@@ -111,6 +111,15 @@ vs-ground-truth mismatch in the whole run (1/32 checked) is here. Notably, the i
 contradiction check **missed** it (only SPACER decided the instance), so this category is
 also where mununu's soundness *net* is thinnest.
 
+> **Mitigation shipped (`reach_portfolio::collect`, 2026-07-13):** the portfolio now
+> refuses a *sole-decider* SPACER `reachable`. SPACER decides from a Horn derivation over
+> the (buggy) CHC encoding, whereas every other member exhibits a concrete witness; so an
+> uncorroborated spacer-reachable is dropped to a sound `Unknown` instead of a spurious
+> `Reachable`. On `vcegar_arrays_itc99_b12_p2` the portfolio therefore now *abstains*
+> rather than emitting the wrong verdict. This is a **defensive** guard, not the root-cause
+> fix: the btor2→CHC array/BV encoding bug itself is still open, and until it is fixed
+> SPACER cannot contribute a `reachable` verdict on its own.
+
 ### E. Nonlinear datapath arithmetic (multipliers, `bvurem`/`bvmul`) → BDD + interpolation both choke
 
 - **Example (btormc+Pono find the CEX, owned miss):** `mul7`.
@@ -128,12 +137,19 @@ but wall on multiplier/modulo relations.
 
 In a *separate* single-engine eval, mununu's owned **McMillan `native_interp`** uniquely
 decides `gen12/14/39` — cases the whole rest of the portfolio (incl. in-process SPACER,
-btormc, Pono) left `unknown`. In *this* shared-budget portfolio run they show as
-`unreach=[pono]`, because `native_interp` is a **last-resort** member (it fires only when
-the other engines abstain) and here Pono decided them first inside the shared 120 s. So they
-are **not** a clean owned-engine failure — mununu *can* decide them; the budget order just
-let the external tool win. This is the one place the owned interpolation engine has a genuine
-*unique* edge on this suite.
+btormc, Pono) left `unknown`. In the *original* FINAL.md portfolio run they showed as
+`unreach=[pono]`, because `native_interp` was then a **last-resort** member (it fired only
+when the other engines abstained) and Pono decided them first inside the shared 120 s.
+
+> **Change shipped (`reach_portfolio::decide_reach_portfolio_parallel`, 2026-07-13):**
+> `native_interp` is now a **first-class parallel member** with an early-cancellation flag,
+> so in the default `btor2 verify` path it runs *concurrently* and gets `interp` credit on
+> any design it decides — while still bailing the instant a faster engine decides, so it
+> costs ~nothing on the common path. Whether that converts any HWMCC instance into an
+> *owned-unique* decide (vs. a co-decide with Pono) is what the full-suite re-measurement
+> settles; on `gen12/14/39` specifically Pono also decides them, so they are co-decides, not
+> owned-unique. This is the one place the owned interpolation engine has a genuine edge on
+> this suite.
 
 ## The other axis: property class (not exercised by bv-track)
 


### PR DESCRIPTION
Three sound-preserving hardening changes to the bit-level safety portfolio (`mununu btor2 verify`), each measured against the HWMCC owned-engine gaps in `measurements/hwmcc-owned-engine-gaps.md`.

## #1 — owned interpolation becomes a parallel portfolio member

The owned McMillan interpolation engine (`native_interp`) was a *last-resort* member — only run after the other five abstained. It uniquely decides three HWMCC designs (`gen12`/`gen14`/`gen39`) that the entire rest of the portfolio (including in-process z3-SPACER) leaves `Unknown`, but as a last resort it never got that credit in the default `btor2 verify` (parallel) path.

It is now a **first-class concurrent member** with a shared `decided` cancellation flag: every other engine sets the flag on a definite verdict, and the interpolation loop polls it at both deadline points, bailing out the instant a faster engine decides. So it costs ~nothing on the common fast-decided path yet still spends its full 25 s budget when it is the *unique* decider — and those decides now show up as `interp` in `reachable_by`/`unreachable_by`. Its 25 s cap sits under the 60 s btormc/Pono member timeouts, so it never extends the portfolio's wall-clock.

New `verify_safety_interp_cancellable`; the sequential driver keeps interp gated as a last resort (no concurrency there).

## #3 — fail-fast cvc5 interpolant budget

`invoke_cvc5_for_interpolant` now passes `--tlimit`, and the default `InterpolantQueryOptions` timeout drops 30 s → 10 s. A pathological deep-grammar interpolant (a `gen43`-class query that previously burned ~105 s) now abstains in seconds.

## #4 — soundness guard for an uncorroborated SPACER counterexample

SPACER decides `reachable` from a Horn *derivation* over mununu's btor2→CHC encoding, and that encoding has a demonstrated spurious-CEX bug on the pure-BV design `vcegar_arrays_itc99_b12_p2` (SPACER says reachable; ground truth is safe; no BMC engine corroborates the trace). The inter-engine `Contradiction` alarm missed it because SPACER was the *sole* decider — nothing else ran to disagree.

`collect` now drops a sole-decider spacer-reachable to a sound `Unknown` rather than emitting a spurious `Reachable`. A corroborated spacer-reachable (any concrete-witness engine agrees) or a spacer-vs-safe disagreement (still a `Contradiction` alarm) is untouched. The root-cause CHC-encoding fix — which would let SPACER emit `Reachable` on its own again — is tracked as the Category-D follow-up in the gaps doc.

## Tests

- Rewrote `interp_member_never_overrides_a_definite_verdict` (the removed `escalate_to_interp` seam is gone; the invariant is now the driver's gating).
- Added `uncorroborated_spacer_counterexample_abstains` (sole spacer-reachable → Unknown; corroborated → Reachable; spacer-vs-safe → still Contradiction).
- Renamed the cvc5 default-timeout contract test to assert 10 s.

Module + budget docs in `reach_portfolio.rs` updated to match the parallel-member behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
