### PR TITLE
feat(planner): P2.2 — ModelFacts cost facts + residual-register-aware Skip diagnostic

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/model_facts.rs
+++ b/crates/mununu-core/src/adapter/btor2/model_facts.rs
@@ -19,12 +19,25 @@
 
 use std::sync::OnceLock;
 
-use crate::adapter::btor2::ast::Btor2File;
+use crate::adapter::btor2::ast::{Btor2File, Nid};
 use crate::adapter::btor2::bit_blast::{MemoryCellMeta, detect_btor2_memories};
+use crate::adapter::btor2::dep_graph::cone_leaf_nids;
+use crate::adapter::btor2::symbolic_bitblast::effective_bitblast_cap;
 use crate::adapter::sidecar::predicate_image::btor2_encode::{
     Btor2SmtView, EncodeError, encode_design_with_theory,
 };
 use crate::adapter::sidecar::predicate_image::theory::Theory;
+use crate::adapter::sts_ir::BtorSts;
+
+/// A pinnable primary INPUT — a free `input` leaf `(nid, name, width)`. The candidate
+/// surface for auto-config-value (P2.2b): pinning one to a constant removes its `width` bits
+/// from every cone it feeds, shrinking the exact engine's bit-blast toward the cap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InputFact {
+    pub nid: Nid,
+    pub name: String,
+    pub width: u32,
+}
 
 /// Lazy, memoized structural derivations of one BTOR2 model. Cheap to construct
 /// (`new` stores the borrow and empty cells); each accessor computes its fact at most
@@ -33,6 +46,8 @@ pub(crate) struct ModelFacts<'m> {
     model: &'m Btor2File,
     memories: OnceLock<Vec<MemoryCellMeta>>,
     theory: OnceLock<Theory>,
+    total_bits: OnceLock<u32>,
+    free_inputs: OnceLock<Vec<InputFact>>,
 }
 
 impl<'m> ModelFacts<'m> {
@@ -41,7 +56,82 @@ impl<'m> ModelFacts<'m> {
             model,
             memories: OnceLock::new(),
             theory: OnceLock::new(),
+            total_bits: OnceLock::new(),
+            free_inputs: OnceLock::new(),
         }
+    }
+
+    /// The design's state + input leaf cells (canonical seam `BtorSts::leaf_cells`), or an
+    /// empty vec if the model is malformed (facts are best-effort, never fatal).
+    fn leaf_cells(&self) -> Vec<crate::adapter::sts_ir::LeafCell> {
+        BtorSts::new(self.model).leaf_cells().unwrap_or_default()
+    }
+
+    /// Whole-design bit-blast width — the sum of ALL state+input leaf widths (the size the
+    /// exact engine faces when NO cone restriction applies, `keep = None`). Memoized.
+    pub(crate) fn total_bits(&self) -> u32 {
+        *self
+            .total_bits
+            .get_or_init(|| self.leaf_cells().iter().map(|c| c.width).sum())
+    }
+
+    /// The exact engine's cone-of-influence bit width for a property's `seed_atoms` (the
+    /// register names from
+    /// [`crate::adapter::btor2::symbolic_bitblast::formula_seed_atoms`]) — the register+input
+    /// bits it must bit-blast. Mirrors the engine's keep-set cone (`cone_leaf_nids`); an
+    /// empty atom set ⇒ the whole design (`keep = None`). Not memoized (varies per atom set).
+    pub(crate) fn cone_bits(&self, seed_atoms: &[String]) -> u32 {
+        if seed_atoms.is_empty() {
+            return self.total_bits();
+        }
+        let cone = cone_leaf_nids(self.model, seed_atoms);
+        self.leaf_cells()
+            .iter()
+            .filter(|c| cone.contains(&c.nid))
+            .map(|c| c.width)
+            .sum()
+    }
+
+    /// `(cone_bits, cap)` for a property's seed atoms; `cone_bits > cap` is exactly the
+    /// condition under which the exact engine bails to a `Skip` — the signal auto-config-value
+    /// / auto-cutpoint act on.
+    pub(crate) fn cone_vs_cap(&self, seed_atoms: &[String]) -> (u32, u32) {
+        let cb = self.cone_bits(seed_atoms);
+        (cb, effective_bitblast_cap(cb))
+    }
+
+    /// The pinnable primary-input surface — all free `input` leaves, widest first. Memoized.
+    pub(crate) fn free_inputs(&self) -> &[InputFact] {
+        self.free_inputs.get_or_init(|| {
+            let mut v: Vec<InputFact> = self
+                .leaf_cells()
+                .iter()
+                .filter(|c| !c.is_state)
+                .map(|c| InputFact {
+                    nid: c.nid,
+                    name: c.name.clone(),
+                    width: c.width,
+                })
+                .collect();
+            // Widest-first (then by nid) — the greedy auto-config-value order (pin the input
+            // that removes the most cone bits first).
+            v.sort_by(|a, b| b.width.cmp(&a.width).then(a.nid.cmp(&b.nid)));
+            v
+        })
+    }
+
+    /// The free inputs that lie IN the cone of `seed_atoms` — the auto-config-value candidates
+    /// (pinning an out-of-cone input cannot shrink this cone). Widest first.
+    pub(crate) fn pinnable_cone_inputs(&self, seed_atoms: &[String]) -> Vec<InputFact> {
+        if seed_atoms.is_empty() {
+            return self.free_inputs().to_vec();
+        }
+        let cone = cone_leaf_nids(self.model, seed_atoms);
+        self.free_inputs()
+            .iter()
+            .filter(|i| cone.contains(&i.nid))
+            .cloned()
+            .collect()
     }
 
     /// Inferred `$mem` / array memory cells (`detect_btor2_memories`), computed once.
