### PR TITLE
feat(exact): auto-cap-management — decide modestly-wide concrete cones without a manual env cap (Phase 4)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/native_bmc.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_bmc.rs
@@ -554,10 +554,10 @@ mod tests {
     // `q` init 0, `next q = 0` (stays 0), `bad = q`. Never violated (bounded safe).
     const SAFE: &str = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 next 1 3 2\n\
                         6 bad 3\n";
-    // 64-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
-    // depth 5. The 64-bit cone is OVER the exact engine's 40-bit cap, so only a
-    // SAT-based engine (this) decides it — the beyond-cap scale win.
-    const WIDE: &str = "1 sort bitvec 64\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
+    // 80-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
+    // depth 5. The 80-bit cone is OVER the exact engine's auto-cap ceiling (64), so
+    // only a SAT-based engine (this) decides it — the beyond-cap scale win.
+    const WIDE: &str = "1 sort bitvec 80\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
                         6 add 1 4 3\n7 next 1 4 6\n8 constd 1 5\n9 sort bitvec 1\n\
                         10 eq 9 4 8\n11 bad 10\n";
 
@@ -574,7 +574,7 @@ mod tests {
         // Reaches bad at depth 1 / 5 — the deep CEX-only search returns the depth.
         let reach = parser::parse(REACH).expect("parse");
         assert_eq!(bmc_cex_until(&reach, 64, 5_000, far, &never), Some(1));
-        let wide = parser::parse(WIDE).expect("parse"); // depth 5, 64-bit (beyond exact cap)
+        let wide = parser::parse(WIDE).expect("parse"); // depth 5, 80-bit (beyond the auto-cap ceiling)
         assert_eq!(bmc_cex_until(&wide, 64, 5_000, far, &never), Some(5));
         // Bounded-safe design → no CEX within the depth budget → None (never a wrong verdict).
         let safe = parser::parse(SAFE).expect("parse");
@@ -646,8 +646,8 @@ mod tests {
 
     #[test]
     fn decides_beyond_the_exact_40_bit_cap() {
-        // A 64-bit reachability the exact BDD engine abstains on (over-cap); native
-        // BMC finds the depth-5 counterexample bit-precisely.
+        // An 80-bit reachability the exact BDD engine abstains on (over the 64-bit auto-cap
+        // ceiling); native BMC finds the depth-5 counterexample bit-precisely.
         assert_eq!(bmc(WIDE, 10), BmcOutcome::Violated { depth: 5 });
         // And with too small a bound it is honestly bounded, never a wrong SAFE.
         assert_eq!(bmc(WIDE, 3), BmcOutcome::NoCexWithin { k: 3 });
@@ -730,10 +730,10 @@ mod tests {
 
     #[test]
     fn k_induction_proves_safe_beyond_the_exact_40_bit_cap() {
-        // A 64-bit register that stays 0, `bad = (big != 0)`. The exact BDD engine
-        // abstains (over-cap); native k-induction proves it SAFE (1-inductive)
-        // bit-precisely — an in-house UNBOUNDED safety proof past the cap.
-        let wide_safe = "1 sort bitvec 64\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
+        // An 80-bit register that stays 0, `bad = (big != 0)`. The exact BDD engine
+        // abstains (over the 64-bit auto-cap ceiling); native k-induction proves it SAFE
+        // (1-inductive) bit-precisely — an in-house UNBOUNDED safety proof past the cap.
+        let wide_safe = "1 sort bitvec 80\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
                          5 next 1 3 3\n6 sort bitvec 1\n7 neq 6 3 2\n8 bad 7\n";
         assert_eq!(safety(wide_safe, 10), SafetyVerdict::Safe { k: 1 });
     }
@@ -766,8 +766,8 @@ mod tests {
         // The roadmap's `synth_pipeline(W)` signal, distilled to a scale CURVE: a
         // W-bit register that stays 0 (`AG(big == 0)`, encoded `bad = big != 0`),
         // swept over widths. The native k-induction engine proves it SAFE at EVERY
-        // width; the exact BDD engine ABSTAINS once the cone exceeds its 40-bit cap.
-        // That is the in-house scale win charted, not asserted by hand.
+        // width; the exact BDD engine ABSTAINS once the cone exceeds its cap (the
+        // auto-cap ceiling, 64). That is the in-house scale win charted, not asserted by hand.
         use crate::adapter::btor2::symbolic_bitblast::exact_bad_reachable;
         let wide_safe = |w: u32| -> String {
             format!(
@@ -784,9 +784,11 @@ mod tests {
                 "native must prove W={w} SAFE"
             );
         }
-        // The exact engine abstains once the cone is over-cap (≥64 bits here),
-        // where the native engine still decides — the scale delta.
-        for w in [64u32, 128, 256, 512] {
+        // The exact engine abstains once the cone is over-cap (> 64 bits, the auto-cap
+        // ceiling), where the native engine still decides — the scale delta. (At W=64 the
+        // auto-cap now admits the cone and exact DECIDES — covered by
+        // `symbolic_bitblast::auto_cap_admits_modestly_wide_concrete_cone`.)
+        for w in [80u32, 128, 256, 512] {
             assert!(
                 exact_bad_reachable(&wide_safe(w)).is_err(),
                 "the exact engine must abstain (over-cap) at W={w}"

--- a/crates/mununu-core/src/adapter/btor2/native_boolector.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_boolector.rs
@@ -532,10 +532,10 @@ mod tests {
     // `q` init 0, `next q = 0`: never violated (bounded safe).
     const SAFE: &str = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 next 1 3 2\n\
                         6 bad 3\n";
-    // 64-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
-    // depth 5 — a cone OVER the exact engine's 40-bit cap, so a BV engine is the
-    // only one that decides it.
-    const WIDE: &str = "1 sort bitvec 64\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
+    // 80-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
+    // depth 5 — a cone OVER the exact engine's auto-cap ceiling (64), so a BV engine
+    // is the only one that decides it.
+    const WIDE: &str = "1 sort bitvec 80\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
                         6 add 1 4 3\n7 next 1 4 6\n8 constd 1 5\n9 sort bitvec 1\n\
                         10 eq 9 4 8\n11 bad 10\n";
 

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -127,23 +127,49 @@ use crate::mu_calculus::{Control, Formula, FormulaVarId, Guard, ModalKind, Node 
 /// blowup into a clean `Skipped` instead of an OoM panic (the 2026-07-06 `prim_esc_receiver`
 /// failure). Those make it SAFE to raise the cap.
 ///
-/// The effective cap is `MUNUNU_BDD_MAX_BITS` when set (clamped to [`HARD_BITBLAST_CEILING`]),
-/// else this default. The default stays 40 because a wide **counter** has a small BDD but a
-/// slow (`2^W`-iteration) fixpoint the node-budget guard does not catch — raising the default
-/// safely needs an iteration budget too, so for now widening is opt-in.
+/// The conservative default bit cap when `MUNUNU_BDD_MAX_BITS` is unset — the *floor* the
+/// auto-cap never goes below. The common control cone fits well under it, and the tiered arena
+/// (below) keeps the ≤ 40-bit path allocation-identical. A concrete cone that modestly exceeds
+/// it is admitted automatically up to [`AUTO_CAP_CEILING`]; see [`effective_bitblast_cap`].
 const MAX_BITBLAST_BITS: u32 = 40;
+
+/// Auto-cap-management ceiling (verification-execution-planner Phase 4.6). With NO explicit
+/// `MUNUNU_BDD_MAX_BITS`, a concrete cone up to this width is admitted even though it exceeds
+/// the conservative [`MAX_BITBLAST_BITS`] default, so exact decides the CONCRETE model directly
+/// (no abstraction) instead of Skipping to the cube. This is sound now that BOTH failure modes
+/// a wider cone could hit bail deterministically: the mid-build node-budget guard
+/// ([`BddBitBlaster::node_budget`]) bounds BDD *size*, and the fixpoint iteration budget
+/// ([`fixpoint_iter_budget`], #369) bounds the `2^W`-diameter *counter* fixpoint the node guard
+/// alone misses — the exact reason the default stayed at 40 until that budget shipped. 64
+/// covers word-wide control designs (e.g. the OpenTitan i2c `AG EF ack` cone) while staying
+/// inside both guards' bounded-attempt cost; a wider cone still needs an explicit env opt-in.
+const AUTO_CAP_CEILING: u32 = 64;
 
 /// Absolute ceiling the `MUNUNU_BDD_MAX_BITS` override is clamped to — bounds the largest
 /// arena we will allocate regardless of the env value.
 const HARD_BITBLAST_CEILING: u32 = 256;
 
-/// The effective bit cap: the `MUNUNU_BDD_MAX_BITS` override (clamped) or the default.
-fn effective_bitblast_cap() -> u32 {
-    std::env::var("MUNUNU_BDD_MAX_BITS")
+/// The default cap for a cone of `cone_bits` KEPT bits when no env override is present: the
+/// [`MAX_BITBLAST_BITS`] floor, auto-raised to fit the concrete cone up to [`AUTO_CAP_CEILING`]
+/// (never lowered below the floor). Pure — no env read — so the auto-raise thresholds are
+/// unit-testable without touching process-global state.
+fn default_cap_for_cone(cone_bits: u32) -> u32 {
+    MAX_BITBLAST_BITS.max(cone_bits.min(AUTO_CAP_CEILING))
+}
+
+/// The effective bit cap for a cone of `cone_bits` KEPT register+input bits. An explicit
+/// `MUNUNU_BDD_MAX_BITS` is respected exactly (clamped to [`HARD_BITBLAST_CEILING`]) — the user
+/// asked for a specific limit, so we neither raise nor lower it. With NO override, the cap is
+/// [`default_cap_for_cone`]: the conservative default auto-raised to admit a modestly-wide
+/// concrete cone.
+fn effective_bitblast_cap(cone_bits: u32) -> u32 {
+    match std::env::var("MUNUNU_BDD_MAX_BITS")
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
-        .map(|v| v.min(HARD_BITBLAST_CEILING))
-        .unwrap_or(MAX_BITBLAST_BITS)
+    {
+        Some(v) => v.min(HARD_BITBLAST_CEILING),
+        None => default_cap_for_cone(cone_bits),
+    }
 }
 
 /// A bit-vector of BDDs, LSB-first: index `b` is the BDD for bit `b`. Every
@@ -251,9 +277,10 @@ impl BddBitBlaster {
         // R-F5.6 guard — the bit-blaster builds BDDs over every KEPT register+input bit. The
         // bit COUNT is only a crude upper bound on cost (a ROBDD shares structure), so the real
         // robustness gate is the node-budget guard below; this cap just avoids allocating a
-        // large arena for an absurdly wide cone. The cap is `MUNUNU_BDD_MAX_BITS` (clamped) or
-        // the default 40 — see [`effective_bitblast_cap`].
-        let cap = effective_bitblast_cap();
+        // large arena for an absurdly wide cone. The cap is `MUNUNU_BDD_MAX_BITS` (clamped) or,
+        // with no override, the default auto-raised to fit a modestly-wide concrete cone up to
+        // `AUTO_CAP_CEILING` — see [`effective_bitblast_cap`].
+        let cap = effective_bitblast_cap(total_bits);
         if total_bits > cap {
             return Err(format!(
                 "symbolic bit-blaster: design has {total_bits} register+input bits \
@@ -263,8 +290,9 @@ impl BddBitBlaster {
         }
 
         // Arena sizing, TIERED so the common (≤ 40-bit) path is UNCHANGED — 2M inner nodes
-        // (~32 MB) + 512K apply cache. A WIDE cone (only reachable when the cap is raised via
-        // env) gets a larger, env-tunable arena; the node-budget guard (80 % of the arena)
+        // (~32 MB) + 512K apply cache. A WIDE cone (reachable when the auto-cap admits a
+        // modestly-wide concrete cone, or the cap is raised further via env) gets a larger,
+        // env-tunable arena; the node-budget guard (80 % of the arena)
         // bails cleanly before it overflows, and `catch_unwind` is the backstop for a single op
         // that jumps the budget in one apply. The manager is dropped per `BddBitBlaster`, so at
         // most one arena is live at a time.
@@ -4367,19 +4395,22 @@ mod tests {
 
     /// D1.7 — the exact engine DEGRADES GRACEFULLY on a design too large to
     /// bit-blast. `BddBitBlaster::build` rejects a design whose register+input
-    /// bit count exceeds `MAX_BITBLAST_BITS` (40) with a clean `Err` — and does so
+    /// bit count exceeds the effective cap with a clean `Err` — and does so
     /// BEFORE allocating the BDD manager, so there is no OoM / hang. `build` is the
     /// first thing `exact_symbolic_verdict` calls, so the whole exact path returns
     /// `Err` (which `verify_auto`'s exact branch maps to a `Skipped` property, per
     /// `e2e_sysrst`-style graceful degradation). This locks that OoM-safety
-    /// guarantee for the exact path as a fast, non-docker regression.
+    /// guarantee for the exact path as a fast, non-docker regression. The fixture is
+    /// 80-bit — over the [`AUTO_CAP_CEILING`] (64) the no-env auto-cap will admit,
+    /// so it still degrades. (The 41–64-bit admit path is covered by
+    /// `auto_cap_admits_modestly_wide_concrete_cone`.)
     #[test]
     fn d1_7_exact_verdict_over_bit_cap_degrades_gracefully() {
-        // One 48-bit register (48 > the default 40-bit cap), no inputs. The formula is
+        // One 80-bit register (80 > AUTO_CAP_CEILING = 64), no inputs. The formula is
         // immaterial: the cap fires in `build`, before atom resolution or fixpoint
         // evaluation, so a caller degrades to Skipped rather than OoM.
         const WIDE_BTOR2: &str = r#"
-1 sort bitvec 48
+1 sort bitvec 80
 2 sort bitvec 1
 3 state 1 wide
 4 one 1
@@ -4388,11 +4419,62 @@ mod tests {
 "#;
         let formula = crate::mu_calculus::parser::parse("(wide == 0)").expect("formula parses");
         let err = exact_symbolic_verdict(WIDE_BTOR2, &formula)
-            .expect_err("48-bit design exceeds the default MAX_BITBLAST_BITS (40) → clean Err");
+            .expect_err("80-bit design exceeds the auto-cap ceiling (64) → clean Err");
         assert!(
-            err.contains("register+input bits") && err.contains("48"),
+            err.contains("register+input bits") && err.contains("80"),
             "the error must name the bit count + cap so a caller can degrade to \
              Skipped; got: {err}"
+        );
+    }
+
+    /// Auto-cap-management (verification-execution-planner Phase 4.6) — with NO explicit
+    /// `MUNUNU_BDD_MAX_BITS`, a concrete cone that modestly exceeds the conservative 40-bit
+    /// default is admitted up to [`AUTO_CAP_CEILING`] (64), so exact decides the CONCRETE model
+    /// directly instead of Skipping. Locks (a) the pure `default_cap_for_cone` thresholds and
+    /// (b) that a 48-bit concrete cone — which the old 40-bit default rejected (see `d1_7`,
+    /// which used exactly this width before the ceiling shipped) — now DECIDES. No env mutation:
+    /// the positive case relies on the default (env-unset) path; if `MUNUNU_BDD_MAX_BITS` is set
+    /// in the environment the assertion is skipped rather than falsely failing.
+    #[test]
+    fn auto_cap_admits_modestly_wide_concrete_cone() {
+        // Pure threshold math (no env, no BDD): the default floor is never lowered; a 41–64-bit
+        // cone raises the cap to fit; a > 64-bit cone is clamped to the ceiling (⇒ Err upstream).
+        assert_eq!(default_cap_for_cone(8), 40, "≤ floor ⇒ the 40-bit floor");
+        assert_eq!(default_cap_for_cone(40), 40, "exactly the floor");
+        assert_eq!(
+            default_cap_for_cone(48),
+            48,
+            "41–64 ⇒ raised to fit the cone"
+        );
+        assert_eq!(default_cap_for_cone(64), 64, "exactly the ceiling");
+        assert_eq!(
+            default_cap_for_cone(80),
+            64,
+            "> ceiling ⇒ clamped (build then Errs)"
+        );
+
+        // End-to-end: a 48-bit counter cone the old default Skipped now bit-blasts and decides.
+        // `wide` inits to 0 and increments, so `(wide == 0)` holds in the initial state — a
+        // definite verdict only reachable if the cone was admitted (not Skipped).
+        if std::env::var_os("MUNUNU_BDD_MAX_BITS").is_some() {
+            return; // an explicit cap overrides the auto-raise; don't assert against it
+        }
+        const CONE48: &str = r#"
+1 sort bitvec 48
+2 sort bitvec 1
+3 state 1 wide
+4 zero 1
+5 init 1 3 4
+6 one 1
+7 add 1 3 6
+8 next 1 3 7
+"#;
+        let formula = crate::mu_calculus::parser::parse("(wide == 0)").expect("formula parses");
+        assert_eq!(
+            exact_symbolic_verdict(CONE48, &formula),
+            Ok(ExactVerdict::Holds),
+            "a 48-bit concrete cone (> the 40-bit floor, ≤ the 64-bit ceiling) must be \
+             admitted by the auto-cap and decided, not Skipped"
         );
     }
 
@@ -4423,17 +4505,19 @@ mod tests {
     }
 
     /// R-F5.6 — cone-of-influence restriction lifts the bit cap when the property's cone is
-    /// small even though the FULL design is over 40 bits. `fsm` (2-bit) cycles 1→2→3→0→…; `wide`
-    /// (45-bit) is an out-of-cone counter `fsm` never reads. The full build hits the cap (47 >
-    /// 40), but `exact_symbolic_verdict` restricts to the cone of `fsm == 0` = {fsm} (pinning
-    /// `wide` to a constant) and DECIDES `EF (fsm == 0)` = Holds. Locks that (a) COI is wired
-    /// into the exact path, and (b) pinning the out-of-cone datapath is verdict-preserving —
-    /// the whole point of R-F5.6, as a fast non-docker regression.
+    /// small even though the FULL design is over the cap. `fsm` (2-bit) cycles 1→2→3→0→…; `wide`
+    /// (70-bit) is an out-of-cone counter `fsm` never reads. The full build hits the cap (72 >
+    /// the 64-bit auto-cap ceiling), but `exact_symbolic_verdict` restricts to the cone of
+    /// `fsm == 0` = {fsm} (pinning `wide` to a constant) and DECIDES `EF (fsm == 0)` = Holds.
+    /// `wide` is 70-bit (not 45) so the full design exceeds the auto-cap ceiling — COI, not the
+    /// auto-raise, is what makes this decidable. Locks that (a) COI is wired into the exact path,
+    /// and (b) pinning the out-of-cone datapath is verdict-preserving — the whole point of
+    /// R-F5.6, as a fast non-docker regression.
     #[test]
     fn rf5_6_coi_lifts_bit_cap_on_out_of_cone_datapath() {
         const FSM_PLUS_WIDE_CTR: &str = r#"
 1 sort bitvec 2
-2 sort bitvec 45
+2 sort bitvec 70
 3 state 1 fsm
 4 one 1
 5 add 1 3 4
@@ -4445,12 +4529,12 @@ mod tests {
 11 add 2 9 10
 12 next 2 9 11
 "#;
-        // The full design is 2 + 45 = 47 bits — over the cap.
+        // The full design is 2 + 70 = 72 bits — over the 64-bit auto-cap ceiling.
         let file = parser::parse(FSM_PLUS_WIDE_CTR).expect("parse");
         let full_err = BddBitBlaster::build(&file).err();
         assert!(
-            full_err.as_ref().is_some_and(|e| e.contains("47")),
-            "full 47-bit build must still hit the cap; got {full_err:?}",
+            full_err.as_ref().is_some_and(|e| e.contains("72")),
+            "full 72-bit build must still hit the cap; got {full_err:?}",
         );
         // The exact verdict restricts to the {fsm} cone (2 bits), pinning `wide` → decidable.
         // `fsm` inits to 1 and cycles to 0, so `EF (fsm == 0)` holds from the initial state.

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -733,12 +733,12 @@ mod tests {
 
     #[test]
     fn native_engine_decides_beyond_the_exact_cap_in_portfolio() {
-        // A 64-bit register that stays 0, `bad = (big != 0)`: SAFE, but the 64-bit
-        // cone is over the exact engine's 40-bit cap. With no btormc/pono on PATH
-        // and the exact engine abstaining, the portfolio would previously be
+        // An 80-bit register that stays 0, `bad = (big != 0)`: SAFE, but the 80-bit
+        // cone is over the exact engine's auto-cap ceiling (64). With no btormc/pono on
+        // PATH and the exact engine abstaining, the portfolio would previously be
         // Unknown; the in-house native engine (k-induction) now proves it
         // Unreachable — the scale win, in-process, no subprocess.
-        const WIDE_SAFE: &str = "1 sort bitvec 64\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
+        const WIDE_SAFE: &str = "1 sort bitvec 80\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
                                  5 next 1 3 3\n6 sort bitvec 1\n7 neq 6 3 2\n8 bad 7\n";
         let file = parser::parse(WIDE_SAFE).expect("parse");
         let out = decide_reach_portfolio(&file);
@@ -749,21 +749,21 @@ mod tests {
         );
         assert!(
             !out.unreachable_by.contains(&"exact"),
-            "the exact engine must abstain on the over-cap 64-bit design: {out:?}"
+            "the exact engine must abstain on the over-cap 80-bit design: {out:?}"
         );
     }
 
     #[test]
     fn spacer_decides_beyond_native_k_induction_in_portfolio() {
-        // A 64-bit counter that STALLS at 0 (init 0, next = (c==0)?0:c+1), bad = (c==MAX).
+        // An 80-bit counter that STALLS at 0 (init 0, next = (c==0)?0:c+1), bad = (c==MAX).
         // Reachable set is {0} ⇒ SAFE, but:
-        //   - the exact BDD engine abstains (64-bit > its 40-bit cone cap);
+        //   - the exact BDD engine abstains (80-bit > its auto-cap ceiling of 64);
         //   - native k-induction abstains — the property is not provable by *simple*
         //     k-induction: an unreachable free path MAX-k → … → MAX stays ¬bad until
-        //     the last step at every depth, so it never closes below depth 2^64-1.
+        //     the last step at every depth, so it never closes below depth 2^80-1.
         // Only SPACER's invariant discovery (`c == 0`) decides it, so the portfolio
         // verdict is carried uniquely by "spacer". (btormc/pono absent in make-ci.)
-        const WIDE_STALL: &str = "1 sort bitvec 64\n2 zero 1\n3 one 1\n4 state 1 c\n5 init 1 4 2\n\
+        const WIDE_STALL: &str = "1 sort bitvec 80\n2 zero 1\n3 one 1\n4 state 1 c\n5 init 1 4 2\n\
              6 sort bitvec 1\n7 eq 6 4 2\n8 add 1 4 3\n9 ite 1 7 2 8\n\
              10 next 1 4 9\n11 ones 1\n12 eq 6 4 11\n13 bad 12\n";
         let file = parser::parse(WIDE_STALL).expect("parse");
@@ -779,7 +779,7 @@ mod tests {
         );
         assert!(
             !out.unreachable_by.contains(&"exact"),
-            "the exact engine must abstain on the over-cap 64-bit design: {out:?}"
+            "the exact engine must abstain on the over-cap 80-bit design: {out:?}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -335,12 +335,12 @@ mod tests {
 13 init 2 6 5
 ";
 
-    /// A 64-bit register `big` that stays 0 — `AG(big == 0)` HOLDS and is
-    /// 1-inductive. The 64-bit cone EXCEEDS the exact engine's 40-bit cap, so the
-    /// exact member abstains and only the subprocess members (btormc k-induction /
+    /// An 80-bit register `big` that stays 0 — `AG(big == 0)` HOLDS and is
+    /// 1-inductive. The 80-bit cone EXCEEDS the exact engine's auto-cap ceiling (64), so
+    /// the exact member abstains and only the subprocess members (btormc k-induction /
     /// Pono IC3) can decide it — the "beyond the BDD cap" value proof.
     const WIDE_STATE: &str = "\
-1 sort bitvec 64
+1 sort bitvec 80
 2 zero 1
 3 state 1 big
 4 init 1 3 2
@@ -380,8 +380,8 @@ mod tests {
     #[test]
     #[ignore = "requires btormc + pono (mununu-sva); run with --ignored"]
     fn e2e_rescue_decides_beyond_exact_cap() {
-        // A 64-bit invariant the exact BDD engine cannot touch (over its 40-bit
-        // cap) — proving the subprocess members extend reach past the cap. The
+        // An 80-bit invariant the exact BDD engine cannot touch (over its auto-cap
+        // ceiling of 64) — proving the subprocess members extend reach past the cap. The
         // exact member must ABSTAIN; a subprocess member must carry the verdict.
         let f = parse("nu X. ((big == 0) && [] X)");
         let (verdict, outcome) =
@@ -389,7 +389,7 @@ mod tests {
         assert_eq!(verdict, RescueVerdict::Holds, "outcome: {outcome:?}");
         assert!(
             !outcome.unreachable_by.contains(&"exact"),
-            "the exact engine must abstain on the 64-bit (over-cap) design; got {outcome:?}"
+            "the exact engine must abstain on the 80-bit (over-cap) design; got {outcome:?}"
         );
         assert!(
             outcome

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -2180,13 +2180,20 @@ mod tests {
         assert_eq!(recoverability_property_str("st == 0"), "AG EF (st == 0)");
     }
 
-    // A ≥48-bit free-running counter (over the exact ~40-bit cone cap) whose value
+    // An 80-bit free-running counter (over the 64-bit auto-cap ceiling) whose value
     // gates a small 2-state FSM (`st`: 0=idle, 1=busy). The counter feeds st's
     // next-state (idle advances to busy only when `cnt == 0`), so the counter is IN
     // st's cone-of-influence → the exact engine over-caps. busy ALWAYS returns to idle,
     // so every reachable state can reach idle ⇒ AG EF (st==0) HOLDS.
+    //
+    // Width note: this MUST exceed AUTO_CAP_CEILING (64), not just the 40-bit floor. For an
+    // `AG EF (control-target)` property the EF-reachability fixpoint converges in ~2 iterations
+    // regardless of the counter's width (a free-running counter never *blocks* reaching idle),
+    // so the fixpoint iteration budget never fires — only the bit cap does. At ≤ 64 bits the
+    // auto-cap would admit the cone and exact would DECIDE (a win), defeating the "exact
+    // abstains" premise this test needs.
     const WIDE_RECOVERABLE: &str = "\
-1 sort bitvec 48
+1 sort bitvec 80
 2 sort bitvec 2
 3 sort bitvec 1
 4 state 1 cnt
@@ -2205,12 +2212,12 @@ mod tests {
 17 next 2 9 16
 ";
 
-    // Same 48-bit counter (over the exact cap) but st's next-state is `stuck (2)`
-    // UNCONDITIONALLY — the `ite(cnt==0, 2, 2)` keeps the counter syntactically in st's
-    // cone (so the exact engine over-caps) while every state moves to the absorbing
-    // trap. From `stuck`, idle is unreachable ⇒ AG EF (st==0) VIOLATED.
+    // Same 80-bit counter (over the 64-bit auto-cap ceiling, per WIDE_RECOVERABLE's width note)
+    // but st's next-state is `stuck (2)` UNCONDITIONALLY — the `ite(cnt==0, 2, 2)` keeps the
+    // counter syntactically in st's cone (so the exact engine over-caps) while every state moves
+    // to the absorbing trap. From `stuck`, idle is unreachable ⇒ AG EF (st==0) VIOLATED.
     const WIDE_TRAP: &str = "\
-1 sort bitvec 48
+1 sort bitvec 80
 2 sort bitvec 2
 3 sort bitvec 1
 4 state 1 cnt
@@ -2282,12 +2289,12 @@ mod tests {
     }
 
     // === The proof the slice decides AT SCALE ==================================
-    // On a design whose cone exceeds the exact ~40-bit cap, the exact engine ABSTAINS
-    // (Unknown) while the cube path DECIDES — in both polarities.
+    // On a design whose cone exceeds the exact auto-cap ceiling (64), the exact engine
+    // ABSTAINS (Unknown) while the cube path DECIDES — in both polarities.
 
     #[test]
     fn wide_design_exact_abstains_but_cube_decides_holds() {
-        // The 48-bit counter feeds st's cone ⇒ the exact engine over-caps (Unknown),
+        // The 80-bit counter feeds st's cone ⇒ the exact engine over-caps (Unknown),
         // but the cube abstraction (which drops the counter) decides Holds.
         assert_eq!(
             exact_verdict(WIDE_RECOVERABLE, "st == 0"),

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -170,7 +170,7 @@ mod tests {
     // vendored design is the EXTRACTED control FSM (18 state bits — within the exact
     // engine's ~40-bit cap, so the exact engine decides it); the OVER-CAP cube +
     // smt-hyper-must scale path is proven separately by the wide-fixture differential
-    // tests in `crate::adapter::recoverability` (a 48-bit design where the exact engine
+    // tests in `crate::adapter::recoverability` (an 80-bit design where the exact engine
     // abstains and the cube path decides both polarities).
     #[test]
     #[ignore = "requires sv2v + Yosys + z3 (mununu-sva docker image); run with --ignored"]


### PR DESCRIPTION
## What

The exact BDD engine Skipped any property whose **concrete** cone exceeded the conservative 40-bit default cap (`MAX_BITBLAST_BITS`), forcing users to hand-set `MUNUNU_BDD_MAX_BITS`. This adds **auto-cap-management** (verification-execution-planner Phase 4.6): `default_cap_for_cone(cone_bits)` auto-raises the 40-bit floor to `min(cone_bits, AUTO_CAP_CEILING=64)` when no env override is present, so the exact engine **decides the concrete model directly** instead of Skipping.

## Why it's sound now

The default stayed at 40 for exactly one reason: a wide free-running counter has a *small* BDD (the node-budget guard misses it) but a `2^W`-diameter fixpoint. #369 shipped a deterministic fixpoint iteration budget that guards that hang. With **both** guards live — node-budget (BDD *size*) and iteration-budget (*counter diameter*) — a modestly-wider cone bails deterministically on either failure mode, and a *decided* verdict carries zero abstraction (exact is the differential oracle). An explicit `MUNUNU_BDD_MAX_BITS` is still respected exactly.

## Payoff

The OpenTitan i2c `AG EF (wb_ack_o == 1)` recoverability property (44-reg concrete cone) now decides **HOLDS automatically** — previously it needed a hand-set `MUNUNU_BDD_MAX_BITS=64`. Confirmed end-to-end in the `mununu-sva-pono` image with **no** env cap set.

## Tests

- New `auto_cap_admits_modestly_wide_concrete_cone`: pure threshold math + a 48-bit cone the old floor Skipped that now decides.
- The codebase convention "64-bit = beyond the exact cap" moved 40→64, so every fixture asserting exact-abstention was bumped to 80-bit — exact (`d1_7`, `rf5_6`), recoverability (`wide_design` ×2), and the reach engines (`native_bmc` scale-curve + `WIDE`, `native_boolector` `WIDE`, `reach_portfolio` `WIDE_SAFE`/`WIDE_STALL`, `reach_rescue` `WIDE_STATE`) — comments made honest to the new ceiling.
- `make ci` green: 2445 passed / 0 failed / 49 ignored.

## Surface

Exact-engine-internal robustness knob, **not** a new user-facing capability — all three surfaces (verify-auto CLI, API, UI) route through the exact engine and benefit uniformly; `MUNUNU_BDD_MAX_BITS` still overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)