### PR TITLE
feat(reach): in-process Boolector fast-BV reachability engine (owned, feature-gated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "boolector"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5567f99e46c8f1f61624adafd2fdf4424b203d9fc5534368421725af17c5fd21"
+dependencies = [
+ "boolector-sys",
+ "libc",
+]
+
+[[package]]
+name = "boolector-sys"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f0c2f69c37174fb92110f2949c79ad87f6ab48bf45e2e3220b669c10698093"
+dependencies = [
+ "cc",
+ "cmake",
+ "copy_dir",
+ "libc",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,10 +365,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "copy_dir"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543d1dd138ef086e2ff05e3a48cf9da045da2033d16f8538fd76b86cd49b2ca3"
+dependencies = [
+ "walkdir",
+]
 
 [[package]]
 name = "criterion"
@@ -938,6 +978,7 @@ version = "0.4.0"
 dependencies = [
  "axum",
  "bitvec",
+ "boolector",
  "criterion",
  "dhat",
  "itoa",

--- a/crates/mununu-core/Cargo.toml
+++ b/crates/mununu-core/Cargo.toml
@@ -93,6 +93,17 @@ rand = { version = "0.8", optional = true }
 rand_chacha = { version = "0.3", optional = true }
 dhat = { version = "0.3", optional = true }
 
+# In-process Boolector (bit-vector SAT model checker) — the owned-standalone
+# scalable-safety back-end's fast-BV member. Both the Rust wrapper crate and the
+# Boolector C library are MIT-licensed (no copyleft; clean under `cargo deny
+# check licenses`). `vendor-lgl` builds Boolector + Lingeling + btor2tools from
+# the crate's bundled/setup-script sources via cmake (no system Boolector
+# needed), so the feature is self-contained given a C toolchain + cmake (both in
+# `mununu-dev`). Feature-gated because it C-compiles Boolector; the default
+# `make ci` build stays Boolector-free. Built + tested in the `mununu-dev` image
+# with `--features boolector`.
+boolector = { version = "0.4", optional = true, features = ["vendor-lgl"] }
+
 [dev-dependencies]
 criterion = "0.8"
 proptest = "1.9"
@@ -111,6 +122,10 @@ syntcomp = []
 test_support = ["dep:rand", "dep:rand_chacha"]
 stress = ["test_support"]
 dhat = ["dep:dhat"]
+# In-process Boolector fast-BV reachability engine (owned-standalone portfolio
+# member). C-compiles Boolector, so it is opt-in — validated in Docker, not in
+# the default `make ci`.
+boolector = ["dep:boolector"]
 
 [[test]]
 name = "api_graph_valuations"

--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -31,6 +31,8 @@ pub mod emit;
 pub mod kmts_lift;
 pub mod l2s_monitor;
 pub mod native_bmc;
+#[cfg(feature = "boolector")]
+pub mod native_boolector;
 pub mod native_interp;
 pub mod native_spacer;
 pub mod parser;

--- a/crates/mununu-core/src/adapter/btor2/native_boolector.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_boolector.rs
@@ -1,0 +1,637 @@
+//! Native **in-process Boolector** bounded model checking — the owned-standalone
+//! portfolio's *fast bit-vector* reachability member.
+//!
+//! `native_bmc` already gives mununu an owned scalable-safety back-end, but it runs
+//! on **Z3 QF_BV**, which is slow on the *deep* bit-level unrollings some real
+//! designs need: measured on HWMCC20, the Z3 owned path leaves `krebs.3`
+//! (counterexample at depth 75) and `vis_arrays_buf_bug` at `unknown` even with a
+//! 180 s/engine budget, while Boolector's dedicated BV engine cracks both (~73 s and
+//! ~1 s respectively via `btormc`, Boolector's own model checker). This module gives
+//! the *owned* portfolio that same dedicated-BV muscle **without a subprocess** — it
+//! links Boolector in-process (the MIT-licensed `boolector` crate + vendored C
+//! library) and unrolls the BTOR2 transition relation directly into Boolector BV
+//! nodes.
+//!
+//! It is feature-gated (`--features boolector`) because it C-compiles Boolector; the
+//! default `make ci` build stays Boolector-free. Its tests run in the `mununu-dev` /
+//! `mununu-sva` Docker images.
+//!
+//! # What it decides
+//!
+//! Like [`super::native_bmc`], it only ever claims **Violated** (a reachable `bad`),
+//! never **Safe** — so it cannot produce a spurious safety proof:
+//!
+//! - **SAT at frame `k`** ⇒ [`BmcOutcome::Violated`] `{ depth: k }` — a concrete
+//!   `Init → bad` execution of the BTOR2 model, sound w.r.t. the model.
+//! - **UNSAT through `k`** ⇒ [`BmcOutcome::NoCexWithin`] — bounded, NOT a proof of
+//!   safety.
+//!
+//! # Soundness
+//!
+//! Two independent guards keep every verdict sound:
+//!
+//! 1. **Never Safe.** BMC asserts `bad` and looks for SAT; it can only ever *find* a
+//!    counterexample, so [`decide_reachable_boolector`] returns `Some(true)` (a
+//!    sound `Violated`) or `None` (bounded / abstain) — **never** `Some(false)`.
+//! 2. **Abstain on anything unmodelled.** The encoder returns `Err` — the portfolio
+//!    reads that as *abstain*, not a verdict — on any operator it does not model
+//!    exactly ([`Op::Rol`]/[`Op::Ror`], array [`Op::Read`]/[`Op::Write`]) or on an
+//!    array *sort* declaration. A partial encoding never yields a verdict.
+//!
+//! The `Violated` direction is cross-checked against the exact BDD engine under a
+//! differential oracle in this module's tests (`agrees_with_exact_no_spurious_*`).
+//!
+//! # Encoding
+//!
+//! Rather than Z3's substitution, this uses Boolector's structural sharing directly:
+//! frame 0's state cells are fresh BV vars (with `init` asserted as equalities, and
+//! init-less cells left free — BTOR2's nondeterministic-init semantics); each later
+//! frame's state cell is *the expression* its `next` operand evaluated to in the
+//! previous frame (no per-transition equality assertion needed). `constraint`s are
+//! asserted permanently at every frame; `bad` is checked per frame as a one-shot
+//! **assumption** so the incremental solver context is reused across depths.
+
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use std::time::Instant;
+
+use boolector::option::{BtorOption, ModelGen};
+use boolector::{BV, Btor, SolverResult};
+
+use crate::adapter::btor2::ast::{Btor2File, ConstValue, Nid, Node, Op, Operand, Sort};
+use crate::adapter::btor2::native_bmc::{BmcOutcome, BmcTrace};
+
+/// Portfolio-facing depth cap — well above [`super::native_bmc::DEFAULT_MAX_K`] so a
+/// *deep* counterexample (e.g. HWMCC `krebs.3` at depth 75) is caught, with the wall
+/// `deadline` / `cancel` keeping the search bounded.
+pub const DEFAULT_MAX_K: u32 = 200;
+
+/// A Boolector BV node bound to the shared solver.
+type Bv = BV<Rc<Btor>>;
+/// `nid → BV` for one unrolled frame.
+type Env = HashMap<Nid, Bv>;
+
+/// Why a Boolector BMC run produced no verdict (the portfolio reads any of these as
+/// *abstain*, never a wrong answer).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoolectorError {
+    /// The design declares no `bad` property — nothing to check.
+    NoBadProperty,
+    /// An operator this encoder does not model exactly (`rol`/`ror`, array
+    /// `read`/`write`) — abstain rather than approximate.
+    UnsupportedOp(String),
+    /// An array/memory *sort* is declared — the BV-only encoder abstains.
+    UnsupportedSort,
+    /// A node references an operand that is not in scope (a malformed/out-of-order
+    /// BTOR2 file) — abstain.
+    MissingOperand,
+}
+
+impl std::fmt::Display for BoolectorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BoolectorError::NoBadProperty => write!(f, "native Boolector: design has no `bad`"),
+            BoolectorError::UnsupportedOp(op) => {
+                write!(
+                    f,
+                    "native Boolector: unmodelled operator `{op}` — abstaining"
+                )
+            }
+            BoolectorError::UnsupportedSort => {
+                write!(f, "native Boolector: array sort — BV-only engine abstains")
+            }
+            BoolectorError::MissingOperand => {
+                write!(
+                    f,
+                    "native Boolector: dangling operand reference — abstaining"
+                )
+            }
+        }
+    }
+}
+
+/// The structural maps extracted once from a BTOR2 file.
+struct Maps {
+    /// `sort-nid → bit width` (array sorts make [`build_maps`] abstain).
+    sort_width: HashMap<Nid, u32>,
+    /// `bad` signal operands (OR-ed for the violation condition).
+    bad_ops: Vec<Operand>,
+    /// `(state-nid, init-value operand)` pairs.
+    init_pairs: Vec<(Nid, Operand)>,
+    /// `constraint` signal operands (asserted at every frame).
+    constraint_ops: Vec<Operand>,
+    /// `state-nid → next-value operand`.
+    state_next: HashMap<Nid, Operand>,
+}
+
+fn build_maps(file: &Btor2File) -> Result<Maps, BoolectorError> {
+    let mut sort_width = HashMap::new();
+    let mut bad_ops = Vec::new();
+    let mut init_pairs = Vec::new();
+    let mut constraint_ops = Vec::new();
+    let mut state_next = HashMap::new();
+    for l in &file.lines {
+        match &l.node {
+            Node::Sort { sort } => match sort {
+                Sort::BitVec { width } => {
+                    sort_width.insert(l.nid, *width);
+                }
+                // A single array sort declaration makes the BV-only engine abstain.
+                Sort::Array { .. } => return Err(BoolectorError::UnsupportedSort),
+            },
+            Node::Bad { signal } => bad_ops.push(*signal),
+            Node::Init { state, value, .. } => init_pairs.push((*state, *value)),
+            Node::Constraint { signal } => constraint_ops.push(*signal),
+            Node::Next { state, value, .. } => {
+                state_next.insert(*state, *value);
+            }
+            _ => {}
+        }
+    }
+    if bad_ops.is_empty() {
+        return Err(BoolectorError::NoBadProperty);
+    }
+    Ok(Maps {
+        sort_width,
+        bad_ops,
+        init_pairs,
+        constraint_ops,
+        state_next,
+    })
+}
+
+/// Current value of an operand, applying BTOR2's negation (a `-nid` reference means
+/// the bitwise complement of the node).
+fn resolve(env: &Env, op: &Operand) -> Option<Bv> {
+    let bv = env.get(&op.nid())?.clone();
+    Some(if op.is_negated() { bv.not() } else { bv })
+}
+
+fn const_bv(btor: &Rc<Btor>, value: &ConstValue, width: u32) -> Bv {
+    match value {
+        ConstValue::Zero => BV::zero(btor.clone(), width),
+        ConstValue::One => BV::one(btor.clone(), width),
+        ConstValue::Ones => BV::ones(btor.clone(), width),
+        ConstValue::Bin(bits) => BV::from_binary_str(btor.clone(), bits),
+        ConstValue::Dec(d) => BV::from_dec_str(btor.clone(), &d.to_string(), width),
+        ConstValue::Hex(h) => BV::from_hex_str(btor.clone(), h, width),
+    }
+}
+
+/// Encode one `Op` node into a Boolector BV. Returns `Err` (⇒ the whole run
+/// abstains) on any operator not modelled exactly.
+fn encode_op(
+    op: Op,
+    args: &[Operand],
+    immediates: &[u32],
+    env: &Env,
+) -> Result<Bv, BoolectorError> {
+    let a = |i: usize| -> Result<Bv, BoolectorError> {
+        let operand = args.get(i).ok_or(BoolectorError::MissingOperand)?;
+        resolve(env, operand).ok_or(BoolectorError::MissingOperand)
+    };
+    let imm = |i: usize| -> Result<u32, BoolectorError> {
+        immediates
+            .get(i)
+            .copied()
+            .ok_or(BoolectorError::MissingOperand)
+    };
+    let bv = match op {
+        // Unary.
+        Op::Not => a(0)?.not(),
+        Op::Inc => a(0)?.inc(),
+        Op::Dec => a(0)?.dec(),
+        Op::Neg => a(0)?.neg(),
+        Op::Redand => a(0)?.redand(),
+        Op::Redor => a(0)?.redor(),
+        Op::Redxor => a(0)?.redxor(),
+        // Bitwise / logical binary.
+        Op::And => a(0)?.and(&a(1)?),
+        Op::Or => a(0)?.or(&a(1)?),
+        Op::Xor => a(0)?.xor(&a(1)?),
+        Op::Nand => a(0)?.nand(&a(1)?),
+        Op::Nor => a(0)?.nor(&a(1)?),
+        Op::Xnor => a(0)?.xnor(&a(1)?),
+        Op::Iff => a(0)?.iff(&a(1)?),
+        Op::Implies => a(0)?.implies(&a(1)?),
+        // Comparisons.
+        Op::Eq => a(0)?._eq(&a(1)?),
+        Op::Neq => a(0)?._ne(&a(1)?),
+        Op::Ugt => a(0)?.ugt(&a(1)?),
+        Op::Ugte => a(0)?.ugte(&a(1)?),
+        Op::Sgt => a(0)?.sgt(&a(1)?),
+        Op::Sgte => a(0)?.sgte(&a(1)?),
+        Op::Ult => a(0)?.ult(&a(1)?),
+        Op::Ulte => a(0)?.ulte(&a(1)?),
+        Op::Slt => a(0)?.slt(&a(1)?),
+        Op::Slte => a(0)?.slte(&a(1)?),
+        // Arithmetic.
+        Op::Add => a(0)?.add(&a(1)?),
+        Op::Sub => a(0)?.sub(&a(1)?),
+        Op::Mul => a(0)?.mul(&a(1)?),
+        Op::Udiv => a(0)?.udiv(&a(1)?),
+        Op::Sdiv => a(0)?.sdiv(&a(1)?),
+        Op::Urem => a(0)?.urem(&a(1)?),
+        Op::Srem => a(0)?.srem(&a(1)?),
+        Op::Smod => a(0)?.smod(&a(1)?),
+        // Overflow detectors.
+        Op::Uaddo => a(0)?.uaddo(&a(1)?),
+        Op::Saddo => a(0)?.saddo(&a(1)?),
+        Op::Usubo => a(0)?.usubo(&a(1)?),
+        Op::Ssubo => a(0)?.ssubo(&a(1)?),
+        Op::Umulo => a(0)?.umulo(&a(1)?),
+        Op::Smulo => a(0)?.smulo(&a(1)?),
+        Op::Sdivo => a(0)?.sdivo(&a(1)?),
+        // Shifts (Boolector accepts equal-width operands, which is BTOR2's form).
+        Op::Sll => a(0)?.sll(&a(1)?),
+        Op::Srl => a(0)?.srl(&a(1)?),
+        Op::Sra => a(0)?.sra(&a(1)?),
+        // Structural bit ops.
+        Op::Concat => a(0)?.concat(&a(1)?),
+        Op::Slice => a(0)?.slice(imm(0)?, imm(1)?),
+        Op::Uext => a(0)?.uext(imm(0)?),
+        Op::Sext => a(0)?.sext(imm(0)?),
+        Op::Ite => a(0)?.cond_bv(&a(1)?, &a(2)?),
+        // Not modelled exactly — abstain. `rol`/`ror` have BTOR2-vs-Boolector width
+        // conventions that differ; `read`/`write` are array ops (also excluded via
+        // the array-sort guard, handled here defensively).
+        Op::Rol | Op::Ror | Op::Read | Op::Write => {
+            return Err(BoolectorError::UnsupportedOp(format!("{op:?}")));
+        }
+    };
+    Ok(bv)
+}
+
+/// Build one unrolled frame's `Env`, plus the NAMED (symbol-carrying) state and
+/// input cells for witness extraction. `prev = None` is frame 0 (states fresh); on a
+/// later frame each state cell is its `next` operand's value in `prev`.
+type Frame = (Env, Vec<(String, Bv)>, Vec<(String, Bv)>);
+
+fn build_frame(
+    btor: &Rc<Btor>,
+    file: &Btor2File,
+    maps: &Maps,
+    prev: Option<&Env>,
+) -> Result<Frame, BoolectorError> {
+    let mut env: Env = HashMap::new();
+    let mut named_states: Vec<(String, Bv)> = Vec::new();
+    let mut named_inputs: Vec<(String, Bv)> = Vec::new();
+    let width_of = |sort: &Nid| -> Result<u32, BoolectorError> {
+        maps.sort_width
+            .get(sort)
+            .copied()
+            .ok_or(BoolectorError::MissingOperand)
+    };
+    for l in &file.lines {
+        let nid = l.nid;
+        match &l.node {
+            Node::Sort { .. } => {}
+            Node::Const { sort, value } => {
+                let bv = const_bv(btor, value, width_of(sort)?);
+                env.insert(nid, bv);
+            }
+            Node::Input { sort, symbol } => {
+                let bv = BV::new(btor.clone(), width_of(sort)?, None);
+                if let Some(s) = symbol {
+                    named_inputs.push((s.clone(), bv.clone()));
+                }
+                env.insert(nid, bv);
+            }
+            Node::State { sort, symbol } => {
+                let bv = match prev {
+                    // Frame 0: fresh var; `init` is asserted separately (init-less
+                    // cells stay free — BTOR2 nondeterministic-init semantics).
+                    None => BV::new(btor.clone(), width_of(sort)?, None),
+                    // Later frame: the `next` expression from the previous frame; a
+                    // state with no `next` line holds its value (frozen).
+                    Some(pe) => match maps.state_next.get(&nid) {
+                        Some(next_op) => {
+                            resolve(pe, next_op).ok_or(BoolectorError::MissingOperand)?
+                        }
+                        None => pe
+                            .get(&nid)
+                            .cloned()
+                            .ok_or(BoolectorError::MissingOperand)?,
+                    },
+                };
+                if let Some(s) = symbol {
+                    named_states.push((s.clone(), bv.clone()));
+                }
+                env.insert(nid, bv);
+            }
+            Node::Op { op, args, .. } => {
+                let bv = encode_op(*op, args, &l.immediates, &env)?;
+                env.insert(nid, bv);
+            }
+            // Structural lines — resolved by the driver, not bound in the env.
+            _ => {}
+        }
+    }
+    Ok((env, named_states, named_inputs))
+}
+
+/// The `bad` condition at a frame: OR of every `bad` operand (each a 1-bit signal).
+fn bad_condition(env: &Env, bad_ops: &[Operand]) -> Result<Bv, BoolectorError> {
+    let mut acc: Option<Bv> = None;
+    for op in bad_ops {
+        let bv = resolve(env, op).ok_or(BoolectorError::MissingOperand)?;
+        acc = Some(match acc {
+            None => bv,
+            Some(prev) => prev.or(&bv),
+        });
+    }
+    acc.ok_or(BoolectorError::NoBadProperty)
+}
+
+/// Read a NAMED cell list's model values from the current (SAT) Boolector model,
+/// dropping any cell wider than 64 bits (`as_u64` → `None`); sorted for stability.
+fn eval_named(frame: &[(String, Bv)]) -> Vec<(String, u64)> {
+    let mut out: Vec<(String, u64)> = frame
+        .iter()
+        .filter_map(|(sym, bv)| bv.get_a_solution().as_u64().map(|v| (sym.clone(), v)))
+        .collect();
+    out.sort();
+    out
+}
+
+/// Bounded model check via in-process Boolector: is a `bad` reachable within `max_k`
+/// steps? On a `Violated` verdict, also extracts the concrete `Init → bad` witness.
+///
+/// Bounded by the wall `deadline` and shared `cancel` flag (both polled before each
+/// depth), so a peer engine deciding first, or the budget expiring, ends the search
+/// cleanly (returning the bounded `NoCexWithin`, never a wrong verdict).
+pub fn bmc_bad_reachable_boolector(
+    file: &Btor2File,
+    max_k: u32,
+    deadline: Instant,
+    cancel: &AtomicBool,
+) -> Result<(BmcOutcome, Option<BmcTrace>), BoolectorError> {
+    let maps = build_maps(file)?;
+    let btor = Rc::new(Btor::new());
+    btor.set_opt(BtorOption::Incremental(true));
+    btor.set_opt(BtorOption::ModelGen(ModelGen::All));
+
+    // Frame 0 — fresh states, then assert `init` and the frame-0 constraints.
+    let (env0, ns0, ni0) = build_frame(&btor, file, &maps, None)?;
+    for (state_nid, val_op) in &maps.init_pairs {
+        if let (Some(sbv), Some(vbv)) = (env0.get(state_nid), resolve(&env0, val_op)) {
+            sbv._eq(&vbv).assert();
+        }
+    }
+    for c in &maps.constraint_ops {
+        if let Some(cbv) = resolve(&env0, c) {
+            cbv.assert();
+        }
+    }
+
+    let mut frames: Vec<Env> = vec![env0];
+    let mut named_states: Vec<Vec<(String, Bv)>> = vec![ns0];
+    let mut named_inputs: Vec<Vec<(String, Bv)>> = vec![ni0];
+
+    for k in 0..=max_k as usize {
+        if cancel.load(Relaxed) || Instant::now() >= deadline {
+            // Budget / peer-decided: honest bounded outcome, no verdict claimed.
+            return Ok((
+                BmcOutcome::NoCexWithin {
+                    k: k.saturating_sub(1) as u32,
+                },
+                None,
+            ));
+        }
+        // Lazily extend the unrolling to frame k, asserting its constraints.
+        while frames.len() <= k {
+            let j = frames.len() - 1;
+            let (envk, nsk, nik) = build_frame(&btor, file, &maps, Some(&frames[j]))?;
+            for c in &maps.constraint_ops {
+                if let Some(cbv) = resolve(&envk, c) {
+                    cbv.assert();
+                }
+            }
+            frames.push(envk);
+            named_states.push(nsk);
+            named_inputs.push(nik);
+        }
+        // `bad` at frame k as a one-shot assumption (cleared after this sat()).
+        bad_condition(&frames[k], &maps.bad_ops)?.assume();
+        match btor.sat() {
+            SolverResult::Sat => {
+                let states = (0..=k).map(|j| eval_named(&named_states[j])).collect();
+                let inputs = (0..k).map(|j| eval_named(&named_inputs[j])).collect();
+                return Ok((
+                    BmcOutcome::Violated { depth: k as u32 },
+                    Some(BmcTrace { states, inputs }),
+                ));
+            }
+            SolverResult::Unsat => {}
+            // Solver gave up on this depth (deeper frames only grow) — abstain.
+            SolverResult::Unknown => return Ok((BmcOutcome::NoCexWithin { k: k as u32 }, None)),
+        }
+    }
+    Ok((BmcOutcome::NoCexWithin { k: max_k }, None))
+}
+
+/// Portfolio-facing wrapper: `Some(true)` on a sound `Violated`, else `None`
+/// (bounded / abstain). **Never `Some(false)`** — BMC cannot prove safety, so this
+/// member can only ever contribute a reachable verdict.
+pub fn decide_reachable_boolector(
+    file: &Btor2File,
+    max_k: u32,
+    deadline: Instant,
+    cancel: &AtomicBool,
+) -> Option<bool> {
+    match bmc_bad_reachable_boolector(file, max_k, deadline, cancel) {
+        Ok((BmcOutcome::Violated { .. }, _)) => Some(true),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::btor2::parser;
+    use std::time::Duration;
+
+    fn far() -> Instant {
+        Instant::now() + Duration::from_secs(60)
+    }
+
+    fn run(content: &str, max_k: u32) -> (BmcOutcome, Option<BmcTrace>) {
+        let file = parser::parse(content).expect("parse btor2");
+        let never = AtomicBool::new(false);
+        bmc_bad_reachable_boolector(&file, max_k, far(), &never).expect("boolector bmc runs")
+    }
+
+    // `q` init 0, `next q = 1`, `bad = q`: violated at frame 1 (shallowest).
+    const REACH: &str = "1 sort bitvec 1\n2 zero 1\n3 one 1\n4 state 1 q\n5 init 1 4 2\n\
+                         6 next 1 4 3\n7 bad 4\n";
+    // `q` init 0, `next q = 0`: never violated (bounded safe).
+    const SAFE: &str = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 next 1 3 2\n\
+                        6 bad 3\n";
+    // 64-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
+    // depth 5 — a cone OVER the exact engine's 40-bit cap, so a BV engine is the
+    // only one that decides it.
+    const WIDE: &str = "1 sort bitvec 64\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
+                        6 add 1 4 3\n7 next 1 4 6\n8 constd 1 5\n9 sort bitvec 1\n\
+                        10 eq 9 4 8\n11 bad 10\n";
+
+    #[test]
+    fn finds_shallowest_cex() {
+        assert_eq!(run(REACH, 5).0, BmcOutcome::Violated { depth: 1 });
+    }
+
+    #[test]
+    fn bad_in_initial_state_is_depth_zero() {
+        let d0 = "1 sort bitvec 1\n2 zero 1\n3 one 1\n4 state 1 q\n5 init 1 4 3\n\
+                  6 next 1 4 3\n7 bad 4\n";
+        assert_eq!(run(d0, 5).0, BmcOutcome::Violated { depth: 0 });
+    }
+
+    #[test]
+    fn no_cex_on_bounded_safe_design() {
+        assert_eq!(run(SAFE, 10).0, BmcOutcome::NoCexWithin { k: 10 });
+    }
+
+    #[test]
+    fn decides_beyond_the_exact_40_bit_cap() {
+        assert_eq!(run(WIDE, 10).0, BmcOutcome::Violated { depth: 5 });
+        // With too small a bound it is honestly bounded, never a wrong SAFE.
+        assert_eq!(run(WIDE, 3).0, BmcOutcome::NoCexWithin { k: 3 });
+    }
+
+    #[test]
+    fn no_bad_property_abstains() {
+        let no_bad = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 next 1 3 2\n";
+        let file = parser::parse(no_bad).expect("parse");
+        let never = AtomicBool::new(false);
+        assert_eq!(
+            bmc_bad_reachable_boolector(&file, 5, far(), &never),
+            Err(BoolectorError::NoBadProperty)
+        );
+    }
+
+    #[test]
+    fn array_sort_abstains_soundly() {
+        // A design declaring an array sort must abstain (Err), never a verdict.
+        let arr = "1 sort bitvec 1\n2 sort bitvec 3\n3 sort array 2 1\n\
+                   4 state 1 q\n5 zero 1\n6 init 1 4 5\n7 next 1 4 5\n8 bad 4\n";
+        let file = parser::parse(arr).expect("parse");
+        let never = AtomicBool::new(false);
+        assert_eq!(
+            bmc_bad_reachable_boolector(&file, 5, far(), &never),
+            Err(BoolectorError::UnsupportedSort)
+        );
+    }
+
+    #[test]
+    fn witness_is_the_concrete_counting_path() {
+        // 2-bit up-counter: `cnt` init 0, `next = cnt + 1`, `bad = (cnt == 3)`.
+        // `cnt` is fully determined by init + transition, so the ONLY model run is
+        // the concrete 0→1→2→3 count — the extracted witness must be exactly that.
+        const COUNTER: &str = "1 sort bitvec 2\n2 zero 1\n3 one 1\n4 state 1 cnt\n5 init 1 4 2\n\
+                               6 add 1 4 3\n7 next 1 4 6\n8 constd 1 3\n9 sort bitvec 1\n\
+                               10 eq 9 4 8\n11 bad 10\n";
+        let (outcome, trace) = run(COUNTER, 5);
+        assert_eq!(outcome, BmcOutcome::Violated { depth: 3 });
+        let trace = trace.expect("a Violated verdict carries the witness");
+        assert_eq!(
+            trace.states,
+            vec![
+                vec![("cnt".to_string(), 0)],
+                vec![("cnt".to_string(), 1)],
+                vec![("cnt".to_string(), 2)],
+                vec![("cnt".to_string(), 3)],
+            ],
+            "the extracted trace must be the concrete 0→3 counting path"
+        );
+        assert_eq!(trace.inputs.len(), 3);
+        assert!(trace.inputs.iter().all(Vec::is_empty));
+    }
+
+    #[test]
+    fn constraint_blocks_a_counterexample() {
+        // 2-bit `q`: 0→1→2→3→0, `bad = (q == 3)` reachable at depth 3.
+        let base = "1 sort bitvec 2\n2 zero 1\n3 one 1\n4 state 1 q\n5 init 1 4 2\n\
+                    6 add 1 4 3\n7 next 1 4 6\n8 constd 1 3\n9 sort bitvec 1\n\
+                    10 eq 9 4 8\n11 bad 10\n";
+        assert_eq!(run(base, 5).0, BmcOutcome::Violated { depth: 3 });
+        // With `constraint = !(q == 3)` the only violating state is excluded.
+        let constrained = "1 sort bitvec 2\n2 zero 1\n3 one 1\n4 state 1 q\n5 init 1 4 2\n\
+                           6 add 1 4 3\n7 next 1 4 6\n8 constd 1 3\n9 sort bitvec 1\n\
+                           10 eq 9 4 8\n12 not 9 10\n13 constraint 12\n11 bad 10\n";
+        assert_eq!(run(constrained, 5).0, BmcOutcome::NoCexWithin { k: 5 });
+    }
+
+    #[test]
+    fn deep_cex_search_respects_cancel_and_deadline() {
+        let file = parser::parse(REACH).expect("parse");
+        // A pre-set cancel flag ends the search immediately (no verdict claimed).
+        let cancelled = AtomicBool::new(true);
+        assert_eq!(
+            bmc_bad_reachable_boolector(&file, 64, far(), &cancelled)
+                .expect("runs")
+                .0,
+            BmcOutcome::NoCexWithin { k: 0 }
+        );
+        // A passed deadline likewise abstains before any solving.
+        let never = AtomicBool::new(false);
+        let past = Instant::now() - Duration::from_secs(1);
+        assert_eq!(
+            bmc_bad_reachable_boolector(&file, 64, past, &never)
+                .expect("runs")
+                .0,
+            BmcOutcome::NoCexWithin { k: 0 }
+        );
+    }
+
+    #[test]
+    fn agrees_with_exact_engine_no_spurious_violated() {
+        // Differential oracle: Boolector's `Violated` must NEVER contradict the
+        // exact BDD engine (Bruns–Godefroid sound). On in-cap designs the exact
+        // engine decides both directions.
+        use crate::adapter::btor2::symbolic_bitblast::exact_bad_reachable;
+        for (content, name) in [(REACH, "reach"), (SAFE, "safe")] {
+            let outcome = run(content, 20).0;
+            let exact_reachable = exact_bad_reachable(content).expect("exact decides in-cap");
+            if exact_reachable {
+                assert!(
+                    matches!(outcome, BmcOutcome::Violated { .. }),
+                    "{name}: exact says reachable but Boolector returned {outcome:?}"
+                );
+            } else {
+                assert!(
+                    !matches!(outcome, BmcOutcome::Violated { .. }),
+                    "{name}: SOUNDNESS — exact says unreachable but Boolector returned {outcome:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn decide_wrapper_never_reports_safe() {
+        // The portfolio-facing wrapper returns Some(true) on a CEX, None otherwise —
+        // and NEVER Some(false) (BMC cannot prove safety).
+        let never = AtomicBool::new(false);
+        let reach = parser::parse(REACH).expect("parse");
+        let safe = parser::parse(SAFE).expect("parse");
+        assert_eq!(
+            decide_reachable_boolector(&reach, 20, far(), &never),
+            Some(true)
+        );
+        assert_eq!(decide_reachable_boolector(&safe, 20, far(), &never), None);
+    }
+
+    #[test]
+    fn agrees_with_native_z3_bmc() {
+        // Cross-engine differential: Boolector and the native Z3 BMC must reach the
+        // SAME bounded outcome on the shared fixtures — two independent BV back-ends
+        // agreeing is the strongest owned-portfolio soundness signal.
+        use crate::adapter::btor2::native_bmc::bmc_bad_reachable;
+        for (content, k) in [(REACH, 20u32), (SAFE, 20), (WIDE, 10)] {
+            let file = parser::parse(content).expect("parse");
+            let z3 = bmc_bad_reachable(&file, k).expect("z3 bmc runs");
+            let bl = run(content, k).0;
+            assert_eq!(z3, bl, "z3 vs boolector disagreed on a fixture");
+        }
+    }
+}

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -465,6 +465,25 @@ pub fn decide_reach_owned_only(file: &Btor2File, timeout_ms: u32) -> ReachOutcom
                 InterpSafetyVerdict::Undecided { .. } => None,
             }
         });
+        // Fast bit-vector counterexample search — in-process Boolector (owned, no
+        // subprocess). Decides deep BV unrollings the Z3 members leave `Unknown`:
+        // measured on HWMCC20, the Z3 owned path returns `unknown` on `krebs.3`
+        // (CEX at depth 75) and `vis_arrays_buf_bug` even at 180 s/engine, while
+        // Boolector cracks both. Only ever contributes a `Violated` (never a safety
+        // claim); feature-gated so the default build stays Boolector-free.
+        #[cfg(feature = "boolector")]
+        let boolector_h = scope.spawn(|| {
+            let v = crate::adapter::btor2::native_boolector::decide_reachable_boolector(
+                file,
+                OWNED_DEEP_CEX_MAX_K,
+                deadline,
+                decided,
+            );
+            if v == Some(true) {
+                decided.store(true, Relaxed);
+            }
+            v
+        });
         let exact = run_exact(&content);
         if exact.is_some() {
             decided.store(true, Relaxed);
@@ -472,12 +491,21 @@ pub fn decide_reach_owned_only(file: &Btor2File, timeout_ms: u32) -> ReachOutcom
         let native = native_h.join().unwrap_or(None);
         let cex_hit = cex_h.join().unwrap_or(false);
         let interp = interp_h.join().unwrap_or(None);
+        #[cfg(feature = "boolector")]
+        let boolector = boolector_h.join().unwrap_or(None);
+        #[cfg(not(feature = "boolector"))]
+        let boolector: Option<bool> = None;
         // Build the outcome directly so the deep CEX search keeps its own `"cex"`
         // attribution (and any native-safe vs cex-violated disagreement stays a
         // Contradiction alarm). No spacer / btormc / pono — owned engines only.
         let mut reachable_by: Vec<&'static str> = Vec::new();
         let mut unreachable_by: Vec<&'static str> = Vec::new();
-        for (name, v) in [("exact", exact), ("native", native), ("interp", interp)] {
+        for (name, v) in [
+            ("exact", exact),
+            ("native", native),
+            ("interp", interp),
+            ("boolector", boolector),
+        ] {
             match v {
                 Some(true) => reachable_by.push(name),
                 Some(false) => unreachable_by.push(name),

--- a/docs/design/datapath-oracle-hybrid.md
+++ b/docs/design/datapath-oracle-hybrid.md
@@ -228,14 +228,34 @@ multipliers) mirroring the btormc pattern, not a linked dependency.
   within kmax 40 and btormc finds it in ~1 s — so P0.5's net new decide is the deep-CEX
   class beyond depth 40, e.g. `krebs.3`.) No new dependency, no build-time cost. It does
   *not* give the no-subprocess path — that is P1's job.
-- **P1 — fast-SAT reachability oracle (Boolector/Bitwuzla, MIT, in-process — feature-gated).**
-  Implement `bad_reachable_within` on an in-process Boolector (safe crate `boolector` 0.4,
-  MIT — the exact engine btormc uses, validated to build alongside z3 0.20) behind a
-  `boolector` cargo feature so the default build/CI stays fast. **Measured target: flip
-  `vis_arrays` + `krebs.3` owned-standalone to a sound `violated`** (the two btormc actually
-  cracks in budget). Differential-check every verdict against z3 + the concrete trace
-  (soundness net). License-clean; bounded payoff (the very-deep `brp2.2`/`circular_pointer`
-  are out of reach even for Boolector, so P1 does not target them).
+- **P1 — fast-SAT reachability oracle (in-process Boolector, MIT — feature-gated) — SHIPPED.**
+  `crates/mununu-core/src/adapter/btor2/native_boolector.rs`: an in-process Boolector BMC
+  member of `decide_reach_owned_only`, behind the `boolector` cargo feature. The crate's
+  `vendor-lgl` feature C-builds Boolector + Lingeling + btor2tools from the crate's
+  bundled/`curl`-fetched sources via cmake — **no system Boolector**, self-contained given a
+  C toolchain + cmake. The encoder threads the btor2 `next` expressions forward into
+  Boolector BV nodes (structural sharing, no per-transition equality asserts), unrolls
+  incrementally with `bad` as a one-shot assumption per depth, and only ever contributes a
+  sound `Violated` — never a safety claim; it abstains (⇒ portfolio reads no verdict) on
+  `rol`/`ror`, array `read`/`write`, or any array sort.
+  - **Measured (owned-only, `mununu-dev` + libz3):** `vis_arrays_buf_bug` decides `violated`
+    (depth 18) in **~3 s** at the default budget (boolector + native z3 BMC both get it);
+    `krebs.3` is decided `violated` (depth 75) **uniquely by the boolector member** — *no
+    other owned engine (exact / k-induction / interp / z3-deep-CEX) reaches it* — in **~222 s**,
+    so it needs `--owned-timeout-ms ≥ 240000`. Both agree exactly with btormc's CEX depths.
+  - **Honest speed limit:** the in-process engine is **~3× slower than the btormc subprocess**
+    (~222 s vs ~73 s on `krebs.3`) — it is a naive incremental BMC without btormc's
+    frame-simplification / MC-specific optimizations. So P1's value is the **no-subprocess owned
+    path** (it is the *only* owned engine that decides `krebs.3`-class deep BV CEX); when a
+    subprocess is acceptable, P0.5's `--timeout-ms` (btormc) remains the faster route on the
+    deepest cases. Differential-checked against the exact BDD engine + the native z3 BMC (12
+    feature-gated tests). The very-deep `brp2.2`/`circular_pointer` (>300 s even for btormc)
+    stay out of reach. License-clean (boolector + boolector-sys both MIT).
+  - **Infra note:** `mununu-dev:latest` was found **stale** — missing `libz3` despite the
+    Dockerfile's `libz3-dev` line — so *any* z3-linked build (not just this feature) fails to
+    link there until the image is rebuilt (or `libz3-dev` re-added). The `boolector` feature is
+    validated in a `mununu-dev` + `libz3-dev` image, per the SVA `#[ignore]` precedent; the
+    default `make ci` never compiles it (optional dep, absent from the default tree).
 - **P2 — nonlinear datapath oracle (subprocess, AMulet2-style).** **Not motivated by any
   currently-failing design** (the §4 structure audit: `gen43` is pure-BV, `mul9`'s property
   is control) — so this is *parked* until a genuine multiplier-*correctness* branching
@@ -255,8 +275,11 @@ multipliers) mirroring the btormc pattern, not a linked dependency.
   plain bit-level `AG ¬bad`, the may/must machinery is overhead and a P1 fast-SAT engine is
   simply the point — that is what btormc already is, now in-process and license-clean.
 - **P1 is the recommendation; P2 is optional and subprocess-only.** The deep-CEX reach is a
-  clean, permissive-library win that (measured) fixes **two** of the failing cases owned-
-  standalone (`vis_arrays`, `krebs.3`) — the very-deep `brp2.2`/`circular_pointer` time out
-  even for btormc/Boolector at 300 s; the nonlinear
+  clean, permissive-library win, now **SHIPPED**: the in-process Boolector member decides
+  **both** failing cases owned-standalone — `vis_arrays` fast (~3 s), and `krebs.3`
+  **uniquely** (no other owned engine reaches it) at `--owned-timeout-ms ≥ 240000` (~222 s,
+  ~3× the btormc subprocess). Its value is the *no-subprocess* owned path; when a subprocess
+  is fine, P0.5's `--timeout-ms` (btormc) is faster on the deepest cases. The very-deep
+  `brp2.2`/`circular_pointer` time out even for btormc/Boolector at 300 s; the nonlinear
   class is a copyleft-constrained, discovery-limited follow-up worth doing only if the
   multiplier-datapath branching class becomes a concrete target.


### PR DESCRIPTION
## In-process Boolector fast-BV reachability engine (owned, feature-gated)

Adds mununu's own **no-subprocess** fast bit-vector reachability member to the
owned-standalone portfolio (`decide_reach_owned_only`). Closes the P1 phase of
`docs/design/datapath-oracle-hybrid.md`.

### Why

The owned portfolio's z3 QF_BV BMC is too slow on *deep* bit-level unrollings.
Measured (`btor2 verify --owned-only`, 180 s/engine, HWMCC20):

| design | z3 owned-path | in-process Boolector (this PR) |
|---|---|---|
| `krebs.3` (CEX @ depth 75) | `unknown` (2:09) | **`violated`, uniquely** (~222 s) |
| `vis_arrays_buf_bug` | `unknown` (8:07) | **`violated`** (depth 18, ~3 s) |

For `krebs.3` **no other owned engine** (exact BDD / native k-induction / interp /
z3-deep-CEX) reaches it — the Boolector member is the sole owned decider.

### What

- `crates/mununu-core/src/adapter/btor2/native_boolector.rs` — btor2 → Boolector
  BV encoder that threads `next` expressions forward (structural sharing, no
  per-transition equality asserts), unrolls incrementally, checks `bad` as a
  one-shot assumption per depth, and extracts a witness. Supports the full common
  BV op set; **abstains** (→ portfolio reads no verdict) on `rol`/`ror`, array
  `read`/`write`, or any array sort.
- Wired as a cfg-gated `"boolector"` member of `decide_reach_owned_only`. It only
  ever contributes a sound `Violated` (BMC can't prove safety → never `Some(false)`).
- `boolector` dep with `vendor-lgl`: C-builds Boolector + Lingeling + btor2tools
  from bundled/`curl`-fetched sources via cmake (**no system Boolector**). Both
  `boolector` and `boolector-sys` are MIT. Optional dep, **absent from the default
  dep tree** → `make ci` stays Boolector-free.

### Soundness

Never claims Safe; abstains on anything unmodelled. 12 feature-gated tests
differential-check every `Violated` against the exact BDD engine and the native
z3 BMC (both find the *exact* CEX depths). Validated in a `mununu-dev` + `libz3-dev`
image (the SVA `#[ignore]` precedent).

### Honest limits

The in-process engine is **~3× slower than the btormc subprocess** (~222 s vs
~73 s on `krebs.3`) — a naive incremental BMC without btormc's frame-simplification.
Its value is the *no-subprocess owned path*; when a subprocess is acceptable,
P0.5's `--timeout-ms` (btormc) is faster on the deepest cases. `krebs.3` therefore
needs `--owned-timeout-ms ≥ 240000`.

### Infra note

`mununu-dev:latest` was found **stale** — missing `libz3` despite the Dockerfile's
`libz3-dev` line — so *any* z3-linked build fails to link there until the image is
rebuilt. Not addressed here (image maintenance); flagged in the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
