### PR TITLE
feat(recoverability): counter abstraction for FSM-gated νμ recoverability (b1 + b2)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -1909,6 +1909,408 @@ pub(crate) fn onehot_reencode(file: &Btor2File, meta: &OneHotStateMeta) -> Optio
     Some(Btor2File { lines: out, by_nid })
 }
 
+/// b1 — metadata for a counter register the cube path can collapse to a single
+/// `cnt == threshold` bit via a **may-abstraction** (over-approximating the count,
+/// SOUND for the outer ν / AG-safety; the inner-μ must-obligation is discharged
+/// separately by b2's ranking). Unlike [`OneHotStateMeta`] this abstraction is
+/// LOSSY — it must feed the 3-valued / cube engine, never the exact oracle.
+#[derive(Debug, Clone)]
+pub(crate) struct DownCounterMeta {
+    /// BTOR2 NID of the `state` line.
+    pub nid: Nid,
+    /// Bit-vector width of the counter (collapses to 1 bit).
+    pub width: u32,
+    /// The single constant the counter is compared against externally; the
+    /// abstraction predicate is `cnt == threshold` (usually 0 — expiry).
+    pub threshold: u64,
+}
+
+/// b1 detection — counter registers whose only EXTERNAL use is a comparison of `cnt`
+/// against a single threshold `T` (`eq/neq(cnt, T)`, or `redor(cnt)` = `~|cnt` for the
+/// `T = 0` expiry idiom), and whose `next` value path is built ONLY from arithmetic
+/// strides (`add`/`sub` of `cnt` and a constant), holds (`cnt`), reload constants,
+/// opaque reload values that do NOT reference `cnt` (a prescale input, `clk_cnt >> 2`),
+/// and `ite` muxes. SOUND syntactic sufficient condition:
+/// - a stride leaf (`cnt ± k`) or an opaque reload can produce ANY value ⇒ under the
+///   may-abstraction `cnt == T` becomes a free (nondeterministic) bit — a sound
+///   over-approximation;
+/// - requiring ≥1 stride distinguishes a genuine counter from a one-hot (F1) or a
+///   frozen register (a future fold);
+/// - requiring every external use to be a single-threshold comparison guarantees the
+///   1-bit `{cnt==T}` abstraction PRESERVES those uses (multi-threshold / arithmetic
+///   external uses ⇒ abstain, the value would be needed).
+///
+/// Guards/conditions are not walked (like F1). Read-only; `counter_may_abstract`
+/// consumes this.
+pub(crate) fn detect_down_counter(file: &Btor2File) -> Vec<DownCounterMeta> {
+    use crate::adapter::btor2::ast::Op;
+    let mut out = Vec::new();
+    'states: for line in &file.lines {
+        let Node::State { sort, .. } = &line.node else {
+            continue;
+        };
+        let Some(width) = parser::bv_width(file, *sort) else {
+            continue;
+        };
+        if width < 2 {
+            continue;
+        }
+        let cnt = line.nid;
+        let Some(next) = parser::find_next_value_operand(file, cnt) else {
+            continue;
+        };
+
+        // Walk the next-state VALUE path; classify every leaf. Collect the node
+        // set so external-use analysis can exclude the counter's own logic.
+        let mut value_path: std::collections::HashSet<Nid> = std::collections::HashSet::new();
+        let mut has_stride = false;
+        let mut visited: std::collections::HashSet<Nid> = std::collections::HashSet::new();
+        let mut stack = vec![next.nid()];
+        while let Some(nid) = stack.pop() {
+            if !visited.insert(nid) {
+                continue;
+            }
+            value_path.insert(nid);
+            let Some(n) = file.lookup(nid) else {
+                continue 'states;
+            };
+            match &n.node {
+                // Reload / floor constant.
+                Node::Const { .. } => {}
+                // Hold — the counter feeding its own next.
+                Node::State { .. } if nid == cnt => {}
+                // A mux — recurse into THEN/ELSE only (not the condition).
+                Node::Op {
+                    op, args, sort: s, ..
+                } if parser::bv_width(file, *s) == Some(width)
+                    && *op == Op::Ite
+                    && args.len() >= 3 =>
+                {
+                    stack.push(args[1].nid());
+                    stack.push(args[2].nid());
+                }
+                // A stride: `cnt ± k` (k a constant). Operands are NOT pushed — the
+                // count itself is abstracted away, so its value is irrelevant.
+                Node::Op {
+                    op, args, sort: s, ..
+                } if parser::bv_width(file, *s) == Some(width)
+                    && (*op == Op::Add || *op == Op::Sub)
+                    && args.len() == 2 =>
+                {
+                    let (a, b) = (args[0].nid(), args[1].nid());
+                    let one_is_cnt = a == cnt || b == cnt;
+                    let other = if a == cnt { b } else { a };
+                    if one_is_cnt && resolve_btor2_constant(file, other).is_some() {
+                        has_stride = true;
+                    } else {
+                        continue 'states; // stride over another register ⇒ not a simple counter
+                    }
+                }
+                // An OPAQUE reload value that does NOT reference the counter — a prescale
+                // input (`clk_cnt`), a derived reload (`clk_cnt >> 2`), a floor register.
+                // Accepted as a value-path leaf (NOT recursed) and abstracted to a free
+                // may-bit; sound because a free bit over-approximates any reload value.
+                // A node that DOES reference `cnt` but is not a recognised stride/hold ⇒
+                // abstain (it could hide a use we cannot cleanly collapse).
+                other if !node_refs_nid(other, cnt) => {}
+                _ => continue 'states,
+            }
+        }
+        if !has_stride {
+            continue;
+        }
+
+        // External uses — every node DIRECTLY referencing `cnt` that is not part of
+        // the counter's own logic (value path, its `next`/`init` lines, the state
+        // line) must be `eq/neq(cnt, T)` for a single constant `T`.
+        let mut threshold: Option<u64> = None;
+        for l in &file.lines {
+            if l.nid == cnt || value_path.contains(&l.nid) {
+                continue;
+            }
+            match &l.node {
+                Node::Next { state, .. } | Node::Init { state, .. } if *state == cnt => continue,
+                _ => {}
+            }
+            if !node_refs_nid(&l.node, cnt) {
+                continue;
+            }
+            // The external use must be a comparison of `cnt` against a single threshold:
+            // `eq/neq(cnt, T)`, or `redor(cnt)` (the `~|cnt` / `|cnt` idiom = `cnt != 0`,
+            // threshold 0 — the DOMINANT "counter expired" check in RTL).
+            let Node::Op { op, args, .. } = &l.node else {
+                continue 'states;
+            };
+            let t = match op {
+                Op::Redor if args.len() == 1 && args[0].nid() == cnt => 0u64,
+                Op::Eq | Op::Neq if args.len() == 2 => {
+                    let (a, b) = (args[0].nid(), args[1].nid());
+                    let other = if a == cnt {
+                        b
+                    } else if b == cnt {
+                        a
+                    } else {
+                        continue 'states;
+                    };
+                    let Some(t) = resolve_btor2_constant(file, other) else {
+                        continue 'states; // compared to a non-constant (another register) ⇒ abstain
+                    };
+                    t
+                }
+                _ => continue 'states,
+            };
+            match threshold {
+                None => threshold = Some(t),
+                Some(prev) if prev == t => {}
+                Some(_) => continue 'states, // ≥2 distinct thresholds ⇒ abstain
+            }
+        }
+        if let Some(threshold) = threshold {
+            out.push(DownCounterMeta {
+                nid: cnt,
+                width,
+                threshold,
+            });
+        }
+    }
+    out
+}
+
+/// b1 — the may-abstraction rewrite. Collapse the W-bit counter `meta.nid` to a
+/// 1-bit `cnt_z` (`⟺ cnt == threshold`), replacing each arithmetic-stride branch of
+/// its next-state with a FRESH INPUT (a nondeterministic bit ⇒ over-approximating
+/// the count). Holds map to `cnt_z`; reload constants `C` map to the bit `(C == T)`;
+/// external `eq/neq(cnt, T)` reads become `eq/neq(cnt_z, 1)`. Abstains (returns None)
+/// on any unhandled reference to `cnt` — never a partial rewrite.
+///
+/// LOSSY (over-approximation): the result must feed the 3-valued / cube engine, whose
+/// `smt_must_edge` construction reads the free-input stride as a **may-edge**. SOUND for
+/// the outer ν (AG-safety) — holds transfers, a would-be violation on the may-edge falls
+/// to ⊥. NEVER feed to the exact oracle (its 2-valued `Violated` would be unsound).
+pub(crate) fn counter_may_abstract(file: &Btor2File, meta: &DownCounterMeta) -> Option<Btor2File> {
+    use crate::adapter::btor2::ast::{ConstValue, Op, Sort};
+    let cnt = meta.nid;
+    let t = meta.threshold;
+
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut prelude: Vec<Line> = Vec::new();
+    // 1-bit sort (reuse or create).
+    let bit_sort = file
+        .lines
+        .iter()
+        .find_map(|l| match &l.node {
+            Node::Sort {
+                sort: Sort::BitVec { width },
+            } if *width == 1 => Some(l.nid),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            let n = next_nid;
+            next_nid += 1;
+            prelude.push(Line {
+                nid: n,
+                node: Node::Sort {
+                    sort: Sort::BitVec { width: 1 },
+                },
+                immediates: Vec::new(),
+                source_line: 0,
+            });
+            n
+        });
+    let mut mk_const = |v: i128| -> Nid {
+        let n = next_nid;
+        next_nid += 1;
+        prelude.push(Line {
+            nid: n,
+            node: Node::Const {
+                sort: bit_sort,
+                value: ConstValue::Dec(v),
+            },
+            immediates: Vec::new(),
+            source_line: 0,
+        });
+        n
+    };
+    let const_0 = mk_const(0);
+    let const_1 = mk_const(1);
+    let bit_for = |is_t: bool| Operand(if is_t { const_1 } else { const_0 });
+
+    // Classify the value-path nodes. `may_input` maps a value leaf whose exact value
+    // is abstracted away — a stride (`cnt ± k`) OR an opaque reload (a prescale input) —
+    // to a fresh 1-bit may-bit. `dropped` are the STRIDE nodes only: they reference
+    // `cnt` (soon 1-bit) so must be removed; opaque reloads may be shared and are kept.
+    let next_op = parser::find_next_value_operand(file, cnt)?;
+    let mut may_input: std::collections::HashMap<Nid, Nid> = std::collections::HashMap::new();
+    let mut dropped: std::collections::HashSet<Nid> = std::collections::HashSet::new();
+    let mut ite_nodes: std::collections::HashSet<Nid> = std::collections::HashSet::new();
+    let fresh_may = |next_nid: &mut Nid, prelude: &mut Vec<Line>| -> Nid {
+        let inp = *next_nid;
+        *next_nid += 1;
+        prelude.push(Line {
+            nid: inp,
+            node: Node::Input {
+                sort: bit_sort,
+                symbol: Some(format!("__cnt{cnt}_may{inp}")),
+            },
+            immediates: Vec::new(),
+            source_line: 0,
+        });
+        inp
+    };
+    {
+        let mut vis: std::collections::HashSet<Nid> = std::collections::HashSet::new();
+        let mut st = vec![next_op.nid()];
+        while let Some(nid) = st.pop() {
+            if !vis.insert(nid) {
+                continue;
+            }
+            let n = file.lookup(nid)?;
+            match &n.node {
+                Node::Const { .. } => {}
+                Node::State { .. } if nid == cnt => {}
+                Node::Op { op, args, sort, .. }
+                    if parser::bv_width(file, *sort) == Some(meta.width)
+                        && *op == Op::Ite
+                        && args.len() >= 3 =>
+                {
+                    ite_nodes.insert(nid);
+                    st.push(args[1].nid());
+                    st.push(args[2].nid());
+                }
+                Node::Op { op, args, sort, .. }
+                    if parser::bv_width(file, *sort) == Some(meta.width)
+                        && (*op == Op::Add || *op == Op::Sub)
+                        && args.len() == 2 =>
+                {
+                    // A stride ⇒ a fresh may-bit; the node references cnt ⇒ drop it.
+                    let inp = fresh_may(&mut next_nid, &mut prelude);
+                    may_input.insert(nid, inp);
+                    dropped.insert(nid);
+                }
+                other if !node_refs_nid(other, cnt) => {
+                    // An opaque reload value (prescale input, floor register) ⇒ a fresh
+                    // may-bit. KEEP the node (it may be shared with other logic).
+                    let inp = fresh_may(&mut next_nid, &mut prelude);
+                    may_input.insert(nid, inp);
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    // Map a value operand to its 1-bit abstraction.
+    let rewire_val = |o: &Operand| -> Option<Operand> {
+        let n = o.nid();
+        if n == cnt {
+            Some(Operand(cnt)) // hold
+        } else if let Some(&inp) = may_input.get(&n) {
+            Some(Operand(inp)) // stride / opaque reload → may-bit
+        } else if ite_nodes.contains(&n) {
+            Some(Operand(n)) // nested ite (rewritten in place)
+        } else {
+            // reload constant → (C == T); anything else is unhandled.
+            resolve_btor2_constant(file, n).map(|c| bit_for(c == t))
+        }
+    };
+
+    let mut out: Vec<Line> = Vec::with_capacity(file.lines.len() + prelude.len());
+    out.extend(prelude);
+    for line in &file.lines {
+        let nid = line.nid;
+        // Drop the stride nodes — replaced by fresh may-bits.
+        if dropped.contains(&nid) {
+            continue;
+        }
+        let node = match &line.node {
+            Node::State { symbol, .. } if nid == cnt => Node::State {
+                sort: bit_sort,
+                symbol: symbol.clone(),
+            },
+            Node::Init { state, value, .. } if *state == cnt => {
+                let c = resolve_btor2_constant(file, value.nid())?;
+                Node::Init {
+                    sort: bit_sort,
+                    state: cnt,
+                    value: bit_for(c == t),
+                }
+            }
+            Node::Next { state, value, .. } if *state == cnt => Node::Next {
+                sort: bit_sort,
+                state: cnt,
+                value: rewire_val(value)?,
+            },
+            // A value-path `ite`: sort → 1, operands remapped (condition unchanged).
+            Node::Op {
+                op: Op::Ite,
+                args,
+                symbol,
+                ..
+            } if ite_nodes.contains(&nid) => {
+                if args.len() < 3 {
+                    return None;
+                }
+                Node::Op {
+                    op: Op::Ite,
+                    sort: bit_sort,
+                    args: vec![args[0], rewire_val(&args[1])?, rewire_val(&args[2])?],
+                    symbol: symbol.clone(),
+                }
+            }
+            // External `redor(cnt)` (= `cnt != 0`, the `~|cnt` gate) → `not(cnt)` (= `!cnt_z`;
+            // valid because `redor` fixes the threshold at 0, so `cnt_z ⟺ cnt == 0`).
+            Node::Op {
+                op: Op::Redor,
+                args,
+                symbol,
+                sort,
+            } if args.len() == 1 && args[0].nid() == cnt => {
+                if t != 0 {
+                    return None;
+                }
+                Node::Op {
+                    op: Op::Not,
+                    sort: *sort,
+                    args: vec![Operand(cnt)],
+                    symbol: symbol.clone(),
+                }
+            }
+            // External `eq/neq(cnt, T)` → `eq/neq(cnt, 1)` (cnt is now the `==T` bit).
+            Node::Op {
+                op: op @ (Op::Eq | Op::Neq),
+                args,
+                symbol,
+                sort,
+            } if args.iter().any(|a| a.nid() == cnt) => {
+                if args.len() != 2 {
+                    return None;
+                }
+                let new_args = if args[0].nid() == cnt {
+                    vec![Operand(cnt), Operand(const_1)]
+                } else {
+                    vec![Operand(const_1), Operand(cnt)]
+                };
+                Node::Op {
+                    op: *op,
+                    sort: *sort,
+                    args: new_args,
+                    symbol: symbol.clone(),
+                }
+            }
+            // Any OTHER reference to cnt ⇒ abstain.
+            other if node_refs_nid(other, cnt) => return None,
+            other => other.clone(),
+        };
+        out.push(Line {
+            nid,
+            node,
+            immediates: line.immediates.clone(),
+            source_line: line.source_line,
+        });
+    }
+    let by_nid = out.iter().enumerate().map(|(i, l)| (l.nid, i)).collect();
+    Some(Btor2File { lines: out, by_nid })
+}
+
 /// §Phase 10 §10.2 stage 1 — validate detected memory cells against
 /// the sidecar's `memories[]` declarations. Returns Ok when every
 /// detected memory has a matching sidecar entry with matching
@@ -6014,6 +6416,216 @@ mod tests {
                 vo, vr,
                 "re-encode changed the verdict for `{prop}`: {vo:?} vs {vr:?}"
             );
+        }
+    }
+
+    /// b1 — a 3-bit down-counter `cnt` (reload 4 at expiry, decrement otherwise)
+    /// gating a 1-bit `phase` toggle. Detection must find the COUNTER (a `sub`
+    /// stride on its value path + only `eq(cnt, 0)` external uses) and REJECT
+    /// `phase` (a `not` on its value path — not an arithmetic counter).
+    const GATED_PHASE_COUNTER: &str = r#"
+1 sort bitvec 3
+2 sort bitvec 1
+3 state 1 cnt
+4 state 2 phase
+5 const 1 100
+6 const 1 001
+7 zero 1
+8 zero 2
+9 eq 2 3 7
+10 sub 1 3 6
+11 ite 1 9 5 10
+12 next 1 3 11
+13 init 1 3 5
+14 not 2 4
+15 ite 2 9 14 4
+16 next 2 4 15
+17 init 2 4 8
+"#;
+
+    #[test]
+    fn detect_down_counter_finds_gated_counter_rejects_toggle() {
+        use crate::adapter::btor2::parser::parse;
+        let file = parse(GATED_PHASE_COUNTER).expect("parses");
+        let cs = detect_down_counter(&file);
+        assert_eq!(cs.len(), 1, "only cnt is a counter, not phase: {cs:?}");
+        assert_eq!(cs[0].nid, 3);
+        assert_eq!(cs[0].width, 3);
+        assert_eq!(cs[0].threshold, 0, "compared only against cnt == 0");
+    }
+
+    /// b1 SOUNDNESS DIFFERENTIAL — the may-abstraction must **simulate** the
+    /// concrete model (over-approximation): for every concrete step
+    /// `c → c'`, there is a choice of the fresh may-input under which the
+    /// abstract model steps `α(c) → α(c')`, where `α` maps `cnt ↦ (cnt == T)`
+    /// and leaves other registers untouched. Simulation ⇒ every universal
+    /// (ν / AG-safety) property that holds on the abstract model holds on the
+    /// concrete one — the direction b1 claims. A rewrite bug (wrong reload
+    /// constant, dropped edge, inverted threshold) breaks the simulation here.
+    #[test]
+    fn counter_may_abstract_simulates_concrete_sound_overapprox() {
+        use crate::adapter::btor2::parser::parse;
+        use std::collections::HashMap;
+        let concrete = parse(GATED_PHASE_COUNTER).expect("parses");
+        let meta = &detect_down_counter(&concrete)[0];
+        let abstract_file = counter_may_abstract(&concrete, meta).expect("abstractable");
+
+        // cnt collapsed 3 → 1 bit; phase unchanged.
+        let cnt_w = abstract_file.lines.iter().find_map(|l| match &l.node {
+            Node::State { sort, .. } if l.nid == 3 => parser::bv_width(&abstract_file, *sort),
+            _ => None,
+        });
+        assert_eq!(cnt_w, Some(1), "cnt re-encoded to the {{==0}} bit");
+
+        // Re-parse the serialized abstract model + collect the may-input symbol(s).
+        let abstract_src = crate::adapter::btor2::emit::emit_btor2(&abstract_file);
+        let abstract_re = parse(&abstract_src).expect("abstract re-parses");
+        let may_syms: Vec<String> = abstract_re
+            .lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                Node::Input {
+                    symbol: Some(s), ..
+                } if s.starts_with("__cnt") => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(!may_syms.is_empty(), "the stride became a may-input");
+
+        let alpha = |cnt: u128| -> u128 { if cnt == meta.threshold as u128 { 1 } else { 0 } };
+        // Exhaustive: every concrete (cnt, phase). The counter is autonomous
+        // (no primary inputs), so the abstract model's only inputs are may-inputs.
+        for cnt in 0..(1u128 << meta.width) {
+            for phase in 0..2u128 {
+                let cregs = HashMap::from([("cnt".to_string(), cnt), ("phase".to_string(), phase)]);
+                let cnext =
+                    simulate_one_step(&concrete, &cregs, &HashMap::new()).expect("concrete step");
+                let want_cnt = alpha(cnext["cnt"]);
+                let want_phase = cnext["phase"];
+
+                // ∃ may-input choice reproducing α(c') in the abstract model.
+                let mut matched = false;
+                for may in 0..(1u128 << may_syms.len()) {
+                    let aregs = HashMap::from([
+                        ("cnt".to_string(), alpha(cnt)),
+                        ("phase".to_string(), phase),
+                    ]);
+                    let ainps: HashMap<String, u128> = may_syms
+                        .iter()
+                        .enumerate()
+                        .map(|(i, s)| (s.clone(), (may >> i) & 1))
+                        .collect();
+                    let anext =
+                        simulate_one_step(&abstract_re, &aregs, &ainps).expect("abstract step");
+                    if anext["cnt"] == want_cnt && anext["phase"] == want_phase {
+                        matched = true;
+                        break;
+                    }
+                }
+                assert!(
+                    matched,
+                    "no abstract step simulates concrete cnt={cnt} phase={phase} \
+                     → (cnt'={}, phase'={want_phase}); abstraction is NOT a sound \
+                     over-approximation",
+                    cnext["cnt"]
+                );
+            }
+        }
+    }
+
+    /// b1 GENERALIZED — the DOMINANT real-RTL counter idiom: an INPUT reload value
+    /// (`rld`, a prescale register/input) and a `redor(cnt)` (`~|cnt`) expiry gate.
+    /// Detection must find it (the const-reload/`eq`-gate form is essentially
+    /// synthetic-only), and the may-abstraction must still SIMULATE the concrete model.
+    #[test]
+    fn counter_may_abstract_generalized_input_reload_redor_gate() {
+        use crate::adapter::btor2::parser::parse;
+        use std::collections::HashMap;
+        // cnt: `~|cnt ? reload(rld) : cnt-1` (redor gate + INPUT reload); phase toggles
+        // at expiry (cnt==0). rld is a 3-bit input; the redor node (9) gates both.
+        let src = r#"
+1 sort bitvec 3
+2 sort bitvec 1
+3 state 1 cnt
+4 state 2 phase
+5 input 1 rld
+6 const 1 001
+7 const 1 100
+8 zero 2
+9 redor 2 3
+10 sub 1 3 6
+11 ite 1 9 10 5
+12 next 1 3 11
+13 init 1 3 7
+14 not 2 9
+15 not 2 4
+16 ite 2 14 15 4
+17 next 2 4 16
+18 init 2 4 8
+"#;
+        let concrete = parse(src).expect("parses");
+        let cs = detect_down_counter(&concrete);
+        assert_eq!(
+            cs.len(),
+            1,
+            "input-reload + redor-gated counter must be detected: {cs:?}"
+        );
+        assert_eq!(cs[0].nid, 3);
+        assert_eq!(cs[0].threshold, 0, "redor(cnt) fixes the threshold at 0");
+        let ab = counter_may_abstract(&concrete, &cs[0]).expect("abstractable");
+        let cnt_w = ab.lines.iter().find_map(|l| match &l.node {
+            Node::State { sort, .. } if l.nid == 3 => parser::bv_width(&ab, *sort),
+            _ => None,
+        });
+        assert_eq!(cnt_w, Some(1));
+        let ab_src = crate::adapter::btor2::emit::emit_btor2(&ab);
+        let ab_re = parse(&ab_src).expect("abstract re-parses");
+        let may: Vec<String> = ab_re
+            .lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                Node::Input {
+                    symbol: Some(s), ..
+                } if s.starts_with("__cnt") => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        let alpha = |c: u128| if c == 0 { 1 } else { 0 };
+        // Exhaustive over concrete (cnt, phase, rld input); ∃ may-input reproduces α(c').
+        for cnt in 0..8u128 {
+            for phase in 0..2u128 {
+                for rld in 0..8u128 {
+                    let cregs =
+                        HashMap::from([("cnt".to_string(), cnt), ("phase".to_string(), phase)]);
+                    let cinps = HashMap::from([("rld".to_string(), rld)]);
+                    let cnext =
+                        simulate_one_step(&concrete, &cregs, &cinps).expect("concrete step");
+                    let (want_cnt, want_phase) = (alpha(cnext["cnt"]), cnext["phase"]);
+                    let mut matched = false;
+                    for m in 0..(1u128 << may.len()) {
+                        let aregs = HashMap::from([
+                            ("cnt".to_string(), alpha(cnt)),
+                            ("phase".to_string(), phase),
+                        ]);
+                        let mut ainps: HashMap<String, u128> = may
+                            .iter()
+                            .enumerate()
+                            .map(|(i, s)| (s.clone(), (m >> i) & 1))
+                            .collect();
+                        ainps.insert("rld".to_string(), rld); // kept but dead in the abstract
+                        let anext =
+                            simulate_one_step(&ab_re, &aregs, &ainps).expect("abstract step");
+                        if anext["cnt"] == want_cnt && anext["phase"] == want_phase {
+                            matched = true;
+                            break;
+                        }
+                    }
+                    assert!(
+                        matched,
+                        "no abstract step simulates cnt={cnt} phase={phase} rld={rld}"
+                    );
+                }
+            }
         }
     }
 

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -959,6 +959,79 @@ pub fn verify_recoverability_with_predicates(
     }
 }
 
+/// b2 — decide `AG EF good` by COMPOSING a ranking certificate (every in-cone
+/// down-counter that gates progress always eventually expires) with b1's counter
+/// may-abstraction ([`counter_may_abstract`](crate::adapter::btor2::bit_blast::counter_may_abstract)),
+/// then the EXACT engine on the resulting SMALL model. This is the νμ lever for an
+/// FSM-gated-by-counter recoverability target (e.g. i2c's SCL recurrence) that the
+/// bare cube leaves `⊥` because the wide counter blows its state space and the
+/// may-abstracted decrement carries no must-progress.
+///
+/// **Soundness.** b1 replaces each certified counter with a 1-bit `cnt == T` register
+/// whose decrement is a free (may) input — its ONLY added behaviour.
+/// [`ranking_certificate_holds`] certifies each such counter descends to its threshold
+/// from every reachable state, so the abstract "counter expires" step is a genuine
+/// eventuality; and because the gated advance is conditioned on `cnt == T`, the FSM is
+/// held while `cnt ≠ T`, so the abstract single-step expiry and the concrete K-step
+/// descent reach the SAME control state. Hence every abstract `EF good` witness lifts to
+/// a concrete path, and the over-approximating outer `AG` only strengthens a `Holds`
+/// claim. We therefore trust ONLY a `Holds` verdict on the abstract model; a `Violated`
+/// there could be a spurious over-approximation and is mapped to abstain (`None`).
+/// `good_registers` are excluded from abstraction so the property atom never desyncs.
+///
+/// **Detection scope.** [`detect_down_counter`](crate::adapter::btor2::bit_blast::detect_down_counter)
+/// recognises a counter whose stride operates on the raw state nid (hand-authored BTOR2,
+/// clean adapters) and whose expiry gate is `eq/neq(cnt, T)` or `redor(cnt)`. Yosys often
+/// wire-indirects a synchronous counter through an async-reset mux — the decrement reads
+/// `sub(ite(reset, cnt, reset_const), 1)` rather than `sub(cnt, 1)` — so on such lifts the
+/// stride is not yet seen and this rescue abstains (falls through to the cube, never
+/// unsound). A bounded reset-mux "see-through" in the detector is the follow-on that would
+/// extend this to yosys-lifted RTL. Even then, a counter whose reload is gated by a
+/// demonic input (an `ena`/sync that an adversary can hold to stall the descent) has no
+/// ranking certificate — `AG EF good` there genuinely needs a fairness assumption mununu
+/// cannot make, and the abstain is the sound answer.
+fn verify_recoverability_counter_abstracted(
+    file: &crate::adapter::btor2::ast::Btor2File,
+    good: &str,
+    good_registers: &[String],
+) -> Option<PropertyVerdict> {
+    use crate::adapter::btor2::bit_blast::{counter_may_abstract, detect_down_counter};
+    let symbols = crate::adapter::btor2::parser::collect_symbols(file);
+    // Gating down-counters the good atom does NOT read, each with a ranking-certified
+    // descent to its threshold (so its abstract may-expiry is a real eventuality).
+    let counters: Vec<_> = detect_down_counter(file)
+        .into_iter()
+        .filter(|c| {
+            symbols
+                .get(&c.nid)
+                .is_none_or(|s| !good_registers.contains(s))
+        })
+        .filter(|c| {
+            symbols.get(&c.nid).is_some_and(|s| {
+                ranking_certificate_holds(file, std::slice::from_ref(s), Some(c.threshold))
+            })
+        })
+        .collect();
+    if counters.is_empty() {
+        return None;
+    }
+    // Apply b1 to every certified counter (disjoint registers, NIDs preserved).
+    let mut abstracted = file.clone();
+    for c in &counters {
+        abstracted = counter_may_abstract(&abstracted, c)?;
+    }
+    let abstract_src = crate::adapter::btor2::emit::emit_btor2(&abstracted);
+    let formula_str = format!("nu Y. ((mu X. (({good}) || <> X)) && [] Y)");
+    let formula = mu_parser::parse(&formula_str).ok()?;
+    match crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict(&abstract_src, &formula)
+    {
+        Ok(crate::adapter::btor2::symbolic_bitblast::ExactVerdict::Holds) => {
+            Some(PropertyVerdict::Holds)
+        }
+        _ => None,
+    }
+}
+
 /// P2 Slice 1 — decide recoverability `AG EF good` via the **predicate-cube +
 /// `smt-hyper-must`** path, so the νμ property decides beyond the exact engine's
 /// ~40-bit cone cap.
@@ -1032,6 +1105,17 @@ pub fn verify_recoverability_scalable(
         && ranking_certificate_holds(&file, &[counter], Some(threshold))
     {
         return Ok(PropertyVerdict::Holds);
+    }
+
+    // b2 COUNTER-ABSTRACTION RESCUE: when `good` is gated (through an FSM) by one or more
+    // in-cone DOWN-COUNTERS whose descent is ranking-certified, collapse each to its
+    // `{cnt==T}` bit (b1) and decide `AG EF good` with the EXACT engine on the resulting
+    // small model. Handles the FSM-gated-by-counter shape (i2c's SCL recurrence) that the
+    // direct counter-gate rescue above and the bare cube both miss. Sound: only a `Holds`
+    // is trusted (see `verify_recoverability_counter_abstracted`); a non-Holds falls through
+    // to the cube, so this is never less sound than the prior behaviour.
+    if let Some(v) = verify_recoverability_counter_abstracted(&file, good, &good_registers) {
+        return Ok(v);
     }
 
     // Seed predicates = [good] ++ [good register's OTHER control states] ++ extra. The `good`
@@ -3023,5 +3107,111 @@ mod tests {
         assert!(parse_extra_predicate("no_colon").is_err());
         assert!(parse_extra_predicate("n:reg").is_err());
         assert!(parse_extra_predicate("n:reg=notanumber").is_err());
+    }
+
+    // === b2: counter-abstraction recoverability =================================
+
+    /// A `w`-bit down-counter `cnt` (reload 4 at expiry, decrement otherwise) gating a
+    /// 3-state FSM `idle→A→{B|idle}→idle` that advances ONLY when `cnt==0`. When
+    /// `reaches_b` the FSM cycles through `B` (so `AG EF (fsm==2)` HOLDS); otherwise `B`
+    /// is unreachable (so it is VIOLATED). This is the FSM-gated-by-counter shape b2
+    /// targets — the counter gates progress but is not itself the recoverability target.
+    fn fsm_gated_counter(w: usize, reaches_b: bool) -> String {
+        let reload = format!("{:0width$b}", 4, width = w);
+        let dec = format!("{:0width$b}", 1, width = w);
+        let advance_from_a = if reaches_b { 16 } else { 14 }; // A → B, or A → idle
+        format!(
+            r#"
+1 sort bitvec {w}
+2 sort bitvec 2
+3 sort bitvec 1
+4 state 1 cnt
+5 state 2 fsm
+6 const 1 {reload}
+7 const 1 {dec}
+8 zero 1
+9 eq 3 4 8
+10 sub 1 4 7
+11 ite 1 9 6 10
+12 next 1 4 11
+13 init 1 4 6
+14 zero 2
+15 const 2 01
+16 const 2 10
+17 eq 3 5 14
+18 eq 3 5 15
+19 ite 2 18 {advance_from_a} 14
+20 ite 2 17 15 19
+21 ite 2 9 20 5
+22 next 2 5 21
+23 init 2 5 14
+"#
+        )
+    }
+
+    /// b2 SOUNDNESS — on the SMALL (exact-decidable) recoverable model the exact engine
+    /// is the ground-truth oracle (Holds), and b2 must AGREE. This is the differential
+    /// oracle for the counter-abstraction composition.
+    #[test]
+    fn b2_matches_exact_oracle_on_recoverable_fsm() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        let small = fsm_gated_counter(3, true);
+        let f = mu_parser::parse("nu Y. ((mu X. ((fsm == 2) || <> X)) && [] Y)").unwrap();
+        // ORACLE: the exact engine decides the small model directly.
+        assert_eq!(
+            exact_symbolic_verdict(&small, &f).expect("exact decides small"),
+            ExactVerdict::Holds,
+            "ground truth: the FSM cycles through B forever"
+        );
+        // b2 on the same model → the same definite verdict.
+        let file = crate::adapter::btor2::parser::parse(&small).unwrap();
+        assert_eq!(
+            verify_recoverability_counter_abstracted(&file, "fsm == 2", &["fsm".to_string()]),
+            Some(PropertyVerdict::Holds),
+            "b2 must agree with the exact oracle"
+        );
+    }
+
+    /// b2 SOUNDNESS — b2 must NEVER fabricate a `Holds`. On the unrecoverable model the
+    /// oracle says Violated; b2 must abstain (`None`), since only a `Holds` on the
+    /// over-approximating abstract model is sound.
+    #[test]
+    fn b2_abstains_on_unrecoverable_fsm_never_fabricates_holds() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        let trap = fsm_gated_counter(3, false);
+        let f = mu_parser::parse("nu Y. ((mu X. ((fsm == 2) || <> X)) && [] Y)").unwrap();
+        // ORACLE: B is unreachable ⇒ AG EF (fsm==2) is Violated.
+        assert_eq!(
+            exact_symbolic_verdict(&trap, &f).expect("exact decides trap"),
+            ExactVerdict::Violated,
+            "ground truth: B is unreachable"
+        );
+        // b2 must NOT return Holds — abstain (the cube then decides Violated).
+        let file = crate::adapter::btor2::parser::parse(&trap).unwrap();
+        assert_eq!(
+            verify_recoverability_counter_abstracted(&file, "fsm == 2", &["fsm".to_string()]),
+            None,
+            "b2 must abstain (never fabricate Holds) on a real Violated"
+        );
+    }
+
+    /// b2 SIZE LEVER — a 40-bit counter puts the exact cone over the bit-blast cap, so
+    /// the exact engine cannot decide it directly; the public escalating entry routes
+    /// through b2, which collapses the counter and decides Holds.
+    #[test]
+    fn b2_decides_wide_counter_gated_recoverability() {
+        use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
+        let wide = fsm_gated_counter(40, true);
+        let f = mu_parser::parse("nu Y. ((mu X. ((fsm == 2) || <> X)) && [] Y)").unwrap();
+        // Guard: the wide counter genuinely exceeds the exact cap (else the test is vacuous).
+        assert!(
+            exact_symbolic_verdict(&wide, &f).is_err(),
+            "the 40-bit counter must exceed the exact bit-cap"
+        );
+        // The escalating public entry (exact → scalable → b2) decides Holds.
+        assert_eq!(
+            verify_recoverability(&wide, "fsm == 2").expect("b2 decides the wide design"),
+            PropertyVerdict::Holds,
+        );
     }
 }


