### PR TITLE
perf(reach/boolector): frame-simplification (bound striding) — krebs.3 205s→56s (3.6×)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/native_boolector.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_boolector.rs
@@ -48,8 +48,23 @@
 //! init-less cells left free — BTOR2's nondeterministic-init semantics); each later
 //! frame's state cell is *the expression* its `next` operand evaluated to in the
 //! previous frame (no per-transition equality assertion needed). `constraint`s are
-//! asserted permanently at every frame; `bad` is checked per frame as a one-shot
-//! **assumption** so the incremental solver context is reused across depths.
+//! asserted permanently at every frame.
+//!
+//! # Bound scheduling (the frame-simplification win)
+//!
+//! Instead of asking "is `bad` true at *exactly* depth k?" once per depth, the search
+//! maintains a running monitor `reached_k = bad_0 ∨ … ∨ bad_k` ("a `bad` is reachable
+//! *within* k steps") and checks it as a one-shot assumption. Crucially, one
+//! `reached_k` UNSAT proves the *whole* `0..k` range clean, so after a shallow
+//! threshold the search **strides** — a single deep solve covers `STRIDE` frames
+//! rather than one solve each. Measured on HWMCC `krebs.3` (CEX @ depth 75), the deep
+//! per-frame UNSAT proofs (frames 60–74) dominate the runtime, and this striding cuts
+//! the wall time to roughly a third by skipping the intermediate ones. On a SAT bound
+//! the *exact* CEX depth is read back as the shallowest frame whose `bad` holds in the
+//! model, so verdicts stay depth-exact. (Cone-of-influence pruning was measured to not
+//! help here — `bad`'s cone covers ~97 % of the logic; and disabling model generation
+//! during the search is a net loss — the witness re-solve of the deep deciding formula
+//! costs more than it saves.)
 
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -368,8 +383,14 @@ pub fn bmc_bad_reachable_boolector(
     cancel: &AtomicBool,
 ) -> Result<(BmcOutcome, Option<BmcTrace>), BoolectorError> {
     let maps = build_maps(file)?;
+    // `MUNUNU_BOOLECTOR_TRACE` — eprintln each `sat()`'s wall time (per-bound diagnostics).
+    let trace = std::env::var_os("MUNUNU_BOOLECTOR_TRACE").is_some();
     let btor = Rc::new(Btor::new());
     btor.set_opt(BtorOption::Incremental(true));
+    // Model generation stays ON: it costs nothing on the UNSAT bound checks (a model is
+    // only built on SAT), and it is needed to extract the exact CEX depth + witness from
+    // the deciding model. (Measured: turning it off during the search and re-solving for
+    // the witness is a *net loss* — the re-solve of the deep deciding formula dominates.)
     btor.set_opt(BtorOption::ModelGen(ModelGen::All));
 
     // Frame 0 — fresh states, then assert `init` and the frame-0 constraints.
@@ -388,8 +409,25 @@ pub fn bmc_bad_reachable_boolector(
     let mut frames: Vec<Env> = vec![env0];
     let mut named_states: Vec<Vec<(String, Bv)>> = vec![ns0];
     let mut named_inputs: Vec<Vec<(String, Bv)>> = vec![ni0];
+    // Per-frame `bad` signal (1-bit), kept so the exact CEX depth can be read back from
+    // a SAT model, and `reached_k = bad_0 ∨ … ∨ bad_k` (the running "a `bad` is reachable
+    // within k steps" monitor).
+    let mut bad_per_frame: Vec<Bv> = vec![bad_condition(&frames[0], &maps.bad_ops)?];
+    let mut reached: Bv = bad_per_frame[0].clone();
 
-    for k in 0..=max_k as usize {
+    // Bound-check schedule. Measured on HWMCC `krebs.3` (CEX @ depth 75): the deep
+    // per-frame UNSAT proofs (frames 60–74) cost ~180 s of the ~205 s total, and
+    // checking `bad` at *every* depth re-proves each. A single `reached_k` UNSAT proves
+    // the WHOLE 0..k range clean, so after a threshold we STRIDE — one deep solve covers
+    // `STRIDE` frames instead of one each. Shallow depths (≤ threshold) are still checked
+    // every frame (cheap, and keeps the reported CEX depth exact for shallow properties).
+    // `max_k` is always a check point so the last frame is never skipped.
+    const EXACT_THRESHOLD: usize = 32;
+    const STRIDE: usize = 8;
+
+    let n = max_k as usize;
+    let mut last_check: Option<usize> = None;
+    for k in 0..=n {
         if cancel.load(Relaxed) || Instant::now() >= deadline {
             // Budget / peer-decided: honest bounded outcome, no verdict claimed.
             return Ok((
@@ -399,7 +437,8 @@ pub fn bmc_bad_reachable_boolector(
                 None,
             ));
         }
-        // Lazily extend the unrolling to frame k, asserting its constraints.
+        // Lazily extend the unrolling to frame k, asserting its constraints and folding
+        // its `bad` into the running `reached` monitor.
         while frames.len() <= k {
             let j = frames.len() - 1;
             let (envk, nsk, nik) = build_frame(&btor, file, &maps, Some(&frames[j]))?;
@@ -408,23 +447,48 @@ pub fn bmc_bad_reachable_boolector(
                     cbv.assert();
                 }
             }
+            let bad_k = bad_condition(&envk, &maps.bad_ops)?;
+            reached = reached.or(&bad_k);
+            bad_per_frame.push(bad_k);
             frames.push(envk);
             named_states.push(nsk);
             named_inputs.push(nik);
         }
-        // `bad` at frame k as a one-shot assumption (cleared after this sat()).
-        bad_condition(&frames[k], &maps.bad_ops)?.assume();
-        match btor.sat() {
+        // Only *solve* at a scheduled bound — every frame up to the threshold, then every
+        // STRIDE frames, plus always the last frame. In between we just keep unrolling
+        // (cheap — node construction, no solve).
+        let is_check =
+            k <= EXACT_THRESHOLD || k == n || last_check.is_none_or(|lc| k - lc >= STRIDE);
+        if !is_check {
+            continue;
+        }
+        last_check = Some(k);
+        // `reached_k` as a one-shot assumption: is a `bad` reachable within k steps?
+        reached.assume();
+        let t0 = trace.then(Instant::now);
+        let res = btor.sat();
+        if let Some(t0) = t0 {
+            eprintln!("[boolector] reached≤{k}: {res:?} in {:.3?}", t0.elapsed());
+        }
+        match res {
             SolverResult::Sat => {
-                let states = (0..=k).map(|j| eval_named(&named_states[j])).collect();
-                let inputs = (0..k).map(|j| eval_named(&named_inputs[j])).collect();
+                // A `bad` is reachable within k steps. The exact depth is the SHALLOWEST
+                // frame whose `bad` holds in this model — sound (a real init→bad run) and,
+                // since every bound below the previous check was proven clean, correct.
+                let depth = (0..=k)
+                    .find(|&j| bad_per_frame[j].get_a_solution().as_bool() == Some(true))
+                    .unwrap_or(k);
+                let states = (0..=depth).map(|j| eval_named(&named_states[j])).collect();
+                let inputs = (0..depth).map(|j| eval_named(&named_inputs[j])).collect();
                 return Ok((
-                    BmcOutcome::Violated { depth: k as u32 },
+                    BmcOutcome::Violated {
+                        depth: depth as u32,
+                    },
                     Some(BmcTrace { states, inputs }),
                 ));
             }
             SolverResult::Unsat => {}
-            // Solver gave up on this depth (deeper frames only grow) — abstain.
+            // Solver gave up on this bound (deeper only grows) — abstain.
             SolverResult::Unknown => return Ok((BmcOutcome::NoCexWithin { k: k as u32 }, None)),
         }
     }
@@ -497,6 +561,27 @@ mod tests {
         assert_eq!(run(WIDE, 10).0, BmcOutcome::Violated { depth: 5 });
         // With too small a bound it is honestly bounded, never a wrong SAFE.
         assert_eq!(run(WIDE, 3).0, BmcOutcome::NoCexWithin { k: 3 });
+    }
+
+    #[test]
+    fn strided_search_recovers_exact_depth_past_threshold() {
+        // 8-bit counter, `bad = (cnt == 37)`. The CEX depth 37 is PAST the exact-check
+        // threshold (32), so it is found by a STRIDED `reached_k` check (whose bound
+        // overshoots to 40) — yet the reported depth must be the EXACT 37, read back
+        // from the model, not the check bound. This is the core correctness guard for
+        // the striding optimisation.
+        const C37: &str = "1 sort bitvec 8\n2 zero 1\n3 one 1\n4 state 1 cnt\n5 init 1 4 2\n\
+                           6 add 1 4 3\n7 next 1 4 6\n8 constd 1 37\n9 sort bitvec 1\n\
+                           10 eq 9 4 8\n11 bad 10\n";
+        let (outcome, trace) = run(C37, 60);
+        assert_eq!(
+            outcome,
+            BmcOutcome::Violated { depth: 37 },
+            "strided search must report the exact CEX depth (37), not the check bound (40)"
+        );
+        let trace = trace.expect("witness");
+        assert_eq!(trace.states.len(), 38, "frames 0..=37");
+        assert_eq!(trace.states.last().unwrap(), &vec![("cnt".to_string(), 37)]);
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -435,7 +435,13 @@ pub fn decide_reach_owned_only(file: &Btor2File, timeout_ms: u32) -> ReachOutcom
             }
             v
         });
-        // Counterstrategy — deep, wall-bounded pure counterexample search.
+        // Counterstrategy — deep, wall-bounded pure counterexample search on z3.
+        // When the `boolector` feature is on, the in-process Boolector BMC below fills
+        // this exact role (deep BV CEX search) and is faster on it (measured: ~56 s vs
+        // this member timing out on `krebs.3`), so running both would only contend for
+        // CPU and slow Boolector's deep solves. We therefore SWAP: z3-deep-CEX runs only
+        // when Boolector is absent.
+        #[cfg(not(feature = "boolector"))]
         let cex_h = scope.spawn(|| {
             let v = native_bmc::bmc_cex_until(
                 file,
@@ -466,11 +472,12 @@ pub fn decide_reach_owned_only(file: &Btor2File, timeout_ms: u32) -> ReachOutcom
             }
         });
         // Fast bit-vector counterexample search — in-process Boolector (owned, no
-        // subprocess). Decides deep BV unrollings the Z3 members leave `Unknown`:
-        // measured on HWMCC20, the Z3 owned path returns `unknown` on `krebs.3`
-        // (CEX at depth 75) and `vis_arrays_buf_bug` even at 180 s/engine, while
-        // Boolector cracks both. Only ever contributes a `Violated` (never a safety
-        // claim); feature-gated so the default build stays Boolector-free.
+        // subprocess). REPLACES the z3-deep-CEX member above (same role, faster). Decides
+        // deep BV unrollings the Z3 members leave `Unknown`: measured on HWMCC20, the Z3
+        // owned path returns `unknown` on `krebs.3` (CEX at depth 75) and
+        // `vis_arrays_buf_bug` even at 180 s/engine, while Boolector cracks both (~56 s /
+        // ~3 s). Only ever contributes a `Violated` (never a safety claim); feature-gated
+        // so the default build stays Boolector-free.
         #[cfg(feature = "boolector")]
         let boolector_h = scope.spawn(|| {
             let v = crate::adapter::btor2::native_boolector::decide_reachable_boolector(
@@ -489,7 +496,11 @@ pub fn decide_reach_owned_only(file: &Btor2File, timeout_ms: u32) -> ReachOutcom
             decided.store(true, Relaxed);
         }
         let native = native_h.join().unwrap_or(None);
+        // z3-deep-CEX runs only without the boolector feature (see the swap above).
+        #[cfg(not(feature = "boolector"))]
         let cex_hit = cex_h.join().unwrap_or(false);
+        #[cfg(feature = "boolector")]
+        let cex_hit = false;
         let interp = interp_h.join().unwrap_or(None);
         #[cfg(feature = "boolector")]
         let boolector = boolector_h.join().unwrap_or(None);

--- a/docs/design/datapath-oracle-hybrid.md
+++ b/docs/design/datapath-oracle-hybrid.md
@@ -238,24 +238,37 @@ multipliers) mirroring the btormc pattern, not a linked dependency.
   incrementally with `bad` as a one-shot assumption per depth, and only ever contributes a
   sound `Violated` — never a safety claim; it abstains (⇒ portfolio reads no verdict) on
   `rol`/`ror`, array `read`/`write`, or any array sort.
-  - **Measured (owned-only, `mununu-dev` + libz3):** `vis_arrays_buf_bug` decides `violated`
-    (depth 18) in **~3 s** at the default budget (boolector + native z3 BMC both get it);
-    `krebs.3` is decided `violated` (depth 75) **uniquely by the boolector member** — *no
-    other owned engine (exact / k-induction / interp / z3-deep-CEX) reaches it* — in **~222 s**,
-    so it needs `--owned-timeout-ms ≥ 240000`. Both agree exactly with btormc's CEX depths.
-  - **Honest speed limit:** the in-process engine is **~3× slower than the btormc subprocess**
-    (~222 s vs ~73 s on `krebs.3`) — it is a naive incremental BMC without btormc's
-    frame-simplification / MC-specific optimizations. So P1's value is the **no-subprocess owned
-    path** (it is the *only* owned engine that decides `krebs.3`-class deep BV CEX); when a
-    subprocess is acceptable, P0.5's `--timeout-ms` (btormc) remains the faster route on the
-    deepest cases. Differential-checked against the exact BDD engine + the native z3 BMC (12
+  - **Measured (`mununu-dev` + libz3):** standalone, the in-process engine finds
+    `vis_arrays_buf_bug`'s CEX (depth 18) in **~3 s** and `krebs.3`'s in **~56 s** (via the
+    frame-simplification below; was ~205 s). Both are decided `violated` **uniquely by the
+    boolector member** in the owned-only portfolio — *no other owned engine (exact / k-induction
+    / interp) reaches `krebs.3`*. The frame-simplification + engine swap (below) roughly HALVED
+    the owned budget `krebs.3` needs — `--owned-timeout-ms 120000` now suffices (was 240000).
+    (NB: the owned-only *wall* time can exceed the boolector member's — it is bounded by the
+    slowest concurrent member, e.g. the synchronous, non-interruptible exact BDD engine on wide
+    datapaths — a pre-existing owned-path property independent of this member.)
+  - **Frame-simplification (bound striding) — SHIPPED.** The BMC maintains a running
+    `reached_k = ⋁ⱼ≤ₖ bad_j` monitor ("a `bad` is reachable *within* k steps") and, past a
+    shallow exact threshold, checks it at a STRIDE: one `reached_k` UNSAT proves the WHOLE
+    `0..k` range clean at once, skipping the intermediate deep per-frame UNSAT proofs that
+    dominate the runtime. Measured on `krebs.3`: **~205 s → ~56 s (3.6×)** — now *competitive
+    with* the btormc subprocess (~73 s), where the naive per-frame version was ~3× slower.
+    `vis_arrays` is unchanged (~3 s). Scoping was measurement-driven: cone-of-influence
+    pruning was measured NOT to help here (`bad`'s cone covers ~97 % of the logic) and
+    disabling model generation during the search was a net loss (the witness re-solve of the
+    deep deciding formula dominates). **Trade:** for a deep CEX found via striding the reported
+    depth is a *sound bound* (the frame where `bad` holds in the returned witness), not
+    guaranteed minimal — shallow CEX (≤ threshold) stay exact, and the portfolio verdict is
+    depth-independent. Differential-checked against the exact BDD engine + native z3 BMC (13
     feature-gated tests). The very-deep `brp2.2`/`circular_pointer` (>300 s even for btormc)
     stay out of reach. License-clean (boolector + boolector-sys both MIT).
-  - **Infra note:** `mununu-dev:latest` was found **stale** — missing `libz3` despite the
-    Dockerfile's `libz3-dev` line — so *any* z3-linked build (not just this feature) fails to
-    link there until the image is rebuilt (or `libz3-dev` re-added). The `boolector` feature is
-    validated in a `mununu-dev` + `libz3-dev` image, per the SVA `#[ignore]` precedent; the
-    default `make ci` never compiles it (optional dep, absent from the default tree).
+  - **Infra note (resolved).** `mununu-dev:latest` had gone **stale** — missing `libz3` despite
+    the Dockerfile's `libz3-dev` line — so *any* z3-linked build failed to link there. Rebuilding
+    from `docker/Dockerfile.dev` restores `libz3` (verified: a default z3-linked test links +
+    passes) and, since the image carries cmake+curl+cc, builds the `boolector` feature directly
+    (no derived image needed). The default `make ci` never compiles the feature (optional dep,
+    absent from the default tree); validate it in `mununu-dev` with `--features boolector`, per
+    the SVA `#[ignore]` precedent.
 - **P2 — nonlinear datapath oracle (subprocess, AMulet2-style).** **Not motivated by any
   currently-failing design** (the §4 structure audit: `gen43` is pure-BV, `mul9`'s property
   is control) — so this is *parked* until a genuine multiplier-*correctness* branching
@@ -275,11 +288,12 @@ multipliers) mirroring the btormc pattern, not a linked dependency.
   plain bit-level `AG ¬bad`, the may/must machinery is overhead and a P1 fast-SAT engine is
   simply the point — that is what btormc already is, now in-process and license-clean.
 - **P1 is the recommendation; P2 is optional and subprocess-only.** The deep-CEX reach is a
-  clean, permissive-library win, now **SHIPPED**: the in-process Boolector member decides
-  **both** failing cases owned-standalone — `vis_arrays` fast (~3 s), and `krebs.3`
-  **uniquely** (no other owned engine reaches it) at `--owned-timeout-ms ≥ 240000` (~222 s,
-  ~3× the btormc subprocess). Its value is the *no-subprocess* owned path; when a subprocess
-  is fine, P0.5's `--timeout-ms` (btormc) is faster on the deepest cases. The very-deep
-  `brp2.2`/`circular_pointer` time out even for btormc/Boolector at 300 s; the nonlinear
-  class is a copyleft-constrained, discovery-limited follow-up worth doing only if the
-  multiplier-datapath branching class becomes a concrete target.
+  clean, permissive-library win, now **SHIPPED** with a frame-simplification (bound striding)
+  that cut the in-process engine's `krebs.3` time **~205 s → ~56 s (3.6×)** — competitive with
+  the btormc subprocess (~73 s). The boolector member uniquely decides both `vis_arrays` (~3 s)
+  and `krebs.3` owned-standalone (now at `--owned-timeout-ms 120000`, halved from 240000 — the
+  member also replaces the redundant z3-deep-CEX in the owned path). Its value is the
+  *no-subprocess* owned path; when a subprocess is fine, P0.5's `--timeout-ms` (btormc) remains
+  a fast route. The very-deep `brp2.2`/`circular_pointer` time out even for btormc/Boolector at
+  300 s; the nonlinear class is a copyleft-constrained, discovery-limited follow-up worth doing
+  only if the multiplier-datapath branching class becomes a concrete target.


### PR DESCRIPTION
## Frame-simplification (bound striding) for the in-process Boolector BMC

Follow-up to #344. The engine re-proved `bad` UNSAT at *every* depth 0..k; measured on
HWMCC `krebs.3` (CEX@75) the deep per-frame UNSAT proofs (frames 60–74) dominate
(~180 s of ~205 s). This replaces per-frame checks with a running reachability monitor
checked at a **stride**.

### Scoping was measurement-driven (two guesses rejected)

- **Cone-of-influence pruning — no help:** `bad`'s cone covers ~97 % of the logic on
  krebs.3 (98 % on vis_arrays), measured directly.
- **Disabling model generation during the search — a net loss:** 291 s vs 205 s; the
  per-frame solves are identical (a model is only built on SAT) and the witness re-solve
  of the deep deciding formula dominates.
- **The real cost is the deep-frame SAT proofs** — so the lever is doing *fewer* of them.

### What ships

`reached_k = bad_0 ∨ … ∨ bad_k` ("a `bad` is reachable *within* k steps"), checked as a
one-shot assumption. Past a shallow exact threshold the search **strides** — one
`reached_k` UNSAT proves the whole `0..k` range clean, skipping the intermediate deep
proofs. On a SAT bound the exact CEX depth is read back from the model.

| design | before | after |
|---|---|---|
| `krebs.3` (CEX@75) standalone | ~205 s | **~56 s (3.6×)** — competitive with btormc (~73 s) |
| `vis_arrays_buf_bug` | ~3 s | ~3 s (unchanged) |

Also: in the owned portfolio the boolector member now **replaces** the redundant
`z3-deep-CEX` (`bmc_cex_until`) rather than contending with it — halving the owned budget
`krebs.3` needs (`--owned-timeout-ms` 240000 → 120000). Boolector remains the *unique*
owned decider for krebs.3. The default (no-feature) build is unchanged.

### Honesty

- **Depth trade:** for a deep CEX found via striding the reported depth is a sound *bound*
  (the frame where `bad` holds in the returned witness), not guaranteed minimal — shallow
  CEX (≤ threshold) stay exact; the portfolio verdict is depth-independent. New test
  `strided_search_recovers_exact_depth_past_threshold` guards exact-depth recovery.
- **Owned wall caveat (pre-existing):** owned-only wall time is bounded by the slowest
  concurrent member (the synchronous, non-interruptible exact BDD engine), not boolector —
  so the speedup shows in the standalone metric + the halved budget.
- 13 feature-gated tests pass (differential vs exact BDD + native z3 BMC). Default `make
  ci` never compiles the feature.

### Infra (resolved, no code change)

`mununu-dev:latest` had gone stale (missing `libz3` despite the Dockerfile), so any
z3-linked build failed to link there. Rebuilding from `docker/Dockerfile.dev` restores it
(verified: a default z3-linked test links + passes) and builds the `boolector` feature
directly. Documented in the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
