### PR TITLE
feat(verify-auto): @mununu_predicate abstraction-predicate hints (W1+W2, CLI+API+UI)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1632,6 +1632,15 @@ struct SvVerifyAutoArgs {
     /// state). Surfaced as a `control-slice` scope-caveat note.
     #[arg(long = "cutpoint", value_name = "SIGNAL")]
     cutpoint: Vec<String>,
+    /// Abstraction-predicate hint: a predicate expression (`reg == value`,
+    /// `reg == reg`, `reg >= K`) seeded as a cube dimension for EVERY property,
+    /// even when it does not appear in the property formula. The command-line peer
+    /// of the in-source `// @mununu_predicate <expr>` annotation (both are merged).
+    /// Sound by monotonicity of predicate abstraction — a hint only refines the
+    /// cube (a ⊥ can become definite; a definite verdict never flips). Repeatable
+    /// (e.g. `--predicate "c_state == 0" --predicate "wptr == rptr"`).
+    #[arg(long = "predicate", value_name = "EXPR")]
+    predicate: Vec<String>,
     /// Print a JSON report instead of the human-readable summary.
     #[arg(long)]
     json: bool,
@@ -3182,6 +3191,7 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         auto_stub_flops: !args.no_auto_stub_flops,
         config_values,
         counter_bounds,
+        predicate_hints: args.predicate.clone(),
         // R-F5.5d — `--engine symbolic` routes every property through the R-F5
         // BDD CEGAR loop (no per-cube-pair SMT).
         symbolic_engine: args.engine == EngineArg::Symbolic,

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -605,6 +605,15 @@ pub struct VerifyAutoOptions {
     /// appearing in a self-relational `$past` atom) are bounded; other registers
     /// are ignored.
     pub counter_bounds: std::collections::HashMap<String, u64>,
+    /// W1/W2 — user-supplied **predicate hints** (the CLI `--predicate` / API
+    /// `predicates` peer of the in-source `@mununu_predicate <expr>` annotation).
+    /// Each entry is a predicate expression (`reg == value`, `reg == reg`,
+    /// `reg >= K`) seeded into every property's cube via `seed_from_formula`'s
+    /// `extra_atoms`, MERGED with the scanned `@mununu_predicate` annotations.
+    /// Sound by monotonicity of predicate abstraction — a hint only refines the
+    /// cube (a ⊥ can become definite; a definite verdict never flips; a hint that
+    /// fails classification is dropped). Default empty ⇒ no behaviour change.
+    pub predicate_hints: Vec<String>,
     /// R-F5.5d (2026-07-03) — run each property through the R-F5 **symbolic**
     /// predicate-cube engine (BDD relation + WP CEGAR loop; no per-cube-pair
     /// SMT) instead of the explicit `cegar_refine_loop`. Default `false`
@@ -702,6 +711,7 @@ impl Default for VerifyAutoOptions {
             auto_stub_flops: true,
             config_values: std::collections::HashMap::new(),
             counter_bounds: std::collections::HashMap::new(),
+            predicate_hints: Vec::new(),
             symbolic_engine: false,
             exact_symbolic: false,
             portfolio: None,
@@ -787,6 +797,7 @@ fn seed_from_formula(
     is_input: impl Fn(&str) -> bool,
     combinational_kind: impl Fn(&str) -> Option<CombKind>,
     cone_inputs_of: impl Fn(&str) -> Vec<String>,
+    extra_atoms: &[String],
 ) -> Seeded {
     // Slice 3 (the unwrap lever) — cap how many raw cone inputs a single
     // combinational-of-input atom may add as free cube dimensions. Each added
@@ -886,11 +897,25 @@ fn seed_from_formula(
             }
         }
     };
-    for node in formula.nodes() {
-        let Node::Predicate(atom) = node else {
-            continue;
-        };
-        if !seen.insert(atom.as_str()) {
+    // Formula atoms first, then annotation `@mununu_predicate` atoms — both run the
+    // IDENTICAL provenance classification (state → cube dimension, state-only
+    // combinational → dimension, input-dependent combinational → derived label,
+    // unresolvable → skip). Annotation predicates seed the cube even when they do NOT
+    // appear in the property formula: they are auxiliary invariant HINTS. Soundness is
+    // unaffected — predicate abstraction is monotone, so an extra dimension only
+    // refines the may/must partition (a ⊥ can become definite; a definite verdict can
+    // never flip). A hint that fails classification lands in `unseedable` and is
+    // dropped, never a spurious verdict.
+    let atoms = formula
+        .nodes()
+        .iter()
+        .filter_map(|node| match node {
+            Node::Predicate(atom) => Some(atom.as_str()),
+            _ => None,
+        })
+        .chain(extra_atoms.iter().map(String::as_str));
+    for atom in atoms {
+        if !seen.insert(atom) {
             continue;
         }
         match parse_predicate_expr(atom) {
@@ -916,14 +941,14 @@ fn seed_from_formula(
                         // only, BV `bvadd` at the real register width). Sound — a
                         // pure per-cube observation, like any derived relational.
                         if resolvable {
-                            out.derived_relational.push((atom.clone(), expr));
+                            out.derived_relational.push((atom.to_string(), expr));
                         } else {
-                            out.unseedable.push(atom.clone());
+                            out.unseedable.push(atom.to_string());
                         }
                     } else if regs.iter().all(|r| is_state(r)) {
                         // All-state → a cube DIMENSION (B.1 compound). The SMT
                         // dimension path reads state BVs.
-                        out.compounds.push((atom.clone(), expr));
+                        out.compounds.push((atom.to_string(), expr));
                     } else if resolvable {
                         // H.F — a relational with an input / combinational operand
                         // (`cnt_q >= cfg_detect_timer_i`, `trigger_i !=
@@ -935,11 +960,11 @@ fn seed_from_formula(
                         // `trigger_i != ~trigger_i` ≡ true → HOLDS), KleeneBot where
                         // a free operand swings it. Sound (a pure observation; a
                         // KleeneBot atom is ⊥, never a spurious verdict).
-                        out.derived_relational.push((atom.clone(), expr));
+                        out.derived_relational.push((atom.to_string(), expr));
                     } else {
                         // An operand resolves to nothing in the lifted design —
                         // cannot label it. Honest SKIP.
-                        out.unseedable.push(atom.clone());
+                        out.unseedable.push(atom.to_string());
                     }
                 }
             },
@@ -1011,6 +1036,11 @@ struct AnnotationScan {
     /// `@mununu_guarantee` bodies that did NOT parse — surfaced, never silently
     /// dropped.
     skipped: Vec<String>,
+    /// `@mununu_predicate <expr>` auxiliary abstraction-predicate hints (verbatim
+    /// expr strings, validated as parseable). Seeded into every property's cube via
+    /// `seed_from_formula`'s `extra_atoms`. Sound by monotonicity — a hint only
+    /// refines the cube (a ⊥ can become definite; a definite verdict never flips).
+    predicates: Vec<String>,
 }
 
 /// H.5-GR1 — scan the SV source(s) for `@mununu_guarantee` / `@mununu_assume`
@@ -1053,6 +1083,21 @@ fn scan_annotation_properties(sources: &[(String, String)]) -> AnnotationScan {
                     }
                 }
                 MununuTag::Assume => scan.assumes.push(ann.value.trim().to_string()),
+                MununuTag::Predicate => {
+                    let body = ann.value.trim();
+                    // A bare identifier (`sig` ≡ `sig == 1`) is admitted like a bare
+                    // formula atom; anything else must parse as a predicate expr.
+                    let ok = !body.is_empty()
+                        && (!body.contains(['=', '<', '>', '!'])
+                            || parse_predicate_expr(body).is_ok());
+                    if ok {
+                        scan.predicates.push(body.to_string());
+                    } else {
+                        scan.skipped.push(format!(
+                            "@mununu_predicate `{body}` did not parse as a predicate expression"
+                        ));
+                    }
+                }
                 _ => {}
             }
         }
@@ -1714,6 +1759,15 @@ pub fn verify_auto(
     // Merged BEFORE the empty-check so a design with no SVA but annotation-only
     // properties still verifies.
     let ann_scan = scan_annotation_properties(sources);
+    // W1/W2 — the abstraction-predicate hints seeded into every property's cube:
+    // in-source `@mununu_predicate` annotations MERGED with CLI `--predicate` / API
+    // `predicate` hints. Sound by monotonicity (a hint only refines the cube).
+    let predicate_hints: Vec<String> = ann_scan
+        .predicates
+        .iter()
+        .chain(opts.predicate_hints.iter())
+        .cloned()
+        .collect();
     extraction
         .translated
         .extend(ann_scan.guarantees.iter().cloned());
@@ -2127,6 +2181,7 @@ pub fn verify_auto(
             is_input,
             combinational_kind,
             cone_inputs_of,
+            &predicate_hints,
         );
         // H.H — seed a bound compound `X <= K` for each counter register (a state
         // cell whose `$past` shadow is also present, i.e. a self-relational
@@ -3259,6 +3314,34 @@ module uart_tx(); endmodule"#;
         assert!(annotation_note(&plain).is_none());
     }
 
+    #[test]
+    fn scan_collects_predicate_hints_and_rejects_unparseable() {
+        // W1 — `@mununu_predicate <expr>` hints are collected (literal, relational,
+        // bound); a bare boolean signal is admitted; a malformed comparison is
+        // surfaced in `skipped`, never silently dropped.
+        let sv = "// @mununu_predicate c_state == 0\n\
+                  // @mununu_predicate wptr == rptr\n\
+                  // @mununu_predicate fill >= 30\n\
+                  // @mununu_predicate ready\n\
+                  // @mununu_predicate bogus ==\n\
+                  module m(); endmodule";
+        let scan = scan_annotation_properties(&src(sv));
+        assert_eq!(
+            scan.predicates,
+            vec![
+                "c_state == 0".to_string(),
+                "wptr == rptr".to_string(),
+                "fill >= 30".to_string(),
+                "ready".to_string(),
+            ]
+        );
+        assert!(
+            scan.skipped.iter().any(|s| s.contains("bogus ==")),
+            "malformed predicate surfaced in skipped: {:?}",
+            scan.skipped
+        );
+    }
+
     /// R-F5.5d projection SOUNDNESS fix — an infeasible cube (absent from the
     /// symbolic feasible-cube tally) must project to ⊥, NOT a spurious
     /// definite-False. Regression for the unsound VIOLATED verify-auto returned
@@ -3716,6 +3799,7 @@ module uart_tx(); endmodule"#;
             |_| false,
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert_eq!(s.specs.len(), 1, "one simple reg==val spec");
         assert_eq!(s.specs[0].name, "state == 5");
@@ -3723,6 +3807,80 @@ module uart_tx(); endmodule"#;
         assert_eq!(s.specs[0].value, 5);
         assert!(s.compounds.is_empty());
         assert!(s.unseedable.is_empty());
+    }
+
+    #[test]
+    fn extra_atoms_seed_the_cube_like_formula_atoms() {
+        // W1 (`@mununu_predicate`): an auxiliary predicate `aux == 3` that is NOT in
+        // the formula seeds a cube dimension exactly as a formula atom would — a
+        // simple state spec, plus a relational one as a compound. Dedups against the
+        // formula atom.
+        let f = mu_parser::parse("mu X. ((target == 1) || <> X)").unwrap();
+        let s = seed_from_formula(
+            &f,
+            |n| cells(&["target", "aux", "a", "b"]).contains(n),
+            |_| false,
+            |_| None,
+            |_| Vec::new(),
+            &[
+                "aux == 3".to_string(),
+                "a == b".to_string(),
+                "target == 1".to_string(), // duplicate of the formula atom → deduped
+            ],
+        );
+        assert!(
+            s.specs.iter().any(|p| p.name == "target == 1"),
+            "formula atom still seeded"
+        );
+        assert!(
+            s.specs.iter().any(|p| p.name == "aux == 3"),
+            "extra simple atom seeded as a spec"
+        );
+        assert!(
+            s.compounds.iter().any(|(n, _)| n == "a == b"),
+            "extra relational atom seeded as a compound"
+        );
+        assert_eq!(
+            s.specs.iter().filter(|p| p.name == "target == 1").count(),
+            1,
+            "duplicate extra atom is deduped against the formula atom"
+        );
+    }
+
+    #[test]
+    fn extra_atoms_bound_predicate_routes_to_compound() {
+        // W2 (relational/bound grammar rides the SAME annotation path): a bound
+        // `cnt >= 5` over a state cell seeds a compound dimension (not a literal spec).
+        let f = mu_parser::parse("mu X. ((done == 1) || <> X)").unwrap();
+        let s = seed_from_formula(
+            &f,
+            |n| cells(&["done", "cnt"]).contains(n),
+            |_| false,
+            |_| None,
+            |_| Vec::new(),
+            &["cnt >= 5".to_string()],
+        );
+        assert!(
+            s.compounds.iter().any(|(n, _)| n == "cnt >= 5"),
+            "bound hint seeded as a compound dimension"
+        );
+        assert!(s.unseedable.is_empty(), "a state bound is seedable");
+    }
+
+    #[test]
+    fn extra_atoms_empty_is_the_baseline() {
+        // No `@mununu_predicate` hints ⇒ identical to the pre-W1 behaviour.
+        let f = mu_parser::parse("nu X. ((state == 5) && [] X)").unwrap();
+        let s = seed_from_formula(
+            &f,
+            |n| cells(&["state"]).contains(n),
+            |_| false,
+            |_| None,
+            |_| Vec::new(),
+            &[],
+        );
+        assert_eq!(s.specs.len(), 1);
+        assert_eq!(s.specs[0].name, "state == 5");
     }
 
     #[test]
@@ -3735,6 +3893,7 @@ module uart_tx(); endmodule"#;
             |_| false,
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert!(s.specs.is_empty(), "relational atom is not a simple spec");
         assert_eq!(s.compounds.len(), 1, "one compound (relational) predicate");
@@ -3768,6 +3927,7 @@ module uart_tx(); endmodule"#;
             |_| false,
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert!(
             s.unseedable.contains(&"gnt_o != 0".to_string()),
@@ -3790,6 +3950,7 @@ module uart_tx(); endmodule"#;
             |_| false,
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert_eq!(s.specs.len(), 1);
         assert_eq!(s.specs[0].name, "busy");
@@ -3810,6 +3971,7 @@ module uart_tx(); endmodule"#;
             |n| cells(&["cfg_enable_i"]).contains(n),
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert!(
             s.unseedable.is_empty(),
@@ -3837,6 +3999,7 @@ module uart_tx(); endmodule"#;
             |n| cells(&["trigger_i"]).contains(n),
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert_eq!(s.specs.len(), 1);
         assert_eq!(s.specs[0].name, "trigger_i");
@@ -3877,6 +4040,7 @@ module uart_tx(); endmodule"#;
             |n| cells(&["cfg_enable_i"]).contains(n),
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert!(s.specs.is_empty());
         assert!(
@@ -3914,6 +4078,7 @@ module uart_tx(); endmodule"#;
                     .then_some(CombKind::StateOnly)
             },
             |_| Vec::new(),
+            &[],
         );
         assert_eq!(
             s.specs.len(),
@@ -3939,6 +4104,7 @@ module uart_tx(); endmodule"#;
                     .then_some(CombKind::StateOnly)
             },
             |_| Vec::new(),
+            &[],
         );
         assert_eq!(s.specs.len(), 1);
         assert_eq!(s.specs[0].register, "err_code");
@@ -3957,6 +4123,7 @@ module uart_tx(); endmodule"#;
             |_| false,
             |n| cells(&["sig"]).contains(n).then_some(CombKind::StateOnly),
             |_| Vec::new(),
+            &[],
         );
         assert_eq!(s.specs.len(), 1, "a cube dimension");
     }
