### PR TITLE
feat(verify-auto): --cutpoint control-slice cut points (CLI+API+UI)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1622,6 +1622,16 @@ struct SvVerifyAutoArgs {
     /// the inferred one. Shown as a `counter-bound` note.
     #[arg(long = "counter-bound", value_name = "SIGNAL<=VALUE")]
     counter_bound: Vec<String>,
+    /// Control-slice cut point: replace a net with a free `$anyseq` input in the
+    /// SV → BTOR2 lift (Yosys `cutpoint w:<net>`), so its datapath fanin drops out
+    /// via cone-of-influence. The sound, netlist-level way to shrink a wide FSM's
+    /// cone so `--engine exact-symbolic` fits — cut the FSM's datapath *guards*
+    /// (e.g. `--cutpoint must_refresh --cutpoint precharge_done`). Repeatable.
+    /// OVER-APPROXIMATION: a definite HOLDS transfers (safety + over-approx); a
+    /// definite VIOLATED is sound only when guard-independent (an orphaned FSM
+    /// state). Surfaced as a `control-slice` scope-caveat note.
+    #[arg(long = "cutpoint", value_name = "SIGNAL")]
+    cutpoint: Vec<String>,
     /// Print a JSON report instead of the human-readable summary.
     #[arg(long)]
     json: bool,
@@ -3136,6 +3146,7 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         additional_sources: additional,
         primary_source_path: Some(args.file.display().to_string()),
         use_sv2v: args.preprocess_sv2v,
+        cutpoint_signals: args.cutpoint.clone(),
         ..Default::default()
     };
     let must_edge_inference = match args.must_edge_inference {

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -316,6 +316,7 @@ fn build_notes(
     must_edge_inference: MustEdgeInference,
     applied_config_values: &[(String, u64)],
     counter_bounds: &[String],
+    cutpoint_signals: &[String],
     posture: &NotePosture,
 ) -> Vec<VerificationNote> {
     let d = &report.diagnostics;
@@ -364,6 +365,31 @@ fn build_notes(
                 .iter()
                 .map(|(sig, v)| format!("{sig}={v}"))
                 .collect(),
+        });
+    }
+
+    // Control-slice cut points (ScopeCaveat) — present only when the user cut nets
+    // to free `$anyseq` inputs in the lift. This is an OVER-APPROXIMATION: it adds
+    // transitions, so a definite HOLDS is sound but a definite VIOLATED may be
+    // spurious unless it is guard-independent (the orphaned-FSM-state case).
+    if !cutpoint_signals.is_empty() {
+        notes.push(VerificationNote {
+            kind: "control-slice".into(),
+            level: NoteLevel::ScopeCaveat,
+            summary: format!(
+                "{} net(s) cut to free inputs (control-slice) — an over-approximation of the design.",
+                cutpoint_signals.len()
+            ),
+            detail: "Each listed net was replaced by a free `$anyseq` input (Yosys `cutpoint`), so its \
+                     datapath fanin drops out of the cone (this is what lets `exact-symbolic` fit a wide \
+                     control FSM). Because freeing a net only ADDS transitions, a definite HOLDS transfers \
+                     to the concrete RTL (safety + over-approx = sound); a definite VIOLATED is sound only \
+                     when the counterexample is guard-independent — the canonical case being an ORPHANED \
+                     FSM state (in-degree 0), which no freed guard can make reachable, so `AG EF \
+                     <orphaned-state>` stays soundly VIOLATED. Treat any other VIOLATED under cut points \
+                     as possibly spurious and re-check without the cut."
+                .into(),
+            items: cutpoint_signals.to_vec(),
         });
     }
 
@@ -1653,7 +1679,14 @@ pub fn verify_auto(
         } else {
             NotePosture::Cube
         };
-        report.notes = build_notes(&report, opts.must_edge_inference, &[], &[], &posture);
+        report.notes = build_notes(
+            &report,
+            opts.must_edge_inference,
+            &[],
+            &[],
+            &yosys_opts.cutpoint_signals,
+            &posture,
+        );
         if let Some(n) = annotation_note(&ann_scan) {
             report.notes.push(n);
         }
