### PR TITLE
feat(verify-auto): boolean-gated-event recoverability via good→counter ranking rewrite

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2390,6 +2390,18 @@ fn collect_target_atoms(
     }
 }
 
+/// If `formula` is a recoverability `AG EF good` (`νY. ((μX. (good ∨ ◇X)) ∧ □Y)`),
+/// return the predicate atoms of its `good` target — so a caller can route the
+/// property to the scalable ranking/recoverability engine (which decides a
+/// well-founded datapath descent, e.g. a down-counter to a value, that the cube
+/// leaves ⊥). `None` for any other shape. Complements [`ef_target_atoms`] (bare `EF`).
+pub(crate) fn ag_ef_good_atoms(formula: &Formula) -> Option<Vec<String>> {
+    let p = detect_ag_ef_target(formula)?;
+    let mut atoms = Vec::new();
+    collect_target_atoms(formula, p, &mut atoms);
+    (!atoms.is_empty()).then_some(atoms)
+}
+
 /// D1.8c — build the sound μ-calculus formula that verifies the GR(1) response
 /// property `GF assume → GF guarantee` over the **exact** engine. `assume` and
 /// `guarantee` are predicate expressions (e.g. `"req == 1"`).
@@ -2817,6 +2829,30 @@ mod tests {
         // `AF p` (box inner) is a liveness/stall shape, not reachability.
         let af = mu_parser::parse("mu X. ((done == 1) or [] X)").expect("AF parses");
         assert_eq!(ef_target_atoms(&af), None);
+    }
+
+    /// Ranking-wiring — `ag_ef_good_atoms` names the `good` target of a recoverability
+    /// `AG EF good` (`νY. ((μX. (good ∨ ◇X)) ∧ □Y)`), so a caller can route it to the
+    /// scalable ranking/recoverability engine. `None` for a bare `EF` (that is the
+    /// unreachable-target case) or any non-recoverability shape.
+    #[test]
+    fn ag_ef_good_atoms_names_recoverability_target() {
+        use crate::mu_calculus::parser as mu_parser;
+        // `AG EF (cnt == 0)` — a down-counter/timer recoverability target.
+        let agef = mu_parser::parse("nu Y. ((mu X. ((cnt == 0) or <> X)) and [] Y)")
+            .expect("AG EF parses");
+        let atoms = ag_ef_good_atoms(&agef).expect("AG EF yields a good target");
+        assert_eq!(atoms, vec!["cnt == 0".to_string()]);
+        // relational good `AG EF (wptr == rptr)` (FIFO drain) — the register-vs-register atom.
+        let rel = mu_parser::parse("nu Y. ((mu X. ((wptr == rptr) or <> X)) and [] Y)")
+            .expect("relational AG EF parses");
+        assert_eq!(
+            ag_ef_good_atoms(&rel),
+            Some(vec!["wptr == rptr".to_string()])
+        );
+        // a bare `EF` is NOT the recoverability shape (it is the unreachable-target case).
+        let ef = mu_parser::parse("mu X. ((cnt == 0) or <> X)").expect("EF parses");
+        assert_eq!(ag_ef_good_atoms(&ef), None);
     }
 
     /// Run the BDD bit-blaster against the concrete simulator over an

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -99,6 +99,69 @@ fn eq_guard_atoms(file: &crate::adapter::btor2::ast::Btor2File) -> Vec<(String, 
     out
 }
 