@@ -3979,6 +4146,7 @@ module uart_tx(); endmodule"#;
                     .then_some(CombKind::InputDependent)
             },
             |_| Vec::new(),
+            &[],
         );
         assert!(
             !s.input_registers.contains("trigger_active"),
@@ -4021,6 +4189,7 @@ module uart_tx(); endmodule"#;
                     Vec::new()
                 }
             },
+            &[],
         );
         assert!(
             s.derived.iter().any(|p| p.register == "trigger_active"),
@@ -4059,6 +4228,7 @@ module uart_tx(); endmodule"#;
                     Vec::new()
                 }
             },
+            &[],
         );
         assert!(
             s.derived.iter().any(|p| p.register == "wide"),
@@ -4090,6 +4260,7 @@ module uart_tx(); endmodule"#;
             |n| n == "cfg_detect_timer_i",
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert!(
             s.compounds.is_empty(),
@@ -4121,6 +4292,7 @@ module uart_tx(); endmodule"#;
             |_| false,
             |_| None,
             |_| Vec::new(),
+            &[],
         );
         assert!(
             s.derived_relational.is_empty(),
@@ -5769,6 +5941,7 @@ endmodule
             |_| false,
             |_| None,
             |_| Vec::new(),
+            &[],
         );
 
         // Mirror verify_auto's default cegar_opts (must Off; may = SmtAllPairs —

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1226,6 +1226,7 @@ pub async fn sv_verify_auto_handler(
         auto_stub_flops: request.auto_stub_flops.unwrap_or(true),
         config_values,
         counter_bounds,
+        predicate_hints: request.predicate.clone(),
         // Engine selection (`"explicit"` | `"symbolic"` | `"exact-symbolic"` |
         // `"portfolio-sequential"` | `"portfolio-parallel"`). Unspecified ⇒ the
         // default `portfolio-sequential`. `engine_selection` is the single place the

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1347,6 +1347,14 @@ pub struct SvVerifyAutoRequest {
     /// Default empty.
     #[serde(default)]
     pub cutpoint: Vec<String>,
+    /// Abstraction-predicate hints, mirroring the CLI `--predicate` and the in-source
+    /// `// @mununu_predicate <expr>` annotation (all three are merged). Each entry is a
+    /// predicate expression (`"reg == value"`, `"reg == reg"`, `"reg >= K"`) seeded as a
+    /// cube dimension for EVERY property, even when absent from the property formula.
+    /// Sound by monotonicity — a hint only refines the cube (a ⊥ can become definite; a
+    /// definite verdict never flips; an unclassifiable hint is dropped). Default empty.
+    #[serde(default)]
+    pub predicate: Vec<String>,
     /// Engine selector, mirroring the CLI `--engine`: `"explicit"`, `"symbolic"`,
     /// `"exact-symbolic"`, `"portfolio-sequential"`, `"portfolio-parallel"`.
     /// **Unspecified ⇒ the default `"portfolio-sequential"`** (2026-07-06): run

--- a/crates/mununu-core/src/contract/discover.rs
+++ b/crates/mununu-core/src/contract/discover.rs
@@ -299,6 +299,9 @@ impl AnnotationSummary {
                 // codesign extractor's ISR detection, not by the
                 // contract pipeline. Ignore here.
                 MununuTag::Isr => {}
+                // `@mununu_predicate` is a cube-abstraction hint consumed by
+                // `sv verify-auto`'s seeder, not by the contract pipeline. Ignore.
+                MununuTag::Predicate => {}
             }
         }
         s

--- a/crates/mununu-core/src/mununu_annotations/mod.rs
+++ b/crates/mununu-core/src/mununu_annotations/mod.rs
@@ -53,6 +53,12 @@ pub enum MununuTag {
     /// reactive-modules ISR + main-thread interleaving in Doc C
     /// §C.5. Annotation-only; no naming-convention defaults.
     Isr,
+    /// `@mununu_predicate <expr>` — an auxiliary abstraction-predicate HINT
+    /// for the predicate cube (SV verify-auto). The `<expr>` is a predicate
+    /// expression (`reg == value`, `reg == reg`, `reg >= K`) that seeds a cube
+    /// dimension even when it does not appear in any property formula. Sound by
+    /// monotonicity of predicate abstraction — a hint only refines the cube.
+    Predicate,
 }
 
 impl MununuTag {
@@ -68,6 +74,7 @@ impl MununuTag {
             "controllable" => Some(MununuTag::Controllable),
             "uncontrollable" => Some(MununuTag::Uncontrollable),
             "isr" => Some(MununuTag::Isr),
+            "predicate" => Some(MununuTag::Predicate),
             _ => None,
         }
     }
@@ -82,6 +89,7 @@ impl MununuTag {
             MununuTag::Controllable => "controllable",
             MununuTag::Uncontrollable => "uncontrollable",
             MununuTag::Isr => "isr",
+            MununuTag::Predicate => "predicate",
         }
     }
 }

