### PR TITLE
fix(reach): subprocess-isolate z3-SPACER so its flaky Fixedpoint SIGSEGV can't crash the verify

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -245,6 +245,11 @@ enum Btor2Command {
     /// `contradiction` means two sound engines disagree — a soundness alarm,
     /// never a silent guess. Engines whose binary is absent simply abstain.
     Verify(Btor2VerifyArgs),
+    /// Internal: run z3-SPACER on a BTOR2 read from stdin, print `safe`/`unsafe`/
+    /// `unknown`. The portfolio self-execs this to run SPACER in an isolated child
+    /// process (z3's Fixedpoint can flaky-segfault); not a user-facing verb.
+    #[command(hide = true)]
+    SpacerCheck(Btor2SpacerCheckArgs),
     /// Decide a response-liveness property `AG(request → AF grant)` at scale.
     ///
     /// "Whenever `request` holds, `grant` is eventually reached on every path"
@@ -586,6 +591,14 @@ struct Btor2LiftKmtsArgs {
 }
 
 /// Arguments for `mununu btor2 verify` — the multi-engine safety portfolio.
+/// Internal `btor2 spacer-check` args — BTOR2 is read from stdin.
+#[derive(Args, Debug)]
+struct Btor2SpacerCheckArgs {
+    /// z3-SPACER wall-clock timeout in milliseconds.
+    #[arg(long, default_value_t = 10_000)]
+    timeout_ms: u32,
+}
+
 #[derive(Args, Debug)]
 struct Btor2VerifyArgs {
     /// Path to the BTOR2 input file.
@@ -1966,6 +1979,14 @@ enum GraphOutputType {
 }
 
 fn main() {
+    // Export our own path so the reachability portfolio can run z3-SPACER in an
+    // ISOLATED child (`btor2 spacer-check`) — z3's Fixedpoint can flaky-segfault on some
+    // CHC encodings, and isolating it keeps a crash from taking down the whole verify.
+    // Set once here, before any threads, so the later concurrent reads are race-free.
+    if let Ok(exe) = std::env::current_exe() {
+        // SAFETY: single-threaded at process start; no other thread reads/writes env yet.
+        unsafe { std::env::set_var("MUNUNU_SELF_EXE", exe) };
+    }
     let cli = Cli::parse();
     init_tracing(cli.quiet);
     if let Err(err) = dispatch(cli.command) {
@@ -2461,6 +2482,7 @@ fn handle_btor2(command: Btor2Command) -> Result<(), String> {
         Btor2Command::LiftKmts(args) => btor2_lift_kmts(args),
         Btor2Command::Cegar(args) => btor2_cegar(args),
         Btor2Command::Verify(args) => btor2_verify(args),
+        Btor2Command::SpacerCheck(args) => btor2_spacer_check(args),
         Btor2Command::VerifyLiveness(args) => btor2_verify_liveness(args),
         Btor2Command::VerifyLivenessAll(args) => btor2_verify_liveness_all(args),
         Btor2Command::VerifyRecoverability(args) => btor2_verify_recoverability(args),
@@ -2688,6 +2710,35 @@ fn per_response_decided_by(
 /// `violated` = reachable, `unknown` = undecided) + the per-engine reachability
 /// breakdown as JSON. Surface peer of the API `POST /api/v1/btor2/verify`; both share
 /// the verdict label via [`mununu_core::verdict::PropertyVerdict`].
+/// Internal `btor2 spacer-check`: read a BTOR2 design from stdin, run z3-SPACER, print
+/// `safe` / `unsafe` / `unknown`. The reachability portfolio self-execs this so SPACER
+/// runs in a throwaway child — z3's Fixedpoint can flaky-segfault, and isolating it
+/// keeps a crash from taking down the whole verify. Always exits 0 on a clean run; a
+/// segfault in the child is what the parent reads as "abstain".
+fn btor2_spacer_check(args: Btor2SpacerCheckArgs) -> Result<(), String> {
+    use mununu_core::adapter::btor2::native_bmc::SafetyVerdict;
+    use std::io::Read;
+    let mut content = String::new();
+    std::io::stdin()
+        .read_to_string(&mut content)
+        .map_err(|e| format!("btor2 spacer-check: read stdin: {e}"))?;
+    // A parse failure abstains (`unknown`) rather than erroring — the parent treats any
+    // non-verdict output as abstain, so a hard error would just be noise on this path.
+    let verdict = match mununu_core::adapter::btor2::parser::parse(&content) {
+        Ok(file) => match mununu_core::adapter::btor2::native_spacer::decide_bad_safety_spacer(
+            &file,
+            Some(args.timeout_ms),
+        ) {
+            Ok(SafetyVerdict::Safe { .. }) => "safe",
+            Ok(SafetyVerdict::Violated { .. }) => "unsafe",
+            _ => "unknown",
+        },
+        Err(_) => "unknown",
+    };
+    println!("{verdict}");
+    Ok(())
+}
+
 fn btor2_verify(args: Btor2VerifyArgs) -> Result<(), String> {
     use mununu_core::adapter::reach_portfolio::{
         decide_reach_owned_only, decide_reach_portfolio_parallel,

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -12,7 +12,10 @@
 //! - the in-house **SPACER** engine (IC3/PDR + interpolation via Z3's Fixedpoint,
 //!   [`native_spacer`](crate::adapter::btor2::native_spacer)) — decides safe
 //!   properties whose inductive invariant native k-induction cannot reach by simple
-//!   induction, also in-process;
+//!   induction. It is run in an ISOLATED child process (a self-exec of the hidden
+//!   `btor2 spacer-check` subcommand, gated on `MUNUNU_SELF_EXE`) because z3's
+//!   Fixedpoint can flaky-`SIGSEGV` on some CHC encodings; a crash in the child is
+//!   read as a sound `Unknown`, never a crash of the whole verify;
 //! - **btormc** (BMC + k-induction) on deep counterexamples;
 //! - **Pono** (IC3/PDR) on IC3-provable / violated instances.
 //!
@@ -140,11 +143,64 @@ fn run_native(file: &Btor2File) -> Option<bool> {
 /// cannot reach by simple induction below a large depth — also in-process, no
 /// subprocess.
 fn run_spacer(file: &Btor2File) -> Option<bool> {
-    match native_spacer::decide_bad_safety_spacer(file, Some(native_spacer::DEFAULT_TIMEOUT_MS)) {
+    // z3's Fixedpoint (SPACER) has a demonstrated FLAKY SIGSEGV on some CHC encodings
+    // (e.g. `vis_arrays_bufferAlloc`) — a z3-internal abort, uncatchable in-process and
+    // independent of concurrency (it segfaults even run alone). When the CLI / server
+    // exports `MUNUNU_SELF_EXE`, run SPACER in an ISOLATED child process (a self-exec of
+    // the hidden `btor2 spacer-check` subcommand) so a segfault becomes a non-success
+    // child exit we read as ABSTAIN rather than a crash of the whole verify. Without that
+    // env var (unit tests, or an embedding without the CLI binary) fall back to the
+    // in-process engine — those paths never exercise a crash-triggering design.
+    match std::env::var_os("MUNUNU_SELF_EXE") {
+        Some(exe) => run_spacer_isolated(
+            std::path::Path::new(&exe),
+            file,
+            native_spacer::DEFAULT_TIMEOUT_MS,
+        ),
+        None => run_spacer_in_process(file, native_spacer::DEFAULT_TIMEOUT_MS),
+    }
+}
+
+/// In-process SPACER — the direct engine call. Used as the fallback when no isolated
+/// self-exec target is available (tests / non-CLI embeddings).
+fn run_spacer_in_process(file: &Btor2File, timeout_ms: u32) -> Option<bool> {
+    match native_spacer::decide_bad_safety_spacer(file, Some(timeout_ms)) {
         Ok(SafetyVerdict::Violated { .. }) => Some(true),
         Ok(SafetyVerdict::Safe { .. }) => Some(false),
         Ok(SafetyVerdict::Unknown { .. }) | Err(_) => None,
     }
+}
+
+/// SPACER in an isolated child (`<exe> btor2 spacer-check --timeout-ms <t>`, BTOR2 on
+/// stdin, `safe`/`unsafe`/`unknown` on stdout). A z3-Fixedpoint SIGSEGV in the child is
+/// a non-success exit ⇒ `None` (abstain); a timeout ⇒ `None`; a clean verdict maps like
+/// the in-process engine. This contains the crash to a throwaway process — the verify
+/// itself never dies.
+fn run_spacer_isolated(exe: &std::path::Path, file: &Btor2File, timeout_ms: u32) -> Option<bool> {
+    let content = emit_btor2(file);
+    let mut cmd = std::process::Command::new(exe);
+    // `--quiet` keeps the child's tracing off stdout; we still scan for the verdict
+    // line defensively (the child may print a startup log line before it).
+    cmd.args(["--quiet", "btor2", "spacer-check", "--timeout-ms"])
+        .arg(timeout_ms.to_string());
+    // Wall headroom over the child's own z3 timeout so we read its verdict rather than
+    // killing it; a hung or segfaulting child is bounded either way.
+    let wall = std::time::Duration::from_millis(u64::from(timeout_ms) + 5_000);
+    let (status, stdout, _stderr) =
+        crate::adapter::run_with_timeout(&mut cmd, Some(content.as_bytes()), wall).ok()??;
+    if !status.success() {
+        return None; // SIGSEGV / error exit — the isolation payoff: abstain, don't crash.
+    }
+    // The verdict is the last `safe`/`unsafe`/`unknown` line the child printed.
+    for line in stdout.lines().rev() {
+        match line.trim() {
+            "safe" => return Some(false),
+            "unsafe" => return Some(true),
+            "unknown" => return None,
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Budget for the interpolation member. In the parallel driver it runs concurrently


### PR DESCRIPTION
## Subprocess-isolate z3-SPACER so its flaky Fixedpoint SIGSEGV can't crash the verify

### The bug (pre-existing, latent)

z3's Fixedpoint (SPACER) has a demonstrated **flaky segfault** on some CHC encodings
(`vis_arrays_bufferAlloc`, `miim`'s emitted form) — a z3-internal abort, **uncatchable
in-process** and **independent of concurrency** (it segfaults even running alone: ~3/5 at
a 120s budget, still nonzero at 10s). The reachability portfolio runs SPACER in-process,
so that crash took down the whole `btor2 verify` nondeterministically.

Found while probing whether SPACER could join the no-subprocess `--owned-only` path — it
can't, and this is the crash it would have exposed there. Owned-only stays strictly
in-process and SPACER-free.

### The fix

Run SPACER in an **isolated child process**: the CLI/server exports `MUNUNU_SELF_EXE`, and
`run_spacer` self-execs a hidden `btor2 spacer-check` subcommand (BTOR2 on stdin,
`safe`/`unsafe`/`unknown` on stdout, bounded by the existing `run_with_timeout`). A SIGSEGV
in the child is a non-success exit the parent reads as **abstain**; a hang is killed at the
timeout. When `MUNUNU_SELF_EXE` is unset (unit tests, non-CLI embeddings), it falls back to
the in-process engine — those paths never exercise a crash-triggering design, so existing
tests are unaffected.

### Validated (mununu-dev)

- Full portfolio on `vis_arrays_bufferAlloc`: **10/10 clean** (was ~3/5 SIGSEGV).
- SPACER still contributes: `vcegar_QF_BV_itc99_b13_p10` → `holds`/spacer always; `miim`
  flaky-decides **3/6 `holds`/spacer, 3/6 abstain** — never a crash, never a wrong verdict
  (the child dies → parent abstains; the child survives → real safety proof).

Default build unchanged; owned-only unchanged. `spacer-check` is a hidden internal verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