### PR DESCRIPTION
## What

Counter abstraction for **FSM-gated νμ recoverability** — decide `AG EF good` when `good` is gated, through an FSM, by one or more in-cone down-counters whose descent is ranking-certified. The bare cube leaves such a target ⊥ (the wide counter blows its state space, and a may-abstracted decrement carries no must-progress for the inner `EF`). Composes with the merged one-hot re-encode (#365) as the second structural collapse.

**b1** — `detect_down_counter` + `counter_may_abstract` (btor2/bit_blast): collapse a counter register whose only external use is a threshold comparison to the single bit `cnt == T`, replacing each stride branch of its next-state with a fresh (may) input. Handles the dominant real-RTL idioms — an **input / opaque reload** value (a prescale register, `clk_cnt >> 2`, mapped to a free may-bit) and the **`redor(cnt)` (`~|cnt`) expiry gate** — not only const-reload / `eq`-gate.

**b2** — `verify_recoverability_counter_abstracted` (recoverability): compose a ranking certificate (`ranking_certificate_holds` — every gating counter always eventually expires) with b1's collapse, then decide `AG EF good` with the **exact** engine on the resulting small model. Wired into `verify_recoverability_scalable` ahead of the cube.

## Soundness

b1's only added behaviour is the free counter-decrement; the ranking certifies each expiry is a real eventuality; and because the gated advance is conditioned on `cnt == T`, the FSM is held while `cnt ≠ T`, so the abstract single-step expiry and the concrete K-step descent reach the **same** control state. Every abstract `EF good` witness therefore lifts to a concrete path, and the over-approximating outer `AG` only strengthens a `Holds`. **Only `Holds` is trusted**; a `Violated` on the abstract model could be a spurious over-approximation and falls through to the cube — never less sound than before.

## Validation

| test | asserts |
|---|---|
| `counter_may_abstract_simulates_concrete_sound_overapprox` | the may-abstraction **simulates** the concrete model (every concrete step has a matching abstract step ⇒ AG-soundness) |
| `counter_may_abstract_generalized_input_reload_redor_gate` | same simulation soundness for the input-reload + `redor`-gate idiom |
| `b2_matches_exact_oracle_on_recoverable_fsm` | b2 **agrees** with the exact oracle (Holds) on a small recoverable model |
| `b2_abstains_on_unrecoverable_fsm_never_fabricates_holds` | b2 **abstains** (never fabricates Holds) where the oracle says Violated |
| `b2_decides_wide_counter_gated_recoverability` | b2 **decides** a 40-bit counter-gated recoverability the exact engine cannot (cone over the bit cap) |

0 regression on the recoverability (35) + bit_blast (102) suites.

## Detection scope (honest limits, documented on the fn)

The stride must read the raw state nid. **Yosys often wire-indirects** a synchronous counter through an async-reset mux — the decrement reads `sub(ite(reset, cnt, reset_const), 1)` rather than `sub(cnt, 1)` — so on such lifts detection abstains (sound: falls through to the cube). A bounded reset-mux **see-through** in the detector is the follow-on that extends this to yosys-lifted RTL (e.g. OpenCores i2c's clock divider, nid 143). Independently, a counter whose reload is gated by a **demonic input** (an `ena`/sync an adversary can hold to stall the descent) has no ranking certificate — that recurrence genuinely needs a fairness assumption mununu cannot make, and the abstain is the sound answer.

Internal engine transform reached from the recoverability escalation — no user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
