### PR TITLE
feat(mu-calculus): accept hierarchical (dotted) atom names in the formula parser

### DIFF
--- a/crates/mununu-core/src/mu_calculus/parser.rs
+++ b/crates/mununu-core/src/mu_calculus/parser.rs
@@ -626,21 +626,33 @@ impl<'a> Parser<'a> {
 
     fn parse_identifier(&mut self) -> Option<String> {
         self.skip_whitespace();
-        let mut chars = self.input[self.pos..].chars();
-        let first = chars.next()?;
+        let rest = &self.input[self.pos..];
+        let first = rest.chars().next()?;
         if !is_ident_start(first) {
             return None;
         }
         let mut len = first.len_utf8();
-        for ch in chars {
-            if !is_ident_continue(ch) {
+        // Absorb identifier chars, plus a hierarchical separator `.` (`a.b.c`,
+        // e.g. a flattened SV register `byte_controller.bit_controller.cnt`) —
+        // but ONLY when the `.` is followed by another identifier char. This keeps
+        // a fixpoint binder's `.` in `nu X.(…)` (a `.` before `(`/whitespace) for
+        // the binder parser, so hierarchical atom names do not swallow the binder
+        // separator. Bit-selects (`[N]`) are still not part of an identifier.
+        loop {
+            let tail = &rest[len..];
+            let mut it = tail.chars();
+            let Some(ch) = it.next() else { break };
+            // A `.` joins the identifier only when followed by another identifier
+            // char (`a.b.c`); a binder's `.` in `nu X.(…)` is left unconsumed.
+            if is_ident_continue(ch) || (ch == '.' && it.next().is_some_and(is_ident_continue)) {
+                len += ch.len_utf8();
+            } else {
                 break;
             }
-            len += ch.len_utf8();
         }
-        let ident = &self.input[self.pos..self.pos + len];
+        let ident = rest[..len].to_owned();
         self.pos += len;
-        Some(ident.to_owned())
+        Some(ident)
     }
 
     fn expect_char(&mut self, ch: char) -> Result<(), ParseError> {
@@ -935,6 +947,31 @@ mod tests {
                 ),
             }
         }
+    }
+
+    #[test]
+    fn hierarchical_dotted_atom_names_parse() {
+        // A flattened SV register `a.b.c` is ONE atom (shadow-register grounding on
+        // an internal register), while the fixpoint binder's `.` in `nu X.(…)` is
+        // NOT absorbed into the variable.
+        let f = parse("mu Z. (byte_controller.bit_controller.cnt == 0 || <> Z)")
+            .expect("dotted atom parses");
+        assert!(
+            f.nodes().iter().any(|n| matches!(
+                n, Node::Predicate(p) if p == "byte_controller.bit_controller.cnt == 0"
+            )),
+            "hierarchical atom kept whole: {:?}",
+            f.nodes()
+        );
+        // `reg == reg` with dotted operands on BOTH sides (relational atom).
+        parse("nu Y. ((a.b == c.d) && [] Y)").expect("dotted reg==reg parses");
+        // The binder variable is X (bound), not swallowed into a dotted atom — the
+        // `.` before `(` stays the binder separator.
+        let b = parse("nu X.(<> true && [] X)").expect("binder still parses");
+        assert!(
+            b.nodes().iter().any(|n| matches!(n, Node::Variable(_))),
+            "X binds as a variable, the binder `.` is not absorbed"
+        );
     }
 
     fn predicate_name(formula: &Formula, id: NodeId) -> &str {


### PR DESCRIPTION
The mu-calculus formula parser rejected dotted identifiers (`a.b.c`), so a property could not reference a flattened SV register by its hierarchical name (`byte_controller.bit_controller.dscl_oen == 1`) — only flat top-level signals, which for RTL are typically the combinational output ports. That blocked **shadow-register grounding** (grounding a recoverability property on the REGISTERED driver of a combinational output).

`parse_identifier` now absorbs a `.` into an identifier ONLY when followed by another identifier char (`a.b.c`), so a fixpoint binder's `.` in `nu X.(…)` stays the binder separator. Relational `reg == reg` with dotted operands on both sides also parses.

**Validated:** grounding i2c's SCL recoverability on the registered `dscl_oen` (now parses) decides `EF dscl_oen == 1` (HOLDS) where the combinational `scl_padoen_o` version was ⊥.

Tests: `hierarchical_dotted_atom_names_parse`; 35 existing parser tests still pass (no binder regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)