### PR TITLE
feat(sv): --frontend slang — expose the read_slang RTL front-end (P1.1a)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -404,6 +404,31 @@ enum EngineArg {
 /// R.2.5b session-1 follow-up (2026-06-06) — must-edge inference
 /// selector for `mununu btor2 cegar`. Mirrors the values of
 /// [`mununu_core::adapter::btor2::kmts_lift::MustEdgeInference`].
+/// RTL front-end for the SV → BTOR2 lift (CLI mirror of
+/// [`mununu_core::adapter::yosys::SvFrontend`]).
+#[derive(Clone, Debug, Copy, clap::ValueEnum, Default)]
+enum SvFrontendArg {
+    /// Env-driven default: `MUNUNU_YOSYS_FRONTEND=slang` → slang, else read_verilog.
+    #[default]
+    Auto,
+    /// Force yosys `read_verilog` (+ sv2v per `--preprocess-sv2v`).
+    Verilog,
+    /// Force the yosys-slang plugin (`read_slang`) — lifts modern-SV constructs
+    /// `read_verilog`/sv2v reject (`while` loops, `module M import pkg::*;`).
+    /// Requires the yosys-slang plugin (present in the `mununu-sva` image).
+    Slang,
+}
+
+impl From<SvFrontendArg> for mununu_core::adapter::yosys::SvFrontend {
+    fn from(a: SvFrontendArg) -> Self {
+        match a {
+            SvFrontendArg::Auto => Self::Auto,
+            SvFrontendArg::Verilog => Self::Verilog,
+            SvFrontendArg::Slang => Self::Slang,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Copy, clap::ValueEnum, Default)]
 enum MustEdgeInferenceArg {
     /// Pre-R.2.5b behaviour (default). Only MayOnly edges emitted;
@@ -1590,6 +1615,12 @@ struct SvVerifyAutoArgs {
     /// on-disk include-search directory has no analog there.
     #[arg(long = "include-dir", value_name = "DIR")]
     include_dirs: Vec<PathBuf>,
+    /// RTL front-end for the lift. `slang` forces the yosys-slang plugin
+    /// (`read_slang`), which lifts modern-SV constructs `read_verilog`/sv2v
+    /// reject (`while` loops, `module M import pkg::*;`). Requires the
+    /// yosys-slang plugin (present in the mununu-sva image).
+    #[arg(long = "frontend", value_enum, default_value_t = SvFrontendArg::Auto)]
+    frontend: SvFrontendArg,
     /// Max CEGAR iterations per property.
     #[arg(long, default_value_t = 16)]
     max_iterations: usize,
@@ -1699,6 +1730,13 @@ struct SvLiftArgs {
     /// name-staging of additional sources already resolves cross-file includes.
     #[arg(long = "include-dir", value_name = "DIR")]
     include_dirs: Vec<PathBuf>,
+    /// RTL front-end for the lift. `slang` forces the yosys-slang plugin
+    /// (`read_slang`), which lifts modern-SV constructs `read_verilog` and sv2v
+    /// reject (`while` loops, `module M import pkg::*;`). Requires the
+    /// yosys-slang plugin (present in the mununu-sva image). `auto` (default)
+    /// keeps the env-driven behaviour; `verilog` forces read_verilog.
+    #[arg(long = "frontend", value_enum, default_value_t = SvFrontendArg::Auto)]
+    frontend: SvFrontendArg,
 }
 
 /// Arguments for `mununu sv verify` — SV-direct safety portfolio.
@@ -2087,6 +2125,30 @@ fn parse_cli_controller_mode(
     } else {
         ControllerMode::Projection
     })
+}
+
+#[cfg(test)]
+mod sv_frontend_arg_tests {
+    use super::*;
+    use mununu_core::adapter::yosys::SvFrontend;
+
+    // Guards against a copy-paste swap in the CLI → core front-end mapping
+    // (e.g. Slang accidentally routed to Verilog would silently disable the
+    // whole slang-lift capability while still reporting "frontend=slang").
+    #[test]
+    fn frontend_arg_maps_to_core_variant() {
+        assert_eq!(SvFrontend::from(SvFrontendArg::Auto), SvFrontend::Auto);
+        assert_eq!(
+            SvFrontend::from(SvFrontendArg::Verilog),
+            SvFrontend::Verilog
+        );
+        assert_eq!(SvFrontend::from(SvFrontendArg::Slang), SvFrontend::Slang);
+    }
+
+    #[test]
+    fn frontend_arg_default_is_auto() {
+        assert!(matches!(SvFrontendArg::default(), SvFrontendArg::Auto));
+    }
 }
 
 #[cfg(test)]
@@ -3178,6 +3240,7 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         use_sv2v: args.preprocess_sv2v,
         cutpoint_signals: args.cutpoint.clone(),
         extra_include_dirs: args.include_dirs.clone(),
+        frontend: args.frontend.into(),
         ..Default::default()
     };
     let must_edge_inference = match args.must_edge_inference {
@@ -5097,6 +5160,7 @@ fn read_sv_lift(args: &SvLiftArgs) -> Result<mununu_core::adapter::sv_verify::Sv
         top: args.top.clone(),
         use_sv2v: args.preprocess_sv2v,
         include_dirs: args.include_dirs.clone(),
+        frontend: args.frontend.into(),
     })
 }
 

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -26,7 +26,7 @@ use crate::adapter::liveness_rescue::{
 };
 use crate::adapter::reach_portfolio::{ReachOutcome, decide_reach_portfolio_parallel};
 use crate::adapter::recoverability::verify_recoverability_with_predicates;