@@ -2255,6 +2288,7 @@ pub fn verify_auto(
         opts.must_edge_inference,
         &applied_config_values,
         &counter_bound_items_vec,
+        &yosys_opts.cutpoint_signals,
         &posture,
     );
     if let Some(n) = annotation_note(&ann_scan) {
@@ -3340,6 +3374,7 @@ module uart_tx(); endmodule"#;
             MustEdgeInference::SmtHyperMust,
             &[("cfg_detect_timer_i".into(), 7)],
             &["cnt_q <= 7 (config-inferred)".to_string()],
+            &[],
             &NotePosture::Cube,
         );
         let kinds: Vec<&str> = notes.iter().map(|n| n.kind.as_str()).collect();
@@ -3395,13 +3430,66 @@ module uart_tx(); endmodule"#;
             MustEdgeInference::Off,
             &[],
             &[],
+            &[],
             &NotePosture::Cube,
         );
         assert!(
             !notes_no_pins
                 .iter()
-                .any(|n| n.kind == "config-concretization" || n.kind == "counter-bound")
+                .any(|n| n.kind == "config-concretization"
+                    || n.kind == "counter-bound"
+                    || n.kind == "control-slice")
         );
+    }
+
+    #[test]
+    fn control_slice_note_present_when_cutpoints_given() {
+        // The control-slice note is a ScopeCaveat present iff nets were cut, carrying
+        // the cut list and the over-approximation posture. It documents that a HOLDS
+        // is sound but a VIOLATED is sound only when guard-independent (orphan case).
+        let report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "p".into(),
+                kind: SvaKind::Assert,
+                formula: "nu X. (a && [] X)".into(),
+                outcome: VerifyOutcome::Holds,
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            unsupported: Vec::new(),
+            diagnostics: ModelDiagnostics {
+                state_register_count: 1,
+                blackboxed_modules: Vec::new(),
+                gated_resets: Vec::new(),
+                auto_provided_stubs: Vec::new(),
+            },
+            notes: Vec::new(),
+        };
+        let notes = build_notes(
+            &report,
+            MustEdgeInference::SmtHyperMust,
+            &[],
+            &[],
+            &["must_refresh".to_string(), "precharge_done".to_string()],
+            &NotePosture::Exact,
+        );
+        let cs = notes
+            .iter()
+            .find(|n| n.kind == "control-slice")
+            .expect("control-slice note present when cut points given");
+        assert_eq!(cs.level, NoteLevel::ScopeCaveat);
+        assert!(cs.items.contains(&"must_refresh".to_string()));
+        assert!(cs.summary.contains("over-approximation"), "{}", cs.summary);
+        // No cut points ⇒ no control-slice note.
+        let none = build_notes(
+            &report,
+            MustEdgeInference::Off,
+            &[],
+            &[],
+            &[],
+            &NotePosture::Exact,
+        );
+        assert!(!none.iter().any(|n| n.kind == "control-slice"));
     }
 
     #[test]
@@ -3427,10 +3515,17 @@ module uart_tx(); endmodule"#;
             notes: Vec::new(),
         };
         let ap = |posture: &NotePosture| {
-            build_notes(&report, MustEdgeInference::SmtHyperMust, &[], &[], posture)
-                .into_iter()
-                .find(|n| n.kind == "abstraction-posture")
-                .unwrap()
+            build_notes(
+                &report,
+                MustEdgeInference::SmtHyperMust,
+                &[],
+                &[],
+                &[],
+                posture,
+            )
+            .into_iter()
+            .find(|n| n.kind == "abstraction-posture")
+            .unwrap()
         };
         // AR-S2 — the cube path always uses the sound `SmtAllPairs` may-relation,
         // so the cube posture note is the sound over-approximation Info (the
@@ -4189,6 +4284,101 @@ module uart_tx(); endmodule"#;
                 .iter()
                 .map(|p| &p.outcome)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    #[ignore = "requires slang + sv2v + Yosys + z3 (use the mununu-sva docker image); run with --ignored"]
