### PR TITLE
feat(verify-auto): unreachable-target witness for violated EF reachability props (A.4)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -3288,24 +3288,33 @@ fn render_verify_auto_text(report: &mununu_core::adapter::slang::verify_auto::Au
         if !p.seeded_predicates.is_empty() {
             println!("        predicates: {}", p.seeded_predicates.join(", "));
         }
-        // D1.8b — the exact engine's stall-lasso counterexample (reset → prefix →
-        // repeating ¬p cycle), present only for a Violated bare `AF p`.
+        // The exact engine's counterexample: either the A.4 unreachable-target witness
+        // for a bare `EF p` (reachability) — "the design never reaches <p>", the repair
+        // signal a safety check never produces — or the D1.8b stall-lasso / trap-path
+        // (reset → prefix → repeating ¬p cycle) for a `AF`/`AG AF`/`AG EF` failure.
         if let Some(cex) = &p.counterexample {
-            println!("        counterexample (stall lasso):");
-            let render_state = |st: &[(String, u64)]| {
-                st.iter()
-                    .map(|(k, v)| format!("{k}={v}"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-            for st in &cex.prefix {
-                println!("          -> {}", render_state(st));
+            if !cex.unreachable_target.is_empty() {
+                println!(
+                    "        counterexample: target UNREACHABLE from reset - the design never reaches {}",
+                    cex.unreachable_target.join(" ∧ ")
+                );
+            } else {
+                println!("        counterexample (stall lasso):");
+                let render_state = |st: &[(String, u64)]| {
+                    st.iter()
+                        .map(|(k, v)| format!("{k}={v}"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                for st in &cex.prefix {
+                    println!("          -> {}", render_state(st));
+                }
+                for (i, st) in cex.cycle.iter().enumerate() {
+                    let marker = if i == 0 { "(*)" } else { "   " };
+                    println!("          {marker} {}", render_state(st));
+                }
+                println!("          (cycle repeats forever - the property is avoided)");
             }
-            for (i, st) in cex.cycle.iter().enumerate() {
-                let marker = if i == 0 { "(*)" } else { "   " };
-                println!("          {marker} {}", render_state(st));
-            }
-            println!("          (cycle repeats forever - the property is avoided)");
         }
     }
     for (name, reason) in &report.unsupported {

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2352,6 +2352,44 @@ fn ef_target_at(
     }
 }
 
+/// A `Violated` bare `EF p = μX. (p ∨ ◇X)` (reachability) means exactly that the
+/// target `p` is **UNREACHABLE** from the reset state — there is no counterexample
+/// *trace* (no path reaches `p`), so the actionable witness is the *target itself*:
+/// "the design never reaches `p`". Under cut points the model is an over-approximation
+/// (freeing a net only ADDS transitions ⇒ MORE reachability), so a `p` that is
+/// unreachable even in the over-approximation is unreachable in the concrete RTL too —
+/// the unreachability transfers **soundly**.
+///
+/// If `formula` is that bare-`EF` shape, return the predicate-atom strings that make up
+/// its target `p` (naming the unreachable target for a repair witness); `None` for any
+/// other shape. Complements the `AF`/`AG AF` stall lasso and the `AG EF` trap path,
+/// which witness *liveness/recoverability* failures with a concrete path.
+pub(crate) fn ef_target_atoms(formula: &Formula) -> Option<Vec<String>> {
+    let p = ef_target_at(formula, formula.root())?;
+    let mut atoms = Vec::new();
+    collect_target_atoms(formula, p, &mut atoms);
+    (!atoms.is_empty()).then_some(atoms)
+}
+
+/// Collect the distinct predicate-atom strings under a formula sub-node (the `EF`
+/// target `p`), descending through boolean structure only. Modal/fixpoint nodes are
+/// not expected inside a reachability target and are ignored.
+fn collect_target_atoms(
+    formula: &Formula,
+    node: crate::mu_calculus::NodeId,
+    out: &mut Vec<String>,
+) {
+    match formula.node(node) {
+        MuNode::Predicate(name) if !out.contains(name) => out.push(name.clone()),
+        MuNode::And(a, b) | MuNode::Or(a, b) => {
+            collect_target_atoms(formula, *a, out);
+            collect_target_atoms(formula, *b, out);
+        }
+        MuNode::Not(a) => collect_target_atoms(formula, *a, out),
+        _ => {}
+    }
+}
+
 /// D1.8c — build the sound μ-calculus formula that verifies the GR(1) response
 /// property `GF assume → GF guarantee` over the **exact** engine. `assume` and
 /// `guarantee` are predicate expressions (e.g. `"req == 1"`).
@@ -2758,6 +2796,28 @@ mod tests {
     use super::*;
     use crate::adapter::btor2::bit_blast::simulate_one_step;
     use crate::adapter::btor2::parser;
+
+    /// A.4 — `ef_target_atoms` names the reachability target of a bare `EF p`
+    /// (`μX. (p ∨ ◇X)`), whose violation is the "target unreachable" repair witness,
+    /// and returns `None` for the liveness/recoverability shapes (which carry a concrete
+    /// path witness instead).
+    #[test]
+    fn ef_target_atoms_names_bare_ef_reachability_target() {
+        use crate::mu_calculus::parser as mu_parser;
+        // bare `EF p` = μX.(p ∨ ◇X): the reachability target is the single atom.
+        let ef = mu_parser::parse("mu X. ((round_counter == 31) or <> X)").expect("EF parses");
+        let atoms = ef_target_atoms(&ef).expect("bare EF yields a target");
+        assert_eq!(atoms.len(), 1);
+        assert!(atoms[0].contains("round_counter"));
+        // `AG EF p` (recoverability, νμ) is NOT a bare EF — its failure is a trap PATH,
+        // not an unreachable target, so no unreachable-target witness here.
+        let agef = mu_parser::parse("nu Y. ((mu X. ((busy == 0) or <> X)) and [] Y)")
+            .expect("AG EF parses");
+        assert_eq!(ef_target_atoms(&agef), None);
+        // `AF p` (box inner) is a liveness/stall shape, not reachability.
+        let af = mu_parser::parse("mu X. ((done == 1) or [] X)").expect("AF parses");
+        assert_eq!(ef_target_atoms(&af), None);
+    }
 
     /// Run the BDD bit-blaster against the concrete simulator over an
     /// exhaustive enumeration of the given (symbol, bit-width) leaves.

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -111,6 +111,12 @@ pub struct ExactCounterexample {
     /// P3 — the INPUT assignment driving each transition of `prefix ++ cycle` (`inputs[i]` is
     /// the input at path-state `i`), for RTL replay. Empty when the engine did not record inputs.
     pub inputs: Vec<Vec<(String, u64)>>,
+    /// A.4 — the UNREACHABLE-target witness for a `Violated` bare `EF p` (reachability):
+    /// there is no trace (`prefix`/`cycle` empty), because the target `p` is never reached
+    /// from reset. These are the predicate-atom strings comprising `p` — the actionable
+    /// repair signal "the design never reaches `<atoms>`". Empty for the stall-lasso /
+    /// trap-path (liveness/recoverability) counterexamples, which carry a concrete path.
+    pub unreachable_target: Vec<String>,
 }
 
 /// Convert an engine [`StallLasso`](crate::adapter::btor2::symbolic_bitblast::StallLasso)
@@ -130,7 +136,26 @@ fn exact_counterexample_from_lasso(
         prefix: conv(lasso.prefix),
         cycle: conv(lasso.cycle),
         inputs: conv(lasso.inputs),
+        unreachable_target: Vec::new(),
     }
+}
+
+/// A.4 — build the UNREACHABLE-target counterexample for a `Violated` bare `EF p`
+/// (`μX. (p ∨ ◇X)`): the violation *is* the proof that `p` is unreachable from reset,
+/// so no trace exists. Returns the target's predicate atoms as the witness (empty
+/// path). `None` when `formula` is not a bare `EF` shape (a liveness/recoverability
+/// failure keeps its concrete stall-lasso / trap-path witness instead).
+fn ef_unreachable_counterexample(
+    formula: &crate::mu_calculus::Formula,
+) -> Option<ExactCounterexample> {
+    crate::adapter::btor2::symbolic_bitblast::ef_target_atoms(formula).map(|atoms| {
+        ExactCounterexample {
+            prefix: Vec::new(),
+            cycle: Vec::new(),
+            inputs: Vec::new(),
+            unreachable_target: atoms,
+        }
+    })
 }
 
 /// Model-level diagnostics for an automated verification run — what the lift
@@ -2027,12 +2052,17 @@ pub fn verify_auto(
                 match exact_symbolic_verdict_with_witness(&btor2, &formula) {
                     Ok((ExactVerdict::Holds, _)) => (VerifyOutcome::Holds, None),
                     Ok((ExactVerdict::Violated, witness)) => {
-                        // A definite full-state counterexample (not a cube tally); for
-                        // a bare `AF p` the witness carries the concrete stall lasso
-                        // (D1.8b) — reset → prefix → ¬p cycle.
+                        // A definite full-state counterexample (not a cube tally). For a
+                        // liveness/recoverability failure (`AF p` / `AG AF p` / `AG EF p`)
+                        // the witness carries the concrete path (stall lasso / trap path).
+                        // Failing that, a bare `EF p` (reachability) violation carries the
+                        // A.4 unreachable-target witness — no trace, because the target is
+                        // simply never reached (sound under the over-approximating cut).
                         (
                             VerifyOutcome::Violated { false_cells: 1 },
-                            witness.map(exact_counterexample_from_lasso),
+                            witness
+                                .map(exact_counterexample_from_lasso)
+                                .or_else(|| ef_unreachable_counterexample(&formula)),
                         )
                     }
                     Err(e) => (
@@ -2412,6 +2442,7 @@ fn escalate_bottom(
                                     prefix: trace.states,
                                     cycle: Vec::new(),
                                     inputs: trace.inputs,
+                                    unreachable_target: Vec::new(),
                                 });
                             }
                             notes.push(rescue_note(&prop.name, "VIOLATED", &engines));
@@ -2554,6 +2585,23 @@ fn liveness_rescue_note(name: &str, verdict: &str, engines: &[&str]) -> Verifica
 
 #[cfg(test)]
 mod tests {
+    /// A.4 — a `Violated` bare `EF p` (reachability) yields the unreachable-target
+    /// witness: no path (`prefix`/`cycle` empty), the target atoms naming what the
+    /// design never reaches. A recoverability (`AG EF`) shape is not a bare `EF` and
+    /// keeps its concrete trap-path witness instead (no unreachable-target here).
+    #[test]
+    fn bare_ef_violation_yields_unreachable_target_witness() {
+        use crate::mu_calculus::parser as mu_parser;
+        let ef = mu_parser::parse("mu X. ((round_counter == 31) or <> X)").expect("EF parses");
+        let cx = super::ef_unreachable_counterexample(&ef).expect("bare EF → unreachable witness");
+        assert!(cx.prefix.is_empty() && cx.cycle.is_empty() && cx.inputs.is_empty());
+        assert_eq!(cx.unreachable_target.len(), 1);
+        assert!(cx.unreachable_target[0].contains("round_counter"));
+        let agef = mu_parser::parse("nu Y. ((mu X. ((busy == 0) or <> X)) and [] Y)")
+            .expect("AG EF parses");
+        assert!(super::ef_unreachable_counterexample(&agef).is_none());
+    }
+
     use super::*;
     use crate::mu_calculus::parser as mu_parser;
 
@@ -2590,6 +2638,7 @@ mod tests {
             prefix: vec![vec![("st".to_string(), 0)]],
             cycle: vec![vec![("st".to_string(), 3)]],
             inputs: vec![vec![("esc".to_string(), 1)]],
+            unreachable_target: Vec::new(),
         }
     }
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1284,6 +1284,7 @@ pub async fn sv_verify_auto_handler(
                 CounterexampleView {
                     prefix: states(&c.prefix),
                     cycle: states(&c.cycle),
+                    unreachable_target: c.unreachable_target.clone(),
                 }
             });
             PropertyVerdictView {

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1454,6 +1454,11 @@ pub struct CounterexampleView {
     pub prefix: Vec<Vec<CexCellView>>,
     /// The repeating stall cycle; the last state steps back to `cycle[0]`.
     pub cycle: Vec<Vec<CexCellView>>,
+    /// A.4 — for a `Violated` bare `EF p` (reachability): the target predicate atoms that
+    /// are UNREACHABLE from reset ("the design never reaches these"). Empty for the
+    /// stall-lasso / trap-path (liveness) counterexamples, which carry `prefix`/`cycle`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unreachable_target: Vec<String>,
 }
 
 /// One register's concrete value in a counterexample state.


### PR DESCRIPTION
## What

A `Violated` bare `EF p` (`μX.(p ∨ ◇X)`) means the target `p` is **unreachable from reset** — the "dead feature / never reaches X" repair signal a safety check can never produce (a behaviour-removing bug keeps the reachable-state set a *subset* of the golden's, so every safety `AG q` still holds). The exact engine already witnessed `AF`/`AG AF` failures (stall lasso) and `AG EF` (trap path), but a bare reachability violation carried **no witness**. This adds it.

No trace is needed — the violation *itself* proves unreachability — and it is **sound under the over-approximating control-slice cut** (freeing a net only ADDS reachability, so still-unreachable is concretely unreachable).

## Surface parity (CLI + API + UI)

- **core**: `ef_target_atoms` (bare-EF target atoms); `ExactCounterexample.unreachable_target`; `ef_unreachable_counterexample` wired into the exact-symbolic VIOLATED branch.
- **CLI** (`mununu sv verify-auto`): `counterexample: target UNREACHABLE from reset - the design never reaches <atoms>`.
- **API**: `CounterexampleView.unreachable_target`.
- **UI**: `SvVerifyAutoRunner` renders it — companion PR in mununu-ui (`feat/verify-auto-unreachable-target-witness`).

## Validation

- `make ci`-equivalent locally: fmt ✓, clippy `-D warnings` (mununu-dev) ✓, pre-commit (incl. doctests) ✓.
- Unit tests: `ef_target_atoms_names_bare_ef_reachability_target`, `bare_ef_violation_yields_unreachable_target_witness`.
- **e2e in the `mununu-sva` image** on present_cipher M_0017 (frozen round counter, `round_counter <= round_counter + 1'b1` → `+ 1'b0`): `EF round_counter==31` → VIOLATED → `target UNREACHABLE from reset - the design never reaches round_counter == 31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)