-use crate::adapter::yosys::{YosysOptions, sv_to_btor2};
+use crate::adapter::yosys::{SvFrontend, YosysOptions, sv_to_btor2};
 use crate::verdict::PropertyVerdict;
 
 /// The SV → BTOR2 lift inputs shared by every SV-direct verb.
@@ -44,6 +44,10 @@ pub struct SvLift {
     /// without the fragment being read as a standalone compilation unit.
     /// Feeds [`YosysOptions::extra_include_dirs`]; empty by default.
     pub include_dirs: Vec<std::path::PathBuf>,
+    /// RTL front-end selection. `Slang` forces the yosys-slang plugin, which
+    /// lifts modern-SV constructs `read_verilog`/sv2v reject. Feeds
+    /// [`YosysOptions::frontend`]; `Auto` by default.
+    pub frontend: SvFrontend,
 }
 
 impl SvLift {
@@ -54,6 +58,7 @@ impl SvLift {
             additional_sources: self.additional_sources.clone(),
             use_sv2v: self.use_sv2v,
             extra_include_dirs: self.include_dirs.clone(),
+            frontend: self.frontend,
             ..Default::default()
         };
         sv_to_btor2(&self.source, &yopts)
@@ -150,6 +155,7 @@ mod tests {
             top: None,
             use_sv2v: false,
             include_dirs: Vec::new(),
+            frontend: SvFrontend::Auto,
         }
     }
 
@@ -199,6 +205,7 @@ mod tests {
             top: Some("aes_cipher_control_fsm".into()),
             use_sv2v: true,
             include_dirs: Vec::new(),
+            frontend: SvFrontend::Auto,
         };
         let verdict = sv_verify_recoverability(&lift, "aes_cipher_ctrl_cs == 9")
             .expect("recoverability decides on the AES cipher-control FSM");

--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -57,6 +57,28 @@ use std::time::Duration;
 /// trips on the fixtures the feature actually targets.
 const PER_MODULE_YOSYS_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// RTL front-end selection for the SV → BTOR2 lift.