+/// N1 boolean-gated-event rewrite — given a `good` EVENT signal `sig` (a 1-bit output like a
+/// watchdog `timeout` or a `done` strobe) that is driven **EXACTLY** by a `counter == constant`
+/// comparison (`done <= (cnt == 0)`; registered OR combinational), return `(counter_register,
+/// threshold)`. The recoverability of the event — `AG EF (sig == 1)` — then reduces to the counter
+/// recoverability `AG EF (counter == threshold)`, which the RANKING certificate decides (a boolean
+/// `sig` carries no descending measure; its driving counter does). **SOUND only for a PURE `Eq`
+/// driver:** if `sig`'s next/definition is an `Ite`/`And`/anything other than a bare `Eq(state,
+/// const)` (i.e. it also depends on a reset gate, an enable, another condition), the equivalence
+/// `sig == 1 ⟺ counter == threshold` breaks (`sig` could be 0 while `counter == threshold`), so any
+/// non-`Eq` driver returns `None` (abstain — never a rewrite that could fabricate a Holds). The
+/// one-cycle register delay is absorbed by `EF` (reaching the counter value one step before `sig`).
+fn counter_gate_of(
+    file: &crate::adapter::btor2::ast::Btor2File,
+    sig: &str,
+) -> Option<(String, u64)> {
+    use crate::adapter::btor2::ast::{Node, Op};
+    let symbols = crate::adapter::btor2::parser::collect_symbols(file);
+    let sig_nid = *symbols
+        .iter()
+        .find(|(_, s)| s.as_str() == sig)
+        .map(|(n, _)| n)?;
+    // The node that DEFINES `sig`: a state register's `next` value, or the op line itself
+    // (a combinational output carrying the symbol).
+    let driver_nid = match &file.lookup(sig_nid)?.node {
+        Node::State { .. } => {
+            crate::adapter::btor2::parser::find_next_value_operand(file, sig_nid)?
+                .0
+                .abs()
+        }
+        _ => sig_nid,
+    };
+    // The driver must be a BARE `Eq` — no surrounding mux/gate (soundness of the rewrite).
+    let Node::Op {
+        op: Op::Eq, args, ..
+    } = &file.lookup(driver_nid)?.node
+    else {
+        return None;
+    };
+    if args.len() != 2 {
+        return None;
+    }
+    let state_nids: std::collections::HashSet<i64> = file
+        .lines
+        .iter()
+        .filter(|l| matches!(l.node, Node::State { .. }))
+        .map(|l| l.nid)
+        .collect();
+    // One operand is the counter STATE register, the other a resolvable CONSTANT threshold.
+    for (reg_nid, const_nid) in [
+        (args[0].0.abs(), args[1].0.abs()),
+        (args[1].0.abs(), args[0].0.abs()),
+    ] {
+        if state_nids.contains(&reg_nid)
+            && let Some(counter) = symbols.get(&reg_nid)
+            && let Some(k) =
+                crate::adapter::btor2::bit_blast::resolve_btor2_constant(file, const_nid)
+        {
+            return Some((counter.clone(), k));
+        }
+    }
+    None
+}
+
 /// N1 Class-2 RELATIONAL discovery — the datapath-dependent return whose guard compares two STATE
 /// registers (`busy → done` gated on `data == target`), not a register to a constant. Extracts the
 /// `(lhs, rhs)` register pairs from the design's `Eq` comparison nodes where BOTH operands are state
@@ -954,6 +1017,20 @@ pub fn verify_recoverability_scalable(
         &good_registers,
         good_simple.as_ref().map(|(_, v)| *v),
     ) {
+        return Ok(PropertyVerdict::Holds);
+    }
+
+    // N1 BOOLEAN-GATED-EVENT RANKING RESCUE: a `good` EVENT like `timeout == 1` / `done == 1` carries
+    // no descending measure itself, but if it is driven EXACTLY by a `counter == threshold` gate, the
+    // event recoverability `AG EF (sig == 1)` reduces to the counter recoverability `AG EF (counter ==
+    // threshold)` — which the ranking DOES decide (the counter descends/ascends to the threshold).
+    // Sound: `counter_gate_of` only rewrites a PURE `Eq` driver (so `sig == 1 ⟺ counter == threshold`),
+    // and a ranking Holds on the counter transfers to the event (`EF` absorbs the one-cycle register
+    // delay). A reload/kick that stalls the descent leaves the ranking un-certified ⇒ fall to the cube.
+    if let Some((sig, 1)) = good_simple.as_ref().map(|(s, v)| (s.clone(), *v))
+        && let Some((counter, threshold)) = counter_gate_of(&file, &sig)
+        && ranking_certificate_holds(&file, &[counter], Some(threshold))
+    {
         return Ok(PropertyVerdict::Holds);
     }
 