--- a/wiki/Property-Templates.md
+++ b/wiki/Property-Templates.md
@@ -76,6 +76,37 @@ Example — an I²C master (protocol + shared-bus classes), `<error>` = `AL == 1
 > may return **⊥** in the cube — that is an honest "not decided", never a pass; see
 > [Hardware Verification Patterns](Hardware-Verification-Patterns.md) for the ranking/recoverability path.
 
+## Abstraction-predicate hints (`@mununu_predicate`)
+
+> Source of truth: [`MununuTag::Predicate`](../crates/mununu-core/src/mununu_annotations/mod.rs) / [`seed_from_formula`](../crates/mununu-core/src/adapter/slang/verify_auto.rs) — surface: (CLI+API+UI)
+
+When a cube ⊥ is caused by a *missing* abstraction predicate — the property's own atoms don't pin the
+inductive invariant that decides it — you can **seed extra cube dimensions** without changing the property.
+Three equivalent surfaces, all merged:
+
+- **In-source annotation:** `// @mununu_predicate <expr>` alongside the design (the property-writing agent's
+  in-file channel).
+- **CLI:** `mununu sv verify-auto … --predicate "<expr>"` (repeatable).
+- **API / UI:** the `predicate: string[]` field / the "Abstraction-predicate hints" box.
+
+`<expr>` is a predicate expression — a literal `reg == value`, a relational `reg == reg`, or a bound
+`reg >= K` — routed through the SAME classification as a formula atom (state → cube dimension, state-only
+combinational → dimension, input-dependent combinational → derived label, unresolvable → dropped).
+
+```systemverilog
+// @mununu_predicate byte_controller.c_state == 0   // the FSM's idle/completion invariant
+// @mununu_predicate wptr == rptr                    // a FIFO's "drained" relation
+// @mununu_guarantee nu Y.((mu X.(scl_padoen_o == 1 || <> X)) && [] Y)
+```
+
+**Soundness.** Predicate abstraction is *monotone*: a hint only refines the may/must partition, so a ⊥ can
+become definite but a definite `HOLDS`/`VIOLATED` can **never** flip, and a mis-bound hint is dropped — you
+can suggest freely. A hint is *not* an assumption (it never constrains the design). Its value is two-fold:
+turning a ⊥ into a decide when the deciding invariant is a statable *state* relation, and **removing a
+spurious `VIOLATED`** (a cutpoint over-approximation the extra dimension refutes). It does **not** decide a
+recoverability target that is itself a *combinational* output — that needs the target bound as a derived
+predicate, not a state hint.
+
 ## Using Templates
 
 ### CLI