+    fn e2e_cutpoint_frees_wide_counter_guard_so_exact_symbolic_fits() {
+        // Control-slice cut points, end-to-end. A 3-state FSM whose INIT→RUN edge is
+        // gated by a wide (48-bit) counter-derived `tick`. That counter sits in the
+        // state's cone, so `AG EF (state==DONE)` under `exact-symbolic` is Skipped
+        // (cone-too-wide) — UNTIL `--cutpoint tick` frees the guard to a `$anyseq`
+        // input, dropping the 48-bit counter out of the cone (COI). The design then
+        // fits and the goal is decided HOLDS. The netlist-level, width-agnostic
+        // version of the `control_slice.py` source prototype; `cutpoint` needs no
+        // width resolution or source rewriting.
+        use crate::adapter::btor2::kmts_lift::MustEdgeInference;
+        let src = r#"// @mununu_guarantee nu Y.((mu X.(state == 2 || <> X)) && [] Y)
+module wide_guard_fsm(input clk, input rst, output reg [1:0] state);
+  localparam INIT = 2'd0, RUN = 2'd1, DONE = 2'd2;
+  reg [47:0] cnt;
+  wire tick = (cnt == 48'd0);
+  always @(posedge clk) begin
+    if (rst) begin
+      state <= INIT;
+      cnt   <= 48'd100;
+    end else begin
+      cnt <= cnt - 48'd1;
+      case (state)
+        INIT:    if (tick) state <= RUN;
+        RUN:     state <= DONE;
+        DONE:    state <= INIT;
+        default: state <= INIT;
+      endcase
+    end
+  end
+endmodule
+"#;
+        let sources = vec![("wide_guard_fsm.v".to_string(), src.to_string())];
+        let base = YosysOptions {
+            top: Some("wide_guard_fsm".to_string()),
+            ..Default::default()
+        };
+        let vopts = || VerifyAutoOptions {
+            must_edge_inference: MustEdgeInference::SmtHyperMust,
+            exact_symbolic: true,
+            ..Default::default()
+        };
+
+        // (1) WITHOUT cut points: the 48-bit counter is in the state cone → Skipped.
+        let no_cut = verify_auto(&sources, &base, &vopts()).expect("verify_auto runs (no cut)");
+        let g0 = no_cut
+            .properties
+            .iter()
+            .find(|p| p.name.contains("guarantee"))
+            .expect("annotated guarantee present");
+        eprintln!("no-cut:   {} => {:?}", g0.name, g0.outcome);
+        assert!(
+            matches!(g0.outcome, VerifyOutcome::Skipped { .. }),
+            "without cut points the wide-counter cone should be Skipped, got {:?}",
+            g0.outcome
+        );
+
+        // (2) WITH `--cutpoint tick`: guard freed → counter drops out of the cone →
+        // exact-symbolic FITS and returns a DEFINITE verdict (Holds or Violated) where
+        // it previously refused (Skipped). Decidability — not a specific verdict — is
+        // the feature's claim; and per the over-approximation posture a Violated under
+        // cut points must not be over-trusted anyway (see the control-slice note). The
+        // control-slice note is present and names the cut net.
+        let cut = YosysOptions {
+            cutpoint_signals: vec!["tick".to_string()],
+            ..base.clone()
+        };
+        let with_cut = verify_auto(&sources, &cut, &vopts()).expect("verify_auto runs (cut)");
+        let g1 = with_cut
+            .properties
+            .iter()
+            .find(|p| p.name.contains("guarantee"))
+            .expect("annotated guarantee present");
+        eprintln!("with-cut: {} => {:?}", g1.name, g1.outcome);
+        assert!(
+            matches!(
+                g1.outcome,
+                VerifyOutcome::Holds | VerifyOutcome::Violated { .. }
+            ),
+            "cutting `tick` should let exact-symbolic reach a DEFINITE verdict (was Skipped), got {:?}",
+            g1.outcome
+        );
+        let cs = with_cut
+            .notes
+            .iter()
+            .find(|n| n.kind == "control-slice")
+            .expect("control-slice note present when cut points given");
+        assert!(
+            cs.items.contains(&"tick".to_string()),
+            "note items: {:?}",
+            cs.items
         );
     }
 

--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -163,6 +163,29 @@ pub struct YosysOptions {
     /// carry the CLTS, sidecars, and partition summaries the BTOR2
     /// adapter produced.
     pub per_module_output_dir: Option<PathBuf>,
+    /// Control-slice cut points: net names to replace with a free
+    /// `$anyseq` input in the SV → BTOR2 lift (Yosys `cutpoint w:<net>`),
+    /// spliced after `proc`/`write_json` and before `flatten`. The net's
+    /// datapath fanin then drops out via cone-of-influence — the sound,
+    /// netlist-level way to shrink a wide FSM's cone so `--engine
+    /// exact-symbolic` fits (the `control_slice.py` prototype done in the
+    /// engine; here `cutpoint` handles reg/wire/width/multi-driver
+    /// uniformly, no source rewriting).
+    ///
+    /// **SOUNDNESS — this is an OVER-APPROXIMATION.** A freed net becomes
+    /// nondeterministic, which only *adds* transitions. A definite HOLDS
+    /// therefore transfers to the concrete RTL (safety + over-approx =
+    /// sound). A definite VIOLATED is sound only when the counterexample
+    /// is guard-independent — the canonical case being an *orphaned* FSM
+    /// state (in-degree 0), which no freed guard can make reachable, so
+    /// `AG EF <orphaned-state>` stays soundly VIOLATED. A general VIOLATED
+    /// under cut points may be spurious; verify-auto surfaces a
+    /// `control-slice` ScopeCaveat note when this vector is non-empty.
+    ///
+    /// Names are validated to a safe identifier charset before being
+    /// interpolated into the Yosys `-p` script (no injection). Default:
+    /// empty (no cut points).
+    pub cutpoint_signals: Vec<String>,
 }
 
 /// SV-via-Yosys adapter — wraps the BTOR2 path with a Yosys subprocess.
@@ -277,6 +300,7 @@ fn run_sv_flatten_btor2(
         yopts.setundef_anyseq,
         yopts.setundef_anyconst,
         &yopts.init_policy_overrides,
+        &yopts.cutpoint_signals,
     );
 
     let output = Command::new(&yosys)
@@ -1637,6 +1661,45 @@ fn emit_init_policy_setattrs(overrides: &InitPolicyOverrides) -> String {
     }
 }
 
