### PR TITLE
ci: install cargo-audit as a prebuilt binary (fix perpetually-red security-audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Run cargo audit
-        uses: rustsec/audit-check@v2
+      # Install cargo-audit as a PREBUILT binary. `rustsec/audit-check@v2` runs
+      # `cargo install cargo-audit`, which builds the tool from source and has been
+      # failing to compile `cargo-audit v0.22.2` on the runner (a build failure of the
+      # tool, not a real advisory) — leaving this job perpetually red. The prebuilt
+      # binary skips the compile entirely.
+      - uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit
+      - name: Run cargo audit
+        run: cargo audit
 
   license-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`rustsec/audit-check@v2` runs `cargo install cargo-audit`, which builds the tool from source; on the runner it has been **failing to compile `cargo-audit v0.22.2`** (a build failure of the tool itself — exit 101 with aborted intermediate artifacts — **not** a real advisory). So `security-audit` was perpetually red and every merge needed `--admin` to bypass it.

**Fix:** use `taiki-e/install-action` (prebuilt cargo-audit binary, no compile) + a plain `cargo audit`.

Verified locally against the workspace `Cargo.lock`: **0 vulnerabilities, 4 informational warnings** (proc-macro-error unmaintained, anyhow/rand unsound, spin yanked — all transitive), and `cargo audit` **exits 0** on warnings → the job goes green. After this it becomes a *real* gate that fails only on an actual future vulnerability, and the `--admin`-over-security-audit merge workaround goes away. Also drops the deprecated Node-20 warning from `audit-check@v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)