### PR TITLE
fix(btor2): verify-liveness binds a registered-output grant atom

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -138,6 +138,39 @@ pub(crate) fn input_nid_and_sort(
     })
 }
 
+/// Resolve an OUTPUT port symbol to `(driver_nid, sort_nid)` — the net driving the
+/// named output.
+///
+/// A *registered* output (e.g. a grant flop) surfaces here even when the underlying
+/// state cell is unnamed after the standard `flatten; opt_clean; dffunmap` lift drops
+/// state symbols but keeps port names. Comparing the driver's value is a **sound**
+/// per-cycle observation for the response monitor: it is exactly the signal's value
+/// each step, and the l2s `AF` semantics stay sound whether the driver is a pure
+/// function of state or of state+inputs (a `b`-free lasso is still a genuine
+/// never-granted path). A *negated* output operand is skipped — binding its
+/// un-negated net would flip the comparison sense — so it falls through to the
+/// caller's bind error rather than binding the wrong polarity.
+pub(crate) fn output_nid_and_sort(
+    file: &crate::adapter::btor2::ast::Btor2File,
+    signal: &str,
+) -> Option<(Nid, Nid)> {
+    let drv = file.lines.iter().find_map(|l| match &l.node {
+        Node::Output {
+            signal: op,
+            symbol: Some(sym),
+        } if sym == signal && !op.is_negated() => Some(op.nid()),
+        _ => None,
+    })?;
+    let sort = match &file.lookup(drv)?.node {
+        Node::Input { sort, .. }
+        | Node::State { sort, .. }
+        | Node::Const { sort, .. }
+        | Node::Op { sort, .. } => *sort,
+        _ => return None,
+    };
+    Some((drv, sort))
+}
+
 /// H.O.1b — append a `bad` monitor for `AG (signal ⋈ value)`.
 ///
 /// `signal` must resolve to a state register (value-alias / reset-mux aware, like

--- a/crates/mununu-core/src/adapter/btor2/l2s_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/l2s_monitor.rs
@@ -36,7 +36,7 @@
 use crate::adapter::btor2::ast::{Nid, Node};
 use crate::adapter::btor2::bad_monitor::{
     BAD_COND_SYMBOL, btor2_cmp_keyword, find_or_make_bool_sort, input_nid_and_sort,
-    state_nid_and_sort,
+    output_nid_and_sort, state_nid_and_sort,
 };
 use crate::adapter::btor2::parser;
 use crate::adapter::btor2::predicate_expr::CmpOp;
@@ -78,12 +78,17 @@ fn emit_atom(
     role: &str,
 ) -> Result<Nid, AdapterError> {
     let (signal, op, value) = atom;
+    // Resolve against a state cell, a primary input, or a named output port. The
+    // output case (registered grants like `level1` / `q`) is essential: the standard
+    // lift keeps port names but drops state-cell names, so a grant signal surfaces
+    // only as an `output` — comparing its driver net per-cycle is a sound observation.
     let (nid, sort) = state_nid_and_sort(file, signal, reset_pinned)
         .or_else(|| input_nid_and_sort(file, signal))
+        .or_else(|| output_nid_and_sort(file, signal))
         .ok_or_else(|| {
             err(format!(
-                "adapter/btor2/l2s_monitor: {role} `{signal}` is neither a state cell nor a \
-                 primary input, so the response monitor cannot bind it"
+                "adapter/btor2/l2s_monitor: {role} `{signal}` is not a state cell, a primary \
+                 input, or a named output, so the response monitor cannot bind it"
             ))
         })?;
     let cst = e.push(format!("constd {sort} {value}"));
@@ -241,5 +246,42 @@ mod tests {
             false,
         );
         assert!(e.is_err(), "an atom that binds no signal must error");
+    }
+
+    // The real-lift shape: `flatten; opt_clean; dffunmap` keeps port names but drops
+    // state-cell names, so a registered grant surfaces only as a named `output` over
+    // an *unnamed* state. Binding the grant atom must follow the output to its driver.
+    const REGISTERED_OUTPUT: &str = "\
+1 sort bitvec 1
+2 input 1 req
+3 state 1
+4 zero 1
+5 init 1 3 4
+6 next 1 3 2
+7 output 3 grant
+";
+
+    #[test]
+    fn binds_registered_output_grant() {
+        // `grant` is a named output over the unnamed state 3; `req` is a primary input.
+        let out = emit_response_l2s_monitor(
+            REGISTERED_OUTPUT,
+            ("req", CmpOp::Eq, 1),
+            ("grant", CmpOp::Eq, 1),
+            false,
+        )
+        .expect("a registered-output grant must bind via output_nid_and_sort");
+        let file = parser::parse(&out).expect("emitted BTOR2 re-parses");
+        assert!(
+            file.lines
+                .iter()
+                .any(|l| matches!(l.node, Node::Bad { .. })),
+            "the monitor emits a bad line"
+        );
+        // The grant comparison binds the output's driver (state 3), not the output line.
+        assert!(
+            out.contains("eq 1 3 "),
+            "grant compares against driver nid 3"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The l2s response-liveness monitor (`emit_atom`) resolved a request/grant atom only against a **named state cell** or a **primary input**. After the standard `flatten; opt_clean; dffunmap` lift, yosys keeps top-level **port** names but drops **state-cell** symbols — so a registered grant (`level1`, `q`, …) surfaces only as a named `output` and failed to bind (*"an atom binds no signal"*), even though `verify-recoverability` already binds the same signal via a stronger resolver.

## Fix

- Add `output_nid_and_sort` — resolve an output-port symbol to its **driver net** — and extend the l2s resolver to **state → input → output**.
- Soundness: comparing the driver value per-cycle is a valid observation for the l2s `AF` reduction (a `b`-free lasso is still a genuine never-granted path), and reset-agnostic. A **negated** output operand is skipped rather than bound with flipped polarity.
- Regression test `binds_registered_output_grant` uses the real-lift shape (a named output over an *unnamed* state).

## Validation

- `make ci` equivalent green in the pinned image: fmt ✅, clippy ✅, **2683 tests pass, 0 failed**.
- End-to-end: `AG((level1==1) → AF (level2==1))` on `versatile_counter` (both registered outputs) now binds and returns a definite `violated`, decided by `exact + native + spacer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)