@@ -93,5 +183,71 @@ mod tests {
         assert_eq!(facts.theory(), Theory::BvOnly);
         // The memoized memory set equals a fresh direct detection.
         assert_eq!(facts.memories().len(), detect_btor2_memories(&file).len());
+    }
+
+    // A design with an 8-bit counter `ctrl` (next = ctrl+1, self-contained cone), an 8-bit
+    // register `other` fed by an 8-bit input `cfg`, and a 1-bit input `en`.
+    const COST_FIXTURE: &str = "\
+1 sort bitvec 8
+2 sort bitvec 1
+3 state 1 ctrl
+4 one 1
+5 add 1 3 4
+6 next 1 3 5
+7 input 1 cfg
+8 input 2 en
+9 state 1 other
+10 next 1 9 7
+";
+
+    #[test]
+    fn total_bits_sums_all_leaf_widths() {
+        let file = parser::parse(COST_FIXTURE).expect("parse");
+        let facts = ModelFacts::new(&file);
+        // ctrl(8) + cfg(8) + en(1) + other(8) = 25.
+        assert_eq!(facts.total_bits(), 25);
+        // Memoized: second read agrees.
+        assert_eq!(facts.total_bits(), 25);
+    }
+
+    #[test]
+    fn free_inputs_are_inputs_only_widest_first() {
+        let file = parser::parse(COST_FIXTURE).expect("parse");
+        let facts = ModelFacts::new(&file);
+        let names: Vec<(&str, u32)> = facts
+            .free_inputs()
+            .iter()
+            .map(|i| (i.name.as_str(), i.width))
+            .collect();
+        // Only the two inputs (not the state registers), widest first.
+        assert_eq!(names, vec![("cfg", 8), ("en", 1)]);
+    }
+
+    #[test]
+    fn cone_bits_restricts_to_the_property_cone() {
+        let file = parser::parse(COST_FIXTURE).expect("parse");
+        let facts = ModelFacts::new(&file);
+        // Empty atoms ⇒ the whole design (matches the exact engine's keep = None).
+        assert_eq!(facts.cone_bits(&[]), facts.total_bits());
+        // `ctrl`'s cone is self-contained (next = ctrl+1) ⇒ just its own 8 bits; `cfg`/`en`/
+        // `other` are excluded. Cone restriction genuinely shrinks the count.
+        let ctrl_cone = facts.cone_bits(&["ctrl".to_string()]);
+        assert!(
+            ctrl_cone < facts.total_bits(),
+            "ctrl's cone ({ctrl_cone}) must exclude the unrelated leaves"
+        );
+        assert_eq!(ctrl_cone, 8, "ctrl's cone is ctrl alone");
+        // `other`'s cone pulls in `cfg` (other' = cfg) ⇒ 8 + 8 = 16, and `cfg` is a pinnable
+        // in-cone input while none is in ctrl's cone.
+        assert_eq!(facts.cone_bits(&["other".to_string()]), 16);
+        assert_eq!(
+            facts
+                .pinnable_cone_inputs(&["other".to_string()])
+                .iter()
+                .map(|i| i.name.clone())
+                .collect::<Vec<_>>(),
+            vec!["cfg".to_string()]
+        );
+        assert!(facts.pinnable_cone_inputs(&["ctrl".to_string()]).is_empty());
     }
 }

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -162,7 +162,7 @@ fn default_cap_for_cone(cone_bits: u32) -> u32 {
 /// asked for a specific limit, so we neither raise nor lower it. With NO override, the cap is
 /// [`default_cap_for_cone`]: the conservative default auto-raised to admit a modestly-wide
 /// concrete cone.
-fn effective_bitblast_cap(cone_bits: u32) -> u32 {
+pub(crate) fn effective_bitblast_cap(cone_bits: u32) -> u32 {
     match std::env::var("MUNUNU_BDD_MAX_BITS")
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
@@ -2093,6 +2093,28 @@ pub(crate) fn collect_predicate_registers(
         }
         PredicateExpr::Not(a) => collect_predicate_registers(a, out),
     }
+}
+
+/// The exact engine's cone SEED ATOMS for a formula — the register names its predicate atoms
+/// reference (via [`collect_predicate_registers`]). These seed the cone-of-influence keep-set
+/// that sets how many register+input bits the exact engine must bit-blast; the planner reads
+/// them (with `ModelFacts::cone_bits`) to predict a cone-over-cap Skip and pick pinnable
+/// inputs (P2.2). This is the UNRESOLVED extraction (no alias canonicalization) —
+/// diagnostic-grade for the planner's cost estimate; the exact engine additionally resolves
+/// aliases for its authoritative keep-set. An atom-free formula yields no seeds ⇒ the caller
+/// treats the whole design as the cone.
+pub(crate) fn formula_seed_atoms(formula: &Formula) -> Vec<String> {
+    let mut regs: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for node in formula.nodes() {
+        if let MuNode::Predicate(name) = node
+            && let Ok(expr) = parse_predicate_atom_bool(name)
+        {
+            collect_predicate_registers(&expr, &mut regs);
+        }
+    }
+    let mut v: Vec<String> = regs.into_iter().collect();
+    v.sort();
+    v
 }
 
 /// Directly decide whether ANY `bad` property of a BTOR2 design is REACHABLE from the reset

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -236,12 +236,29 @@ pub fn rescue_skipped(
     notes
 }
 
-/// P2.2a — actionable Skip diagnostic (the first `ModelFacts` consumer). For each property
-/// STILL Skipped after the exact attempt, use `ModelFacts` to check whether the exact engine
-/// bailed because the property's cone exceeds the bit cap (`cone_bits > cap`); if so, attach a
-/// note naming the cone width, the cap, and the pinnable in-cone config inputs — the surface a
-/// `--config-value` pin (or auto-config-value, P2.2b) would shrink so it decides. (Mirrors the
-/// actionable-⊥ note #385; verdict-equivalent — a diagnostic, never a verdict change.)
+/// P2.2a/b — **residual-register-aware** actionable Skip diagnostic (the `ModelFacts`
+/// consumer). For each property STILL Skipped after the exact attempt, use `ModelFacts` to
+/// check whether the exact engine bailed because the property's cone exceeds the bit cap
+/// (`cone_bits > cap`); if so, attach a note naming the cone width and the cap.
+///
+/// The **key fact** (P2.2b, measure-first 2026-07-26) is the *residual* — the register bits
+/// that remain even after pinning **every** in-cone free input
+/// (`residual = cone_bits − Σ pinnable_input_widths`). This is what decides whether
+/// `--config-value` pinning can actually help:
+///
+/// - `residual ≤ cap` — **input-inflated** cone: pinning the in-cone inputs drops the cone to
+///   ~`residual` bits ≤ cap, so `--config-value SIGNAL=VALUE` (a scoped verdict) decides it.
+///   The note lists the pinnable inputs and how far pinning gets.
+/// - `residual > cap` — **register-dominated** cone: even pinning ALL in-cone inputs leaves
+///   `residual` register bits over the cap, so `--config-value` **cannot** decide it. The note
+///   says so and points at the real levers (structural compression: one-hot re-encode /
+///   counter abstraction; or cutpoint, posture-permitting).
+///
+/// A measure-first sweep (i2c 122 / gost 360 / present_cipher 144 residual register bits, all
+/// above the 64-bit cap) showed the corpus's over-cap cones are register-dominated — so the
+/// earlier "just pin the wide inputs" advice over-promised. This diagnostic tells the truth
+/// per property instead of assuming input-inflation. Verdict-equivalent — a diagnostic, never
+/// a verdict change.
 fn skip_over_cap_notes(report: &AutoVerifyReport, design_btor2: &str) -> Vec<VerificationNote> {
     use crate::adapter::btor2::model_facts::ModelFacts;
     use crate::adapter::btor2::symbolic_bitblast::formula_seed_atoms;
@@ -261,32 +278,60 @@ fn skip_over_cap_notes(report: &AutoVerifyReport, design_btor2: &str) -> Vec<Ver
         let atoms = formula_seed_atoms(&formula);
         let (cone_bits, cap) = facts.cone_vs_cap(&atoms);
         if cone_bits <= cap {
-            // Skipped for another reason (atom-less cube, unsupported op) — not a cap issue,
-            // so auto-config-value cannot help; leave it to the existing Skip provenance.
+            // Skipped for another reason (atom-less cube, unsupported op) — not a cap issue;
+            // leave it to the existing Skip provenance.
             continue;
         }
         let inputs = facts.pinnable_cone_inputs(&atoms);
+        let input_bits: u32 = inputs.iter().map(|i| i.width).sum();
+        // The register bits that remain even after pinning EVERY in-cone input — the true test
+        // of whether config-value pinning can bring the cone under the cap.
+        let residual = cone_bits.saturating_sub(input_bits);
         let items: Vec<String> = inputs
             .iter()
             .take(8)
             .map(|i| format!("{}({} bits)", i.name, i.width))
             .collect();
+        let detail = if residual <= cap {
+            // Input-inflated: pinning these inputs fits the cap → config-value decides.
+            format!(
+                "The exact engine bit-blasts a property's cone-of-influence; this cone exceeds \
+                 the bit cap, so it bailed to Skipped. The cone is INPUT-inflated: pinning the \
+                 {} in-cone free input(s) below ({input_bits} bits) to representative constants \
+                 (`--config-value SIGNAL=VALUE`) drops the cone to ~{residual} register bits (≤ \
+                 the {cap}-bit cap), so exact decides — a verdict scoped to the pinned \
+                 configuration.",
+                inputs.len()
+            )
+        } else {
+            // Register-dominated: even pinning all inputs leaves > cap register bits.
+            format!(
+                "The exact engine bit-blasts a property's cone-of-influence; this cone exceeds \
+                 the bit cap, so it bailed to Skipped. This cone is REGISTER-dominated: even \
+                 pinning ALL {} in-cone free input(s) ({input_bits} bits) leaves ~{residual} \
+                 register bits (still > the {cap}-bit cap), so `--config-value` CANNOT bring it \
+                 under the cap. The decidable lever here is sound register reduction — \
+                 structural compression (one-hot re-encode, counter abstraction) or a cutpoint \
+                 (safety-posture only; unsound for νμ) — not input concretization.",
+                inputs.len()
+            )
+        };
         notes.push(VerificationNote {
             kind: "skip-over-cap-reason".into(),
             level: NoteLevel::ScopeCaveat,
             summary: format!(
                 "`{}`: Skipped — the exact cone is {cone_bits} register+input bits (> the \
-                 {cap}-bit cap), too wide to bit-blast.",
-                prop.name
+                 {cap}-bit cap); {} even fully input-pinned ({residual} residual register \
+                 bits {} {cap}).",
+                prop.name,
+                if residual <= cap {
+                    "config-value decidable"
+                } else {
+                    "register-dominated"
+                },
+                if residual <= cap { "≤" } else { ">" },
             ),
-            detail: "The exact engine bit-blasts a property's cone-of-influence; this cone \
-                     exceeds the bit cap, so it bailed to Skipped. The cone is inflated by wide \
-                     free INPUTS the design compares against — pinning the widest in-cone ones \
-                     to representative constants (`--config-value SIGNAL=VALUE`) removes their \
-                     bits and can bring the cone under the cap so exact decides (a verdict \
-                     scoped to the pinned configuration). Auto-deriving these pins is the \
-                     planner's next increment (P2.2b)."
-                .into(),
+            detail,
             items,
         });
     }
