### PR TITLE
fix(yosys): native SV lift normalizes memories (memory_collect) before write_btor

### DIFF
--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -873,7 +873,14 @@ fn build_per_module_script(
     let setundef_pass = select_setundef_pass(setundef_anyseq, setundef_anyconst);
     let per_signal = emit_init_policy_setattrs(init_policy_overrides);
     format!(
-        "{}; hierarchy -check -top {module}; {per_signal}proc; flatten; async2sync; chformal -lower; dffunmap; {setundef_pass}; write_btor {}",
+        // `memory_collect` normalizes memory read/write accesses into `$mem` cells
+        // (fixing an internal yosys assert on some fifo styles when a raw `$mem`
+        // reaches `write_btor`) while KEEPING the memory as a BTOR2 array — the
+        // bit-blaster resolves array sorts, so this stays scalable (no map-to-flops
+        // explosion). Unlike `memory`/`memory -nomap`, it runs NO internal `opt_clean`,
+        // so it does not drop dead registers (which would change memory-free lifts).
+        // No-op when the design has no memories.
+        "{}; hierarchy -check -top {module}; {per_signal}proc; memory_collect; flatten; async2sync; chformal -lower; dffunmap; {setundef_pass}; write_btor {}",
         read_cmds.join("; "),
         btor_out.display()
     )
@@ -1700,7 +1707,9 @@ fn build_script(
     let setundef_pass = select_setundef_pass(setundef_anyseq, setundef_anyconst);
     let per_signal = emit_init_policy_setattrs(init_policy_overrides);
     format!(
-        "{}; {hier}; {per_signal}proc; write_json {}; cutpoint -blackbox; flatten; async2sync; chformal -lower; dffunmap; {setundef_pass}; write_btor {}",
+        // `memory_collect` (see the single-module lift above): normalize memory ports
+        // for BTOR2 array emission, no opt_clean / map-to-flops. No-op when memory-free.
+        "{}; {hier}; {per_signal}proc; write_json {}; cutpoint -blackbox; memory_collect; flatten; async2sync; chformal -lower; dffunmap; {setundef_pass}; write_btor {}",
         read_cmds.join("; "),
         hier_json_out.display(),
         btor_out.display()


### PR DESCRIPTION
## Problem
The native SV→BTOR2 lift omitted memory normalization, so a design's `\$mem` (e.g. a fifo) reached `write_btor` and tripped an internal yosys assert (`kernel/mem.cc:492: port.en == State::S1`) — **crashing `context eval`, `sv verify-auto`, and `sv discover` on any memory-containing design** (e.g. an SPI core with a fifo).

## Fix
Add `memory_collect` after `proc` in both native lift scripts (single-module + per-module). It gathers memory accesses into `\$mem` cells so `write_btor` emits a clean BTOR2 **array** — the bit-blaster already resolves `Sort::Array` — so it stays scalable (no map-to-flops explosion). `memory_collect` runs **no internal `opt_clean`** (unlike `memory` / `memory -nomap`), so it does not drop dead registers: **a no-op for memory-free designs** (byte-identical lift).

## Validation
- SPI (`simple_spi_top` + fifo) now lifts via `sv discover` (was crashing).
- Full host suite green (the pre-commit hook passed); memory-free lifts unchanged.

_Note: `memory -nomap` was tried first but its internal `opt_clean` drops dead registers, changing memory-free lifts — `memory_collect` avoids that._

🤖 Generated with [Claude Code](https://claude.com/claude-code)