### PR TITLE
feat(recoverability): MathSAT must-precondition interpolation — decides the emergent-invariant ⊥ WP can't (F.1)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -1361,11 +1361,6 @@ pub fn cegar_refine_loop(
             .failure_subgame
             .as_ref()
             .expect("KleeneBot implies failure_subgame is Some (R.5.0 invariant)");
-        // F.1 — a Craig-discovered COMPOUND relational/bound invariant is installed into
-        // `lift_opts.compound_exprs` (not returned as a cube dimension), so count them: the
-        // loop must NOT treat "0 new simple predicates" as source-exhaustion when a compound
-        // landed and will refine the next iteration's compound-aware re-lift.
-        let mut compounds_added_this_iter = 0usize;
         let new_predicates = match &cegar_opts.predicate_source {
             PredicateSource::Manual(callback) => callback(subgame, &current_predicates),
             PredicateSource::WeakestPrecondition => {
@@ -1393,20 +1388,27 @@ pub fn cegar_refine_loop(
                     ),
                     None => (Vec::new(), Vec::new()),
                 };
+                // A discovered compound needs BOTH a `compound_exprs` entry AND a matching
+                // PredicateSpec in the predicate set: the lift keys the cube dimension by NAME (the
+                // spec's register/value are placeholders — the actual constraint is the expr). Push
+                // the spec into the returned predicates so it lands in `current_predicates` and the
+                // next compound-aware re-lift sees a well-formed dimension.
+                let mut out = simple;
                 for expr in compound {
                     if lift_opts.compound_exprs.values().any(|e| e == &expr) {
                         continue; // re-discovery, not progress
                     }
                     let name = format!("craig_compound_{}", lift_opts.compound_exprs.len());
-                    lift_opts.compound_exprs.insert(name, expr);
-                    compounds_added_this_iter += 1;
+                    let placeholder = expr.registers().into_iter().next().unwrap_or_default();
+                    lift_opts.compound_exprs.insert(name.clone(), expr);
+                    out.push(PredicateSpec {
+                        name,
+                        register: placeholder,
+                        value: 0,
+                    });
                 }
-                if !simple.is_empty() {
-                    simple
-                } else if compounds_added_this_iter > 0 {
-                    // A compound landed → the next iteration's compound-aware re-lift refines
-                    // the abstraction even with no new simple dimension. Continue the loop.
-                    Vec::new()
+                if !out.is_empty() {
+                    out
                 } else {
                     // No transition-aware progress → the legacy propositional Craig query (F.2,
                     // kept as a fallback pending removal), then WP — never silently terminate.
@@ -1441,10 +1443,7 @@ pub fn cegar_refine_loop(
             approximants_at_end,
         });
 
-        // F.1 — a Craig compound installed into `lift_opts.compound_exprs` is progress even with
-        // 0 new simple dimensions; only exhaust when NEITHER a simple predicate NOR a compound
-        // was added this iteration.
-        if added_count == 0 && compounds_added_this_iter == 0 {
+        if added_count == 0 {
             // Track I.1 — countertrace over the exhausted-source cube.
             let counterexample = build_counterexample_trace(
                 &lift_result.clts,
@@ -1655,27 +1654,21 @@ fn cube_index_to_region(
         .collect()
 }
 
-/// F.1 — TRANSITION-AWARE Craig refinement (the strong primitive wired into the ⊥-refinement).
-/// For each classifying MayOnly transition `(src_cube → target_cube)` of the failure subgame,
-/// pose `A = source-region(cur) ∧ T`, `B = ¬target-region(nx)` over the EXACT transition
-/// (`synthesize_refinement_predicate`) and collect the separating predicate. Unlike
-/// [`craig_interpolation_predicates`] — a propositional, transition-FREE cube-fact query that can
-/// only ever return a differing cube bit — this reads the DATAPATH, so cvc5 can return the
-/// relational/bound invariant (`data == target`, `reg <= K`) a branching ⊥ needs (the emergent-K
-/// case). Splits results: a simple `reg == value` becomes a cube DIMENSION (`PredicateSpec`); any
-/// other shape (`!=` / relational / bound) becomes a compound EXPR the caller installs into the
-/// SmtAllPairs+Eager compound-aware lift. The primitive addresses only NAMED state cells; a
-/// property atom over a combinational output contributes a weaker region but never an unsound
-/// predicate. cvc5-absent / no-interpolant / out-of-grammar ⇒ that transition yields nothing and
-/// the caller falls back to WP.
+/// F.1 — TRANSITION-AWARE Craig refinement, MUST-PRECONDITION query (the recoverability-correct
+/// interpolation). For each classifying MayOnly transition `(src_cube → target_cube)` of the ⊥
+/// failure subgame, the target cube is the good-ward cube, so `must_precondition_interpolant`
+/// interpolates the MUST-PRECONDITION of reaching it — `A = source ∧ T_a ∧ target(next_a)` vs
+/// `B = source ∧ T_b ∧ ¬target(next_b)`, two next-state frames sharing the current state — yielding
+/// the invariant `I(cur)` that makes the target must-reachable (the WP relation the ⊥ needs, e.g.
+/// `data == target` / `reg <= K`). This is the query a recoverability MUST-OBLIGATION ⊥ needs, NOT a
+/// safety spurious-edge query. Solved by **MathSAT** proof-based lazy-BV interpolation; cvc5's SyGuS
+/// BV interpolation returns `fail` on this shape, so mathsat is REQUIRED to decide (mathsat-absent ⇒
+/// this yields nothing and the caller falls back to WP — sound, just undecided).
 ///
-/// ⚠️ OPEN PIECE (2026-07-24): this is a *safety spurious-edge* query (find a predicate making a
-/// step INFEASIBLE). A RECOVERABILITY ⊥ is a MUST-OBLIGATION failure — the may-edge to `good` is
-/// REAL, not spurious — so for recoverability this query decides NOTHING (empirically: it exhausts
-/// to ⊥; see `craig_refinement_wiring_is_sound_but_naive_query_does_not_yet_decide_recoverability`).
-/// The recoverability-correct query interpolates the MUST-PRECONDITION of `good` — a ∀∃/hyper-must
-/// query that cvc5's SyGuS BV interpolation cannot yet synthesize. This function is the SOUND wiring
-/// FOUNDATION; the deciding query is the CAV-paper research still to land.
+/// Splits results: a simple `reg == value` becomes a cube DIMENSION (`PredicateSpec`); any other
+/// shape (`!=` / relational / bound) becomes a compound EXPR the caller installs into the
+/// SmtAllPairs+Eager compound-aware lift. Addresses only NAMED state cells; a property atom over a
+/// combinational output contributes a weaker region but never an unsound predicate.
 #[allow(clippy::type_complexity)]
 fn craig_refinement_over_transition(
     subgame: &FailureSubgame,
@@ -1688,7 +1681,7 @@ fn craig_refinement_over_transition(
     Vec<crate::adapter::btor2::predicate_expr::PredicateExpr>,
 ) {
     use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
-    use crate::adapter::btor2::refine::{RefineOutcome, synthesize_refinement_predicate};
+    use crate::adapter::btor2::refine::{RefineOutcome, must_precondition_interpolant};
     use crate::clts::StateId;
     let mut simple: Vec<PredicateSpec> = Vec::new();
     let mut compound: Vec<PredicateExpr> = Vec::new();
@@ -1704,8 +1697,13 @@ fn craig_refinement_over_transition(
         let target_idx = transition.target().index();
         let source = cube_index_to_region(current_predicates, *src_idx);
         let target = cube_index_to_region(current_predicates, target_idx);
+        // F.1 must-precondition (2026-07-24) — the classifying transition's TARGET cube is the
+        // good-ward cube, so interpolate the MUST-PRECONDITION of reaching it (`{cur:T→target}` vs
+        // `{cur:T→¬target}`) rather than a safety spurious-edge query — the recoverability-correct
+        // query the ⊥ needs. Solved by MathSAT proof-based lazy-BV interpolation; mathsat-absent /
+        // no-interpolant ⇒ nothing here and the caller falls back to WP.
         if let RefineOutcome::Predicate(p) =
-            synthesize_refinement_predicate(file, &source, &target, timeout_ms)
+            must_precondition_interpolant(file, &source, &target, timeout_ms)
         {
             // Dedup identical interpolants across the classifying transitions.
             if !seen.insert(format!("{p:?}")) {
@@ -2553,23 +2551,19 @@ mod tests {
         );
     }
 
-    /// F.1 (2026-07-24) — the transition-aware Craig refinement is SOUND on a recoverability
-    /// property but the SAFETY spurious-edge query does NOT yet decide it (a documented FOUNDATION,
-    /// not a working decider). `busy` returns to idle (`busy==0`) exactly when `data == target`;
-    /// `data`/`target` increment in LOCKSTEP so `data == target` is INVARIANT (never syntactically
-    /// compared beyond the gate). `AG EF (busy==0)` genuinely HOLDS (exact oracle), yet the cube
-    /// over `{busy==0}` alone leaves ⊥. **EMPIRICAL FINDING (2026-07-24): the wired
-    /// `synthesize_refinement_predicate` query (`A = source ∧ T`, `B = ¬target` — a *safety
-    /// spurious-edge* refinement) does NOT decide this — BOTH Craig and WP exhaust to ⊥.** A
-    /// recoverability ⊥ is a MUST-OBLIGATION failure (the may-edge to `good` is REAL, not spurious),
-    /// so the safety query correctly finds no separating predicate. The recoverability-correct query
-    /// interpolates the MUST-PRECONDITION of `good` (`{cur:T→good}` vs `{cur:T→¬good}`, a ∀∃/
-    /// hyper-must query) — the OPEN piece: cvc5's SyGuS BV interpolation returns `fail` on that
-    /// shape (see the planner-plan finding). This test therefore locks the FIRM soundness property
-    /// (Craig NEVER falsifies a HOLDS) and RECORDS the non-deciding behaviour, so a future
-    /// must-precondition backend can be checked against it.
+    /// F.1 (2026-07-24) — the must-precondition Craig refinement is SOUND on a recoverability
+    /// property (never falsifies a HOLDS), and its DECIDING is gated on MathSAT (host make-ci has no
+    /// mathsat → the query is inert → WP fallback → sound-but-undecided; the deciding is validated in
+    /// `e2e_craig_must_precondition_decides_emergent_recoverability`, `mununu-sva`). `busy` returns to
+    /// idle (`busy==0`) exactly when `data == target`; `data`/`target` increment in LOCKSTEP so
+    /// `data == target` is INVARIANT (never syntactically compared beyond the gate). `AG EF (busy==0)`
+    /// genuinely HOLDS (exact oracle), yet the cube over `{busy==0}` alone leaves ⊥. The
+    /// recoverability-correct query interpolates the MUST-PRECONDITION of the good-ward target
+    /// (`{cur:T→target}` vs `{cur:T→¬target}`) — MathSAT's proof-based lazy-BV interpolation derives
+    /// `data == target` from the transition (cvc5's SyGuS returns `fail`). This host test locks the
+    /// FIRM soundness property; the functional decide/exhaust is reported (mathsat-gated).
     #[test]
-    fn craig_refinement_wiring_is_sound_but_naive_query_does_not_yet_decide_recoverability() {
+    fn craig_refinement_recoverability_sound_must_precondition_mathsat_gated() {
         use crate::adapter::btor2::kmts_lift::{MayEdgeInference, MustEdgeInference};
         use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
         const D: &str = "1 sort bitvec 1\n2 sort bitvec 3\n3 state 1 busy\n4 state 2 data\n\
@@ -2622,11 +2616,100 @@ mod tests {
             !craig_verdicts.contains(&Trit::False),
             "Craig refinement must never falsify a HOLDS recoverability; got {craig_verdicts:?}"
         );
-        // FUNCTIONAL (cvc5-gated): report whether Craig closed the ⊥ that WP cannot.
+        // FUNCTIONAL (mathsat-gated): report whether the must-precondition closed the ⊥ WP cannot.
         let wp = run(PredicateSource::WeakestPrecondition);
         eprintln!(
-            "F.1 emergent-recoverability: craig={:?} wp={:?}",
+            "F.1 must-precondition recoverability: craig={:?} wp={:?}",
             craig.terminated_with, wp.terminated_with
+        );
+    }
+
+    /// F.1 e2e (2026-07-24) — with MathSAT present, the must-precondition Craig refinement DECIDES
+    /// the emergent-invariant recoverability the WP splitter cannot. Same `data==target`-gated
+    /// `AG EF (busy==0)` design (exact oracle HOLDS); MathSAT's lazy-BV interpolation discovers
+    /// `data == target`, the ⊥ closes → `Converged` with the sound HOLDS verdict, whereas WP
+    /// exhausts. `#[ignore]`d (needs MathSAT, subprocess-only per the not-bundled policy — run in the
+    /// `mununu-sva` image with `MUNUNU_MATHSAT_PATH` set).
+    #[test]
+    #[ignore = "requires MathSAT (mununu-sva image); run with --ignored + MUNUNU_MATHSAT_PATH"]
+    fn e2e_craig_must_precondition_decides_emergent_recoverability() {
+        use crate::adapter::btor2::kmts_lift::{MayEdgeInference, MustEdgeInference};
+        use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
+        const D: &str = "1 sort bitvec 1\n2 sort bitvec 3\n3 state 1 busy\n4 state 2 data\n\
+5 state 2 target\n6 one 1\n7 zero 1\n8 zero 2\n9 one 2\n10 init 1 3 6\n11 init 2 4 8\n\
+12 init 2 5 8\n13 add 2 4 9\n14 next 2 4 13\n15 add 2 5 9\n16 next 2 5 15\n17 eq 1 4 5\n\
+18 ite 1 17 7 3\n19 next 1 3 18\n";
+        let formula =
+            parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").expect("formula");
+        assert_eq!(
+            exact_symbolic_verdict(D, &formula).map(|v| format!("{v:?}")),
+            Ok("Holds".to_string()),
+            "oracle: the recoverability HOLDS"
+        );
+        let initial = vec![PredicateSpec {
+            name: "busy == 0".into(),
+            register: "busy".into(),
+            value: 0,
+        }];
+        let opts = CegarOptions {
+            max_iterations: 8,
+            predicate_source: PredicateSource::CraigInterpolation,
+            max_cube_count: 1024,
+            capture_approximants: false,
+            enable_approximant_reuse: false,
+            smart_uf_cap: false,
+            lift_strategy: LiftStrategy::Eager,
+            must_edge_inference: MustEdgeInference::SmtHyperMust,
+            may_edge_inference: MayEdgeInference::SmtAllPairs,
+            emit_ctxdsl: false,
+        };
+        let env = Environment::new(2);
+        let trace = cegar_refine_loop(
+            &formula,
+            D,
+            initial,
+            &env,
+            &AdapterOptions::default(),
+            &opts,
+        )
+        .expect("cegar succeeds");
+        // The must-precondition invariant `data==target` closes the ⊥ → the loop CONVERGES.
+        assert_eq!(
+            trace.terminated_with,
+            CegarTermination::Converged,
+            "with MathSAT the must-precondition refinement must DECIDE (converge), not exhaust; \
+             final predicates: {:?}",
+            trace.final_predicates
+        );
+        // MathSAT discovered the emergent relational invariant as a compound cube dimension.
+        assert!(
+            trace
+                .final_predicates
+                .iter()
+                .any(|s| s.name.starts_with("craig_compound")),
+            "the must-precondition should have discovered a compound invariant; got {:?}",
+            trace.final_predicates
+        );
+        // The recoverability verdict is read at the RESET cube (as `verify_recoverability` does):
+        // reset ⇒ busy=1 (`busy==0` FALSE) and every discovered invariant (`data==target`) TRUE. The
+        // abstraction legitimately marks the UNREACHABLE `{busy≠0 ∧ data≠target}` cube False, so the
+        // sound check is the RESET cube — where the property must be True (HOLDS), matching the exact
+        // oracle — NOT "no False anywhere".
+        let busy0 = trace
+            .final_predicates
+            .iter()
+            .position(|s| s.name == "busy == 0")
+            .expect("busy==0 is a dimension");
+        let init_cube = (0..trace.final_predicates.len()).fold(0usize, |acc, i| {
+            if i == busy0 { acc } else { acc | (1 << i) }
+        });
+        assert_eq!(
+            trace.final_verdict.verdict_at(init_cube),
+            Trit::True,
+            "the recoverability must HOLD at the reset cube (matching the oracle); all verdicts: {:?}",
+            (0..trace.final_verdict.len())
+                .map(|i| trace.final_verdict.verdict_at(i))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/mununu-core/src/adapter/btor2/native_interp.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_interp.rs
@@ -797,6 +797,76 @@ pub(crate) fn run_cvc5_raw(query: &str, timeout_ms: u32) -> Result<String, Strin
     Ok(String::from_utf8_lossy(&buf).to_string())
 }
 
+/// Locate the MathSAT 5 binary: `MUNUNU_MATHSAT_PATH` or `mathsat` on PATH. Unlike cvc5's
+/// `locate_tool` (which invokes `--version`), MathSAT uses `-version` (single dash), so this does
+/// a light `-version` probe purely to confirm the binary is invokable; the actual interpolation
+/// query surfaces any real problem as an `Err`.
+fn locate_mathsat() -> Result<std::path::PathBuf, String> {
+    use std::path::PathBuf;
+    let path = std::env::var("MUNUNU_MATHSAT_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("mathsat"));
+    match std::process::Command::new(&path).arg("-version").output() {
+        Ok(_) => Ok(path),
+        Err(e) => Err(format!(
+            "mathsat unavailable ({e}); set MUNUNU_MATHSAT_PATH or use the `mununu-sva` image \
+             (proof-based lazy-BV interpolation — the must-precondition query cvc5's SyGuS \
+             interpolation cannot synthesize)."
+        )),
+    }
+}
+
+/// Run MathSAT 5 on an interpolation query, returning raw stdout. Forces the LAZY BV solver
+/// (`-theory.bv.eager=false`) — the eager (bit-blast) solver cannot produce interpolation proofs
+/// (`"eager bv solver does not support proof generation"`). The query must use MathSAT's
+/// `(! φ :interpolation-group g)` + `(get-interpolant (g))` API (distinct from cvc5's
+/// `(get-interpolant I B)`). Output is `<sat-result>\n<interpolant s-expr>`.
+pub(crate) fn run_mathsat_raw(query: &str, timeout_ms: u32) -> Result<String, String> {
+    use std::io::{Read, Write};
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+    let bin = locate_mathsat()?;
+    let mut child = Command::new(&bin)
+        .arg("-theory.bv.eager=false")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn mathsat: {e}"))?;
+    // The taken stdin is a temporary dropped at the end of this statement → EOF is sent.
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(query.as_bytes())
+        .map_err(|e| format!("write mathsat stdin: {e}"))?;
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms as u64 + 2_000);
+    let mut killed = false;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if Instant::now() > deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    killed = true;
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(e) => return Err(format!("wait mathsat: {e}")),
+        }
+    }
+    if killed {
+        return Err(format!("mathsat exceeded {timeout_ms}ms"));
+    }
+    let mut buf = Vec::new();
+    if let Some(mut so) = child.stdout.take() {
+        let _ = so.read_to_end(&mut buf);
+    }
+    Ok(String::from_utf8_lossy(&buf).to_string())
+}
+
 /// Extract the interpolant term from cvc5's `(define-fun I () Bool <body>)` reply
 /// (cvc5 ≥ 1.x). Falls back to a bare top-level s-expression if `define-fun` is
 /// absent.

--- a/crates/mununu-core/src/adapter/btor2/refine.rs
+++ b/crates/mununu-core/src/adapter/btor2/refine.rs
@@ -215,6 +215,191 @@ pub fn synthesize_refinement_predicate(
     })
 }
 
+/// F.1 must-precondition interpolant (2026-07-24) — the RECOVERABILITY-correct query that the
+/// safety [`synthesize_refinement_predicate`] cannot pose. For a ⊥ cube `source` and the `good`
+/// target, interpolate the MUST-PRECONDITION of `good`: `A = source ∧ T_a ∧ good(next_a)` (current
+/// states whose transition CAN reach good) vs `B = source ∧ T_b ∧ ¬good(next_b)` (those whose
+/// transition can reach ¬good), over TWO independent next-state frames (`__a` / `__b`) so the only
+/// shared vocabulary is the CURRENT state — the interpolant `I(cur)` is then the invariant
+/// separating good-reaching from ¬good-reaching current states, i.e. the WP relation the ⊥ needs.
+///
+/// Solved by **MathSAT** proof-based lazy-BV interpolation ([`crate::adapter::btor2::native_interp::run_mathsat_raw`]);
+/// cvc5's SyGuS BV interpolation returns `fail` on this shape. MathSAT emits the WP as
+/// `(= K (ite <cond> K …))`; `<cond>` (e.g. `(= data target)`) is the discovered relational
+/// invariant, extracted below. `Unavailable` when: mathsat absent / no interpolant (a
+/// nondeterministic cur reaching BOTH good and ¬good — the `A∧B` SAT case) / a `good`/`source` atom
+/// over a non-state register / an interpolant outside the parseable grammar.
+pub fn must_precondition_interpolant(
+    file: &Btor2File,
+    source: &[PredicateExpr],
+    good: &[PredicateExpr],
+    timeout_ms: u32,
+) -> RefineOutcome {
+    let cfg = z3::Config::new();
+    z3::with_z3_config(&cfg, || {
+        let view = match encode_design(file) {
+            Ok(v) => v,
+            Err(e) => return RefineOutcome::Unavailable(format!("encode: {e:?}")),
+        };
+        let name_to_nid: HashMap<String, Nid> = view
+            .signals
+            .iter()
+            .filter(|s| s.kind == SignalKind::State)
+            .filter_map(|s| s.symbol.clone().map(|sym| (sym, s.nid)))
+            .collect();
+        let nid_to_name: HashMap<Nid, String> =
+            name_to_nid.iter().map(|(n, &d)| (d, n.clone())).collect();
+        // `cur` is BARE-named so the interpolant — over the SHARED cur vocabulary — parses to a
+        // clean state predicate; the two next frames get distinct suffixes.
+        let frame = |suffix: &str| -> HashMap<Nid, BV> {
+            view.state_curr
+                .iter()
+                .filter_map(|(nid, bv)| {
+                    let sym = nid_to_name.get(nid)?;
+                    Some((*nid, BV::new_const(format!("{sym}{suffix}"), bv.get_size())))
+                })
+                .collect()
+        };
+        let cur = frame("");
+        let nx_a = frame("__a");
+        let nx_b = frame("__b");
+        let inp = |suffix: &str| -> HashMap<Nid, BV> {
+            view.inputs
+                .iter()
+                .map(|(nid, bv)| {
+                    (
+                        *nid,
+                        BV::new_const(format!("in{nid}{suffix}"), bv.get_size()),
+                    )
+                })
+                .collect()
+        };
+        let in_a = inp("__ina");
+        let in_b = inp("__inb");
+        let instantiate = |nx: &HashMap<Nid, BV>, ip: &HashMap<Nid, BV>| -> Bool {
+            let mut subs: Vec<(&BV, &BV)> = Vec::new();
+            for (nid, bv) in &view.state_curr {
+                if let Some(c) = cur.get(nid) {
+                    subs.push((bv, c));
+                }
+            }
+            for (nid, bv) in &view.state_next {
+                if let Some(n) = nx.get(nid) {
+                    subs.push((bv, n));
+                }
+            }
+            for (nid, bv) in &view.inputs {
+                if let Some(i) = ip.get(nid) {
+                    subs.push((bv, i));
+                }
+            }
+            view.transition.substitute(&subs)
+        };
+        let t_a = instantiate(&nx_a, &in_a);
+        let t_b = instantiate(&nx_b, &in_b);
+        let build = |ps: &[PredicateExpr], f: &HashMap<Nid, BV>| -> Option<Bool> {
+            let lookup = |name: &str| -> Option<BV> {
+                name_to_nid.get(name).and_then(|nid| f.get(nid)).cloned()
+            };
+            let mut conj = Vec::new();
+            for p in ps {
+                conj.push(p.build_constraint(&lookup)?);
+            }
+            Some(if conj.is_empty() {
+                Bool::from_bool(true)
+            } else {
+                Bool::and(&conj.iter().collect::<Vec<_>>())
+            })
+        };
+        let source_bool = match build(source, &cur) {
+            Some(b) => b,
+            None => return RefineOutcome::Unavailable("source over a non-state register".into()),
+        };
+        let good_a = match build(good, &nx_a) {
+            Some(b) => b,
+            None => return RefineOutcome::Unavailable("good over a non-state register".into()),
+        };
+        let good_b = match build(good, &nx_b) {
+            Some(b) => b,
+            None => return RefineOutcome::Unavailable("good over a non-state register".into()),
+        };
+        let a = Bool::and(&[&source_bool, &t_a, &good_a]);
+        let b = Bool::and(&[&source_bool, &t_b, &good_b.not()]);
+        let (a_decls, a_body) = match serialize_term(&a) {
+            Some(x) => x,
+            None => return RefineOutcome::Unavailable("serialize A".into()),
+        };
+        let (b_decls, b_body) = match serialize_term(&b) {
+            Some(x) => x,
+            None => return RefineOutcome::Unavailable("serialize B".into()),
+        };
+        let mut decls: BTreeSet<String> = BTreeSet::new();
+        decls.extend(a_decls);
+        decls.extend(b_decls);
+        let mut query = String::from("(set-option :produce-interpolants true)\n");
+        for d in &decls {
+            query.push_str(d);
+            query.push('\n');
+        }
+        query.push_str(&format!(
+            "(assert (! {a_body} :interpolation-group g1))\n\
+             (assert (! {b_body} :interpolation-group g2))\n\
+             (check-sat)\n(get-interpolant (g1))\n"
+        ));
+        let stdout = match crate::adapter::btor2::native_interp::run_mathsat_raw(&query, timeout_ms)
+        {
+            Ok(s) => s,
+            Err(e) => return RefineOutcome::Unavailable(e),
+        };
+        parse_mathsat_interpolant(&stdout)
+    })
+}
+
+/// Parse MathSAT's `get-interpolant` reply (`<sat-result>\n<interpolant s-expr>`) into a
+/// [`PredicateExpr`]. The must-precondition WP is emitted as `(= K (ite <cond> K <else>))` — the
+/// `ite` CONDITION is the relational invariant, and the rich #318 parser rejects `ite` directly,
+/// so it is peeled off first. Falls back to parsing the whole term (a plain comparison).
+fn parse_mathsat_interpolant(stdout: &str) -> RefineOutcome {
+    let Some(term) = stdout
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with('(') && !l.starts_with("(error"))
+    else {
+        let head = stdout.lines().next().unwrap_or("").trim();
+        return RefineOutcome::Unavailable(format!("mathsat: no interpolant (status `{head}`)"));
+    };
+    let candidate = ite_condition(term).unwrap_or_else(|| term.to_string());
+    // Reuse the rich #318 parser by wrapping the candidate in cvc5's `define-fun` envelope.
+    let wrapped = format!("(define-fun I () Bool {candidate})");
+    match parse_interpolant_to_predicate_expr(&wrapped) {
+        Some(pe) => RefineOutcome::Predicate(pe),
+        None => RefineOutcome::Unavailable(format!("mathsat interpolant outside grammar: {term}")),
+    }
+}
+
+/// The first `(ite <cond> …)` condition s-expression in `term` (the WP relation), if present.
+fn ite_condition(term: &str) -> Option<String> {
+    let p = term.find("(ite ")?;
+    let after = term[p + "(ite ".len()..].trim_start();
+    if !after.starts_with('(') {
+        return after.split_whitespace().next().map(str::to_string);
+    }
+    let mut depth = 0usize;
+    for (i, c) in after.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(after[..=i].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// P2.3b — the Craig interpolant AT CUT `cut` of the depth-`depth` BMC unrolling
 /// `Init(s0) ∧ T(s0,s1) ∧ … ∧ T(s_{depth-1}, s_depth)` with `bad` at any step
 /// `≥ cut`: `A = Init ∧ (prefix to s_cut)` vs `B = ¬(bad reachable from s_cut
@@ -800,6 +985,40 @@ mod tests {
             found_bound,
             "expected to discover the bound invariant cnt<=5; got {preds:?}"
         );
+    }
+
+    #[test]
+    fn mathsat_interpolant_parse_extracts_ite_condition_and_bare_comparison() {
+        use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
+        // The WP form MathSAT emits for the must-precondition query — the `ite` CONDITION is the
+        // relational invariant `data == target`; the sat-status line is skipped.
+        let out = "unsat\n(= (_ bv0 1) (ite (= data target) (_ bv0 1) busy))\n";
+        match parse_mathsat_interpolant(out) {
+            RefineOutcome::Predicate(PredicateExpr::CmpReg { lhs, op, rhs }) => {
+                assert_eq!(op, CmpOp::Eq);
+                assert!(
+                    (lhs == "data" && rhs == "target") || (lhs == "target" && rhs == "data"),
+                    "extracted the wrong relation: {lhs} {op:?} {rhs}"
+                );
+            }
+            other => panic!("expected CmpReg data==target from the ite condition; got {other:?}"),
+        }
+        // A bare comparison (no ite) parses directly.
+        assert!(matches!(
+            parse_mathsat_interpolant("unsat\n(bvule cnt (_ bv5 8))\n"),
+            RefineOutcome::Predicate(PredicateExpr::Cmp { op: CmpOp::Le, .. })
+        ));
+        // No interpolant (SAT / empty) → Unavailable, never a fabricated predicate.
+        assert!(matches!(
+            parse_mathsat_interpolant("sat\n"),
+            RefineOutcome::Unavailable(_)
+        ));
+        // `ite_condition` peels the condition; a term with no ite returns None.
+        assert_eq!(
+            ite_condition("(= (_ bv0 1) (ite (= data target) (_ bv0 1) busy))").as_deref(),
+            Some("(= data target)")
+        );
+        assert_eq!(ite_condition("(= data target)"), None);
     }
 
     /// Validation sweep: run the interpolation invariant-discovery over every


### PR DESCRIPTION
## What

The recoverability CEGAR ⊥-refinement now poses the **recoverability-correct** interpolation query and **decides** the datapath-dependent ⊥ class that predicate-splitting (WP) and the safety spurious-edge query both leave undecided.

A recoverability ⊥ is a **must-obligation** failure (`EF good` is ⊥ because `good` isn't must-reachable, *not* because a step is spurious). The correct query interpolates the **must-precondition** of the good-ward target — `A = source ∧ T_a ∧ good(next_a)` vs `B = source ∧ T_b ∧ ¬good(next_b)` over two independent next-state frames sharing the current state — so the interpolant `I(cur)` is the invariant that makes `good` must-reachable.

## Why MathSAT

cvc5's SyGuS BV interpolation returns `fail` on this shape; **MathSAT's proof-based lazy-BV interpolation** (`-theory.bv.eager=false`) derives it. Added `run_mathsat_raw`/`locate_mathsat` (MathSAT's `(! φ :interpolation-group g)` API), `must_precondition_interpolant` (the two-frame encoder), and the parse-back — MathSAT emits the WP as `(= K (ite <cond> K …))`, so `ite_condition` peels the `<cond>` relation (`data == target`) and the #318 parser turns it into a `PredicateExpr`. Wired into `craig_refinement_over_transition` (the classifying transition's target cube **is** the good-ward cube, so it's a drop-in). A discovered compound installs into both `compound_exprs` and the predicate set (a `PredicateSpec` placeholder — the lift keys dimensions by name).

## Validation

- **e2e** `e2e_craig_must_precondition_decides_emergent_recoverability` (`#[ignore]`d — MathSAT is subprocess-only per the not-bundled policy; **validated in the `mununu-sva` image** with `MUNUNU_MATHSAT_PATH`): the lockstep `data==target`-gated `AG EF (busy==0)` (exact oracle HOLDS) → the loop **Converges**, `data==target` is discovered as a compound dimension, and the verdict is **HOLDS at the reset cube** — matching the oracle. WP exhausts to ⊥.
- **Host unit** `mathsat_interpolant_parse_extracts_ite_condition_and_bare_comparison` (the ite-peel + parse, no MathSAT).
- `make ci` green (2448 passed; mathsat-absent on the host ⇒ the query is inert ⇒ WP fallback ⇒ sound).

## Surface

Engine-internal ⊥-refinement, opt-in via `MUNUNU_CRAIG_REFINE` (default WeakestPrecondition — the per-transition MathSAT cost is opt-in until corpus cost/benefit is measured). Sound + monotone under SmtHyperMust. No CLI/API/UI change.

This lands the CAV-paper Class-2 emergent-K core (interpolation-driven relational-invariant discovery for recoverability), working on the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)