### PR TITLE
fix(recoverability): actionable ⊥-diagnosis on yosys lifts (symbol-gate + output-seed)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -6711,6 +6711,358 @@ mod tests {
         eprintln!("  F2 total bit-saving on this cone: {f2_total}");
     }
 
+    /// MK.0 feasibility probe for mixed-precision KMTS (`.claude/plans/mixed-precision-kmts.md`).
+    /// The go/no-go before building the pipeline: partition the cone's state registers into
+    /// CONTROL (`C`, kept concrete) vs DATAPATH (`D`, predicate-abstracted), and bound the
+    /// reachable concrete-control state count `|Reach_C|`. If `|Reach_C|` is enumerable the
+    /// approach applies; if it explodes on a control-web design (i2c) the control cannot stay
+    /// concrete and mixed-precision degrades to the plain cube.
+    ///
+    /// A register is DATAPATH iff its value (through value-movement ops + register stages)
+    /// reaches an ARITHMETIC op or a READ index — its magnitude/bits are computed on, so it
+    /// cannot be enumerated. CONTROL uses — driving an `ite` SELECT (`args[0]`), `eq`/ordering
+    /// COMPARISONS, bit REDUCTIONS — do NOT make a register datapath; those are exactly the
+    /// decision-tree edges the concrete control LTS must keep exact. Small-value-set registers
+    /// (`detect_enum_states`, `detect_down_counter`) and frozen/config registers are always
+    /// control with a KNOWN reachable count (the "tight" bound); a narrow non-enum control
+    /// register contributes a CRUDE `2^width` upper bound (its reachable subset is unknown to a
+    /// syntactic probe — that gap is what MK.1's actual reachability closes).
+    ///
+    /// `MUNUNU_PROBE_BTOR2=<file> MUNUNU_PROBE_ATOMS=<sig[,sig...]>`; no atoms ⇒ whole design.
+    #[test]
+    #[ignore = "MK.0 probe — set MUNUNU_PROBE_BTOR2 + MUNUNU_PROBE_ATOMS"]
+    fn probe_mixed_precision_reach_c_partition() {
+        use crate::adapter::btor2::ast::{Nid, Node, Op};
+        use crate::adapter::btor2::dep_graph::cone_leaf_nids;
+        use std::collections::{HashMap, HashSet};
+
+        let path = std::env::var("MUNUNU_PROBE_BTOR2").expect("set MUNUNU_PROBE_BTOR2");
+        let content = std::fs::read_to_string(&path).expect("read btor2");
+        let file = parser::parse(&content).expect("parse btor2");
+        let atoms: Vec<String> = std::env::var("MUNUNU_PROBE_ATOMS")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        // state widths + the shipped small-value-set detectors
+        let mut state_width: HashMap<Nid, u32> = HashMap::new();
+        for l in &file.lines {
+            if let Node::State { sort, .. } = &l.node {
+                state_width.insert(l.nid, parser::bv_width(&file, *sort).unwrap_or(0));
+            }
+        }
+        let enum_values: HashMap<Nid, usize> = detect_enum_states(&file)
+            .iter()
+            .map(|m| (m.nid, m.values.len()))
+            .collect();
+        let counter_nids: HashSet<Nid> = detect_down_counter(&file).iter().map(|m| m.nid).collect();
+
+        let cone_states: Vec<Nid> = if atoms.is_empty() {
+            state_width.keys().copied().collect()
+        } else {
+            let leaves = cone_leaf_nids(&file, &atoms);
+            state_width
+                .keys()
+                .copied()
+                .filter(|n| leaves.contains(n))
+                .collect()
+        };
+
+        // frozen check + forward-use map + sequential (next) movement
+        let mut next_of: HashMap<Nid, Nid> = HashMap::new();
+        let mut uses: HashMap<Nid, Vec<(Op, usize, Nid)>> = HashMap::new();
+        let mut next_drives: HashMap<Nid, Vec<Nid>> = HashMap::new();
+        for l in &file.lines {
+            match &l.node {
+                Node::Next { state, value, .. } => {
+                    next_of.insert(*state, value.nid().abs());
+                    next_drives
+                        .entry(value.nid().abs())
+                        .or_default()
+                        .push(*state);
+                }
+                Node::Op { op, args, .. } => {
+                    for (i, a) in args.iter().enumerate() {
+                        uses.entry(a.nid().abs()).or_default().push((*op, i, l.nid));
+                    }
+                }
+                _ => {}
+            }
+        }
+        let is_const =
+            |nid: Nid| matches!(file.lookup(nid).map(|l| &l.node), Some(Node::Const { .. }));
+        let frozen = |s: Nid| match next_of.get(&s) {
+            None => true,
+            Some(&nv) => nv == s || is_const(nv),
+        };
+
+        // datapath discriminator: value reaches an arith op or a Read index
+        fn feeds_datapath(
+            uses: &HashMap<Nid, Vec<(Op, usize, Nid)>>,
+            next_drives: &HashMap<Nid, Vec<Nid>>,
+            start: Nid,
+        ) -> bool {
+            let arith = |o: Op| {
+                matches!(
+                    o,
+                    Op::Add
+                        | Op::Sub
+                        | Op::Mul
+                        | Op::Neg
+                        | Op::Inc
+                        | Op::Dec
+                        | Op::Sdiv
+                        | Op::Udiv
+                        | Op::Smod
+                        | Op::Srem
+                        | Op::Urem
+                        | Op::Sll
+                        | Op::Srl
+                        | Op::Sra
+                        | Op::Rol
+                        | Op::Ror
+                )
+            };
+            let control = |o: Op| {
+                matches!(
+                    o,
+                    Op::Eq
+                        | Op::Neq
+                        | Op::Sgt
+                        | Op::Ugt
+                        | Op::Sgte
+                        | Op::Ugte
+                        | Op::Slt
+                        | Op::Ult
+                        | Op::Slte
+                        | Op::Ulte
+                        | Op::Redand
+                        | Op::Redor
+                        | Op::Redxor
+                )
+            };
+            let mut seen = HashSet::new();
+            let mut stack = vec![start];
+            while let Some(n) = stack.pop() {
+                if !seen.insert(n) {
+                    continue;
+                }
+                if let Some(driven) = next_drives.get(&n) {
+                    stack.extend(driven.iter().copied());
+                }
+                let Some(users) = uses.get(&n) else { continue };
+                for &(op, idx, un) in users {
+                    if arith(op) {
+                        return true; // magnitude/bits computed on ⇒ datapath
+                    }
+                    if op == Op::Read && idx == 1 {
+                        return true; // indexes a table ⇒ datapath
+                    }
+                    if control(op) || (op == Op::Ite && idx == 0) {
+                        continue; // control comparison / select — NOT datapath, stop here
+                    }
+                    stack.push(un); // value-movement: concat/slice/uext/sext/ite-branch/bitwise
+                }
+            }
+            false
+        }
+
+        const WIDE: u32 = 16; // a non-enum non-counter register wider than this is treated as data
+        let mut c_regs: Vec<(Nid, u32, f64, &str)> = Vec::new();
+        let mut d_regs: Vec<(Nid, u32, &str)> = Vec::new();
+        let mut log2_tight = 0.0f64; // enum/counter/frozen — reachable count KNOWN
+        let mut log2_flags = 0.0f64; // 1-bit control (FSM/flags) — genuinely control, correlated
+        let mut log2_multibit = 0.0f64; // multi-bit non-enum control — the RISK (shift/byte/data?)
+        let mut coupled = 0usize; // D registers that ALSO drive a control decision (div r_bit)
+        let mut counters: Vec<(Nid, u32, u64)> = Vec::new(); // nid, width, reachable range
+        let mut multibit: Vec<(Nid, u32)> = Vec::new(); // the risk regs MK.1 must measure
+
+        for &s in &cone_states {
+            let w = *state_width.get(&s).unwrap_or(&0);
+            if let Some(&nv) = enum_values.get(&s) {
+                let l = (nv.max(1) as f64).log2();
+                log2_tight += l;
+                c_regs.push((s, w, l, "enum"));
+            } else if counter_nids.contains(&s) {
+                let init =
+                    init_value_of(&file, s).and_then(|op| resolve_btor2_constant(&file, op.nid()));
+                let range = init
+                    .map(|v| v.saturating_add(1))
+                    .unwrap_or(1u64 << w.min(63));
+                let l = (range.max(1) as f64).log2();
+                log2_tight += l;
+                counters.push((s, w, range));
+                c_regs.push((s, w, l, "counter"));
+            } else if frozen(s) {
+                c_regs.push((s, w, 0.0, "frozen/config(1 val)"));
+            } else if feeds_datapath(&uses, &next_drives, s) {
+                let drives_ctrl = uses.get(&s).is_some_and(|us| {
+                    us.iter().any(|&(op, idx, _)| {
+                        (op == Op::Ite && idx == 0) || matches!(op, Op::Eq | Op::Neq)
+                    })
+                });
+                if drives_ctrl {
+                    coupled += 1;
+                }
+                d_regs.push((s, w, "datapath(arith/index)"));
+            } else if w > WIDE {
+                d_regs.push((s, w, "wide-nonenum(data)"));
+            } else if w == 1 {
+                log2_flags += 1.0;
+                c_regs.push((s, w, 1.0, "flag(1-bit)"));
+            } else {
+                log2_multibit += w as f64;
+                multibit.push((s, w));
+                c_regs.push((s, w, w as f64, "multibit-control(2^w)"));
+            }
+        }
+
+        let log2_crude = log2_flags + log2_multibit;
+        let bits_c = log2_tight + log2_crude;
+        let bits_d: u32 = d_regs.iter().map(|(_, w, _)| *w).sum();
+        eprintln!(
+            "=== MK.0 mixed-precision partition + |Reach_C| bound: {} cone regs, atoms={:?} ===",
+            cone_states.len(),
+            atoms
+        );
+        let mut by_tag: std::collections::BTreeMap<&str, (usize, u32)> =
+            std::collections::BTreeMap::new();
+        for (_, w, _, t) in &c_regs {
+            let e = by_tag.entry(t).or_default();
+            e.0 += 1;
+            e.1 += w;
+        }
+        eprintln!("  CONTROL (C): {} regs (kept concrete)", c_regs.len());
+        for (t, (n, b)) in &by_tag {
+            eprintln!("    {:24} {:3} regs {:4} bits", t, n, b);
+        }
+        eprintln!(
+            "  DATAPATH (D): {} regs, {} bits (predicate-abstracted)",
+            d_regs.len(),
+            bits_d
+        );
+        if !counters.is_empty() {
+            eprintln!("  counters (concrete-enumeration cost = the reachable RANGE, not 1 bit):");
+            for (nid, w, range) in &counters {
+                let note = if *range > (1 << 12) {
+                    " ⚠ WIDE — needs counter/ranking-abstraction, not concrete enumeration"
+                } else {
+                    ""
+                };
+                eprintln!("    nid={nid} width={w} range={range}{note}");
+            }
+        }
+        eprintln!(
+            "  |Reach_C| ≤ 2^{:.1}  =  tight(enum/counter) 2^{:.1} · flags(1-bit) 2^{:.1} · multibit-control 2^{:.1}",
+            bits_c, log2_tight, log2_flags, log2_multibit
+        );
+        if bits_c <= 40.0 {
+            eprintln!("     crude bound ≈ {} states", bits_c.exp2() as u128);
+        }
+        eprintln!(
+            "  mixed C-D coupling (D regs that also drive control, e.g. div r_bit): {coupled}"
+        );
+        // Concrete enumeration cost is dominated by the counter RANGES + the multibit-control regs;
+        // 1-bit flags are FSM-correlated (reachable ≪ 2^flags). A WIDE counter (range ≫ 2^12) means
+        // the control itself needs counter/ranking-abstraction — the flat 2-way split degrades.
+        let wide_counter = counters.iter().any(|(_, _, r)| *r > (1 << 12));
+        let hard_core = log2_tight + log2_multibit; // enumeration cost ignoring flag correlation
+        let verdict = if bits_c <= 20.0 {
+            "GREEN — |Reach_C| enumerable even at the crude bound ⇒ mixed-precision APPLIES cleanly"
+        } else if wide_counter {
+            "AMBER — a WIDE counter sits in the control cone: fully-concrete control is NOT small; \
+             mixed-precision needs the control ITSELF layered (concrete FSM + ranking-abstracted \
+             counter + predicate data), a 3-way split beyond the design's flat concrete-control/\
+             predicate-data. The FSM/flag skeleton may still be small — MK.1 must measure it after \
+             lifting the counters out."
+        } else if hard_core <= 20.0 {
+            "INCONCLUSIVE(cheap) — enumeration cost (counters + multibit-control) is small; the \
+             large bound is only the 1-bit-flag 2^w over-estimate (FSM-correlated, reachable ≪ 2^n) \
+             ⇒ plausibly tractable, MK.1 reachability confirms"
+        } else {
+            "RED — multibit-control state alone is large ⇒ concrete control does NOT stay small; \
+             those registers must move to D (predicated) or the split degrades to the cube"
+        };
+        eprintln!("  VERDICT: {verdict}");
+        if !multibit.is_empty() {
+            eprintln!(
+                "  multibit-control regs (the RISK — MK.1 must measure their reachable subset or move to D):"
+            );
+            for (nid, w) in &multibit {
+                eprintln!("    nid={nid} width={w}");
+            }
+        }
+    }
+
+    /// MK.0 cross-check — run the #385 recoverability-⊥ diagnosis (+ the scalable verdict) on a
+    /// lifted design, to decide whether a register-dominated ⊥ is (a) config/sequence/counter
+    /// dependent (mixed-precision's concrete-FSM does NOT help) or (b) "coarse-but-closable"
+    /// abstraction, i.e. FSM-predicate-coarseness (the one case a concrete control skeleton fixes).
+    /// `MUNUNU_PROBE_BTOR2=<file> MUNUNU_PROBE_GOOD="REG == VALUE"`.
+    #[test]
+    #[ignore = "MK.0 cross-check — set MUNUNU_PROBE_BTOR2 + MUNUNU_PROBE_GOOD"]
+    fn probe_recoverability_bot_diagnosis() {
+        let path = std::env::var("MUNUNU_PROBE_BTOR2").expect("set MUNUNU_PROBE_BTOR2");
+        let good = std::env::var("MUNUNU_PROBE_GOOD").expect("set MUNUNU_PROBE_GOOD");
+        let content = std::fs::read_to_string(&path).expect("read btor2");
+        let verdict =
+            crate::adapter::recoverability::verify_recoverability_scalable(&content, &good, &[]);
+        let diag = crate::adapter::recoverability::diagnose_recoverability_bot(&content, &good);
+        eprintln!("=== MK.0 cross-check: recoverability ⊥ diagnosis for `AG EF ({good})` ===");
+        eprintln!("  scalable verdict: {verdict:?}");
+        eprintln!(
+            "  uncertified gating counters: {:?}",
+            diag.uncertified_counters
+        );
+        eprintln!("  wide data/config influences: {:?}", diag.wide_influences);
+        eprintln!(
+            "  is_empty (coarse-but-closable ⇒ possible FSM-coarseness): {}",
+            diag.is_empty()
+        );
+        eprintln!("  HINT: {}", diag.hint());
+        // The shipped diagnosis is SYMBOL-gated (skips unnamed regs), so on yosys lifts it misses
+        // internal counters. Re-scan the cone by NID to reveal what the symbol gate dropped.
+        if let Ok(file) = parser::parse(&content) {
+            use crate::adapter::btor2::ast::{Nid, Node};
+            use crate::adapter::btor2::dep_graph::cone_leaf_nids;
+            let atom = good.split("==").next().unwrap_or(&good).trim().to_string();
+            let leaves = cone_leaf_nids(&file, std::slice::from_ref(&atom));
+            let named: std::collections::HashMap<Nid, String> = file
+                .lines
+                .iter()
+                .filter_map(|l| match &l.node {
+                    Node::State {
+                        symbol: Some(s), ..
+                    }
+                    | Node::Op {
+                        symbol: Some(s), ..
+                    } => Some((l.nid, s.clone())),
+                    _ => None,
+                })
+                .collect();
+            eprintln!("  --- cone down-counters BY NID (bypassing the diagnosis symbol gate) ---");
+            for c in detect_down_counter(&file) {
+                if leaves.contains(&c.nid) {
+                    let nm = named.get(&c.nid).map(|s| s.as_str()).unwrap_or("<UNNAMED>");
+                    eprintln!(
+                        "    counter nid={} width={} threshold={} name={} — the diagnosis {} it",
+                        c.nid,
+                        c.width,
+                        c.threshold,
+                        nm,
+                        if named.contains_key(&c.nid) {
+                            "sees"
+                        } else {
+                            "SKIPS (unnamed)"
+                        }
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn detect_enum_states_finds_fsm_rejects_counter() {
         use crate::adapter::btor2::parser::parse;

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1114,11 +1114,27 @@ pub fn diagnose_recoverability_bot(btor2_content: &str, good: &str) -> Recoverab
     let symbols = collect_symbols(&file);
 
     // The good's BACKWARD cone (crossing state boundaries): the named cells/inputs whose value
-    // transitively determines the recovery target.
-    let mut queue: std::collections::VecDeque<i64> = good_registers
-        .iter()
-        .filter_map(|gr| symbols.iter().find_map(|(n, s)| (s == gr).then_some(*n)))
-        .collect();
+    // transitively determines the recovery target. Resolve each good register to a seed nid — an
+    // Input/State/Op-alias (via `symbols`) OR a top-level `output` node carrying the atom. A lifted
+    // design's recovery target is commonly an `output` (e.g. i2c's `scl_padoen_o`), which
+    // `collect_symbols` does NOT index — without this fallback the cone seeds empty and the diagnosis
+    // reports "no obstacle" on exactly the lifted designs it serves. Seed from the output nid; the
+    // walk below follows `Node::Output.signal` into the driving logic.
+    let resolve_seed = |gr: &String| -> Option<i64> {
+        symbols
+            .iter()
+            .find_map(|(n, s)| (s == gr).then_some(*n))
+            .or_else(|| {
+                file.lines.iter().find_map(|l| match &l.node {
+                    Node::Output {
+                        symbol: Some(s), ..
+                    } if s == gr => Some(l.nid),
+                    _ => None,
+                })
+            })
+    };
+    let mut queue: std::collections::VecDeque<i64> =
+        good_registers.iter().filter_map(resolve_seed).collect();
     let mut cone: std::collections::HashSet<i64> = std::collections::HashSet::new();
     while let Some(nid) = queue.pop_front() {
         if !cone.insert(nid) {
@@ -1144,19 +1160,39 @@ pub fn diagnose_recoverability_bot(btor2_content: &str, good: &str) -> Recoverab
         }
     }
 
-    // (1) Uncertified gating down-counters in the cone (the good does not read them).
+    // (1) Uncertified gating down-counters in the cone (the good does not read them). A yosys-lifted
+    // INTERNAL counter is UNNAMED; the name-based ranking pipeline cannot reference it, so it is
+    // uncertified in practice — report it by a synthesized `nid<N>(<W>-bit)` label rather than
+    // silently dropping it. (Pre-fix the diagnosis was symbol-gated: it skipped every unnamed
+    // obstacle and reported "no structural obstacle" on exactly the real lifted designs it serves —
+    // e.g. i2c's counter-gated ⊥, whose 16-bit SCL prescaler is an unnamed internal register.)
     let counter_nids: std::collections::HashSet<i64> =
         crate::adapter::btor2::bit_blast::detect_down_counter(&file)
             .iter()
             .map(|c| c.nid)
             .collect();
     for c in crate::adapter::btor2::bit_blast::detect_down_counter(&file) {
-        if let Some(sym) = symbols.get(&c.nid)
-            && cone.contains(&c.nid)
-            && !good_registers.contains(sym)
-            && !ranking_certificate_holds(&file, std::slice::from_ref(sym), Some(c.threshold))
-        {
-            diag.uncertified_counters.push((sym.clone(), c.width));
+        if !cone.contains(&c.nid) {
+            continue;
+        }
+        match symbols.get(&c.nid) {
+            // Named: skip if the good reads it, or its descent is ranking-certified (unchanged).
+            Some(sym) => {
+                if !good_registers.contains(sym)
+                    && !ranking_certificate_holds(
+                        &file,
+                        std::slice::from_ref(sym),
+                        Some(c.threshold),
+                    )
+                {
+                    diag.uncertified_counters.push((sym.clone(), c.width));
+                }
+            }
+            // Unnamed lifted counter: unreachable by the name-based ranking pipeline ⇒ uncertified
+            // by construction — surface it by nid so the ⊥ hint is actionable on lifts.
+            None => diag
+                .uncertified_counters
+                .push((format!("nid{}({}-bit)", c.nid, c.width), c.width)),
         }
     }
 
@@ -1171,10 +1207,11 @@ pub fn diagnose_recoverability_bot(btor2_content: &str, good: &str) -> Recoverab
         if counter_nids.contains(nid) || enum_nids.contains(nid) {
             continue;
         }
-        let Some(sym) = symbols.get(nid) else {
-            continue;
-        };
-        if good_registers.contains(sym) {
+        // A NAMED cone register that is the good's own value is not an obstacle; an unnamed lifted
+        // register has no symbol, so it can never be the (named) good register — do not skip it.
+        if let Some(sym) = symbols.get(nid)
+            && good_registers.contains(sym)
+        {
             continue;
         }
         let sort = match file.lookup(*nid).map(|l| &l.node) {
@@ -1184,7 +1221,12 @@ pub fn diagnose_recoverability_bot(btor2_content: &str, good: &str) -> Recoverab
         if let Some(w) = crate::adapter::btor2::parser::bv_width(&file, sort)
             && w >= WIDE_MIN_WIDTH
         {
-            diag.wide_influences.push((sym.clone(), w));
+            // Named: report the symbol; unnamed lifted state: report by nid (the symbol-gate fix).
+            let label = symbols
+                .get(nid)
+                .cloned()
+                .unwrap_or_else(|| format!("nid{nid}({w}-bit)"));
+            diag.wide_influences.push((label, w));
         }
     }
 
@@ -3078,6 +3120,60 @@ mod tests {
             "narrow control-only cone: no wide influence, no uncertified counter"
         );
         assert!(diag.hint().contains("no structural obstacle"));
+    }
+
+    /// Actionable-⊥ diagnosis on a YOSYS-LIFT shape — the gating obstacles are UNNAMED internal
+    /// registers (as in i2c's `scl_padoen_o` cone: the 16-bit SCL prescaler is unnamed). Pre-fix the
+    /// diagnosis was symbol-gated and returned `is_empty()` ("coarse-but-closable") — a false negative.
+    /// The fix must localize the unnamed down-counter + unnamed wide datapath by `nid`.
+    #[test]
+    fn recoverability_bot_diagnosis_localizes_unnamed_lift_obstacles() {
+        // flag' = (cnt == 0); cnt is an UNNAMED 8-bit down-counter; data is an UNNAMED 16-bit datapath
+        // register whose value the recovery rides (flag also samples data's low bit).
+        const D: &str = "1 sort bitvec 1\n2 sort bitvec 8\n3 sort bitvec 16\n\
+4 state 1 flag\n5 state 2\n6 state 3\n\
+7 zero 1\n8 zero 2\n9 zero 3\n10 one 2\n11 one 3\n12 constd 2 200\n\
+13 init 1 4 7\n14 init 2 5 12\n15 init 3 6 9\n\
+16 eq 1 5 8\n17 slice 1 6 0 0\n18 and 1 16 17\n19 next 1 4 18\n\
+20 sub 2 5 10\n21 ite 2 16 8 20\n22 next 2 5 21\n23 add 3 6 11\n24 next 3 6 23\n";
+        let diag = diagnose_recoverability_bot(D, "flag == 1");
+        assert!(
+            !diag.is_empty(),
+            "the unnamed prescaler + datapath must be localized, not skipped by the symbol gate"
+        );
+        assert_eq!(
+            diag.uncertified_counters,
+            vec![("nid5(8-bit)".to_string(), 8)],
+            "the unnamed 8-bit down-counter is reported by nid"
+        );
+        assert_eq!(
+            diag.wide_influences,
+            vec![("nid6(16-bit)".to_string(), 16)],
+            "the unnamed 16-bit datapath the recovery rides is reported by nid"
+        );
+        assert!(diag.hint().contains("ranking certificate"));
+    }
+
+    /// Actionable-⊥ diagnosis when the recovery target is a top-level `output` (the lifted-design
+    /// shape — i2c's `scl_padoen_o`). `collect_symbols` does not index outputs, so pre-fix the cone
+    /// seeded empty and the diagnosis reported "no obstacle". The seed must resolve the output and
+    /// walk its driving logic to localize the unnamed gating counter.
+    #[test]
+    fn recoverability_bot_diagnosis_seeds_from_output_atom() {
+        // out = output(flag); flag' = (cnt == 0); cnt is an UNNAMED 8-bit down-counter.
+        const D: &str = "1 sort bitvec 1\n2 sort bitvec 8\n3 state 1 flag\n4 state 2\n\
+5 zero 1\n6 zero 2\n7 one 2\n8 constd 2 100\n9 init 1 3 5\n10 init 2 4 8\n\
+11 eq 1 4 6\n12 next 1 3 11\n13 sub 2 4 7\n14 ite 2 11 6 13\n15 next 2 4 14\n16 output 3 out\n";
+        let diag = diagnose_recoverability_bot(D, "out == 1");
+        assert!(
+            !diag.is_empty(),
+            "the output-named good must seed the cone and localize the unnamed counter"
+        );
+        assert_eq!(
+            diag.uncertified_counters,
+            vec![("nid4(8-bit)".to_string(), 8)],
+            "seeded from `output out`, the walk reaches the unnamed 8-bit down-counter"
+        );
     }
 
     // Ranking certificate — the well-founded-descent / RANKING class. A down-counter to 0: `cnt`


### PR DESCRIPTION
## What

Fixes the #385 `diagnose_recoverability_bot` (the actionable-⊥ hint) which was **doubly symbol-gated**, making it inert on exactly the yosys-lifted designs it exists to serve:

- its cone **seed** (`collect_symbols`) indexes Input/State/Op-alias symbols but **not `output` nodes**, so an output-named recovery target — the common lifted shape, e.g. i2c's `scl_padoen_o` — resolved to nothing → **empty cone**;
- its obstacle checks required `symbols.get(nid) = Some`, so lifted **unnamed** internal registers (prescalers, shift/data) were **skipped**.

Together these made the diagnosis return "no structural obstacle localized" (`is_empty`) on a genuinely counter/config-gated ⊥ — a false negative that feeds a misleading signal to the P3.2 PWA loop.

## Fix (advisory-only — the hint is never load-bearing, so no soundness / verdict change)

- seed the cone from a top-level `output` node carrying the atom;
- report unnamed obstacles by a synthesized `nid<N>(<W>-bit)` label instead of dropping them.

Named behavior is preserved exactly (the two existing diagnosis tests are unchanged). **+2 regression tests** (unnamed obstacles by nid; output-atom seeding).

**Validated on the real i2c lift:** the diagnosis now localizes `clk_cnt`(16) / `c_state`(18) / `filter_cnt`(14) / `din`(8) with an actionable "recovery rides wide config/data — constrain it, else ⊥ is honest" hint (was empty).

## Also

Lands the **MK.0 mixed-precision-KMTS feasibility probes** (`bit_blast.rs`, `#[ignore]`): `probe_mixed_precision_reach_c_partition` (control/datapath partition + `|Reach_C|` bound) and `probe_recoverability_bot_diagnosis` (the ⊥-diagnosis cross-check). These established that the flat concrete-control/predicate-data split does not crack either real register-dominated ⊥ flavor (div = datapath-coupling, i2c = counter/ranking-gating) and surfaced the diagnosis bug fixed here.

## Test plan

- `cargo test -p mununu-core --lib recoverability_bot_diagnosis` — 4 green (2 preserved + 2 new).
- `make ci` equivalent ran clean in the pre-commit hook (fmt + clippy -D warnings + full test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)