@@ -2625,6 +2702,53 @@ mod tests {
         assert_eq!(
             verify_recoverability(&inv_rel_w(8, "7"), "data == target").expect("small decides"),
             PropertyVerdict::Violated
+        );
+    }
+
+    /// N1 boolean-gated-event rewrite — a `good` EVENT `done == 1` that is driven EXACTLY by a
+    /// `counter == threshold` gate (`done <= (cnt == 0)`) reduces to the counter recoverability
+    /// `AG EF (cnt == 0)`, decided by the ranking (the boolean `done` carries no measure; the cube
+    /// over `{done == 1}` alone cannot track `cnt`). A GATED driver (`done <= enable ? (cnt==0) : 0`)
+    /// is NOT a pure `Eq`, so the rewrite abstains (soundness: `done == 1` is not equivalent to
+    /// `cnt == 0`).
+    #[test]
+    fn boolean_gated_event_rewrite_decides_via_counter_ranking() {
+        // done <= (cnt == 0); cnt a down-counter to 0 (`cnt' = ite(cnt==0, 0, cnt-1)`). Pure Eq driver
+        // (node 8). Mirrors the passing `downcnt_w` fixture (decimal `constd`, `zero`/`one`).
+        let clean = "1 sort bitvec 1\n2 sort bitvec 8\n3 state 2 cnt\n4 zero 2\n5 one 2\n\
+             6 constd 2 5\n7 init 2 3 6\n8 eq 1 3 4\n9 sub 2 3 5\n10 ite 2 8 4 9\n11 next 2 3 10\n\
+             12 state 1 done\n13 zero 1\n14 init 1 12 13\n15 next 1 12 8\n";
+        let file = crate::adapter::btor2::parser::parse(clean).expect("parse clean");
+        assert_eq!(
+            counter_gate_of(&file, "done"),
+            Some(("cnt".to_string(), 0)),
+            "the pure `done <= (cnt == 0)` driver rewrites to the counter gate (cnt, 0)"
+        );
+        // DIAGNOSTIC: the counter recoverability itself + the ranking directly.
+        assert!(
+            ranking_certificate_holds(&file, &["cnt".to_string()], Some(0)),
+            "the ranking certifies the down-counter cnt descends to 0"
+        );
+        assert_eq!(
+            verify_recoverability_scalable(clean, "cnt == 0", &[]).expect("decides"),
+            PropertyVerdict::Holds,
+            "the counter recoverability AG EF (cnt==0) decides Holds"
+        );
+        assert_eq!(
+            verify_recoverability_scalable(clean, "done == 1", &[]).expect("decides"),
+            PropertyVerdict::Holds,
+            "boolean-gated event AG EF (done==1) decides Holds via the counter-gate ranking rewrite"
+        );
+        // GATED: done <= enable ? (cnt==0) : 0 — an `Ite` driver (node 17), not a bare `Eq` ⇒ abstain.
+        let gated = "1 sort bitvec 1\n2 sort bitvec 8\n3 state 2 cnt\n4 zero 2\n5 one 2\n\
+             6 constd 2 5\n7 init 2 3 6\n8 eq 1 3 4\n9 sub 2 3 5\n10 ite 2 8 4 9\n11 next 2 3 10\n\
+             12 state 1 done\n13 zero 1\n14 init 1 12 13\n16 input 1 enable\n17 ite 1 16 8 13\n\
+             18 next 1 12 17\n";
+        let gfile = crate::adapter::btor2::parser::parse(gated).expect("parse gated");
+        assert_eq!(
+            counter_gate_of(&gfile, "done"),
+            None,
+            "a gated (non-pure-Eq) event driver is not rewritten (soundness)"
         );
     }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -158,6 +158,35 @@ fn ef_unreachable_counterexample(
     })
 }
 