### PR DESCRIPTION
## What

Lets a property author (or the independent property-writing agent) seed **extra cube-abstraction predicates** alongside the μ-properties, so a cube ⊥ caused by a *missing* inductive-invariant predicate can be refined **without changing the property**. Three merged surfaces:

- **In-source annotation** — `// @mununu_predicate <expr>` (new `MununuTag::Predicate`, collected by `scan_annotation_properties`; unparseable bodies surfaced in `skipped`, never silently dropped).
- **CLI** — `mununu sv verify-auto … --predicate "<expr>"` (repeatable).
- **API / UI** — `SvVerifyAutoRequest.predicate: string[]` / the runner's "Abstraction-predicate hints" textarea.

All three merge into `VerifyAutoOptions.predicate_hints` and thread through `seed_from_formula`'s new `extra_atoms`, which runs each hint through the **identical provenance classification** as a formula atom: literal `reg == value` → cube-dimension spec; relational `reg == reg` / bound `reg >= K` → compound dimension; state-only combinational → dimension; input-dependent combinational → derived label; unresolvable → dropped. So the whole grammar is one path (this PR folds W1 *literal* + W2 *relational/bounds*). Deduped against the formula's own atoms.

## Soundness

Predicate abstraction is **monotone** (Shoham–Grumberg): an injected dimension only refines the may/must partition, so a ⊥ can become definite but a definite `HOLDS`/`VIOLATED` can **never** flip, and a mis-bound hint is dropped. A hint is **not** an assumption — it never constrains the design. That is what makes it safe for an LLM (or a person) to suggest predicates freely.