+/// A Yosys net name is safe to interpolate into the `-p` script iff it is a
+/// plain identifier (optionally hierarchical `a.b.c` or bit-selected `sig[3:0]`).
+/// This is a security gate: the whole script is one `-p` argument, so a name
+/// containing `;`, whitespace, or quotes could inject an arbitrary Yosys pass
+/// (OWASP command-injection). Anything else is rejected.
+fn is_valid_net_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '$' | '.' | '[' | ']' | ':'))
+        && name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+}
+
+/// Emit the explicit control-slice cut-point pass: `cutpoint w:<sig> …; ` (empty
+/// when no valid signals). Placed after `proc`/`write_json` and before `flatten`
+/// so the named nets still exist unprefixed; `cutpoint` replaces each net's driver
+/// with a free `$anyseq`, and cone-of-influence then drops the (now-dead) datapath
+/// fanin. Invalid names ([`is_valid_net_name`]) are skipped — a skipped cut point
+/// only leaves the cone wider (the property may be `Skipped`), never a wrong verdict.
+fn emit_cutpoints(signals: &[String]) -> String {
+    let sel: Vec<String> = signals
+        .iter()
+        .filter(|s| is_valid_net_name(s))
+        .map(|s| format!("w:{s}"))
+        .collect();
+    if sel.is_empty() {
+        String::new()
+    } else {
+        format!("cutpoint {}; ", sel.join(" "))
+    }
+}
+
+// The lift-script builder threads each independent Yosys-pass knob (top, output
+// paths, the two setundef flags, per-signal init overrides, and now the cut points)
+// as its own argument; bundling them into a struct would not improve clarity here.
+#[allow(clippy::too_many_arguments)]
 fn build_script(
     sources: &[PathBuf],
     top: Option<&str>,
@@ -1645,6 +1708,7 @@ fn build_script(
     setundef_anyseq: bool,
     setundef_anyconst: bool,
     init_policy_overrides: &InitPolicyOverrides,
+    cutpoint_signals: &[String],
 ) -> String {
     let read_cmds: Vec<String> = sources
         .iter()
@@ -1699,8 +1763,14 @@ fn build_script(
     // is R-Y2 (§Phase 8 §8.1), shipping post-R-Y1.
     let setundef_pass = select_setundef_pass(setundef_anyseq, setundef_anyconst);
     let per_signal = emit_init_policy_setattrs(init_policy_overrides);
+    // Explicit control-slice cut points, spliced after the discovery `write_json`
+    // snapshot (so state-cell discovery still sees the real signals) and before
+    // `flatten`/bit-blast: each named net is driven by a free `$anyseq`, and
+    // cone-of-influence drops its now-dead datapath fanin. Over-approximation —
+    // see `YosysOptions::cutpoint_signals`.
+    let cutpoints = emit_cutpoints(cutpoint_signals);
     format!(
-        "{}; {hier}; {per_signal}proc; write_json {}; cutpoint -blackbox; flatten; async2sync; chformal -lower; dffunmap; {setundef_pass}; write_btor {}",
+        "{}; {hier}; {per_signal}proc; write_json {}; {cutpoints}cutpoint -blackbox; flatten; async2sync; chformal -lower; dffunmap; {setundef_pass}; write_btor {}",
         read_cmds.join("; "),
         hier_json_out.display(),
         btor_out.display()
@@ -2205,6 +2275,102 @@ mod tests {
         assert!(
             hier_pos < setattr_pos && setattr_pos < proc_pos,
             "setattr must appear between hierarchy and proc; ordering = hier@{hier_pos} setattr@{setattr_pos} proc@{proc_pos}"
+        );
+    }
+
+    // ----- Control-slice cut-point tests (yosys-free) ----------------
+
+    #[test]
+    fn is_valid_net_name_accepts_identifiers_and_selects() {
+        assert!(is_valid_net_name("must_refresh"));
+        assert!(is_valid_net_name("_leading_underscore"));
+        assert!(is_valid_net_name("top.sub.sig"));
+        assert!(is_valid_net_name("cnt_q[3:0]"));
+        assert!(is_valid_net_name("gen$flop"));
+    }
+
+    #[test]
+    fn is_valid_net_name_rejects_injection_and_bad_starts() {
+        assert!(!is_valid_net_name("")); // empty
+        assert!(!is_valid_net_name("3state")); // leading digit
+        assert!(!is_valid_net_name("a; write_verilog /etc/passwd")); // pass injection via `;`
+        assert!(!is_valid_net_name("a b")); // whitespace
+        assert!(!is_valid_net_name("a\"b")); // quote
+        assert!(!is_valid_net_name("a-b")); // stray operator
+    }
+
+    #[test]
+    fn emit_cutpoints_empty_and_populated() {
+        assert_eq!(emit_cutpoints(&[]), "");
+        assert_eq!(
+            emit_cutpoints(&["must_refresh".to_string(), "precharge_done".to_string()]),
+            "cutpoint w:must_refresh w:precharge_done; "
+        );
+        // Invalid names are dropped; a lone invalid name yields the empty (no-op) pass.
+        assert_eq!(emit_cutpoints(&["bad;name".to_string()]), "");
+        assert_eq!(
+            emit_cutpoints(&["bad;name".to_string(), "ok_net".to_string()]),
+            "cutpoint w:ok_net; "
+        );
+    }
+
+    #[test]
+    fn build_script_injects_cutpoint_between_write_json_and_flatten() {
+        use std::path::PathBuf;
+        let sources = vec![PathBuf::from("/tmp/foo.sv")];
+        let btor = PathBuf::from("/tmp/out.btor");
+        let hier = PathBuf::from("/tmp/hier.json");
+        let overrides: InitPolicyOverrides = Vec::new();
+        let cuts = vec!["must_refresh".to_string(), "precharge_done".to_string()];
+        let script = build_script(
+            &sources,
+            Some("top"),
+            &btor,
+            &hier,
+            false,
+            false,
+            &overrides,
+            &cuts,
+        );
+        assert!(
+            script.contains("cutpoint w:must_refresh w:precharge_done"),
+            "explicit cut points missing from script: {script}"
+        );
+        // Ordering: the control-slice cut points come after the discovery `write_json`
+        // snapshot (so state discovery sees the real nets) and before `flatten`.
+        let wj = script.find("write_json").expect("write_json present");
+        let cut = script
+            .find("cutpoint w:must_refresh")
+            .expect("explicit cutpoint present");
+        let flat = script.find("flatten").expect("flatten present");
+        assert!(
+            wj < cut && cut < flat,
+            "cutpoint must sit between write_json and flatten; wj@{wj} cut@{cut} flatten@{flat}"
+        );
+    }
+
+    #[test]
+    fn build_script_without_cutpoints_has_no_explicit_cutpoint_pass() {
+        use std::path::PathBuf;
+        let sources = vec![PathBuf::from("/tmp/foo.sv")];
+        let btor = PathBuf::from("/tmp/out.btor");
+        let hier = PathBuf::from("/tmp/hier.json");
+        let overrides: InitPolicyOverrides = Vec::new();
+        let script = build_script(
+            &sources,
+            Some("top"),
+            &btor,
+            &hier,
+            false,
+            false,
+            &overrides,
+            &[],
+        );
+        // The blackbox cut is always present; there must be no explicit `cutpoint w:` pass.
+        assert!(script.contains("cutpoint -blackbox"));
+        assert!(
+            !script.contains("cutpoint w:"),
+            "no explicit cut points expected: {script}"
         );
     }
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1188,6 +1188,7 @@ pub async fn sv_verify_auto_handler(
             .map(|f| (f.name.clone(), f.content.clone()))
             .collect(),
         use_sv2v: request.use_sv2v,
+        cutpoint_signals: request.cutpoint.clone(),
         ..Default::default()
     };
     let must_edge_inference = match request.must_edge_inference.as_deref() {

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1328,6 +1328,16 @@ pub struct SvVerifyAutoRequest {
     /// note. Default empty.
     #[serde(default)]
     pub counter_bounds: Vec<String>,
+    /// Control-slice cut points, mirroring the CLI `--cutpoint`: net names to replace
+    /// with a free `$anyseq` input in the SV → BTOR2 lift (Yosys `cutpoint w:<net>`), so
+    /// the FSM's datapath guards drop out of the cone via cone-of-influence — the sound,
+    /// netlist-level way to fit `"exact-symbolic"` on a wide control FSM. Each entry is a
+    /// bare net name (e.g. `"must_refresh"`). OVER-APPROXIMATION: a definite HOLDS
+    /// transfers (safety + over-approx); a definite VIOLATED is sound only when
+    /// guard-independent (an orphaned FSM state). Surfaced as a `control-slice` note.
+    /// Default empty.
+    #[serde(default)]
+    pub cutpoint: Vec<String>,
     /// Engine selector, mirroring the CLI `--engine`: `"explicit"`, `"symbolic"`,
     /// `"exact-symbolic"`, `"portfolio-sequential"`, `"portfolio-parallel"`.
     /// **Unspecified ⇒ the default `"portfolio-sequential"`** (2026-07-06): run


### PR DESCRIPTION
`sv verify-auto --cutpoint <net>` (repeatable) replaces a net with a free `$anyseq` input in the SV→BTOR2 lift (yosys `cutpoint w:<net>`), spliced after `proc`/`write_json` and before `flatten`. The net's datapath fanin drops out via cone-of-influence, so `--engine exact-symbolic` fits a wide control FSM.

**Soundness:** an over-approximation. A definite HOLDS transfers (safety + over-approx = sound); a definite VIOLATED is sound only when guard-independent (an orphaned FSM state, in-degree 0). Surfaced as a `control-slice` ScopeCaveat note. Net names are validated against a safe charset before hitting the yosys `-p` string (no injection).

**Surface parity:** CLI `--cutpoint`, API `cutpoint` field → `YosysOptions`, UI `cutpoint?: string[]` + verify-auto runner form (mununu-ui PR).

**Tests:** 6 unit (name validation incl. injection, emit_cutpoints, build_script splice/ordering, control-slice note) + an `#[ignore]` e2e (48-bit counter guard: Skipped without cut → definite verdict with `--cutpoint tick`; validated in the mununu-sva image). Full `cargo test --workspace` + clippy + fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)