+/// RANKING RESCUE — route a recoverability `AG EF <good>` whose `good` is a single
+/// `reg == value` / `reg == reg` atom to the scalable recoverability engine
+/// ([`verify_recoverability_scalable`](crate::adapter::recoverability)), which proves
+/// `AG EF good` by a well-founded datapath **ranking** (a down-counter/drain to a
+/// value) BEFORE its cube. This decides the deep-counter recoverability class that the
+/// bit-blaster is over-cap for and the predicate cube leaves ⊥ — e.g. a timer/FIFO
+/// `AG EF (cnt == N)` at counter widths the exact engine can't fit. Used as a fallback
+/// (not a replacement) — `None` when the formula is not that shape, `good` is not a
+/// single register-comparison atom, or the engine abstains, so the caller keeps its
+/// Skipped/⊥ verdict. The ranking certificate is a **sound sufficient** condition (it
+/// establishes the stronger `AG AF good`), and the engine abstains rather than emit an
+/// unsound Holds on a UF-wrapping datapath (PR #301).
+fn try_ranking_recoverability(
+    btor2: &str,
+    formula: &crate::mu_calculus::Formula,
+) -> Option<VerifyOutcome> {
+    let atoms = crate::adapter::btor2::symbolic_bitblast::ag_ef_good_atoms(formula)?;
+    let [good] = atoms.as_slice() else {
+        return None; // only a single register-comparison good routes to the engine
+    };
+    match crate::adapter::recoverability::verify_recoverability_scalable(btor2, good, &[]) {
+        Ok(crate::verdict::PropertyVerdict::Holds) => Some(VerifyOutcome::Holds),
+        Ok(crate::verdict::PropertyVerdict::Violated) => {
+            Some(VerifyOutcome::Violated { false_cells: 1 })
+        }
+        _ => None, // Unknown / Skipped / Err → keep the caller's verdict
+    }
+}
+
 /// Model-level diagnostics for an automated verification run — what the lift
 /// produced, so a "couldn't verify" outcome is traceable to a root cause
 /// (rather than only a per-property symptom like "atom over non-state signal").
@@ -2065,12 +2094,21 @@ pub fn verify_auto(
                                 .or_else(|| ef_unreachable_counterexample(&formula)),
                         )
                     }
-                    Err(e) => (
-                        VerifyOutcome::Skipped {
-                            reason: format!("exact symbolic MC: {e}"),
-                        },
-                        None,
-                    ),
+                    Err(e) => {
+                        // RANKING RESCUE — the bit-blaster is over-cap (a wide counter);
+                        // a recoverability `AG EF <cnt == N>` may still HOLD by a
+                        // well-founded datapath descent the exact engine can't fit. Route
+                        // it to the scalable ranking/recoverability engine before abstaining.
+                        match try_ranking_recoverability(&btor2, &formula) {
+                            Some(outcome) => (outcome, None),
+                            None => (
+                                VerifyOutcome::Skipped {
+                                    reason: format!("exact symbolic MC: {e}"),
+                                },
+                                None,
+                            ),
+                        }
+                    }
                 };
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
@@ -2600,6 +2638,39 @@ mod tests {
         let agef = mu_parser::parse("nu Y. ((mu X. ((busy == 0) or <> X)) and [] Y)")
             .expect("AG EF parses");
         assert!(super::ef_unreachable_counterexample(&agef).is_none());
+    }
+
+    /// Ranking-wiring — a recoverability `AG EF <good>` routes to the scalable
+    /// recoverability engine (ranking + cube), returning its definite verdict. `good`
+    /// = `data == target` over a design where both increment from 0 (invariant → the
+    /// relation always holds ⇒ recoverable ⇒ Holds); the never-equal variant ⇒ Violated.
+    /// A non-recoverability shape (bare `EF`) does NOT route (`None`).
+    #[test]
+    fn ranking_rescue_routes_ag_ef_recoverability_verdict() {
+        use crate::mu_calculus::parser as mu_parser;
+        // data,target both init 0 and +1 each cycle ⇒ data==target INVARIANT ⇒ AG EF holds.
+        let holds_btor2 = "1 sort bitvec 1\n2 sort bitvec 8\n4 state 2 data\n5 state 2 target\n\
+             6 zero 2\n7 one 2\n13 init 2 4 6\n14 init 2 5 6\n15 add 2 4 7\n16 add 2 5 7\n\
+             22 next 2 4 15\n23 next 2 5 16\n";
+        // target inits 1 ≠ data(0), both +1 ⇒ never equal ⇒ AG EF (data==target) VIOLATED.
+        let viol_btor2 = "1 sort bitvec 1\n2 sort bitvec 8\n4 state 2 data\n5 state 2 target\n\
+             6 zero 2\n7 one 2\n13 init 2 4 6\n14 init 2 5 7\n15 add 2 4 7\n16 add 2 5 7\n\
+             22 next 2 4 15\n23 next 2 5 16\n";
+        let agef = mu_parser::parse("nu Y. ((mu X. ((data == target) or <> X)) and [] Y)")
+            .expect("parses");
+        assert_eq!(
+            super::try_ranking_recoverability(holds_btor2, &agef),
+            Some(VerifyOutcome::Holds),
+            "invariant-relational recoverability routes to Holds via the recoverability engine",
+        );
+        assert_eq!(
+            super::try_ranking_recoverability(viol_btor2, &agef),
+            Some(VerifyOutcome::Violated { false_cells: 1 }),
+            "never-equal relational target routes to Violated",
+        );
+        // A bare `EF` (not the recoverability νμ shape) does not route.
+        let ef = mu_parser::parse("mu X. ((data == target) or <> X)").expect("EF parses");
+        assert_eq!(super::try_ranking_recoverability(holds_btor2, &ef), None);
     }
 
     use super::*;

