### PR TITLE
feat(btor2 verify): --timeout-ms raises the subprocess budget + depth cap (P0.5)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -606,6 +606,12 @@ struct Btor2VerifyArgs {
     /// let native interpolation and the deep counterexample search reach more designs.
     #[arg(long, value_name = "MS", default_value_t = 60_000)]
     owned_timeout_ms: u32,
+    /// Wall budget (ms) for the SUBPROCESS members (btormc / Pono) in the default full
+    /// portfolio (default 60000). A larger value lets the incremental-SAT model checkers
+    /// reach deeper counterexamples — e.g. `krebs.3`'s depth-75 CEX needs ~73000. Ignored
+    /// under `--owned-only` (which has its own `--owned-timeout-ms`).
+    #[arg(long, value_name = "MS")]
+    timeout_ms: Option<u64>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2685,6 +2691,7 @@ fn per_response_decided_by(
 fn btor2_verify(args: Btor2VerifyArgs) -> Result<(), String> {
     use mununu_core::adapter::reach_portfolio::{
         decide_reach_owned_only, decide_reach_portfolio_parallel,
+        decide_reach_portfolio_parallel_with_timeout,
     };
     use mununu_core::verdict::PropertyVerdict;
 
@@ -2695,9 +2702,13 @@ fn btor2_verify(args: Btor2VerifyArgs) -> Result<(), String> {
 
     // `--owned-only`: mununu-owned engines only (no external SPACER/btormc/Pono).
     // Otherwise the full parallel portfolio — identical merge to the sequential
-    // driver, but wall-clock bounded by the slowest single engine.
+    // driver, but wall-clock bounded by the slowest single engine. `--timeout-ms`
+    // raises the subprocess (btormc/Pono) budget so their incremental SAT reaches
+    // deeper counterexamples.
     let outcome = if args.owned_only {
         decide_reach_owned_only(&file, args.owned_timeout_ms)
+    } else if let Some(ms) = args.timeout_ms {
+        decide_reach_portfolio_parallel_with_timeout(&file, std::time::Duration::from_millis(ms))
     } else {
         decide_reach_portfolio_parallel(&file)
     };

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -297,8 +297,38 @@ pub fn decide_reach_portfolio(file: &Btor2File) -> ReachOutcome {
 /// sequential last resort), a design it decides in time will additionally list
 /// `interp` in `reachable_by` / `unreachable_by`, giving the owned engine its credit.
 pub fn decide_reach_portfolio_parallel(file: &Btor2File) -> ReachOutcome {
+    decide_reach_portfolio_parallel_with_timeout(file, btormc::DEFAULT_TIMEOUT)
+}
+
+/// btormc unrolling depth cap for the **raised-budget** path. The default portfolio caps
+/// btormc at [`btormc::DEFAULT_KMAX`] (40) to bound its cost, but a deep counterexample
+/// needs a deeper unrolling — `krebs.3`'s CEX is at depth 75 — so raising the *time* budget
+/// is useless while the *depth* stays 40 (measured: `--timeout-ms 120000` alone still
+/// returned `unknown` on `krebs.3`). When the caller raises the budget we therefore also
+/// raise the depth cap; btormc unrolls incrementally, so it still stops at the first CEX /
+/// proof / the wall timeout, never pre-paying for the higher cap.
+const DEEP_BUDGET_KMAX: u32 = 1000;
+
+/// [`decide_reach_portfolio_parallel`] with the **subprocess** members' (btormc / Pono)
+/// wall budget set to `subprocess_timeout` instead of the 60 s default. When the budget is
+/// raised above the default, btormc's depth cap is also lifted to [`DEEP_BUDGET_KMAX`] (a
+/// longer budget is pointless if the unrolling stays capped at 40 — see that constant).
+/// Measured: with both raised, `krebs.3`'s depth-75 CEX is found in ~73 s (`unknown` →
+/// `violated`); `vis_arrays_buf_bug`'s is found in ~1 s either way. The in-process members
+/// (exact / native / SPACER / interp) keep their own budgets. Surfaced via `btor2 verify
+/// --timeout-ms`.
+pub fn decide_reach_portfolio_parallel_with_timeout(
+    file: &Btor2File,
+    subprocess_timeout: std::time::Duration,
+) -> ReachOutcome {
     use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
     let content = emit_btor2(file);
+    // Raising the wall budget signals "reach deeper" — so lift btormc's depth cap too.
+    let btormc_kmax = if subprocess_timeout > btormc::DEFAULT_TIMEOUT {
+        DEEP_BUDGET_KMAX
+    } else {
+        btormc::DEFAULT_KMAX
+    };
     // A definite verdict from ANY faster member sets this; the owned interpolation
     // member polls it and abandons its (possibly slow) cvc5 interpolation search early
     // (#1 — run interpolation as a concurrent member, not last-resort, so its unique
@@ -308,15 +338,14 @@ pub fn decide_reach_portfolio_parallel(file: &Btor2File) -> ReachOutcome {
     let decided = &decided;
     std::thread::scope(|scope| {
         let btormc_h = scope.spawn(|| {
-            let v =
-                btormc::decide_via_btormc(file, btormc::DEFAULT_KMAX, btormc::DEFAULT_TIMEOUT).ok();
+            let v = btormc::decide_via_btormc(file, btormc_kmax, subprocess_timeout).ok();
             if matches!(v, Some(McVerdict::Violated) | Some(McVerdict::Safe)) {
                 decided.store(true, Relaxed);
             }
             v
         });
         let pono_h = scope.spawn(|| {
-            let v = pono::decide_via_pono(file, pono::DEFAULT_ENGINE, pono::DEFAULT_TIMEOUT).ok();
+            let v = pono::decide_via_pono(file, pono::DEFAULT_ENGINE, subprocess_timeout).ok();
             if matches!(v, Some(McVerdict::Violated) | Some(McVerdict::Safe)) {
                 decided.store(true, Relaxed);
             }
@@ -629,6 +658,27 @@ mod tests {
         let par = decide_reach_portfolio_parallel(&file);
         assert_eq!(seq, par, "parallel and sequential drivers must agree");
         assert_eq!(par.verdict, ReachVerdict::Reachable);
+    }
+
+    #[test]
+    fn parallel_with_timeout_delegates_and_agrees() {
+        // The `--timeout-ms` variant only changes the subprocess budget; on a design
+        // the exact engine decides (no subprocess needed) it returns the identical
+        // outcome regardless of the budget passed.
+        const COUNTER: &str = "1 sort bitvec 3\n2 zero 1\n3 state 1\n4 init 1 3 2\n5 one 1\n\
+                               6 add 1 3 5\n7 next 1 3 6\n8 ones 1\n9 sort bitvec 1\n\
+                               10 eq 9 3 8\n11 bad 10\n";
+        let file = parser::parse(COUNTER).expect("parse");
+        let default = decide_reach_portfolio_parallel(&file);
+        let custom = decide_reach_portfolio_parallel_with_timeout(
+            &file,
+            std::time::Duration::from_secs(120),
+        );
+        assert_eq!(
+            default, custom,
+            "budget override must not change an exact-decided verdict"
+        );
+        assert_eq!(custom.verdict, ReachVerdict::Reachable);
     }
 
     #[test]

--- a/docs/design/datapath-oracle-hybrid.md
+++ b/docs/design/datapath-oracle-hybrid.md
@@ -85,10 +85,10 @@ implementation; the two new ones are §5.
 
 | Design | Class | Which oracle | Would it decide? |
 |---|---|---|---|
-| `krebs.3` | deep-CEX (@75), non-array | **fast-SAT** | **Yes** — incremental BV-SAT reaches depth 75 |
-| `brp2.2` | deep-CEX (@119) | **fast-SAT** | **Yes** — reaches depth 119 |
-| `circular_pointer_top_w64_d128` | deep-CEX (@~128), wide | **fast-SAT** | **Likely** — incremental SAT scales past z3's monolithic query |
-| `vis_arrays_buf_bug` | deep-CEX (@18–28), **arrays** | **fast-SAT + arrays** | **Yes** — a BV+array SMT backend handles the memory |
+| `vis_arrays_buf_bug` | deep-CEX (@18–28), **arrays** | **fast-SAT + arrays** | **Yes (measured)** — btormc/Boolector: **1 s** (owned z3-BMC: timeout @120 s) |
+| `krebs.3` | deep-CEX (@75), non-array | **fast-SAT** | **Yes (measured)** — btormc/Boolector: **73 s** (owned z3-BMC: never reached it @240 s) |
+| `brp2.2` | deep-CEX (@119) | fast-SAT | **No (measured)** — btormc/Boolector **timed out @300 s**; too deep even for the best BV-SAT in budget |
+| `circular_pointer_top_w64_d128` | deep-CEX (@~128), wide | fast-SAT | **No (measured)** — btormc/Boolector **timed out @300 s** |
 | `mul9` | multipliers present, but **control** property (`bad = and(51,52)`, *not* `out == a·b`) | nonlinear (mismatched) + invariant synthesis | **Partial at best** — mixed logic+arithmetic proof; not a clean multiplier-correctness target the algebraic oracle cracks (§4.2) |
 | `gen43` | 256-bit **pure BV** (0 `mul`/`urem`/`add`) | fast-SAT (width) + **invariant synthesis** | **No by nonlinear oracle** — it has no arithmetic; needs §3 synthesis, not a datapath oracle |
 | `arbitrated_top_*_d64` | wide **proof** (no nonlinearity) | fast-SAT (queries) + **invariant synthesis** | **No by oracle alone** — the wall is §3 invariant *discovery*, not the query speed |
@@ -111,8 +111,12 @@ keep learned clauses, re-solve) instead of z3's grow-and-re-solve. This is exact
 btormc does internally; doing it in-process closes the reach. The abstraction is
 untouched — for a pure `AG ¬bad` the KMTS layer is a thin pass-through and the oracle does
 the work; for a *branching* property over the same design the oracle answers the may/must
-reach queries the Kleene evaluation needs. **This is the recommended first increment** —
-it fixes four of the seven cases and is license-clean (§5).
+reach queries the Kleene evaluation needs. **This is the recommended first increment** and
+is license-clean (§5). **Measured scope (2026-07-13):** it fixes **two** of the deep-CEX
+cases — `vis_arrays` (btormc 1 s) and `krebs.3` (btormc 73 s) — *not* four: `brp2.2` (@119)
+and `circular_pointer_d128` **time out even for btormc/Boolector at 300 s**, so no fast-SAT
+engine (in-process or external) closes them in budget. P1's win is real but bounded to the
+shallow/moderate deep-CEX class.
 
 ### 4.2 The nonlinear oracle in principle — and why the current corpus doesn't need it
 
@@ -214,12 +218,24 @@ multipliers) mirroring the btormc pattern, not a linked dependency.
   through it, with z3 as the sole implementation. Pure refactor; behaviour-identical;
   gated by the existing differential tests. This is the enabling step and carries no
   license risk.
-- **P1 — fast-SAT reachability oracle (Bitwuzla, MIT, in-process).** Implement
-  `bad_reachable_within` (and the may/must reach queries) on Bitwuzla's incremental API.
-  Validate on the §4.1 deep-CEX cases: target `krebs.3` (@75), `brp2.2` (@119),
-  `circular_pointer_top_w64_d128`, `vis_arrays_buf_bug` (arrays) flipping owned-standalone
-  to a sound `violated`. Differential-check every verdict against z3 + the concrete trace
-  (soundness net). **This is the high-value, license-clean increment.**
+- **P0.5 — cheap portfolio budget knob (no dependency) — SHIPPED.** A `--timeout-ms` flag
+  on `btor2 verify` overriding the subprocess-member (btormc/Pono) budget (default 60 s).
+  **Subtlety that a naive version misses (caught empirically):** raising the *time* is
+  useless while btormc's *depth* stays capped at `DEFAULT_KMAX = 40` — `krebs.3`'s CEX is at
+  depth 75 — so the raised-budget path also lifts btormc's `-kmax` (to 1000). Measured:
+  `krebs.3` goes `unknown` @default → `violated via btormc` @`--timeout-ms 120000`.
+  (`vis_arrays_buf_bug` is *already* decided by the default portfolio — its CEX @18–28 is
+  within kmax 40 and btormc finds it in ~1 s — so P0.5's net new decide is the deep-CEX
+  class beyond depth 40, e.g. `krebs.3`.) No new dependency, no build-time cost. It does
+  *not* give the no-subprocess path — that is P1's job.
+- **P1 — fast-SAT reachability oracle (Boolector/Bitwuzla, MIT, in-process — feature-gated).**
+  Implement `bad_reachable_within` on an in-process Boolector (safe crate `boolector` 0.4,
+  MIT — the exact engine btormc uses, validated to build alongside z3 0.20) behind a
+  `boolector` cargo feature so the default build/CI stays fast. **Measured target: flip
+  `vis_arrays` + `krebs.3` owned-standalone to a sound `violated`** (the two btormc actually
+  cracks in budget). Differential-check every verdict against z3 + the concrete trace
+  (soundness net). License-clean; bounded payoff (the very-deep `brp2.2`/`circular_pointer`
+  are out of reach even for Boolector, so P1 does not target them).
 - **P2 — nonlinear datapath oracle (subprocess, AMulet2-style).** **Not motivated by any
   currently-failing design** (the §4 structure audit: `gen43` is pure-BV, `mul9`'s property
   is control) — so this is *parked* until a genuine multiplier-*correctness* branching
@@ -239,6 +255,8 @@ multipliers) mirroring the btormc pattern, not a linked dependency.
   plain bit-level `AG ¬bad`, the may/must machinery is overhead and a P1 fast-SAT engine is
   simply the point — that is what btormc already is, now in-process and license-clean.
 - **P1 is the recommendation; P2 is optional and subprocess-only.** The deep-CEX reach is a
-  clean, permissive-library win that fixes four of the seven failing cases; the nonlinear
+  clean, permissive-library win that (measured) fixes **two** of the failing cases owned-
+  standalone (`vis_arrays`, `krebs.3`) — the very-deep `brp2.2`/`circular_pointer` time out
+  even for btormc/Boolector at 300 s; the nonlinear
   class is a copyleft-constrained, discovery-limited follow-up worth doing only if the
   multiplier-datapath branching class becomes a concrete target.


### PR DESCRIPTION
The **P0.5 cheap win** from the datapath-oracle plan: let the full portfolio decide the deep-CEX class **today**, no new dependency.

## What
`btor2 verify --timeout-ms <MS>` overrides the **subprocess** (btormc/Pono) budget (default 60000). New `reach_portfolio::decide_reach_portfolio_parallel_with_timeout(file, Duration)`; the no-arg version is now a thin wrapper (API/sv-verify/CLI callers unchanged). `--owned-only` keeps its own `--owned-timeout-ms`.

## The subtlety the empirical validation caught
Raising the **time** alone is useless — btormc is capped at `DEFAULT_KMAX = 40`, and `krebs.3`'s CEX is at depth **75**, so `--timeout-ms 120000` *first still returned `unknown`*. The raised-budget path therefore also lifts btormc's `-kmax` to 1000 (`DEEP_BUDGET_KMAX`); btormc unrolls incrementally so it still stops at the first CEX/proof/timeout.

## Measured (mununu-sva)
- `krebs.3`: `unknown` @default → **`violated` via btormc** @`--timeout-ms 120000` (CEX@75 found ~73s)
- `vis_arrays_buf_bug`: **already decided** by the default portfolio (CEX@18–28 within kmax 40, btormc ~1s) — so P0.5's net-new decide is the deep-CEX class **beyond depth 40**.

## Also
Corrects the design note: P1 fixes **two** (`vis_arrays`/`krebs.3`), not four — `brp2.2` (@119) + `circular_pointer_d128` time out even for btormc/Boolector @300s.

Test: `parallel_with_timeout_delegates_and_agrees`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)