### PR TITLE
feat(sv): read_slang --ignore-timing (recover slang-lift regressions)

### DIFF
--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -1946,6 +1946,14 @@ fn build_script(
     // and `--ignore-assertions` drops embedded SVA (extracted separately by the slang
     // `extract_sva` path). `read_verilog` reads each source. Everything after the read is
     // identical, so the lift is frontend-agnostic downstream.
+    //
+    // `--ignore-timing`: slang is stricter than `read_verilog` about `#`-delay timing
+    // controls (`error: unsynthesizable timing control`), which `read_verilog` silently
+    // drops. Ignoring them here matches `read_verilog`'s behaviour and is the correct
+    // cycle-based-verification modelling choice — `#delays` are non-synthesizable and are
+    // not part of the design's synthesized (cycle) behaviour. SOUNDNESS: this is
+    // read_verilog-equivalent, not an extra abstraction. Without it, slang regressed ~18
+    // corpus designs that read_verilog lifts (measured 2026-07-25 lift sweep).
     let read_cmds: Vec<String> = if use_slang {
         let files = sources
             .iter()
@@ -1961,7 +1969,7 @@ fn build_script(
             .map(|d| format!(" -I{}", d.display()))
             .unwrap_or_default();
         vec![format!(
-            "read_slang --ignore-assertions{top_arg}{inc}{extra_inc} {files}"
+            "read_slang --ignore-assertions --ignore-timing{top_arg}{inc}{extra_inc} {files}"
         )]
     } else {
         sources
@@ -2733,6 +2741,10 @@ mod tests {
             "slang read command missing: {script}"
         );
         assert!(
+            script.contains("--ignore-timing"),
+            "read_slang must pass --ignore-timing (read_verilog-equivalent #delay handling): {script}"
+        );
+        assert!(
             script.contains("--top top"),
             "top not passed to read_slang: {script}"
         );
@@ -2839,7 +2851,9 @@ mod tests {
             &inc,
         );
         assert!(
-            script.contains("read_slang --ignore-assertions -I/stage -I/design/pkg /stage/a.sv"),
+            script.contains(
+                "read_slang --ignore-assertions --ignore-timing -I/stage -I/design/pkg /stage/a.sv"
+            ),
             "caller include dir not appended on the slang path: {script}"
         );
     }


### PR DESCRIPTION
## What

Follow-up to `--frontend slang` (#389). The slang RTL front-end rejected `#`-delay timing controls that yosys `read_verilog` silently drops (`error: unsynthesizable timing control`), so `--frontend slang` regressed multi-file corpus designs that read_verilog lifts. Pass `--ignore-timing` alongside the existing `--ignore-assertions`.

## Soundness

`read_verilog`-equivalent, **not** an added abstraction: `#delays` are non-synthesizable and are not part of a design's synthesized (cycle) behaviour — exactly the cycle-based model mununu verifies. Documented as a `SOUNDNESS:` note at the `read_slang` command.

## Measured (mununu-sva image, 83-design AssertLLM2 lift sweep, default vs `--frontend slang`)

| | before | after |
|---|---|---|
| slang regressions | 18 | **12** |
| slang unblocks | 4 | **6** (+`ssp_uart`, +`wishbone_dma_bridge`) |

Designs that already lifted under slang had no timing controls, so their verdicts are unchanged. slang stays opt-in (the remaining 12 regressions are non-timing strictness → never a default). Harvest of the newly-lifted set added **+8 decided HOLDS** ledger rows (wishbone_dma_bridge FSM legal-encoding safety).

## Tests

Unit test asserts `read_slang` now passes `--ignore-timing`; the exact-string slang test updated. Validated in the `mununu-sva` image via the re-sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)