### PR TITLE
feat(btor2): owned-standalone verify (--owned-only) + deep counterexample search

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -591,6 +591,21 @@ struct Btor2VerifyArgs {
     /// Path to the BTOR2 input file.
     #[arg(value_name = "BTOR2_FILE")]
     file: PathBuf,
+    /// Decide with ONLY the mununu-owned engines (exact BDD, native BMC /
+    /// k-induction, native McMillan interpolation, and the deep counterexample
+    /// search) — no external SPACER / btormc / Pono. Answers "what can mununu's own
+    /// algorithms decide on their own?", for no-subprocess deployments and the
+    /// soundness cross-check.
+    ///
+    /// surface: CLI-only — a soundness-audit / no-subprocess diagnostic, peer of the
+    /// CLI-only `verify-safety --engine ic3`; the default full portfolio remains the
+    /// CLI+API+UI path.
+    #[arg(long)]
+    owned_only: bool,
+    /// Per-engine wall budget (ms) for `--owned-only` (default 60000). Larger values
+    /// let native interpolation and the deep counterexample search reach more designs.
+    #[arg(long, value_name = "MS", default_value_t = 60_000)]
+    owned_timeout_ms: u32,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2524,20 +2539,31 @@ fn btor2_verify_safety(args: Btor2VerifySafetyArgs) -> Result<(), String> {
     let content = std::fs::read_to_string(&args.file)
         .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
 
-    let (verdict, engine) = match args.engine {
-        SafetyEngineArg::Cube => (verify_safety_scalable(&content)?, "cube"),
+    let (verdict, engine, detail) = match args.engine {
+        SafetyEngineArg::Cube => (verify_safety_scalable(&content)?, "cube", None),
         SafetyEngineArg::Ic3 => {
             use mununu_core::adapter::btor2::abs_safety::{AbsVerdict, verify_safety_ic3};
             let file = mununu_core::adapter::btor2::parser::parse(&content)
                 .map_err(|e| format!("verify-safety (ic3): parsing BTOR2: {}", e.message))?;
             // Budgets mirror the abs_safety unit tests (32 frames, 8 refinements, 5 s/query),
             // with a longer overall query timeout for the CLI's larger inputs.
-            let verdict = match verify_safety_ic3(&file, 32, 8, 10_000) {
+            let av = verify_safety_ic3(&file, 32, 8, 10_000);
+            // Surface the engine's own diagnosis — the abstain *reason* (grammar ceiling,
+            // frame/blocking limit, refinement stall) or the invariant/CEX size — so the
+            // experimental IC3ia path is diagnosable from the CLI, not opaque.
+            let detail = Some(match &av {
+                AbsVerdict::Safe { predicates } => {
+                    format!("inductive invariant over {predicates} predicates")
+                }
+                AbsVerdict::Unsafe { depth } => format!("counterexample at depth {depth}"),
+                AbsVerdict::Unknown { reason } => reason.clone(),
+            });
+            let verdict = match av {
                 AbsVerdict::Safe { .. } => PropertyVerdict::Holds,
                 AbsVerdict::Unsafe { .. } => PropertyVerdict::Violated,
                 AbsVerdict::Unknown { .. } => PropertyVerdict::Unknown,
             };
-            (verdict, "ic3")
+            (verdict, "ic3", detail)
         }
     };
 
@@ -2546,6 +2572,7 @@ fn btor2_verify_safety(args: Btor2VerifySafetyArgs) -> Result<(), String> {
         "property": "AG !bad",
         "engine": engine,
         "verdict": verdict.as_str(),
+        "detail": detail,
     });
     println!(
         "{}",
@@ -2656,7 +2683,9 @@ fn per_response_decided_by(
 /// breakdown as JSON. Surface peer of the API `POST /api/v1/btor2/verify`; both share
 /// the verdict label via [`mununu_core::verdict::PropertyVerdict`].
 fn btor2_verify(args: Btor2VerifyArgs) -> Result<(), String> {
-    use mununu_core::adapter::reach_portfolio::decide_reach_portfolio_parallel;
+    use mununu_core::adapter::reach_portfolio::{
+        decide_reach_owned_only, decide_reach_portfolio_parallel,
+    };
     use mununu_core::verdict::PropertyVerdict;
 
     let content = std::fs::read_to_string(&args.file)
@@ -2664,12 +2693,18 @@ fn btor2_verify(args: Btor2VerifyArgs) -> Result<(), String> {
     let file = mununu_core::adapter::btor2::parser::parse(&content)
         .map_err(|e| format!("BTOR2 parse error in '{}': {e}", args.file.display()))?;
 
-    // Parallel driver: identical merge to the sequential one, but wall-clock is
-    // bounded by the slowest single engine rather than their sum.
-    let outcome = decide_reach_portfolio_parallel(&file);
+    // `--owned-only`: mununu-owned engines only (no external SPACER/btormc/Pono).
+    // Otherwise the full parallel portfolio — identical merge to the sequential
+    // driver, but wall-clock bounded by the slowest single engine.
+    let outcome = if args.owned_only {
+        decide_reach_owned_only(&file, args.owned_timeout_ms)
+    } else {
+        decide_reach_portfolio_parallel(&file)
+    };
 
     let summary = serde_json::json!({
         "file": args.file.display().to_string(),
+        "engines": if args.owned_only { "owned-only" } else { "full-portfolio" },
         "verdict": PropertyVerdict::from(outcome.verdict).as_str(),
         "reachable_by": outcome.reachable_by,
         "unreachable_by": outcome.unreachable_by,

--- a/crates/mununu-core/src/adapter/btor2/native_bmc.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_bmc.rs
@@ -468,6 +468,75 @@ pub fn decide_bad_safety(
     })
 }
 
+/// Time-boxed **pure counterexample search** — the "counterstrategy" half of the
+/// owned portfolio, run alongside (not inside) the safety proof.
+///
+/// Unrolls the transition relation depth-by-depth on a single init-constrained solver,
+/// looking ONLY for a reachable `bad` (no k-induction step queries to slow it down or
+/// abort it). Returns `Some(depth)` on a concrete, sound `Violated`; `None` if no
+/// counterexample is found within budget.
+///
+/// The point of splitting this out: finding a concrete counterexample is *sound* and
+/// is usually far cheaper than synthesising an equivalent safety invariant, so a deep,
+/// time-boxed CEX search flips many designs that the shallow ([`DEFAULT_MAX_K`]) or
+/// proof-oriented engines leave `Unknown` straight to a definite `Violated`. `max_k`
+/// may therefore be set well above [`DEFAULT_MAX_K`]. Bounded by the wall `deadline`
+/// and `cancel` (both checked before each depth) and by `per_query_ms` per z3 check.
+pub fn bmc_cex_until(
+    file: &Btor2File,
+    max_k: u32,
+    per_query_ms: u32,
+    deadline: std::time::Instant,
+    cancel: &std::sync::atomic::AtomicBool,
+) -> Option<u32> {
+    let (bad_ops, init_pairs, constraint_ops) = extract_props(file);
+    if bad_ops.is_empty() {
+        return None;
+    }
+    let n = max_k as usize;
+    let cfg = z3::Config::new();
+    z3::with_z3_config(&cfg, || {
+        let view = encode_design(file).ok()?;
+        let u = Unroller::build(&view, &bad_ops, &constraint_ops, n);
+        let base = z3::Solver::new();
+        let mut params = z3::Params::new();
+        params.set_u32("timeout", per_query_ms);
+        base.set_params(&params);
+        u.assert_init(&base, &init_pairs);
+        for c in u.constraints_at(0) {
+            base.assert(&c);
+        }
+        for k in 0..=n {
+            // Wall-clock / cancellation bound: abandon the search (return `None`, never
+            // a wrong verdict) when the deadline passes or a peer engine decides first.
+            if cancel.load(std::sync::atomic::Ordering::Relaxed)
+                || std::time::Instant::now() >= deadline
+            {
+                return None;
+            }
+            base.push();
+            base.assert(u.bad_at(k));
+            let res = base.check();
+            base.pop(1);
+            match res {
+                // A concrete init→bad path at depth `k` — sound `Violated`.
+                z3::SatResult::Sat => return Some(k as u32),
+                // This depth's query hit `per_query_ms`; deeper frames only get larger,
+                // so abstain rather than spin.
+                z3::SatResult::Unknown => return None,
+                z3::SatResult::Unsat => {}
+            }
+            if k < n {
+                base.assert(u.transition_at(k));
+                for c in u.constraints_at(k + 1) {
+                    base.assert(&c);
+                }
+            }
+        }
+        None
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -495,6 +564,26 @@ mod tests {
     #[test]
     fn finds_shallowest_cex() {
         assert_eq!(bmc(REACH, 5), BmcOutcome::Violated { depth: 1 });
+    }
+
+    #[test]
+    fn bmc_cex_until_finds_cex_and_abstains_soundly() {
+        use std::sync::atomic::AtomicBool;
+        let far = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        let never = AtomicBool::new(false);
+        // Reaches bad at depth 1 / 5 — the deep CEX-only search returns the depth.
+        let reach = parser::parse(REACH).expect("parse");
+        assert_eq!(bmc_cex_until(&reach, 64, 5_000, far, &never), Some(1));
+        let wide = parser::parse(WIDE).expect("parse"); // depth 5, 64-bit (beyond exact cap)
+        assert_eq!(bmc_cex_until(&wide, 64, 5_000, far, &never), Some(5));
+        // Bounded-safe design → no CEX within the depth budget → None (never a wrong verdict).
+        let safe = parser::parse(SAFE).expect("parse");
+        assert_eq!(bmc_cex_until(&safe, 32, 5_000, far, &never), None);
+        // Cancellation / passed deadline are honored before any work.
+        let cancelled = AtomicBool::new(true);
+        assert_eq!(bmc_cex_until(&reach, 64, 5_000, far, &cancelled), None);
+        let past = far - std::time::Duration::from_secs(120);
+        assert_eq!(bmc_cex_until(&reach, 64, 5_000, past, &never), None);
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -358,6 +358,110 @@ pub fn decide_reach_portfolio_parallel(file: &Btor2File) -> ReachOutcome {
     })
 }
 
+/// Depth cap for the owned-standalone deep counterexample search — well above
+/// [`native_bmc::DEFAULT_MAX_K`] so a *deep* violation is caught, while the wall
+/// deadline + per-query timeout keep the (eagerly-built) unrolling bounded.
+const OWNED_DEEP_CEX_MAX_K: u32 = 128;
+/// Per-z3-check timeout inside the owned deep CEX search.
+const OWNED_CEX_QUERY_MS: u32 = 15_000;
+
+/// The **owned-standalone** driver: decide `bad`-reachability with ONLY the
+/// mununu-owned engines, run concurrently under a shared `timeout_ms` wall budget,
+/// deliberately EXCLUDING the external algorithms (Z3 SPACER, btormc, Pono). It
+/// answers "what can mununu's *own* algorithms decide on their own budget?" — the
+/// ceiling that matters for a no-subprocess deployment and the soundness cross-check.
+///
+/// Two complementary directions run in parallel (first-definite wins; each sets a
+/// shared `decided` flag the others poll and bail on):
+/// - **safety proof (the formula):** the exact BDD engine (≤ 40 bits), native
+///   k-induction, and native McMillan interpolation;
+/// - **counterstrategy (the negation):** a dedicated deep, wall-bounded pure BMC
+///   counterexample search ([`native_bmc::bmc_cex_until`], depth ≤
+///   [`OWNED_DEEP_CEX_MAX_K`]). Finding a concrete counterexample is sound and usually
+///   far cheaper than an equivalent safety proof, so it flips many designs the
+///   proof side leaves `Unknown` straight to `Violated`. It is attributed to the
+///   `"cex"` engine so a native-safe vs cex-violated split still raises the
+///   [`ReachVerdict::Contradiction`] alarm rather than being silently merged.
+pub fn decide_reach_owned_only(file: &Btor2File, timeout_ms: u32) -> ReachOutcome {
+    use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+    let content = emit_btor2(file);
+    let decided = AtomicBool::new(false);
+    let decided = &decided;
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_millis(u64::from(timeout_ms));
+    std::thread::scope(|scope| {
+        // Safety proof — shallow native BMC + k-induction.
+        let native_h = scope.spawn(|| {
+            let v = match native_bmc::decide_bad_safety(
+                file,
+                native_bmc::DEFAULT_MAX_K,
+                Some(timeout_ms),
+            ) {
+                Ok(SafetyVerdict::Violated { .. }) => Some(true),
+                Ok(SafetyVerdict::Safe { .. }) => Some(false),
+                Ok(SafetyVerdict::Unknown { .. }) | Err(_) => None,
+            };
+            if v.is_some() {
+                decided.store(true, Relaxed);
+            }
+            v
+        });
+        // Counterstrategy — deep, wall-bounded pure counterexample search.
+        let cex_h = scope.spawn(|| {
+            let v = native_bmc::bmc_cex_until(
+                file,
+                OWNED_DEEP_CEX_MAX_K,
+                OWNED_CEX_QUERY_MS,
+                deadline,
+                decided,
+            )
+            .map(|_depth| ());
+            if v.is_some() {
+                decided.store(true, Relaxed);
+            }
+            v.is_some()
+        });
+        // Safety proof — McMillan interpolation.
+        let interp_h = scope.spawn(|| {
+            match native_interp::verify_safety_interp_cancellable(
+                file,
+                INTERP_MAX_SUFFIX,
+                64,
+                INTERP_QUERY_TIMEOUT_MS,
+                u64::from(timeout_ms),
+                decided,
+            ) {
+                InterpSafetyVerdict::Unsafe { .. } => Some(true),
+                InterpSafetyVerdict::Safe { .. } => Some(false),
+                InterpSafetyVerdict::Undecided { .. } => None,
+            }
+        });
+        let exact = run_exact(&content);
+        if exact.is_some() {
+            decided.store(true, Relaxed);
+        }
+        let native = native_h.join().unwrap_or(None);
+        let cex_hit = cex_h.join().unwrap_or(false);
+        let interp = interp_h.join().unwrap_or(None);
+        // Build the outcome directly so the deep CEX search keeps its own `"cex"`
+        // attribution (and any native-safe vs cex-violated disagreement stays a
+        // Contradiction alarm). No spacer / btormc / pono — owned engines only.
+        let mut reachable_by: Vec<&'static str> = Vec::new();
+        let mut unreachable_by: Vec<&'static str> = Vec::new();
+        for (name, v) in [("exact", exact), ("native", native), ("interp", interp)] {
+            match v {
+                Some(true) => reachable_by.push(name),
+                Some(false) => unreachable_by.push(name),
+                None => {}
+            }
+        }
+        if cex_hit {
+            reachable_by.push("cex");
+        }
+        ReachOutcome::from_sets(reachable_by, unreachable_by)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -543,6 +647,118 @@ mod tests {
             out.reachable_by.len() >= 2,
             "at least the exact engine + one subprocess member should agree; got {:?}",
             out
+        );
+    }
+
+    #[test]
+    fn owned_only_excludes_external_engines_on_small_counter() {
+        // The owned-standalone driver decides the small reachable counter via the
+        // exact engine and never lists an external member.
+        const COUNTER: &str = "1 sort bitvec 3\n2 zero 1\n3 state 1\n4 init 1 3 2\n5 one 1\n\
+                               6 add 1 3 5\n7 next 1 3 6\n8 ones 1\n9 sort bitvec 1\n\
+                               10 eq 9 3 8\n11 bad 10\n";
+        let file = parser::parse(COUNTER).expect("parse");
+        let out = decide_reach_owned_only(&file, 30_000);
+        assert_eq!(out.verdict, ReachVerdict::Reachable, "outcome: {out:?}");
+        assert!(out.reachable_by.contains(&"exact"), "{out:?}");
+        for ext in ["spacer", "btormc", "pono"] {
+            assert!(
+                !out.reachable_by.contains(&ext) && !out.unreachable_by.contains(&ext),
+                "owned-only must never list {ext}: {out:?}"
+            );
+        }
+    }
+
+    /// The **owned-standalone ceiling** sweep: for every `*.btor2` in
+    /// `MUNUNU_HWMCC_FLAT`, run [`decide_reach_owned_only`] with `MUNUNU_OWNED_TIMEOUT_MS`
+    /// (default 240 000) and report how many the owned engines decide *without any
+    /// external tool*. Cross-checks each definite verdict against an optional
+    /// `MUNUNU_HWMCC_GT` (`basename safe|unsafe` per line) and fails on any mismatch —
+    /// the soundness net. `#[ignore]`d (reads an external corpus, minutes-to-hours).
+    #[test]
+    #[ignore = "owned-only HWMCC ceiling sweep; set MUNUNU_HWMCC_FLAT (+ optional MUNUNU_HWMCC_GT), MUNUNU_OWNED_TIMEOUT_MS default 240000"]
+    fn owned_only_hwmcc_ceiling() {
+        let flat = std::env::var("MUNUNU_HWMCC_FLAT").expect("set MUNUNU_HWMCC_FLAT");
+        let to_ms: u32 = std::env::var("MUNUNU_OWNED_TIMEOUT_MS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(240_000);
+        let gt: std::collections::HashMap<String, String> = std::env::var("MUNUNU_HWMCC_GT")
+            .ok()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .map(|s| {
+                s.lines()
+                    .filter_map(|l| {
+                        let mut it = l.split_whitespace();
+                        Some((it.next()?.to_string(), it.next()?.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut files: Vec<(u64, std::path::PathBuf)> = std::fs::read_dir(&flat)
+            .expect("read MUNUNU_HWMCC_FLAT dir")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|x| x == "btor2"))
+            .map(|p| {
+                (
+                    std::fs::metadata(&p).map(|m| m.len()).unwrap_or(u64::MAX),
+                    p,
+                )
+            })
+            .collect();
+        // Small-file-first: the owned-decidable designs skew small, so the decide
+        // count stabilises early and the large-undecided tail just confirms itself.
+        files.sort();
+        let files: Vec<std::path::PathBuf> = files.into_iter().map(|(_, p)| p).collect();
+        let (mut decided, mut safe, mut unsafe_n) = (0u32, 0u32, 0u32);
+        let mut violations: Vec<String> = Vec::new();
+        for p in &files {
+            let name = p.file_stem().unwrap().to_string_lossy().to_string();
+            let content = std::fs::read_to_string(p).unwrap();
+            let file = match crate::adapter::btor2::parser::parse(&content) {
+                Ok(f) => f,
+                Err(_) => {
+                    eprintln!("  ----  parse-error       {name}");
+                    continue;
+                }
+            };
+            let t0 = std::time::Instant::now();
+            let out = decide_reach_owned_only(&file, to_ms);
+            let secs = t0.elapsed().as_secs();
+            let (label, eng) = match out.verdict {
+                ReachVerdict::Reachable => ("unsafe", out.reachable_by.join("+")),
+                ReachVerdict::Unreachable => ("safe", out.unreachable_by.join("+")),
+                ReachVerdict::Unknown => ("unknown", String::new()),
+                ReachVerdict::Contradiction => ("CONTRADICTION", String::new()),
+            };
+            if label == "safe" || label == "unsafe" {
+                decided += 1;
+                if label == "safe" {
+                    safe += 1;
+                } else {
+                    unsafe_n += 1;
+                }
+                let gtv = gt.get(&name).map(String::as_str).unwrap_or("?");
+                let sound = gtv == "?" || gtv == label;
+                if !sound {
+                    violations.push(format!("{name}: gt={gtv} owned={label}"));
+                }
+                eprintln!(
+                    "{} {secs:>4}s  {label:<7} via {eng:<8} gt={gtv:<7} {name}",
+                    if sound { "✓" } else { "✗✗✗" }
+                );
+            } else {
+                eprintln!("  {secs:>4}s  {label:<7}          {name}");
+            }
+        }
+        eprintln!(
+            "\nOWNED-ONLY CEILING @ {to_ms}ms: {decided}/{} decided ({safe} safe, {unsafe_n} unsafe); soundness violations {}",
+            files.len(),
+            violations.len()
+        );
+        assert!(
+            violations.is_empty(),
+            "SOUNDNESS VIOLATIONS: {violations:?}"
         );
     }
 }


### PR DESCRIPTION
Decide `bad`-reachability with **only the mununu-owned engines** — no external SPACER / btormc / Pono — answering "what can mununu's own algorithms decide on their own?", for no-subprocess deployments and the soundness cross-check.

## Owned-standalone driver — `reach_portfolio::decide_reach_owned_only`

Runs the exact BDD engine, native BMC / k-induction, native McMillan interpolation, **and** a dedicated deep counterexample search, concurrently under a shared wall budget (first-definite wins, early cancellation via a shared `decided` flag).

**CLI:** `mununu btor2 verify --owned-only [--owned-timeout-ms MS]` (default 60 000).
`surface: CLI-only` — a soundness-audit / no-subprocess diagnostic, peer of the CLI-only `verify-safety --engine ic3`; the default full portfolio stays the CLI+API+UI path.

## Deep counterexample search — `native_bmc::bmc_cex_until`

A wall-bounded, cancellable, **CEX-only** unrolling (no k-induction step queries to slow it or abort it) up to depth 128. Finding a concrete counterexample is sound and usually far cheaper than synthesising an equivalent safety invariant, so it flips designs the shallow (`DEFAULT_MAX_K=40`) or proof-oriented engines leave `unknown` straight to a definite `violated`. It carries its own `"cex"` engine attribution, so a native-safe vs cex-violated disagreement still raises the `Contradiction` alarm instead of being silently merged.

## Measured (owned-only @240s, small-first, partial sweep)

| Verdict | Design | Decider | Time |
|---|---|---|---|
| safe | vis_arrays_am2910_p2 | native interpolation | 94s |
| **violated** | circular_pointer_top_w64/w128_d8 | **native+cex** | 10–13s |
| **violated** | shift_register_top_w16/w32/w64_d8 | **native+cex** | 17–23s |

`circular_pointer_top_*` is listed in `measurements/hwmcc-owned-engine-gaps.md` Category C ("deep counterexamples btormc finds, owned engines miss") — the deep CEX search now decides them, in seconds. **0 contradictions** (native and cex agree on every unsafe verdict).

## Also — `verify-safety --engine ic3` surfaces its abstain reason

The experimental IC3ia path mapped `AbsVerdict::Unknown { reason }` to a bare `unknown`, discarding the diagnosis. It now emits a `detail` field (grammar ceiling / frame or blocking limit / invariant size), so the owned IC3ia foundation is diagnosable from the CLI.

## Tests

- `bmc_cex_until_finds_cex_and_abstains_soundly` — finds the depth-1 and depth-5 (64-bit, beyond the exact cap) counterexamples, abstains on a bounded-safe design, honors cancel + deadline.
- `owned_only_excludes_external_engines_on_small_counter` — the owned driver never lists spacer/btormc/pono.
- `owned_only_hwmcc_ceiling` — `#[ignore]`d owned-standalone ceiling sweep over an external corpus (`MUNUNU_HWMCC_FLAT`, `MUNUNU_OWNED_TIMEOUT_MS`), with an optional ground-truth soundness cross-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
