### PR TITLE
fix(verify-auto): structurally auto-pin the async reset (soundness: box/AF)

### DIFF
--- a/crates/mununu-core/src/adapter/fsm_scan.rs
+++ b/crates/mununu-core/src/adapter/fsm_scan.rs
@@ -310,7 +310,15 @@ fn value_alias_nids(file: &Btor2File, state_nid: Nid) -> HashSet<Nid> {
 
 /// Detect the design's reset inputs as `(name, inactive_value)` from each state cell's
 /// reset mux — the set [`inject_reset_init`] / [`pin_inputs_to_constants`] consume.
-fn detect_resets(file: &Btor2File, symbols: &HashMap<Nid, String>) -> Vec<(String, u64)> {
+///
+/// `pub(crate)` so `verify_auto` can reuse it to structurally auto-pin the reset on a
+/// plain-RTL `@mununu_guarantee` design that carries no SVA `disable iff` (otherwise the
+/// free reset input leaves a reset-edge from every state to the reset state, which
+/// soundly-but-spuriously VIOLATES box/`AF`/box-universal properties).
+pub(crate) fn detect_resets(
+    file: &Btor2File,
+    symbols: &HashMap<Nid, String>,
+) -> Vec<(String, u64)> {
     let mut resets: BTreeSet<(String, u64)> = BTreeSet::new();
     for line in &file.lines {
         if !matches!(&line.node, Node::State { .. }) {
@@ -493,5 +501,52 @@ mod tests {
             findings.iter().all(|f| f.register != "flag"),
             "a fully-covered 1-bit register has no illegal encoding to check"
         );
+    }
+
+    fn detect(src: &str) -> Vec<(String, u64)> {
+        let file = crate::adapter::btor2::parser::parse(src).expect("parse");
+        let syms = crate::adapter::btor2::parser::collect_symbols(&file);
+        detect_resets(&file, &syms)
+    }
+
+    #[test]
+    fn detect_resets_active_high_pins_to_zero() {
+        // next(st) = ite(rst, 0 /*reset*/, st+1 /*normal*/): const in THEN ⇒ active-high, inactive = 0.
+        const HI: &str = "\
+1 sort bitvec 1
+2 input 1 rst
+3 sort bitvec 2
+4 state 3 st
+5 zero 3
+6 one 3
+7 add 3 4 6
+8 ite 3 2 5 7
+9 next 3 4 8
+";
+        assert_eq!(detect(HI), vec![("rst".to_string(), 0)]);
+    }
+
+    #[test]
+    fn detect_resets_active_low_pins_to_one() {
+        // next(st) = ite(rst_n, st+1 /*normal*/, 0 /*reset*/): const in ELSE ⇒ active-low, inactive = 1.
+        const LO: &str = "\
+1 sort bitvec 1
+2 input 1 rst_n
+3 sort bitvec 2
+4 state 3 st
+5 zero 3
+6 one 3
+7 add 3 4 6
+8 ite 3 2 7 5
+9 next 3 4 8
+";
+        assert_eq!(detect(LO), vec![("rst_n".to_string(), 1)]);
+    }
+
+    #[test]
+    fn detect_resets_none_without_reset_mux() {
+        // A free-running counter (no reset mux) yields no reset to pin.
+        const NONE: &str = "1 sort bitvec 2\n2 state 1 st\n3 one 1\n4 add 1 2 3\n5 next 1 2 4\n";
+        assert!(detect(NONE).is_empty());
     }
 }

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1696,7 +1696,7 @@ pub fn verify_auto(
     // Reset inputs to pin inactive (reset-gating) — applied to the lifted BTOR2
     // below via `pin_inputs_to_constants`. Empty when gating is off or no
     // `disable iff` reset was recognized.
-    let reset_pins: Vec<(String, u64)> = if opts.gate_reset {
+    let mut reset_pins: Vec<(String, u64)> = if opts.gate_reset {
         extraction
             .reset_signals
             .iter()
@@ -1738,6 +1738,27 @@ pub fn verify_auto(
         }
     }
     report.diagnostics.blackboxed_modules = blackboxed_modules;
+
+    // Structural reset auto-pin. When reset-gating is on but no `disable iff (reset)`
+    // guard was recognized (`reset_pins` empty — the common case for a plain-RTL
+    // `@mununu_guarantee` design with no SVA), detect the async-reset input from the
+    // lifted BTOR2's reset-mux structure (`next(state) = ite(reset, RESET_CONST, normal)`
+    // / active-low branch-swap) and pin it inactive. Without this the reset input stays a
+    // free primary input, so the transition relation carries a reset-edge from every
+    // state to the reset state — and every `[]`/`AF`/box-universal property is then
+    // spuriously VIOLATED (it would have to hold at the reset state too). Diamond/`EF`/
+    // `AG EF` properties are immune (existential), which is why they verified correctly
+    // even without this. The detected reset flows through `inject_reset_init` and
+    // `pin_inputs_to_constants` exactly like a `disable iff`-recognized one, and is
+    // surfaced in `diagnostics.gated_resets`. The `disable iff` path always wins (guard
+    // on `reset_pins.is_empty()`), mirroring the fsm-encoding scan's reset handling.
+    if opts.gate_reset
+        && reset_pins.is_empty()
+        && let Ok(file) = crate::adapter::btor2::parser::parse(&btor2)
+    {
+        let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
+        reset_pins.extend(crate::adapter::fsm_scan::detect_resets(&file, &symbols));
+    }
 
     // Inject `init` lines at the post-reset state so a reset-gated async-reset
     // FSM starts in its real reset state (e.g. an OpenTitan sparse-FSM's non-zero
@@ -4379,6 +4400,64 @@ endmodule
             cs.items.contains(&"tick".to_string()),
             "note items: {:?}",
             cs.items
+        );
+    }
+
+    #[test]
+    #[ignore = "requires slang + sv2v + Yosys + z3 (use the mununu-sva docker image); run with --ignored"]
+    fn e2e_structural_reset_autopin_makes_box_af_sound() {
+        // Structural async-reset auto-pin, end-to-end. A plain-RTL FSM with NO SVA
+        // `disable iff` — so the reset is recognized ONLY by the structural detector
+        // (from the lifted BTOR2 reset-mux `next(st) = ite(rst, 0, normal)`). Without the
+        // auto-pin the free `rst` input leaves a reset-edge from every state to the reset
+        // state, and `AF st==2` (`mu Y.(st==2 || [] Y)`) is spuriously VIOLATED; with it,
+        // `rst` is pinned inactive and AF decides correctly HOLDS. Also asserts the
+        // detected reset is surfaced in `gated_resets` (same path as a `disable iff` one).
+        use crate::adapter::btor2::kmts_lift::MustEdgeInference;
+        let src = r#"// @mununu_guarantee mu Y.(st == 2 || [] Y)
+module cyc(input clk, input rst, output reg [1:0] st);
+  always @(posedge clk)
+    if (rst) st <= 2'd0;
+    else case (st)
+      2'd0: st <= 2'd1;
+      2'd1: st <= 2'd2;
+      2'd2: st <= 2'd0;
+      default: st <= 2'd0;
+    endcase
+endmodule
+"#;
+        let sources = vec![("cyc.v".to_string(), src.to_string())];
+        let yopts = YosysOptions {
+            top: Some("cyc".to_string()),
+            ..Default::default()
+        };
+        let report = verify_auto(
+            &sources,
+            &yopts,
+            &VerifyAutoOptions {
+                must_edge_inference: MustEdgeInference::SmtHyperMust,
+                exact_symbolic: true,
+                ..Default::default()
+            },
+        )
+        .expect("verify_auto runs");
+        // The structural detector pinned the async reset even absent an SVA `disable iff`.
+        assert_eq!(
+            report.diagnostics.gated_resets,
+            vec!["rst=0".to_string()],
+            "structural reset auto-pin should pin rst inactive; got {:?}",
+            report.diagnostics.gated_resets
+        );
+        let g = report
+            .properties
+            .iter()
+            .find(|p| p.name.contains("guarantee"))
+            .expect("annotated guarantee present");
+        eprintln!("AF st==2 => {:?}", g.outcome);
+        assert!(
+            matches!(g.outcome, VerifyOutcome::Holds),
+            "AF st==2 must HOLD once the reset is auto-pinned (was spuriously VIOLATED); got {:?}",
+            g.outcome
         );
     }
 


### PR DESCRIPTION
**Soundness fix.** `sv verify-auto --engine exact-symbolic` returned WRONG (spuriously VIOLATED) verdicts for box-`AX`/`AF`/box-universal properties on plain-RTL `@mununu_guarantee` designs.

**Root cause:** reset was pinned inactive only when recognized from an SVA `disable iff (reset)` guard. A design with `@mununu_guarantee` but no SVA left the reset input FREE, so the lifted BTOR2 carried a reset-edge from every state to the reset state (`next(reg) = ite(rst, RESET_CONST, normal)`, `rst` unpinned). Every `[]`/`AF` property then had to hold at the reset state too → spurious VIOLATED. Diamond/`EF`/`AG EF` are existential and immune (why recoverability always verified correctly). The box evaluation itself is correct.

**Fix:** when reset-gating is on but no `disable iff` reset was recognized (`reset_pins` empty), structurally detect the async reset from the lifted BTOR2 reset-mux and pin it inactive — reusing `fsm_scan::detect_resets` (now `pub(crate)`; active-high → const in `ite` THEN → inactive 0, active-low → const in ELSE → inactive 1). Flows through `inject_reset_init` + `pin_inputs_to_constants` and is surfaced in `diagnostics.gated_resets`. Guarded on `reset_pins.is_empty()` so the `disable iff` path always wins.

**Validated:** cyc/cyc_n/resp box-`AF`/`AX` flip VIOLATED→HOLDS (both polarities); genuine fairness violations (an input stall) stay VIOLATED; the `disable iff` reset e2e are unchanged; arbiter recoverability still 7/7; cutpoint e2e unaffected. Also resolves an apparent "multi-property leakage" (same free-reset root cause). Tests: `detect_resets` unit (high/low/none) + `e2e_structural_reset_autopin_makes_box_af_sound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)