### PR TITLE
feat(planner): P2.1b — fold escalate_bottom into the planner re-plan step

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -2378,11 +2378,15 @@ pub fn verify_auto(
         });
     }
 
-    // ⊥ escalation (P3 router): dispatch each ⊥ property by property_class to its sound
-    // reduction — safety→reach_rescue, box-AF→l2s, νμ recoverability→cube+hyper-must.
-    // Runs before the notes/coverage build so the counts reflect any rescue; each arm is
-    // gated by its own `rescue_bottom_*` opt and only fires on its recognized shape.
-    let rescue_notes = escalate_bottom(&mut report, &btor2, reset_pinned, opts);
+    // ⊥ RE-PLAN (verification-execution-planner P2.1b): the planner's reactive re-plan
+    // step. When the main-path plan leaves a property ⊥, `planner::replan` dispatches it by
+    // property_class to a sound reduction (safety→reach_rescue, box-AF→l2s, νμ
+    // recoverability→exact+COI / cube+hyper-must) — the re-plan edges. Runs before the
+    // notes/coverage build so the counts reflect any rescue; each edge is gated by its own
+    // `rescue_bottom_*` opt and only fires on its recognized shape. (P2.1b routes the
+    // re-plan entry through the planner, delegating the edge-application to the existing
+    // rescue subsystem — verdict-equivalent; P2.1c adds the soundness plan-invariants.)
+    let rescue_notes = crate::planner::replan(&mut report, &btor2, reset_pinned, opts);
 
     // Lever (b) — exact-symbolic rescue for cube-SKIPPED properties. The predicate cube
     // cannot seed an ATOM-LESS modal formula (no-deadlock `nu X.(<> true && [] X)`, a pure