@@ -360,5 +405,92 @@ mod tests {
             assert_eq!(p.ops.len(), 1, "single-engine intent → one operator");
             assert_eq!(p.ops[0].label, label);
         }
+    }
+
+    // ---- P2.2b: residual-register-aware over-cap Skip diagnostic --------------------------
+
+    fn skipped_report(name: &str, formula: &str) -> AutoVerifyReport {
+        use crate::adapter::slang::translate::SvaKind;
+        use crate::adapter::slang::verify_auto::PropertyVerdict;
+        AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: name.into(),
+                kind: SvaKind::Assert,
+                formula: formula.into(),
+                outcome: VerifyOutcome::Skipped {
+                    reason: "cone too wide".into(),
+                },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            unsupported: Vec::new(),
+            diagnostics: Default::default(),
+            notes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn skip_note_register_dominated_says_config_value_cannot_help() {
+        // A 70-bit self-incrementing register: the property cone is 70 bits, ALL register
+        // (no in-cone inputs), so residual = 70 > the 64-bit cap — pinning inputs can't help.
+        let btor2 = "\
+1 sort bitvec 70
+2 sort bitvec 1
+3 state 1 big
+4 one 1
+5 add 1 3 4
+6 next 1 3 5
+";
+        let report = skipped_report("p_reg", "mu X.(big == 0 || <> X)");
+        let notes = skip_over_cap_notes(&report, btor2);
+        assert_eq!(
+            notes.len(),
+            1,
+            "an over-cap Skipped property gets one diagnostic"
+        );
+        let n = &notes[0];
+        assert!(
+            n.summary.contains("register-dominated"),
+            "summary must flag register-domination: {}",
+            n.summary
+        );
+        assert!(
+            n.detail.contains("CANNOT") && n.detail.contains("register reduction"),
+            "detail must say config-value cannot help + point at register reduction: {}",
+            n.detail
+        );
+    }
+
+    #[test]
+    fn skip_note_input_inflated_points_at_config_value() {
+        // A 70-bit INPUT feeding a 1-bit register: cone = 71 (1 register + 70 input), so
+        // residual = 1 ≤ the 64-bit cap — pinning the input via --config-value decides it.
+        let btor2 = "\
+1 sort bitvec 70
+2 sort bitvec 1
+3 input 1 wide
+4 state 2 flag
+5 zero 1
+6 eq 2 3 5
+7 next 2 4 6
+";
+        let report = skipped_report("p_io", "mu X.(flag == 1 || <> X)");
+        let notes = skip_over_cap_notes(&report, btor2);
+        assert_eq!(
+            notes.len(),
+            1,
+            "an over-cap Skipped property gets one diagnostic"
+        );
+        let n = &notes[0];
+        assert!(
+            n.summary.contains("config-value decidable"),
+            "summary must flag config-value decidability: {}",
+            n.summary
+        );
+        assert!(
+            n.detail.contains("--config-value") && n.detail.contains("INPUT-inflated"),
+            "detail must point at --config-value on an input-inflated cone: {}",
+            n.detail
+        );
     }
 }

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -21,8 +21,9 @@
 //! See `.claude/plans/verification-execution-planner.md` §4.2/§4.5.
 
 use crate::adapter::slang::verify_auto::{
-    AutoVerifyReport, PortfolioMode, VerificationNote, VerifyAutoOptions, escalate_bottom,
-    merge_portfolio_reports, outcome_definite, rescue_skipped_via_exact, verify_auto,
+    AutoVerifyReport, NoteLevel, PortfolioMode, VerificationNote, VerifyAutoOptions, VerifyOutcome,
+    escalate_bottom, merge_portfolio_reports, outcome_definite, rescue_skipped_via_exact,
+    verify_auto,
 };
 use crate::adapter::yosys::YosysOptions;
 use crate::adapter::{AdapterError, AdapterErrorKind};
