### PR TITLE
feat(sv-lift): opt-in yosys-slang RTL frontend (read_slang)

### DIFF
--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -353,7 +353,12 @@ fn run_sv_flatten_btor2(
     // Yosys handles cleanly. Activated by `YosysOptions::use_sv2v`
     // (the only switch — wire `--preprocessor sv2v` on the CLI or
     // `use_sv2v: true` on the API into this field).
-    if yopts.use_sv2v {
+    //
+    // A3 — the opt-in slang RTL frontend (`MUNUNU_YOSYS_FRONTEND=slang`). `read_slang`
+    // parses SystemVerilog natively (a superset of what `read_verilog` accepts), so sv2v
+    // is redundant with it and is skipped when slang is active.
+    let slang_plugin = slang_frontend_selection();
+    if yopts.use_sv2v && slang_plugin.is_none() {
         let sv2v = locate_sv2v()?;
         let preprocessed = tmp.path().join("preprocessed.sv");
         // Include-search path. Two sources, in priority order:
@@ -401,9 +406,14 @@ fn run_sv_flatten_btor2(
         yopts.setundef_anyconst,
         &yopts.init_policy_overrides,
         &yopts.cutpoint_signals,
+        slang_plugin.is_some(),
     );
 
-    let output = Command::new(&yosys)
+    let mut yosys_cmd = Command::new(&yosys);
+    if let Some(plugin) = &slang_plugin {
+        yosys_cmd.arg("-m").arg(plugin);
+    }
+    let output = yosys_cmd
         .arg("-q")
         .arg("-p")
         .arg(&script)
@@ -1632,6 +1642,40 @@ fn locate_sv2v() -> Result<PathBuf, AdapterError> {
     })
 }
 
+/// The yosys `-m` argument that loads the yosys-slang frontend plugin (`read_slang`),
+/// or `None` if unavailable. Order: `MUNUNU_YOSYS_SLANG_PLUGIN` (a path to `slang.so`) →
+/// the pinned `mununu-sva` image plugin (loadable by bare name `slang`) → absent.
+///
+/// `read_slang` is a full SystemVerilog front-end that accepts constructs yosys's native
+/// `read_verilog` rejects (a bounded `while` loop in `always @*`, …). mununu uses it for
+/// the **RTL lift only** (`--ignore-assertions` — SVA is extracted separately by the slang
+/// `extract_sva` path, so no `bad` nodes are needed here). Named registers and ports get
+/// the SAME `instance.signal` BTOR2 names as the `read_verilog` path, so cutpoints /
+/// `--config-value` over named signals resolve unchanged.
+fn locate_slang_plugin() -> Option<String> {
+    if let Ok(p) = std::env::var("MUNUNU_YOSYS_SLANG_PLUGIN")
+        && Path::new(&p).exists()
+    {
+        return Some(p);
+    }
+    // The pinned image ships slang.so in yosys's plugin dir → loadable by bare name.
+    if Path::new("/opt/oss-cad-suite/share/yosys/plugins/slang.so").exists() {
+        return Some("slang".to_string());
+    }
+    None
+}
+
+/// The yosys-slang `-m` plugin argument when the slang RTL frontend is selected for this
+/// lift, else `None`. Opt-in via `MUNUNU_YOSYS_FRONTEND=slang` (case-insensitive) AND the
+/// plugin being present. Conservative rollout (A3): opt-in first; a
+/// fallback-on-`read_verilog`-parse-failure and a benchmark-validated default are follow-ups.
+fn slang_frontend_selection() -> Option<String> {
+    match std::env::var("MUNUNU_YOSYS_FRONTEND") {
+        Ok(v) if v.eq_ignore_ascii_case("slang") => locate_slang_plugin(),
+        _ => None,
+    }
+}
+
 /// Run sv2v over `sources`, capture stdout into `out`. sv2v's documented
 /// multi-file mode resolves cross-file packages/interfaces in one pass
 /// and emits a single combined Verilog-2005 stream on stdout.
@@ -1819,11 +1863,36 @@ fn build_script(
     setundef_anyconst: bool,
     init_policy_overrides: &InitPolicyOverrides,
     cutpoint_signals: &[String],
+    use_slang: bool,
 ) -> String {
-    let read_cmds: Vec<String> = sources
-        .iter()
-        .map(|p| format!("read_verilog -formal -sv {}", p.display()))
-        .collect();
+    // A3 — the RTL read command. `read_slang` (yosys-slang plugin) is a full SV front-end
+    // that accepts constructs `read_verilog` rejects; it reads ALL sources in ONE command
+    // and `--ignore-assertions` drops embedded SVA (extracted separately by the slang
+    // `extract_sva` path). `read_verilog` reads each source. Everything after the read is
+    // identical, so the lift is frontend-agnostic downstream.
+    let read_cmds: Vec<String> = if use_slang {
+        let files = sources
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let top_arg = top.map(|t| format!(" --top {t}")).unwrap_or_default();
+        // The staging tempdir (parent of the sources) as an include dir, so a cross-file
+        // `\`include "peer.sv"` between staged sources resolves.
+        let inc = sources
+            .first()
+            .and_then(|p| p.parent())
+            .map(|d| format!(" -I{}", d.display()))
+            .unwrap_or_default();
+        vec![format!(
+            "read_slang --ignore-assertions{top_arg}{inc} {files}"
+        )]
+    } else {
+        sources
+            .iter()
+            .map(|p| format!("read_verilog -formal -sv {}", p.display()))
+            .collect()
+    };
     let hier = match top {
         Some(t) => format!("hierarchy -top {t}"),
         None => "hierarchy -auto-top".to_string(),
@@ -2515,6 +2584,7 @@ mod tests {
             false,
             &overrides,
             &cuts,
+            false,
         );
         assert!(
             script.contains("cutpoint w:must_refresh w:precharge_done"),
@@ -2549,12 +2619,58 @@ mod tests {
             false,
             &overrides,
             &[],
+            false,
         );
         // The blackbox cut is always present; there must be no explicit `cutpoint w:` pass.
         assert!(script.contains("cutpoint -blackbox"));
         assert!(
             !script.contains("cutpoint w:"),
             "no explicit cut points expected: {script}"
+        );
+    }
+
+    // A3 — the slang RTL frontend read command: ONE `read_slang` over all sources with
+    // assertions ignored, no `read_verilog`, and the same frontend-agnostic passes after.
+    #[test]
+    fn build_script_slang_frontend_uses_read_slang() {
+        use std::path::PathBuf;
+        let sources = vec![PathBuf::from("/tmp/a.sv"), PathBuf::from("/tmp/b.sv")];
+        let btor = PathBuf::from("/tmp/out.btor");
+        let hier = PathBuf::from("/tmp/hier.json");
+        let overrides: InitPolicyOverrides = Vec::new();
+        let script = build_script(
+            &sources,
+            Some("top"),
+            &btor,
+            &hier,
+            false,
+            false,
+            &overrides,
+            &[],
+            true, // use_slang
+        );
+        assert!(
+            script.contains("read_slang --ignore-assertions"),
+            "slang read command missing: {script}"
+        );
+        assert!(
+            script.contains("--top top"),
+            "top not passed to read_slang: {script}"
+        );
+        assert!(
+            script.contains("/tmp/a.sv") && script.contains("/tmp/b.sv"),
+            "both sources must be read in one read_slang: {script}"
+        );
+        assert!(
+            !script.contains("read_verilog"),
+            "read_verilog must not appear on the slang path: {script}"
+        );
+        // Downstream is frontend-agnostic — the same lift passes run either way.
+        assert!(
+            script.contains("async2sync")
+                && script.contains("dffunmap")
+                && script.contains("write_btor"),
+            "downstream passes missing: {script}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -224,6 +224,103 @@ struct SvFlattenArtifacts {
 /// [`sv_discover_state_cells`] (which only reads the BTOR2's named state
 /// cells), so the sv2v include-path + Yosys-invocation logic lives in one
 /// place.
+/// Net-type keywords that yosys `read_verilog` / the slang lowering reject in a
+/// PORT header (`input tri0 baud8x`). A net type on a *port* only governs that
+/// port's EXTERNAL resolution (a shared bus with pulls / wired-logic across
+/// modules); verifying the module in isolation, an input is havoc'd and an
+/// output is driven by the module's own logic, so dropping the qualifier is
+/// SOUND — and for inputs it is *exact* (mununu havocs every input regardless of
+/// net type). Without this the whole design is rejected at parse.
+const PORT_NET_TYPE_KEYWORDS: &[&str] = &[
+    "tri0", "tri1", "triand", "trior", "trireg", "wand", "wor", "supply0", "supply1", "uwire",
+    "tri",
+];
+
+/// Drop a rejected net-type qualifier that directly follows a port direction
+/// keyword (`input`/`output`/`inout`) — an A2 lift-widening normalization.
+///
+/// SCOPE: **ports only.** INTERNAL net-type declarations are left untouched:
+/// their pull (`tri0` reads 0 undriven) and wired-resolution (`wand`/`wor`)
+/// semantics DO affect the modeled behaviour, and stripping them soundly depends
+/// on the `setundef` polarity (default `-zero` matches `tri0` but not `tri1`) —
+/// a separate, gated follow-up. Port stripping needs no such gate because a port
+/// net type is invisible to isolated single-module verification.
+///
+/// Tokenizes past `//`/`/* */` comments and `"…"` strings so a `tri0` inside a
+/// comment/string is never rewritten, and skips escaped identifiers (`\tri0`).
+/// A no-op (clone) when there is no such qualifier — safe to run on every staged
+/// source. `input`/`output`/`inout` are reserved keywords (never identifiers),
+/// so a net-type word immediately after one is unambiguously a port qualifier.
+pub(crate) fn strip_port_net_types(src: &str) -> String {
+    const DIRECTIONS: &[&str] = &["input", "output", "inout"];
+    let bytes = src.as_bytes();
+    // (start, end) byte spans of identifier/keyword words that lie in CODE
+    // (outside comments/strings, not escaped identifiers).
+    let mut words: Vec<(usize, usize)> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+        } else if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i = (i + 2).min(bytes.len());
+        } else if c == b'"' {
+            i += 1;
+            while i < bytes.len() && bytes[i] != b'"' {
+                if bytes[i] == b'\\' {
+                    i += 1;
+                }
+                i += 1;
+            }
+            i += 1;
+        } else if c.is_ascii_alphabetic() || c == b'_' {
+            let start = i;
+            while i < bytes.len()
+                && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_' || bytes[i] == b'$')
+            {
+                i += 1;
+            }
+            // A leading backslash makes it an escaped identifier (a NAME) — skip.
+            if start == 0 || bytes[start - 1] != b'\\' {
+                words.push((start, i));
+            }
+        } else {
+            i += 1;
+        }
+    }
+    let mut removals: Vec<(usize, usize)> = Vec::new();
+    for w in words.windows(2) {
+        let d = &src[w[0].0..w[0].1];
+        let n = &src[w[1].0..w[1].1];
+        if DIRECTIONS.contains(&d) && PORT_NET_TYPE_KEYWORDS.contains(&n) {
+            removals.push((w[1].0, w[1].1));
+        }
+    }
+    if removals.is_empty() {
+        return src.to_string();
+    }
+    let mut out = String::with_capacity(src.len());
+    let mut last = 0;
+    for (s, e) in removals {
+        out.push_str(&src[last..s]);
+        // Swallow the whitespace after the removed keyword so `input tri0 x`
+        // collapses to `input x`, not `input  x`.
+        let mut e2 = e;
+        while e2 < bytes.len() && (bytes[e2] == b' ' || bytes[e2] == b'\t') {
+            e2 += 1;
+        }
+        last = e2;
+    }
+    out.push_str(&src[last..]);
+    out
+}
+
 fn run_sv_flatten_btor2(
     content: &str,
     yopts: &YosysOptions,
@@ -235,7 +332,10 @@ fn run_sv_flatten_btor2(
 
     let tmp = TempDir::new("mununu-yosys")?;
     let primary = tmp.path().join("work.sv");
-    write_file(&primary, content)?;
+    // A2 — strip yosys/slang-rejected net-type qualifiers on port headers
+    // (`input tri0 x`) so the design parses; sound (a port net type is invisible
+    // to isolated single-module verification). No-op on sources without them.
+    write_file(&primary, &strip_port_net_types(content))?;
 
     let mut sources = vec![primary.clone()];
     for (name, src) in &yopts.additional_sources {
@@ -243,7 +343,7 @@ fn run_sv_flatten_btor2(
         if let Some(parent) = p.parent() {
             std::fs::create_dir_all(parent).map_err(io_err)?;
         }
-        write_file(&p, src)?;
+        write_file(&p, &strip_port_net_types(src))?;
         sources.push(p);
     }
 
@@ -707,7 +807,10 @@ fn translate_sv_per_module_impl(
 
     let tmp = TempDir::new("mununu-yosys-per-module")?;
     let primary = tmp.path().join("work.sv");
-    write_file(&primary, content)?;
+    // A2 — strip yosys/slang-rejected net-type qualifiers on port headers
+    // (`input tri0 x`) so the design parses; sound (a port net type is invisible
+    // to isolated single-module verification). No-op on sources without them.
+    write_file(&primary, &strip_port_net_types(content))?;
 
     let mut sources = vec![primary.clone()];
     for (name, src) in &yopts.additional_sources {
@@ -715,7 +818,7 @@ fn translate_sv_per_module_impl(
         if let Some(parent) = p.parent() {
             std::fs::create_dir_all(parent).map_err(io_err)?;
         }
-        write_file(&p, src)?;
+        write_file(&p, &strip_port_net_types(src))?;
         sources.push(p);
     }
 
@@ -1870,6 +1973,76 @@ impl Drop for TempDir {
 mod tests {
     use super::*;
     use crate::controllability::BoundaryDirection;
+
+    // A2 — port net-type stripping (`input tri0 x` → `input x`).
+    #[test]
+    fn strip_port_net_types_drops_input_tri0() {
+        // ANSI port list (the rtfsimpleuart case).
+        assert_eq!(
+            strip_port_net_types("module m(\n  input cs_i,\n  input tri0 baud8x, // mode\n);"),
+            "module m(\n  input cs_i,\n  input baud8x, // mode\n);"
+        );
+        // Non-ANSI port declaration statement.
+        assert_eq!(strip_port_net_types("input tri0 baud8x;"), "input baud8x;");
+        // output / inout + the other rejected net types.
+        assert_eq!(strip_port_net_types("output tri1 y;"), "output y;");
+        assert_eq!(strip_port_net_types("inout wand bus;"), "inout bus;");
+        // A ranged port keeps the range (the net type precedes it).
+        assert_eq!(
+            strip_port_net_types("input tri0 [7:0] d;"),
+            "input [7:0] d;"
+        );
+    }
+
+    #[test]
+    fn strip_port_net_types_leaves_non_targets_untouched() {
+        // `wire`/`reg`/`logic` on a port are accepted by yosys — keep them.
+        assert_eq!(strip_port_net_types("input wire clk;"), "input wire clk;");
+        assert_eq!(
+            strip_port_net_types("output reg [3:0] q;"),
+            "output reg [3:0] q;"
+        );
+        // An INTERNAL net-type declaration (no direction before it) is out of
+        // scope — its pull/resolution semantics matter, so it is NOT stripped.
+        assert_eq!(
+            strip_port_net_types("tri0 internal_net;"),
+            "tri0 internal_net;"
+        );
+        assert_eq!(
+            strip_port_net_types("wor wired_or_net;"),
+            "wor wired_or_net;"
+        );
+        // No net types at all: exact clone.
+        assert_eq!(
+            strip_port_net_types("input clk; output y;"),
+            "input clk; output y;"
+        );
+    }
+
+    #[test]
+    fn strip_port_net_types_is_comment_and_string_safe() {
+        // `tri0` inside a line comment / block comment / string is never rewritten.
+        assert_eq!(
+            strip_port_net_types("// input tri0 x\ninput clk;"),
+            "// input tri0 x\ninput clk;"
+        );
+        assert_eq!(
+            strip_port_net_types("/* input tri0 x */ input clk;"),
+            "/* input tri0 x */ input clk;"
+        );
+        assert_eq!(
+            strip_port_net_types("$display(\"input tri0 x\"); input clk;"),
+            "$display(\"input tri0 x\"); input clk;"
+        );
+    }
+
+    #[test]
+    fn strip_port_net_types_preserves_escaped_identifier_named_tri0() {
+        // `\tri0` is an escaped IDENTIFIER (a legal port NAME yosys accepts), not
+        // the net-type keyword — it must survive.
+        let src = "input \\tri0 ;";
+        assert_eq!(strip_port_net_types(src), src);
+    }
 
     #[test]
     fn per_module_yosys_timeout_is_an_actionable_error() {

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -157,6 +157,19 @@ net-type declarations are left untouched (their pull / resolution semantics matt
 
 > Source of truth: [`strip_port_net_types`](../crates/mununu-core/src/adapter/yosys/mod.rs#L254) — surface: (CLI+API+UI)
 
+**Wider front-end via yosys-slang (opt-in).** yosys's native `read_verilog` rejects some legal
+SystemVerilog a full front-end accepts — e.g. a bounded `while` loop in an `always @*` block —
+and black-boxes the module (all its properties then skip). Set `MUNUNU_YOSYS_FRONTEND=slang` (when
+the yosys-slang `read_slang` plugin is present — `MUNUNU_YOSYS_SLANG_PLUGIN`, or the pinned image's
+`share/yosys/plugins/slang.so`) to lift the RTL with `read_slang` (a complete SV front-end) instead.
+It reads the RTL **only** (`--ignore-assertions` — SVA is extracted separately, so nothing is lost)
+and names named registers/ports **identically** to `read_verilog`, so cutpoints / `--config-value` /
+atoms resolve unchanged. Opt-in; a fallback-on-parse-failure default is future work. *(Example: the
+`xgate` coprocessor, whose RISC core has a rejected `while` loop, is black-boxed under `read_verilog`
+but lifts its full 125-register core under `read_slang`.)*
+
+> Source of truth: [`slang_frontend_selection`](../crates/mununu-core/src/adapter/yosys/mod.rs#L1672) — surface: (CLI+API+UI)
+
 ### 2. Properties come from the module's own assertions
 
 `sv verify-auto` checks the SVA the design *carries*; it takes no formula. An agent

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -145,6 +145,18 @@ and returns a **structured error** if one is missing, rather than crashing. Run 
 API on a host that has them installed (the pinned `docker/Dockerfile.sva` image is the
 supported environment). See [`external-tools.md`](external-tools.md).
 
+**Net-type normalization (lift widening).** A net-type qualifier on a *port* header
+(`input tri0 baud8x`) is rejected by both yosys's reader (a parse error) and slang's
+lowering (`net type 'tri0' unsupported`) — the pull / wired-resolution of
+`tri0`/`tri1`/`wand`/`wor`/… is a strength-resolution (simulation) concept a word-level
+backend does not model. mununu strips such a qualifier on **port** declarations before
+staging the source, so the design parses: a port net type only governs that port's
+*external* resolution, so for isolated single-module verification an input is havoc'd and
+an output is driven internally — dropping it is **sound** (exact for inputs). **Internal**
+net-type declarations are left untouched (their pull / resolution semantics matter).
+
+> Source of truth: [`strip_port_net_types`](../crates/mununu-core/src/adapter/yosys/mod.rs#L254) — surface: (CLI+API+UI)
+
 ### 2. Properties come from the module's own assertions
 
 `sv verify-auto` checks the SVA the design *carries*; it takes no formula. An agent


### PR DESCRIPTION
> **Stacked on #371** (net-type strip) — both touch `yosys/mod.rs`. Review/merge #371 first; I'll retarget this to `main` after.

## What

yosys's native `read_verilog` rejects legal SystemVerilog a full front-end accepts — e.g. a bounded `while` loop in an `always @*` block (`xgate_risc.v:307: While loops are only allowed in constant functions!`). The module is then black-boxed and every property over it **SKIPPED**. The yosys-slang plugin's `read_slang` is a complete SV front-end that accepts these.

This adds an **opt-in** slang RTL frontend: `MUNUNU_YOSYS_FRONTEND=slang` (when the plugin is present — `MUNUNU_YOSYS_SLANG_PLUGIN`, or the pinned image's `share/yosys/plugins/slang.so`). When active, `run_sv_flatten_btor2` lifts the RTL with `read_slang --ignore-assertions` (one command over all sources), loads the plugin via yosys `-m`, and skips sv2v (redundant with a native SV front-end). **Everything after the read is identical — the lift is frontend-agnostic downstream.**

## Why the shape is right (the two gating spikes)

- **SVA:** `read_slang` doesn't carry `assert property` to `bad` nodes — *but neither does `read_verilog`*, because mununu **already extracts SVA separately** via the slang `extract_sva` path and checks the mu-calculus formula against the RTL *model*. So `--ignore-assertions` on the lift loses nothing.
- **Naming:** named registers and ports get the **same `instance.signal` BTOR2 names** under both frontends (verified: `5 state 1 u_sub.state_q` identical), so cutpoints / `--config-value` / atoms over named signals resolve unchanged — **no name-mapping shim needed** (the `$…$NNN` names that differ are anonymous auto-nets users never reference).

## Validation

- **Unit**: `build_script_slang_frontend_uses_read_slang` (one `read_slang --ignore-assertions` over all sources, no `read_verilog`, identical downstream passes).
- **E2E in the `mununu-sva` image**: `xgate` (RISC core carries the rejected `while` loop) is **black-boxed under `read_verilog`** (all props skip); under `MUNUNU_YOSYS_FRONTEND=slang` it **lifts the full 122–125-register RISC core** and the wishbone/IRQ atoms **resolve and reach the engine** (naming compatible). Standalone `btor2 verify-recoverability` on the read_slang BTOR2 *decides* `AG EF (wbs_ack_o==0)` HOLDS via exact+COI (5-var cone) — so the lifted model is fully usable; verify-auto's ⊥ under its default reset-gated config is a separate engine-routing matter, not a lift issue.

## Rollout

Opt-in only (conservative). A fallback-on-`read_verilog`-parse-failure and a benchmark-validated default are follow-ups.

## Docs

`docs/verifying-rtl.md` — slang-frontend note + `Source of truth` anchor for `slang_frontend_selection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