@@ -2390,7 +2394,7 @@ pub fn verify_auto(
     // seeding and decides it. Only fires on a cube run under reset-gating (the exact main
     // path already ran exact; A.6 requires reset gating). Sound: exact is the differential
     // oracle — a Skipped property is upgraded only on a DEFINITE Holds/Violated.
-    let exact_skip_notes = rescue_skipped_via_exact(&mut report, &btor2, opts);
+    let exact_skip_notes = crate::planner::rescue_skipped(&mut report, &btor2, opts);
 
     // H.J — provenance notes: surface every abstraction/scoping decision this run
     // made (config concretizations, posture, reset-gating, flop stubs, cut
@@ -2438,7 +2442,7 @@ pub fn verify_auto(
 /// path could decide it. Pure over `(report, design_btor2)`, so it is unit-testable on a
 /// BTOR2 fixture without the SV toolchain. Per-arm rescues are gated by
 /// `rescue_bottom_{safety,liveness,recoverability}`.
-fn escalate_bottom(
+pub(crate) fn escalate_bottom(
     report: &mut AutoVerifyReport,
     design_btor2: &str,
     reset_pinned: bool,
@@ -2598,7 +2602,7 @@ fn escalate_bottom(
 ///
 /// Pure over `(report, design_btor2)`, so it is unit-testable on a BTOR2 fixture without
 /// the SV toolchain.
-fn rescue_skipped_via_exact(
+pub(crate) fn rescue_skipped_via_exact(
     report: &mut AutoVerifyReport,
     design_btor2: &str,
     opts: &VerifyAutoOptions,

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -21,8 +21,8 @@
 //! See `.claude/plans/verification-execution-planner.md` §4.2/§4.5.
 
 use crate::adapter::slang::verify_auto::{
-    AutoVerifyReport, PortfolioMode, VerifyAutoOptions, merge_portfolio_reports, outcome_definite,
-    verify_auto,
+    AutoVerifyReport, PortfolioMode, VerificationNote, VerifyAutoOptions, escalate_bottom,
+    merge_portfolio_reports, outcome_definite, rescue_skipped_via_exact, verify_auto,
 };
 use crate::adapter::yosys::YosysOptions;
 use crate::adapter::{AdapterError, AdapterErrorKind};
@@ -193,6 +193,41 @@ pub fn execute(
             merge_portfolio_reports(&runs, plan.mode)
         }
     }
+}
+
+/// The planner's reactive **re-plan** step (verification-execution-planner §4.5 step 4 /
+/// roadmap P2.1b) — when the main-path plan ([`execute`]) leaves a property `⊥`, feed the
+/// reason back and route it to a sound reduction. The re-plan **edges**, dispatched by
+/// property class (each gated by its own `rescue_bottom_*` opt, firing only on its shape):
+///
+/// - **safety** `AG`-invariant → the reachability portfolio (reduce to a `bad`-monitor);
+/// - **box-AF response** `AG(a→AF b)` → liveness-to-safety (l2s) → the portfolio;
+/// - **νμ recoverability** `AG EF good` → exact+COI (reset-pinned) or cube+`smt-hyper-must`.
+///
+/// P2.1b routes the re-plan **entry** through the planner (so both halves of the
+/// orchestration — main-path [`plan`]/[`execute`] and this reactive step — are planner-owned)
+/// while **delegating the edge application** to the existing rescue subsystem
+/// ([`escalate_bottom`]). Verdict-equivalent. P2.1c adds the soundness plan-invariants here
+/// (cube-νμ exact-corroboration; property-class-aware transfer reporting).
+pub fn replan(
+    report: &mut AutoVerifyReport,
+    design_btor2: &str,
+    reset_pinned: bool,
+    opts: &VerifyAutoOptions,
+) -> Vec<VerificationNote> {
+    escalate_bottom(report, design_btor2, reset_pinned, opts)
+}
+
+/// The companion re-plan edge for cube-**Skipped** (not `⊥`) properties: an atom-less modal
+/// formula the cube cannot seed gets one full-state exact-symbolic attempt, upgraded on a
+/// definite verdict (lever b). Gated to the cube path under reset-gating. Delegates to the
+/// existing [`rescue_skipped_via_exact`] — verdict-equivalent.
+pub fn rescue_skipped(
+    report: &mut AutoVerifyReport,
+    design_btor2: &str,
+    opts: &VerifyAutoOptions,
+) -> Vec<VerificationNote> {
+    rescue_skipped_via_exact(report, design_btor2, opts)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Second increment of the **verification-execution-planner** skeleton (roadmap **P2.1b**), building on the P2.1a seam (#391). Routes the reactive **⊥ re-plan** step (the plan doc's §4.5 step 4) through the planner, so **both halves** of the verify-auto orchestration are now planner-owned — the main-path `plan()`/`execute()` (P2.1a) **and** this reactive re-plan.

- **`planner::replan(report, btor2, reset_pinned, opts)`** — the re-plan entry. Dispatches each `⊥` property by property class to a sound reduction (the re-plan **edges**):
  - safety `AG`-invariant → reachability portfolio,
  - box-AF response `AG(a→AF b)` → l2s → portfolio,
  - νμ recoverability `AG EF good` → exact+COI (reset-pinned) or cube+`smt-hyper-must`.
- **`planner::rescue_skipped(report, btor2, opts)`** — the companion edge for cube-Skipped atom-less modals (one exact attempt, upgrade on a definite verdict).

`verify_auto` now calls `planner::replan` / `planner::rescue_skipped` instead of `escalate_bottom` / `rescue_skipped_via_exact` (both now `pub(crate)`).

## Verdict-equivalence

**By construction** — a verbatim delegation (consistent with P2.1a's `execute()`→`verify_auto`). The edge *application* stays in the existing rescue subsystem (its note-builders + two counterexample helpers are shared with the main `verify_auto` body, so they stay in place); the planner owns the *entry* + the edge model. Evidence:
- the **7 `escalate_bottom` + 2 `rescue_skipped` edge tests** (real BTOR2 fixtures, run in `make ci`) are unchanged and green,
- **end-to-end in `mununu-sva`:** i2c portfolio verify-auto → the re-plan path returns identical verdicts (`ann_0` ⊥ via the νμ edge, `ann_1/2` HOLDS).

## Scope / not-in-this-PR

No new user-visible surface (behind `verify_auto`). Deferred: internalizing the edge logic + the **soundness plan-invariants** (cube-νμ exact-corroboration from the §7.3 finding; property-class-aware transfer reporting) — **P2.1c**, the first increment with real teeth; cost-based re-plan — **P2.2**.

## Tests

`planner::` + `escalate_bottom` + `rescue_skipped` suites green; fmt + clippy (default/api) clean; sva-image e2e verdict-equivalence confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