## Measured result (honest)

On a real corpus (opencores i2c, standard scorer, `@mununu_predicate byte_controller.c_state == 0`):
- **0 ⊥→decided flips** — i2c's recoverability targets are *combinational*, and a *state* hint cannot decide a combinational target (that is a separate combinational-target-support lever, tracked as future W3).
- **+1 soundness fix** — a spurious cutpoint-`VIOLATED` became an honest `⊥` (the extra dimension refutes the over-approximation).
- A previously-unseedable no-deadlock prop became seedable.

The decide-payoff lands on designs whose ⊥ target **is** a statable state relation; the surface is also the prerequisite entry point for the combinational-target work.

## Surface parity

`surface: (CLI+API+UI)` — annotation + CLI `--predicate` + API `predicate[]` + UI textarea, all merged. UI PR: `mununu-ui#<paired>` (`feat/mununu-predicate-hints`).

## Tests

`scan_collects_predicate_hints_and_rejects_unparseable`; `extra_atoms_seed_the_cube_like_formula_atoms` (+ dedup); `extra_atoms_bound_predicate_routes_to_compound`; `extra_atoms_empty_is_the_baseline`. Full `verify_auto` module green (61 tests). Docs: `wiki/Property-Templates.md` § Abstraction-predicate hints (traceable anchor to `MununuTag::Predicate` / `seed_from_formula`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
