### PR TITLE
feat(verify-auto): default to the portfolio (exact-first), not the bare cube (broad ③a)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1644,17 +1644,19 @@ struct SvVerifyAutoArgs {
     /// Print a JSON report instead of the human-readable summary.
     #[arg(long)]
     json: bool,
-    /// R-F5.5d (2026-07-03) — predicate-cube engine: `explicit` (default) or
-    /// `symbolic` (R-F5 BDD relation + CEGAR loop, no per-cube-pair SMT — orders
-    /// of magnitude faster at large `|P|`, the FSM-cone residual). Symbolic
-    /// supports cube-dimension predicates (equality + non-derived compounds) +
-    /// the bare `[]`/`<>` fragment; a derived predicate or guarded modality
-    /// `Skipped`s that property. D1.6 (2026-07-04) — `exact-symbolic` decides
-    /// each property EXACTLY over the reset-gated design's full bit-blasted state
-    /// (no predicate abstraction, so a **definite** 2-valued verdict, never ⊥) —
-    /// it decides `AF`-liveness where both cube engines return Unknown; bounded by
-    /// BDD size (a design too large to bit-blast ⇒ the property is `Skipped`).
-    #[arg(long, value_enum, default_value_t = EngineArg::Explicit)]
+    /// Verify engine. **Default `portfolio-sequential`** (③a, 2026-07-23): run
+    /// `exact-symbolic` → `symbolic` → `explicit` in precision order, merging and
+    /// early-exiting the moment every property is decided. Exact-first because the
+    /// exact engine decides a control property whose cone-of-influence fits the bit
+    /// cap directly (and *cleanly skips* an over-cap cone), where the bare
+    /// predicate-cube `explicit` engine can ⊥ or grind on a wide combinational cone;
+    /// the cube legs still catch what exact skips (input-antecedent, over-cap). Pin a
+    /// single engine with `--engine explicit` (predicate-cube + CEGAR), `symbolic`
+    /// (R-F5 BDD relation, no per-cube-pair SMT), or `exact-symbolic` (EXACT over the
+    /// reset-gated full bit-blast — a **definite** 2-valued verdict, never ⊥; bounded
+    /// by BDD size, over-cap ⇒ `Skipped`). NB: a pinned bare `explicit` on a wide
+    /// combinational cone can hang unless `MUNUNU_CUBE_SMT_RLIMIT` is set (③b).
+    #[arg(long, value_enum, default_value_t = EngineArg::PortfolioSequential)]
     engine: EngineArg,
     #[command(flatten)]
     ci: CiArgs,


### PR DESCRIPTION
> **Broad default change** — pairs with #374 (③b cube rlimit). CI's full test suite is the regression gate; review together.

## What

`sv verify-auto`'s `--engine` default was `EngineArg::Explicit` (the bare predicate cube), which **contradicted** the documented + unit-tested default — `engine_selection(None)` already returns `portfolio-sequential`, and `engine-routing.md` describes the default as portfolio-sequential. The CLI simply never sent `None`. This one-line change **aligns the CLI default with that intent**: `exact-symbolic → symbolic → explicit` in precision order, early-exit when all decided.

## Why (measured — the corpus size-probe)

The exact engine **decides** a control property whose cone-of-influence fits the bit cap, and **cleanly skips** an over-cap cone — whereas the bare cube can **⊥ or grind** on a wide combinational cone (freed-input fanin of 100–250 bits). Under forced exact: **i2c 9/16, uart 14/15**. Under the bare cube: **i2c hung (0/16)**. Exact-first captures those decisions *and* avoids the hang; the cube legs still catch what exact skips (input-antecedent atoms, over-cap cones).

## Pairs with ③b (#374)

The portfolio's cube legs run for props exact skipped; on a wide combinational cone those can still grind, so the deterministic cube rlimit (`MUNUNU_CUBE_SMT_RLIMIT`, #374) bounds them to a fast sound ⊥. **Together: i2c 0/16-hung → 9 decided + fast ⊥ on the rest.**

## Soundness / regression

Every portfolio member is sound; the merge raises a `contradiction` alarm on disagreement rather than guessing (existing `verify_auto_portfolio`). `engine_selection_defaults_to_portfolio_sequential` already asserts this default at the core layer. **The full CI test suite is the regression gate** for the CLI-default change — this is the conservative "make it the documented default" step; the safe rollout was previously behind the `engine_selection` default that the CLI wasn't using.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