@@ -227,7 +228,69 @@ pub fn rescue_skipped(
     design_btor2: &str,
     opts: &VerifyAutoOptions,
 ) -> Vec<VerificationNote> {
-    rescue_skipped_via_exact(report, design_btor2, opts)
+    let mut notes = rescue_skipped_via_exact(report, design_btor2, opts);
+    // P2.2a — the first ModelFacts consumer: an actionable diagnostic for what remains
+    // Skipped. Verdict-equivalent (a note, never a verdict change); P2.2b will *act* on the
+    // same cone-vs-cap facts to auto-pin and re-decide.
+    notes.extend(skip_over_cap_notes(report, design_btor2));
+    notes
+}
+
+/// P2.2a — actionable Skip diagnostic (the first `ModelFacts` consumer). For each property
+/// STILL Skipped after the exact attempt, use `ModelFacts` to check whether the exact engine
+/// bailed because the property's cone exceeds the bit cap (`cone_bits > cap`); if so, attach a
+/// note naming the cone width, the cap, and the pinnable in-cone config inputs — the surface a
+/// `--config-value` pin (or auto-config-value, P2.2b) would shrink so it decides. (Mirrors the
+/// actionable-⊥ note #385; verdict-equivalent — a diagnostic, never a verdict change.)
+fn skip_over_cap_notes(report: &AutoVerifyReport, design_btor2: &str) -> Vec<VerificationNote> {
+    use crate::adapter::btor2::model_facts::ModelFacts;
+    use crate::adapter::btor2::symbolic_bitblast::formula_seed_atoms;
+
+    let Ok(file) = crate::adapter::btor2::parser::parse(design_btor2) else {
+        return Vec::new();
+    };
+    let facts = ModelFacts::new(&file);
+    let mut notes = Vec::new();
+    for prop in &report.properties {
+        if !matches!(prop.outcome, VerifyOutcome::Skipped { .. }) {
+            continue;
+        }
+        let Ok(formula) = crate::mu_calculus::parser::parse(&prop.formula) else {
+            continue;
+        };
+        let atoms = formula_seed_atoms(&formula);
+        let (cone_bits, cap) = facts.cone_vs_cap(&atoms);
+        if cone_bits <= cap {
+            // Skipped for another reason (atom-less cube, unsupported op) — not a cap issue,
+            // so auto-config-value cannot help; leave it to the existing Skip provenance.
+            continue;
+        }
+        let inputs = facts.pinnable_cone_inputs(&atoms);
+        let items: Vec<String> = inputs
+            .iter()
+            .take(8)
+            .map(|i| format!("{}({} bits)", i.name, i.width))
+            .collect();
+        notes.push(VerificationNote {
+            kind: "skip-over-cap-reason".into(),
+            level: NoteLevel::ScopeCaveat,
+            summary: format!(
+                "`{}`: Skipped — the exact cone is {cone_bits} register+input bits (> the \
+                 {cap}-bit cap), too wide to bit-blast.",
+                prop.name
+            ),
+            detail: "The exact engine bit-blasts a property's cone-of-influence; this cone \
+                     exceeds the bit cap, so it bailed to Skipped. The cone is inflated by wide \
+                     free INPUTS the design compares against — pinning the widest in-cone ones \
+                     to representative constants (`--config-value SIGNAL=VALUE`) removes their \
+                     bits and can bring the cone under the cap so exact decides (a verdict \
+                     scoped to the pinned configuration). Auto-deriving these pins is the \
+                     planner's next increment (P2.2b)."
+                .into(),
+            items,
+        });
+    }
+    notes
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

The facts-driven auto-dispatch phase (roadmap **P2.2**) on the P2.1 planner skeleton, in two commits: **(P2.2a)** grow `ModelFacts` with the cost/decidability facts + a first Skip diagnostic, then **(P2.2b)** a measure-first course-correction that makes that diagnostic *honest*.

### P2.2a — `ModelFacts` cost facts + Skip diagnostic

**`ModelFacts` additions** (`adapter/btor2/model_facts.rs`):
- `total_bits()` — whole-design bit-blast width (memoized).
- `cone_bits(seed_atoms)` — the exact engine's cone-of-influence bit width for a property's seed atoms (mirrors its `cone_leaf_nids` keep-set; empty ⇒ whole design).
- `cone_vs_cap(seed_atoms)` → `(cone_bits, cap)` — `cone_bits > cap` is *exactly* the exact engine's Skip condition (`effective_bitblast_cap` is now `pub(crate)`).
- `free_inputs()` / `pinnable_cone_inputs(seed_atoms)` — the pinnable primary-input surface (`InputFact{nid,name,width}`, widest-first).
- shared `symbolic_bitblast::formula_seed_atoms(formula)` — the register names a formula's atoms reference, so the planner's cone estimate tracks the engine's cone.

**First consumer** (`planner::skip_over_cap_notes`): for a property STILL Skipped after the exact attempt with `cone_bits > cap`, attach a `skip-over-cap-reason` note.

### P2.2b — residual-register-aware diagnostic (measure-first course-correction)

The plan doc's premise for the next increment (*auto-config-value*: over-cap cones are "inflated by freed primary inputs", so auto-pinning them decides the property) is **empirically false** on this corpus. A real-binary sweep of the **residual** — the register bits left after pinning **every** in-cone input (`cone_bits − Σ pinnable_input_widths`):

| design | class | exact cone | pinnable inputs | residual **registers** | config-value decides? |
|---|---|---:|---:|---:|---|
| i2c | comm FSM | 139 | 17 | **122** | ❌ >64 |
| gost28147 | crypto CFB | 1195 | 835 | **360** | ❌ |
| present_cipher | block cipher | 226 | 82 | **144** | ❌ |

The over-cap wall is a **register-count** wall, not input-inflation — even pinning all inputs leaves ≫64 register bits, so an auto-config-value action would decide **nothing** here. So the `rescue_over_cap` action was implemented, measured, and **dropped**; instead the Skip diagnostic became **residual-aware**:
- `residual ≤ cap` → **INPUT-inflated**: `--config-value SIGNAL=VALUE` drops the cone under the cap → exact decides (scoped).
- `residual > cap` → **REGISTER-dominated**: `--config-value` **cannot** help; the note points at sound register reduction (one-hot re-encode / counter abstraction) — a cutpoint is safety-posture only, unsound for the νμ props these designs carry.

This corrects the first-cut note's unconditional "pin the wide inputs and exact decides" advice.

## Verdict-equivalence

The facts are pure; the note is **additive** (no verdict logic touched). Evidence: 5 planner unit tests (3 plan-shape + 2 residual-branch: a 70-bit register cone → register-dominated, a 70-bit input → 1-bit register cone → input-inflated) + 3 `ModelFacts` unit tests + the portfolio-merge suite green; **mununu-sva e2e**: i2c exact-symbolic now reports "register-dominated"; portfolio verdicts unchanged (⊥).

## Scope / not-in-this-PR

No new user-visible CLI/API surface (the note rides the existing note path). Deferred: sound register reduction for the register-dominated νμ class (structural compression, roadmap F1–F4); auto-cutpoint (posture-gated) + auto-predicate — P2.2c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
