### PR TITLE
feat(verify-auto): route νμ-recoverability ⊥ rescue through exact+COI first (③a)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -2496,7 +2496,7 @@ fn escalate_bottom(
         LivenessVerdict, reduce_ag_ef_target, response_liveness_rescue,
     };
     use crate::adapter::reach_rescue::{RescueVerdict, reach_portfolio_rescue};
-    use crate::adapter::recoverability::verify_recoverability_scalable;
+    use crate::adapter::recoverability::{verify_recoverability, verify_recoverability_scalable};
     use crate::mu_calculus::{PropertyClass, parser as mu_parser};
     use crate::verdict::PropertyVerdict;
 
@@ -2573,7 +2573,21 @@ fn escalate_bottom(
                     // smt-hyper-must νμ path and abstains (Unknown) if it cannot decide,
                     // so a ⊥ is only ever upgraded to a DEFINITE verdict.
                     let good_str = format!("{} == {}", good.signal, good.value);
-                    if let Ok(v) = verify_recoverability_scalable(design_btor2, &good_str, &[]) {
+                    // ③a routing — try the EXACT+COI recoverability engine FIRST. On a
+                    // control signal whose cone-of-influence fits the bit cap (e.g. a
+                    // wishbone `ack`/`err` whose cone excludes the datapath), exact+COI
+                    // decides the νμ recoverability the cube + smt-hyper-must *abstains*
+                    // on — `verify_recoverability` runs exact and falls to the scalable
+                    // cube path only on an over-cap `Err`. Gated on `reset_pinned`: the
+                    // exact engine is sound only under reset-gating (A.6); with a free
+                    // reset use the cube path, whose over-approximating may-relation
+                    // soundly includes the reset edge.
+                    let recov = if reset_pinned {
+                        verify_recoverability(design_btor2, &good_str)
+                    } else {
+                        verify_recoverability_scalable(design_btor2, &good_str, &[])
+                    };
+                    if let Ok(v) = recov {
                         match v {
                             PropertyVerdict::Holds => {
                                 prop.outcome = VerifyOutcome::Holds;
@@ -2634,18 +2648,21 @@ fn rescue_note(name: &str, verdict: &str, engines: &[&str]) -> VerificationNote 
     }
 }
 
-/// A provenance note for a νμ recoverability property the cube + smt-hyper-must path
-/// rescued from `⊥`.
+/// A provenance note for a νμ recoverability property rescued from `⊥` — by the exact+COI
+/// engine (reset-gated) if its cone fits the bit cap, else the scalable cube + smt-hyper-must
+/// path.
 fn recoverability_rescue_note(name: &str, verdict: &str) -> VerificationNote {
     VerificationNote {
         kind: "recoverability-rescue".into(),
         level: NoteLevel::Info,
         summary: format!(
-            "`{name}`: the cube abstraction left ⊥; the cube + smt-hyper-must νμ path decided \
-             the recoverability property {verdict}"
+            "`{name}`: the cube abstraction left ⊥; the νμ recoverability path (exact+COI \
+             first, then cube + smt-hyper-must) decided it {verdict}"
         ),
-        detail: "The AG EF (recoverability) ⊥ was escalated to the sound predicate-cube + \
-                 smt-hyper-must path (definite νμ verdicts transfer per Bruns–Godefroid / \
+        detail: "The AG EF (recoverability) ⊥ was escalated: exact+COI decides it directly when \
+                 the property's cone fits the bit cap (a wishbone/status control signal whose \
+                 cone excludes the datapath), else the sound predicate-cube + smt-hyper-must \
+                 path. Definite νμ verdicts transfer (exact = oracle; cube per Bruns–Godefroid / \
                  Shoham–Grumberg); box-AF liveness and safety take their own reductions."
             .into(),
         items: Vec::new(),
@@ -3007,6 +3024,38 @@ mod tests {
             matches!(report.properties[0].outcome, VerifyOutcome::Holds),
             "the ⊥ νμ recoverability property must be rescued to Holds by the cube + smt-hyper-must \
              path (property-directed seeding), got {:?}",
+            report.properties[0].outcome
+        );
+        assert!(
+            notes.iter().any(|n| n.kind == "recoverability-rescue"),
+            "a recoverability-rescue provenance note should be recorded"
+        );
+    }
+
+    // ③a routing — under reset-gating, a ⊥ νμ recoverability property is routed through the
+    // EXACT+COI engine (which decides control-cone recoverability the cube abstains on), not
+    // only the scalable cube path. A 2-bit wrapping counter (0→1→2→3→0) satisfies
+    // `AG EF (cnt == 0)` — every state returns to 0 — and exact decides it Holds.
+    #[test]
+    fn escalate_bottom_recoverability_uses_exact_when_reset_pinned() {
+        const COUNTER: &str = "1 sort bitvec 2\n2 sort bitvec 1\n3 zero 1\n4 one 1\n\
+                               5 state 1 cnt\n6 init 1 5 3\n7 add 1 5 4\n8 next 1 5 7\n";
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "recover_to_zero".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                formula: "nu Y.((mu X.(cnt == 0 || <> X)) && [] Y)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        // reset_pinned = true → the ③a exact-first routing is enabled (A.6 sound).
+        let notes = escalate_bottom(&mut report, COUNTER, true, &VerifyAutoOptions::default());
+        assert!(
+            matches!(report.properties[0].outcome, VerifyOutcome::Holds),
+            "reset-pinned recoverability ⊥ must be rescued to Holds via exact+COI, got {:?}",
             report.properties[0].outcome
         );
         assert!(


### PR DESCRIPTION
## What

verify-auto's default engine is the predicate **cube** (`EngineArg::Explicit`), which **abstains (⊥)** on νμ-recoverability properties whose control cone **exact-symbolic+COI decides trivially** — e.g. a wishbone `ack`/`err` recoverability whose cone-of-influence excludes the datapath. The cube's ⊥ escalates to `escalate_bottom`'s recoverability arm, which called `verify_recoverability_scalable` **directly** — the cube + smt-hyper-must path, which abstains the same way.

But `verify_recoverability` **already tries the exact engine first** (falling to the scalable path only on an over-cap `Err`). This routes the rescue through `verify_recoverability` instead of the scalable path directly, so a ⊥ recoverability property gets the exact+COI attempt that decides it.

## Why it's sound

`verify_recoverability` runs `exact_symbolic_verdict` (the differential **oracle**) and returns its verdict when definite, else falls to the scalable cube path — so this can only **add** definite verdicts, never change one. Gated on **`reset_pinned`** (the exact engine is sound only under reset-gating, A.6); with a free reset the cube path is used (its over-approximating may-relation soundly includes the reset edge). No behavioral change when reset is not gated.

## Root cause (from the corpus-coverage arc)

xgate's `AG EF (wbs_ack_o==0)` / `(wbs_err_o==0)` **decide HOLDS via `--engine exact-symbolic`** (2/2, a ~5-var COI cone — the RISC datapath is pruned, not bit-blasted) but **⊥ under the default cube**. The ⊥ was *engine choice*, not the design. (The broader fix — aligning the CLI `--engine` default with the documented `portfolio-sequential` — is a follow-up needing full-suite regression validation.)

## Validation

- **Unit**: `escalate_bottom_recoverability_uses_exact_when_reset_pinned` (a wrapping counter's `AG EF (cnt==0)` decides Holds via exact when reset-pinned); `escalate_bottom_routes_recoverability_to_cube` unchanged (reset_pinned=false → cube path — no regression).
- **E2E in the `mununu-sva` image** (with the yosys-slang lift so xgate's RISC core is modeled): xgate's **default** `sv verify-auto` on `AG EF (wbs_ack_o==0)` was **⊥**; with this fix it decides **HOLDS**, note: *"the cube abstraction left ⊥; the νμ recoverability path (exact+COI first, then cube + smt-hyper-must) decided it HOLDS."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