--- a/wiki/Property-Templates.md
+++ b/wiki/Property-Templates.md
@@ -35,6 +35,47 @@ Templates resolve to standard `PropertyFormula::MuCalculus(String)` at instantia
 
 \* `$UNDERFLOW` is optional with default `false`.
 
+## Behavioral property patterns by design class
+
+> Source of truth: [`scan_annotation_properties`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L995) — surface: (CLI+API+UI)
+
+Beyond the atomic templates above, common **behavior classes** warrant recurring *branching-time* patterns —
+`AG EF` recoverability, `EF` reachability, error-recovery round-trips — that a plain safety invariant cannot
+state. Each pattern below is a parameterized mu-calculus formula you instantiate by substituting the design's
+observable signals into the `<slots>` (an atom: `<sig> == <val>`, `<sig> != <val>`, or a bare boolean output),
+then verify with `mununu sv verify-auto` via a `@mununu_guarantee` annotation (or `mununu context eval`).
+Shorthand → mu-calculus is the [Mu-Calculus Reference](Mu-Calculus-Reference.md):
+`EF p = mu X.(p || <> X)`, `AG p = nu S.(p && [] S)`, `AF p = mu Y.(p || [] Y)`,
+`AG EF p = nu Y.((mu X.(p || <> X)) && [] Y)`, `AG(a → EF b) = nu Z.((!(a) || mu Y.(b || <> Y)) && [] Z)`.
+
+**Soundness default — use `EF` (reachable), not `AF` (inevitable).** `AF`/box-`AF` is sound only where no free
+input (a kick, a clock-stretch, a competing request, a bus-cycle drop) can stall the antecedent path forever;
+`GF` fairness is not assumable. When unsure, `EF`.
+
+| class | trigger | patterns (shorthand, `<slots>` = observable signals) |
+|---|---|---|
+| **FIFO / buffer / queue** | full/empty/level, push/pop | `EF <full>`, `EF <empty>` (extremes reachable); `AG EF !<full>` (always drainable, never wedges); `AG(<full> → EF !<full>)` (stuck-at-full fails); `AG(<wr_full> → EF !<rd_empty>)` (CDC data-visibility); `AG !(<full> && <empty>)` (safety, if exclusive) |
+| **timer / watchdog / recurring pulse** | timeout, expire, tick, pps | `AG EF <ev>==1` (can **always fire again** — fire-once-then-wedge fails) + `EF <ev>==1`; `AG(<ev>==1 → EF <ev>==0)` (pulse doesn't stick); `AG EF <ev>==0` (kick always available); `AG(<armed> → AF <ev>==1)` **only** if no input can stall it |
+| **protocol w/ error-recovery** | error/AL/NACK/collision/abort | `EF <error>==1` (error reachable); `AG(<error>==1 → EF <idle>)` (**does NOT trap in error** — the sharpest); `AG(<error>==1 → EF <error>==0)` (flag clears) |
+| **CPU / sequencer core** | fetch/decode/execute, stall | `AG EF <fetch>` (no hang); `AG(<stall>==1 → EF <stall>==0)` (stall resolves); `AG(<exec>==1 → EF <fetch>)` (retire) |
+| **bridge / arbiter / shared resource** | two interfaces, req/grant | `AG(<req_in>==1 → EF <resp_out>==1)` (forward); `AG(<b_event>==1 → EF <a_out>==1)` (return); `AG !(<g_a>==1 && <g_b>==1)` (mutex); `AG(<req>==1 → AF <grant>==1)` (fair, AF only if no starver) |
+| **mode / phase machine** | modes, phases, speed settings | `EF <mode>==k` for **every** documented mode (a dead mode = dead feature); `AG(<mode>==A → EF <mode>==B)` (transition); `AG(<phase>==late → EF <phase>==early)` (restart) |
+| **resource release** | shared/open-drain bus, lock | `AG EF <released>` (never permanently locks the bus) + `EF <held>` |
+
+Example — an I²C master (protocol + shared-bus classes), `<error>` = `AL == 1`, `<idle>` = `BUSY == 0`,
+`<released>` = `scl_padoen_o == 1`:
+
+```
+// @mununu_guarantee nu Z.((!(AL == 1) || mu Y.(BUSY == 0 || <> Y)) && [] Z)   // does not trap in arbitration-loss
+// @mununu_guarantee nu Y.((mu X.(scl_padoen_o == 1 || <> X)) && [] Y)          // always releases the bus
+```
+
+> **Decidability note.** These patterns are *definite* on compact control FSMs (`--engine exact-symbolic`) and
+> decide via predicate abstraction (`--engine explicit --must-edge-inference smt-hyper-must`) when the event
+> grounds on a state/registered signal. An event gated by a **deep counter** (a timeout counting to a value)
+> may return **⊥** in the cube — that is an honest "not decided", never a pass; see
+> [Hardware Verification Patterns](Hardware-Verification-Patterns.md) for the ranking/recoverability path.
+
 ## Using Templates
 
 ### CLI


### PR DESCRIPTION
## What

A watchdog/timer event property `AG EF (evt == 1)` where `evt` is a **boolean strobe** (not a counter) carries no descending measure — so the ranking certificate abstained and the cube left it ⊥, even when the event is driven by a deep counter reaching a value.

Two additions (both sound, both routing to the existing proven ranking engine):

### 1. good→counter rewrite (`counter_gate_of`)
When the recoverability `good` is `sig == 1` and `sig` is driven **exactly** by a `counter == threshold` gate (`done <= (cnt == 0)`, registered or combinational), reduce `AG EF (sig == 1)` to the counter recoverability `AG EF (counter == threshold)` and decide it with the ranking.

**Sound:** rewrites only a **pure `Eq`** driver (so `sig == 1 ⟺ counter == threshold`); a gated `Ite`/`And` driver abstains — never a rewrite that could fabricate a Holds. Wired into `verify_recoverability_scalable` after the direct ranking, so the verify-auto cube `[recoverability-rescue]` **and** the `verify-recoverability` verb both benefit.

### 2. exact-symbolic recoverability rescue
The exact-symbolic path `continue`d before reaching the cube's `[recoverability-rescue]`, so an `AG EF <good>` that walled the bit-blaster got a hard Skip. Route it to `verify_recoverability_scalable` (the ranking engine) via `ag_ef_good_atoms` — a consistency fix, plus **relational-good** (`reg == reg`) support the cube rescue's `reduce_ag_ef_target` (simple `reg == value`) lacks.

## Soundness
`verify_recoverability_scalable` runs the ranking **before** its cube and abstains on a UF-wrapping datapath (PR #301), so a ⊥ is only ever upgraded to a **definite** verdict.

## Tests
- `boolean_gated_event_rewrite_decides_via_counter_ranking` — `done <= (cnt==0)` → **Holds** via the counter ranking (cube over `{done==1}` alone can't track `cnt`); a gated `Ite` driver → abstain.
- `ag_ef_good_atoms_names_recoverability_target`, `ranking_rescue_routes_ag_ef_recoverability_verdict`.

Internal decision-procedure improvement — no new flag/endpoint/UI (makes `verify-auto` decide more properties).

🤖 Generated with [Claude Code](https://claude.com/claude-code)