### PR TITLE
fix(api): gate ProposeCompositionResponse.findings behind ast-extract

### DIFF
--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -747,8 +747,17 @@ pub struct ProposeCompositionRequest {
 /// Phase B response: list of detected concurrency findings, in source
 /// order. An empty `findings` list is the common case (no concurrency
 /// patterns present); not an error.
+///
+/// The `findings` field is gated behind `ast-extract` because its element
+/// type lives behind that feature. Without `ast-extract` the struct is a
+/// well-formed empty response type: the `#[cfg(not(feature = "ast-extract"))]`
+/// stub of `extraction_propose_composition_handler` returns an error and never
+/// constructs it, so it is only ever serialized on the `ast-extract` path. This
+/// lets `cargo … --features api` (without `ast-extract`) compile — matching the
+/// handler stubs' intent that the API build standalone.
 #[derive(Debug, Serialize)]
 pub struct ProposeCompositionResponse {
+    #[cfg(feature = "ast-extract")]
     pub findings:
         Vec<crate::adapter::extraction::ast_extract::concurrency_detect::DetectedConcurrency>,
 }


### PR DESCRIPTION
`cargo … -p mununu-core --features api` (without `ast-extract`) failed to compile: `ProposeCompositionResponse.findings` referenced `ast_extract::concurrency_detect::DetectedConcurrency`, whose module is `#[cfg(feature = "ast-extract")]`. The propose-composition handler already has the correct split (real impl + a `#[cfg(not(...))]` stub returning "AST extraction not available. Build with --features ast-extract"), so the API is meant to build standalone; only the response struct's field was left ungated.

Gate the **field** (not the struct — the stub handler names the struct in its return type). Without `ast-extract` the struct is a well-formed empty response the stub never constructs, so it is only serialized on the `ast-extract` path.

**Scope correction:** this hardens the *direct* `-p mununu-core --features api` build. It does **not** change CI or the `MUNUNU_PRECOMMIT_FULL` hook, which run `cargo test --features api` from the **workspace root** — where the root `api` feature co-enables `mununu-core/ast-extract`, so they never hit this path. So this is a defensive fix for anyone building `mununu-core` standalone with only `api`, not a CI/hook unblock.

**Validated:** `-p mununu-core --features api`, `--features api,ast-extract`, and default all compile; `cargo test --lib api --features api` (32 tests), `clippy --features api -D warnings`, and `fmt --check` pass. Independent of the cutpoint feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)