### PR TITLE
feat(exact): deterministic fixpoint iteration budget (guards the 2^W-diameter hang)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -1669,6 +1669,24 @@ pub struct ExactModel {
     constraint: BDDFunction,
     tt: BDDFunction,
     ff: BDDFunction,
+    /// Fixpoint ITERATION budget — the total μ/ν fixpoint iterations across one
+    /// [`ExactModel::evaluate`]. A wide FREE COUNTER has a small BDD (so the node-budget
+    /// guard never fires) but a `2^W`-step (reachable-diameter) fixpoint; this bails it to
+    /// a clean `Err` (→ Skipped) DETERMINISTICALLY (machine-independent, unlike a wall clock).
+    /// The other blowup mode — a large BDD — is caught by the node-budget guard + catch_unwind.
+    iter_budget: usize,
+    /// Running total of fixpoint iterations. Interior-mutable because `evaluate` / `fixpoint`
+    /// take `&self`; the exact eval is single-threaded per call.
+    iters: std::cell::Cell<usize>,
+}
+
+/// The exact-engine fixpoint iteration budget: `MUNUNU_BDD_ITER_BUDGET` or a default sized to
+/// catch a wide-counter diameter (`2^W`) while admitting any control fixpoint (small diameter).
+fn fixpoint_iter_budget() -> usize {
+    std::env::var("MUNUNU_BDD_ITER_BUDGET")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1 << 20) // ~1M iterations; a counter's steps are cheap (small BDD) so this is fast to reach
 }
 
 impl BddBitBlaster {
@@ -1707,6 +1725,8 @@ impl BddBitBlaster {
             constraint: self.constraint_bdd.clone(),
             tt: self.tt.clone(),
             ff: self.ff.clone(),
+            iter_budget: fixpoint_iter_budget(),
+            iters: std::cell::Cell::new(0),
         }
     }
 
@@ -1941,6 +1961,18 @@ impl ExactModel {
             self.ff.clone()
         };
         loop {
+            // Iteration budget — bail deterministically before a wide-counter diameter (`2^W`)
+            // fixpoint hangs. Counted across ALL fixpoints in this `evaluate` (nested νμ share
+            // the running total), so a bounded total work regardless of nesting.
+            let n = self.iters.get() + 1;
+            self.iters.set(n);
+            if n > self.iter_budget {
+                return Err(format!(
+                    "symbolic bit-blaster: fixpoint iteration budget exceeded ({n} > {}) — the \
+                     property's reachable diameter is too large to bit-blast; use `--engine explicit`",
+                    self.iter_budget
+                ));
+            }
             bindings.insert(var, x.clone());
             let next = self.eval_node(f, body, atoms, bindings)?;
             if next == x {


### PR DESCRIPTION
feat(exact): deterministic fixpoint iteration budget (guards the 2^W-diameter hang)

Completes the exact-engine robustness pair from the node-budget cap (#368). The node-budget
guard catches a LARGE BDD; it cannot see the OTHER blowup mode — a wide FREE COUNTER whose BDD
is tiny but whose μ/ν fixpoint runs for `2^W` reachable-diameter steps. This adds a per-eval
iteration budget on `ExactModel`: the μ/ν `fixpoint` loop counts iterations (shared across
nested νμ) and bails to a clean `Err` (→ Skipped) when it passes the budget.

- DETERMINISTIC (machine-independent, unlike a wall clock) — a verification tool's verdicts
  must reproduce across machines.
- Env-tunable `MUNUNU_BDD_ITER_BUDGET` (default ~1M). A counter's steps are cheap (small BDD),
  so the budget is reached quickly and the bail is fast.
- Guards BOTH paths: it also protects the DEFAULT (≤40-bit) path, where a 40-bit counter's
  EF could previously have hung; now it degrades gracefully.

Together, {node-budget guard, catch_unwind, iteration budget} cover every exact-engine blowup
mode — large BDD, single-op arena overflow, large diameter — each turning into a clean Skipped
rather than an OoM-panic or a hang. This is what makes it SAFE to raise the bit cap
(`MUNUNU_BDD_MAX_BITS`, #368); the default stays 40 pending a benchmark-driven decision.

0 regression: 56 `symbolic_bitblast` + 35 `recoverability` unchanged at the default cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)