### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build mununu-dev image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.dev
@@ -99,7 +99,7 @@ jobs:
           tool: tokei
       - name: Count lines of code
         run: tokei --output json > tokei.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: tokei-report
           path: tokei.json

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,12 +32,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # The sva image extends `mununu-dev` (FROM mununu-dev), so build dev first
       # and tag it locally for the sva build to pick up.
       - name: Build mununu-dev image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             archive: zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -64,7 +64,7 @@ jobs:
           Compress-Archive -Path target/${{ matrix.target }}/release/mununu.exe -DestinationPath mununu-${{ github.ref_name }}-${{ matrix.target }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mununu-${{ matrix.target }}
           path: mununu-${{ github.ref_name }}-${{ matrix.target }}.*
@@ -74,16 +74,16 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: artifacts/*


### PR DESCRIPTION
## What

GitHub is deprecating the Node 20 runner. The CI run annotations flagged three actions as being force-run on Node 24 already:

- `actions/upload-artifact@v4`
- `docker/build-push-action@v6`
- `docker/setup-buildx-action@v3`

This bumps each flagged action — plus the same Node-20-era actions still pinned in `release.yml` — to the **minimal major that defaults to Node 24**:

| Action | From | To | Note |
|---|---|---|---|
| `actions/upload-artifact` | v4 | **v6** | v5 was still `node20` by default |
| `actions/download-artifact` | v4 | **v7** | skips v8's error-on-hash-mismatch + no-auto-unzip breaking changes |
| `actions/checkout` (release.yml) | v4 | **v5** | ci.yml / e2e.yml already on v5 |
| `docker/build-push-action` | v6 | **v7** | |
| `docker/setup-buildx-action` | v3 | **v4** | |
| `softprops/action-gh-release` | v2 | **v3** | |

## Why these targets

Chose minimal-Node-24 majors over latest to keep the breaking-change surface small. Verified `runs.using: node24` on each target tag.

- Artifact upload/download stay on the same v4-era backend → remain mutually compatible.
- `release.yml`'s download uses `merge-multiple: true` (name-less "download all") → unaffected by download-artifact v5's by-ID single-artifact path change.
- Deliberately avoided `download-artifact@v8`, which defaults hash-mismatch to a hard error and stops auto-unzipping.

## Validation

- YAML lints clean on all three workflows.
- `ci.yml` and `e2e.yml` are exercised by this PR's own CI run. `release.yml` only fires on release events, so its bumps are reviewed by inspection (usage is standard: unique per-matrix artifact names, `generate_release_notes`, `files` glob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)