+///
+/// - `Auto` (default) — the historical behaviour: yosys `read_verilog` (with
+///   optional sv2v), unless `MUNUNU_YOSYS_FRONTEND=slang` is set in the env and
+///   the plugin is present, in which case slang is used.
+/// - `Verilog` — force yosys `read_verilog` (+ sv2v per `use_sv2v`), ignoring the
+///   env override.
+/// - `Slang` — force the yosys-slang plugin (`read_slang`), a full SystemVerilog
+///   front-end that accepts constructs `read_verilog` and sv2v reject (bounded
+///   `while` loops, `module M import pkg::*;`, …). Errors clearly if the plugin is
+///   not found. Validated in the `mununu-sva` image (the plugin ships there).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SvFrontend {
+    /// Env-driven (default): `MUNUNU_YOSYS_FRONTEND=slang` → slang, else read_verilog.
+    #[default]
+    Auto,
+    /// Force yosys `read_verilog` (+ sv2v per `use_sv2v`).
+    Verilog,
+    /// Force the slang front-end (`read_slang`); error if the plugin is absent.
+    Slang,
+}
+
 /// Yosys-specific options.
 #[derive(Debug, Clone, Default)]
 pub struct YosysOptions {
@@ -104,6 +126,12 @@ pub struct YosysOptions {
     /// `--preprocessor sv2v` or the API field `use_sv2v: true` on the
     /// import request.
     pub use_sv2v: bool,
+    /// RTL front-end selection. `Auto` (default) preserves the env-driven
+    /// behaviour; `Slang` forces the yosys-slang plugin (`read_slang`), which
+    /// lifts modern-SV constructs `read_verilog`/sv2v reject (`while` loops,
+    /// `module M import pkg::*;`). Populated from the CLI `--frontend` flag / the
+    /// API `use_slang` field. See [`SvFrontend`].
+    pub frontend: SvFrontend,
     /// When `true`, Yosys's `setundef -anyseq` pass replaces every
     /// undefined net with a fresh symbolic choice instead of pinning
     /// it to zero. Preserves CWE-1245-class bug-bearing semantics
@@ -376,7 +404,24 @@ fn run_sv_flatten_btor2(
     // A3 — the opt-in slang RTL frontend (`MUNUNU_YOSYS_FRONTEND=slang`). `read_slang`
     // parses SystemVerilog natively (a superset of what `read_verilog` accepts), so sv2v
     // is redundant with it and is skipped when slang is active.
-    let slang_plugin = slang_frontend_selection();
+    // Front-end selection: an explicit `Slang` request forces the plugin (and
+    // errors if it is absent — never a silent fall-back to read_verilog, which
+    // would defeat the whole point of asking for slang); `Verilog` forces
+    // read_verilog; `Auto` keeps the env-driven default.
+    let slang_plugin = match yopts.frontend {
+        SvFrontend::Slang => Some(locate_slang_plugin().ok_or_else(|| {
+            AdapterError {
+                kind: AdapterErrorKind::UnsupportedConstruct,
+                message: "adapter/yosys: the slang RTL front-end was requested (--frontend slang \
+                      / use_slang) but the yosys-slang plugin was not found. Set \
+                      MUNUNU_YOSYS_SLANG_PLUGIN to slang.so, or run in the mununu-sva image."
+                    .into(),
+                location: None,
+            }
+        })?),
+        SvFrontend::Verilog => None,
+        SvFrontend::Auto => slang_frontend_selection(),
+    };
     if yopts.use_sv2v && slang_plugin.is_none() {
         let sv2v = locate_sv2v()?;
         let preprocessed = tmp.path().join("preprocessed.sv");
@@ -2842,6 +2887,48 @@ mod tests {
         assert!(
             sv_to_btor2(top, &no_inc).is_err(),
             "expected the lift to fail when the include dir is absent"
+        );
+    }
+
+    // (a) front-end selection — a non-constant `while` loop is rejected by yosys
+    // `read_verilog` ("While loops are only allowed in constant functions!") but
+    // accepted by the slang front-end (`read_slang`), which elaborates it. This is
+    // the real corpus lift blocker the slang front-end unlocks (e.g. AssertLLM2
+    // `xgate`). yosys + yosys-slang-plugin gated → runs in the `mununu-sva` image.
+    #[test]
+    #[ignore = "requires yosys + the yosys-slang plugin (run in the mununu-sva image)"]
+    fn frontend_slang_lifts_while_loop_read_verilog_rejects() {
+        let src = "module m(input [3:0] n, output reg [7:0] y);\n\
+                   integer i;\n\
+                   always @* begin\n\
+                     y = 8'd0; i = 0;\n\
+                     while (i < n) begin y = y + 8'd1; i = i + 1; end\n\
+                   end\n\
+                   endmodule\n";
+
+        // read_verilog rejects the non-constant while loop.
+        let verilog = YosysOptions {
+            top: Some("m".to_string()),
+            frontend: SvFrontend::Verilog,
+            skip_verific_check: true,
+            ..Default::default()
+        };
+        assert!(
+            sv_to_btor2(src, &verilog).is_err(),
+            "read_verilog should reject a non-constant while loop"
+        );
+
+        // The slang front-end elaborates it → the design lifts.
+        let slang = YosysOptions {
+            top: Some("m".to_string()),
+            frontend: SvFrontend::Slang,
+            skip_verific_check: true,
+            ..Default::default()
+        };
+        let lifted = sv_to_btor2(src, &slang);
+        assert!(
+            lifted.as_ref().is_ok_and(|b| !b.is_empty()),
+            "the slang front-end should lift the while loop, got {lifted:?}"
         );
     }
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -875,6 +875,11 @@ pub async fn sv_verify_handler(
         // on-disk include-search dir is a local (CLI) concept; the flat
         // name-staging of `additional_sources` already resolves includes here.
         include_dirs: Vec::new(),
+        frontend: if request.use_slang {
+            crate::adapter::yosys::SvFrontend::Slang
+        } else {
+            crate::adapter::yosys::SvFrontend::Auto
+        },
     };
     let outcome = sv_verify_safety(&lift).map_err(|message| ApiError::BadRequest {
         message,
@@ -914,6 +919,11 @@ pub async fn sv_verify_liveness_handler(
         // on-disk include-search dir is a local (CLI) concept; the flat
         // name-staging of `additional_sources` already resolves includes here.
         include_dirs: Vec::new(),
+        frontend: if request.use_slang {
+            crate::adapter::yosys::SvFrontend::Slang
+        } else {
+            crate::adapter::yosys::SvFrontend::Auto
+        },
     };
     let (verdict, outcome) =
         sv_verify_liveness(&lift, &request.request, &request.grant).map_err(|message| {
@@ -959,6 +969,11 @@ pub async fn sv_verify_liveness_all_handler(
         // on-disk include-search dir is a local (CLI) concept; the flat
         // name-staging of `additional_sources` already resolves includes here.
         include_dirs: Vec::new(),
+        frontend: if request.use_slang {
+            crate::adapter::yosys::SvFrontend::Slang
+        } else {
+            crate::adapter::yosys::SvFrontend::Auto
+        },
     };
     let (verdict, outcomes) =
         sv_verify_liveness_all(&lift, &request.responses).map_err(|message| {
@@ -1010,6 +1025,11 @@ pub async fn sv_verify_recoverability_handler(
         // on-disk include-search dir is a local (CLI) concept; the flat
         // name-staging of `additional_sources` already resolves includes here.
         include_dirs: Vec::new(),
+        frontend: if request.use_slang {
+            crate::adapter::yosys::SvFrontend::Slang
+        } else {
+            crate::adapter::yosys::SvFrontend::Auto
+        },
     };
     let verdict = sv_verify_recoverability_with_predicates(&lift, &request.target, &extra)
         .map_err(|message| ApiError::BadRequest {
@@ -1043,6 +1063,11 @@ pub async fn sv_check_fsm_handler(
         // on-disk include-search dir is a local (CLI) concept; the flat
         // name-staging of `additional_sources` already resolves includes here.
         include_dirs: Vec::new(),
+        frontend: if request.use_slang {
+            crate::adapter::yosys::SvFrontend::Slang
+        } else {
+            crate::adapter::yosys::SvFrontend::Auto
+        },
     };
     let findings =
         sv_check_fsm(&lift, request.max_width).map_err(|message| ApiError::BadRequest {
@@ -1209,6 +1234,11 @@ pub async fn sv_verify_auto_handler(
             .collect(),
         use_sv2v: request.use_sv2v,
         cutpoint_signals: request.cutpoint.clone(),
+        frontend: if request.use_slang {
+            crate::adapter::yosys::SvFrontend::Slang
+        } else {
+            crate::adapter::yosys::SvFrontend::Auto
+        },
         ..Default::default()
     };
     let must_edge_inference = match request.must_edge_inference.as_deref() {

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -4508,6 +4508,7 @@ members = ["x"]
             additional_sources: vec![],
             top: None,
             use_sv2v: false,
+            use_slang: false,
             request: "x == y".to_string(), // relational — rejected before the lift
             grant: "st == 1".to_string(),
         };
@@ -4524,6 +4525,7 @@ members = ["x"]
             additional_sources: vec![],
             top: None,
             use_sv2v: false,
+            use_slang: false,
             target: "not an atom !!".to_string(),
             predicates: Vec::new(),
         };

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1082,6 +1082,11 @@ pub struct SvVerifyRequest {
     /// Run sv2v before Yosys (modern SV). Default `false`.
     #[serde(default)]
     pub use_sv2v: bool,
+    /// Force the slang RTL front-end (`read_slang`) for modern-SV constructs
+    /// yosys/sv2v reject (`while` loops, `import pkg::*;`). Requires the
+    /// yosys-slang plugin. Default `false`.
+    #[serde(default)]
+    pub use_slang: bool,
 }
 
 /// Request for `POST /api/v1/sv/verify-liveness` — the SV lift fields plus the
@@ -1099,6 +1104,10 @@ pub struct SvVerifyLivenessRequest {
     /// Run sv2v before Yosys. Default `false`.
     #[serde(default)]
     pub use_sv2v: bool,
+    /// Force the slang RTL front-end (`read_slang`). Requires the yosys-slang
+    /// plugin. Default `false`.
+    #[serde(default)]
+    pub use_slang: bool,
     /// The request atom (`"REG op VALUE"`).
     pub request: String,
     /// The grant atom that must eventually follow on every path.
@@ -1121,6 +1130,10 @@ pub struct SvVerifyLivenessAllRequest {
     /// Run sv2v before Yosys. Default `false`.
     #[serde(default)]
     pub use_sv2v: bool,
+    /// Force the slang RTL front-end (`read_slang`). Requires the yosys-slang
+    /// plugin. Default `false`.
+    #[serde(default)]
+    pub use_slang: bool,
     /// The response pairs, each `"ANTE => CONS"`. At least one required.
     pub responses: Vec<String>,
 }
@@ -1140,6 +1153,10 @@ pub struct SvVerifyRecoverabilityRequest {
     /// Run sv2v before Yosys. Default `false`.
     #[serde(default)]
     pub use_sv2v: bool,
+    /// Force the slang RTL front-end (`read_slang`). Requires the yosys-slang
+    /// plugin. Default `false`.
+    #[serde(default)]
+    pub use_slang: bool,
     /// The `good` atom to recover to (`"REG op VALUE"`).
     pub target: String,
     /// Extra abstraction predicate(s) for the cube-path escalation, each
@@ -1164,6 +1181,10 @@ pub struct SvCheckFsmRequest {
     /// Run sv2v before Yosys. Default `false`.
     #[serde(default)]
     pub use_sv2v: bool,
+    /// Force the slang RTL front-end (`read_slang`). Requires the yosys-slang
+    /// plugin. Default `false`.
+    #[serde(default)]
+    pub use_slang: bool,
     /// Max state-register width treated as an FSM (wider = datapath/counter, skipped).
     #[serde(default = "default_fsm_max_width")]
     pub max_width: u32,
@@ -1304,6 +1325,11 @@ pub struct SvVerifyAutoRequest {
     /// Run sv2v before Yosys (modern SV). Mirrors `--preprocess-sv2v`.
     #[serde(default)]
     pub use_sv2v: bool,
+    /// Force the slang RTL front-end (`read_slang`) for modern-SV constructs
+    /// yosys/sv2v reject. Mirrors `--frontend slang`. Requires the yosys-slang
+    /// plugin. Default `false`.
+    #[serde(default)]
+    pub use_slang: bool,
     /// Max CEGAR iterations per property (default 16).
     #[serde(default)]
     pub max_iterations: Option<usize>,


### PR DESCRIPTION
## What

The **harness lift track** (roadmap P1.1). Real-binary re-scoping (not hand-yosys) showed the genuine multi-file lift blocker is **not** include resolution — mununu's flat staging already handles that, so #388's `--include-dir` has no payoff on this corpus — but yosys `read_verilog`'s **parser limits**: e.g. AssertLLM2 `xgate`'s non-constant `while` loop, which `read_verilog` **and** sv2v both reject (`While loops are only allowed in constant functions!`), silently black-boxing the module into a vacuous lift.

The yosys-slang plugin (`read_slang`) — a full SystemVerilog front-end — elaborates these constructs. The path was already wired in `build_script` but only reachable via `MUNUNU_YOSYS_FRONTEND=slang`. This exposes it as a first-class, per-call selection.

## Change

- **Core** — `SvFrontend {Auto, Verilog, Slang}` on `YosysOptions`. `Auto` (default) preserves the env-driven behaviour (**zero change** at every existing call site); `Slang` forces `read_slang` and **errors clearly if the plugin is absent** (never a silent fall-back to read_verilog, which would defeat the request); `Verilog` forces read_verilog.
- **CLI** — `--frontend <auto|verilog|slang>` on `SvLiftArgs` (`sv verify` / `verify-liveness` / `verify-liveness-all` / `verify-recoverability` / `check-fsm`) and `SvVerifyAutoArgs`, threaded `SvLift → YosysOptions`.
- **API** — `use_slang: bool` on the 5 SV-verify request models + verify-auto, wired in the handlers (mirrors the existing `use_sv2v`).
- **UI** — companion PR mununu-ui#55 (`use_slang` typed field + checkbox).

## Validation

- **Capability (mununu-sva image):** `xgate check-fsm` → **`"fsm_registers_checked": 11` under `--frontend slang`** vs a `while`-loop ERROR under the default front-end. Lifts a design nothing else could.
- 2 CI-runnable CLI mapping tests (guard the arg→core swap).
- 1 yosys+slang-gated `#[ignore]` e2e test (a non-constant `while` loop lifts under `Slang`, fails under `Verilog`) — **passed in the `mununu-sva` image** alongside the #388 include-dir e2e.
- fmt + clippy (default / api / cli) clean.

## Follow-up

Re-run the lift-blocked AssertLLM2 designs (xgate, and the OpenTitan `import pkg::*` designs) with `--frontend slang` and append fresh timestamped **decided** rows to the benchmark-property ledger — the P1 decided-count payoff this unlocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
