### PR TITLE
fix(planner): remove unsound auto-input-pinning from the composed recoverability plan

### DIFF
--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -219,76 +219,54 @@ pub fn replan(
     escalate_bottom(report, design_btor2, reset_pinned, opts)
 }
 
-/// A **composed** recoverability plan — the point of a *planner*: mechanisms combine. A single
-/// lever rarely flips a ⊥ on its own (measured, this whole track), so this stacks the sound
-/// cone-shrink transforms and the solver refinements into ONE plan, so a design whose complexity
-/// no singleton cracks can still be decided by their combination:
+/// A **composed** recoverability plan — the point of a *planner*: mechanisms combine. It runs the
+/// SOUND, transferable levers as one plan on the (caller-scoped) model:
 ///
-///   COI (auto) → **config-pin** the in-cone free inputs (removes input bits — auto-config-value
-///   as a COMBINATION COMPONENT, not a standalone) → exact-first on the shrunk model → cube +
-///   ranking + guard-atoms + **Craig** on the shrunk model.
+///   exact-first (COI-shrunk) → cube + ranking + guard-atoms + **Craig** on the same model.
 ///
-/// Returns `(verdict, pinned_inputs)`. A verdict reached AFTER pinning is SCOPED to that
-/// configuration (a VIOLATED is a real counterexample at those input values; a HOLDS holds only
-/// for them). Used by the wall-class matrix's `combined` column to MEASURE whether composition
-/// decides what every singleton lever leaves ⊥.
+/// Every verdict it returns TRANSFERS to the design as given: a definite exact verdict, or a
+/// definite 3-valued-KMTS verdict (sound at every alternation depth incl. νμ, Bruns–Godefroid).
+///
+/// **No auto-input-pinning (removed 2026-07-26 — it was unsound).** An earlier version config-pinned
+/// the in-cone free inputs to 0 as a "combination component" and returned the pinned verdict. That is
+/// UNSOUND for `AG EF`: recoverability is **not monotone under input-restriction**. Pinning an input
+/// to a constant restricts BOTH the reachable states (weakening the outer `AG`) AND the available
+/// recovery paths (strengthening the inner `EF`), so neither direction transfers —
+/// - a pinned **HOLDS** omits every other input valuation (holds only for the pins), and
+/// - a pinned **VIOLATED** can be spurious, because pinning removes the very recovery transitions the
+///   inputs would steer through.
+///
+/// Measured on the wall-class set: the only ⊥→"decided" case the input-pin produced was `staller` —
+/// a genuinely VIOLATED design whose stall the input-pin *hid*, yielding a non-transferable scoped
+/// HOLDS that (had the scope been dropped) is a spurious verdict. Auto-config-value was already 0
+/// full-space payoff. A caller wanting an operational sub-question pins RESET itself and passes the
+/// scoped model in — reset-gating is sound and is the caller's scoping to make, not this plan's to
+/// apply silently to free inputs.
 pub fn solve_recoverability_combined(
     design_btor2: &str,
     target: &str,
-) -> (Result<crate::verdict::PropertyVerdict, String>, Vec<String>) {
+) -> Result<crate::verdict::PropertyVerdict, String> {
     use crate::adapter::btor2::cegar::PredicateSource;
-    use crate::adapter::btor2::model_facts::ModelFacts;
-    use crate::adapter::btor2::pin::pin_inputs_to_constants;
     use crate::adapter::recoverability::{
         verify_recoverability, verify_recoverability_scalable_with_source,
     };
     use crate::verdict::PropertyVerdict;
 
-    let definite = |r: &Result<PropertyVerdict, String>| {
-        matches!(r, Ok(PropertyVerdict::Holds | PropertyVerdict::Violated))
-    };
-
-    // Cone seed = the target's compared register (LHS of `reg op value`).
-    let seed: Vec<String> = target
-        .split(['=', '<', '>', '!'])
-        .next()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .into_iter()
-        .collect();
-
-    // config-pin the in-cone free inputs (auto-config-value AS A COMBINATION COMPONENT).
-    let pins: Vec<(String, u64)> = crate::adapter::btor2::parser::parse(design_btor2)
-        .ok()
-        .map(|file| {
-            ModelFacts::new(&file)
-                .pinnable_cone_inputs(&seed)
-                .iter()
-                .map(|i| (i.name.clone(), 0u64))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let (model, applied) = if pins.is_empty() {
-        (design_btor2.to_string(), Vec::new())
-    } else {
-        pin_inputs_to_constants(design_btor2, &pins)
-    };
-
-    // exact-first on the (shrunk) model — pinning may bring the cone under the bit cap so exact
-    // decides where it abstained unpinned; then cube + ranking + guard-atoms + Craig.
-    let exact_first = verify_recoverability(&model, target);
-    if definite(&exact_first) {
-        return (exact_first, applied);
+    // exact-first (with COI) — the strongest sound oracle; then the scalable cube path, which itself
+    // composes cube + ranking + guard-atoms + Craig. Both transfer to the model as given.
+    let exact_first = verify_recoverability(design_btor2, target);
+    if matches!(
+        exact_first,
+        Ok(PropertyVerdict::Holds | PropertyVerdict::Violated)
+    ) {
+        return exact_first;
     }
-    let cube_craig = verify_recoverability_scalable_with_source(
-        &model,
+    verify_recoverability_scalable_with_source(
+        design_btor2,
         target,
         &[],
         PredicateSource::CraigInterpolation,
-    );
-    (cube_craig, applied)
+    )
 }
 
 /// The companion re-plan edge for cube-**Skipped** (not `⊥`) properties: an atom-less modal

--- a/crates/mununu-core/tests/wall_class_matrix.rs
+++ b/crates/mununu-core/tests/wall_class_matrix.rs
@@ -428,7 +428,6 @@ fn wall_class_matrix() {
     let mut soundness_violations = Vec::new();
     let mut craig_unique = Vec::new();
     let mut combined_fullspace = Vec::new(); // ⊥-singletons → combined decides with NO pins (transfers)
-    let mut combined_scoped = Vec::new(); // ⊥-singletons → combined decides but pins applied (scoped)
 
     let mut rtl_classes = std::collections::BTreeSet::new();
     let mut synthetic_classes = std::collections::BTreeSet::new();
@@ -456,15 +455,11 @@ fn wall_class_matrix() {
             &[],
             PredicateSource::CraigInterpolation,
         );
-        // The COMPOSED plan (config-pin + exact + cube + ranking + guard + Craig) — the whole
-        // point of a planner: a lever that is 0 alone can contribute in combination. A HOLDS with
-        // pins applied is SCOPED to that configuration (marked `*`).
-        let (combined, pins) = solve_recoverability_combined(&model, c.target);
-        let comb_str = if pins.is_empty() {
-            v(&combined).to_string()
-        } else {
-            format!("{}*", v(&combined).trim())
-        };
+        // The COMPOSED plan (exact-first + cube + ranking + guard + Craig) — the whole point of a
+        // planner: a lever that is 0 alone can contribute in combination. It runs only SOUND,
+        // transferable levers (the earlier unsound auto-input-pinning was removed — see
+        // `solve_recoverability_combined`), so its verdict is full-space and oracle-comparable.
+        let combined = solve_recoverability_combined(&model, c.target);
         println!(
             "{:32} {:26} {:>6} {:>6} {:>6} {:>7}",
             c.name,
@@ -472,11 +467,18 @@ fn wall_class_matrix() {
             v(&dflt),
             v(&wp),
             v(&craig),
-            comb_str
+            v(&combined)
         );
 
-        // SOUNDNESS invariant — no lever may contradict the oracle.
-        for (lever, r) in [("default", &dflt), ("cube-wp", &wp), ("cube-craig", &craig)] {
+        // SOUNDNESS invariant — no lever may contradict the oracle. The `combined` plan is included:
+        // it now returns only full-space, transferable verdicts, so a contradiction would be a real
+        // composition-soundness bug (the gap the removed input-pinning previously hid).
+        for (lever, r) in [
+            ("default", &dflt),
+            ("cube-wp", &wp),
+            ("cube-craig", &craig),
+            ("combined", &combined),
+        ] {
             let bad = match c.oracle {
                 Oracle::Holds => is_viol(r),
                 Oracle::Violated => is_holds(r),
@@ -512,10 +514,9 @@ fn wall_class_matrix() {
         }
 
         // The COMBINE-MECHANISMS hypothesis: a case EVERY singleton leaves ⊥ that the composed
-        // plan DECIDES. Split by soundness — a decision reached with NO pins is a genuine
-        // FULL-SPACE win (transfers); one reached WITH config-pins is SCOPED: recoverability
-        // (AG EF) is not monotone under input-restriction, so a config-pinned verdict answers only
-        // "recoverable under held inputs" and does NOT transfer to the full space.
+        // plan DECIDES — a genuine FULL-SPACE combination win (transfers). The composed plan now
+        // runs only SOUND, transferable levers (no unsound input-pinning), so any decision it
+        // reaches is full-space and oracle-comparable.
         let all_singletons_bottom = [&dflt, &wp, &craig]
             .iter()
             .all(|r| matches!(r, Ok(PropertyVerdict::Unknown)));
@@ -524,11 +525,7 @@ fn wall_class_matrix() {
             Ok(PropertyVerdict::Holds | PropertyVerdict::Violated)
         );
         if all_singletons_bottom && combined_decides {
-            if pins.is_empty() {
-                combined_fullspace.push(c.name);
-            } else {
-                combined_scoped.push(c.name);
-            }
+            combined_fullspace.push(c.name);
         }
     }
 
@@ -538,22 +535,25 @@ fn wall_class_matrix() {
         "SOUNDNESS VIOLATIONS (a lever contradicted the oracle): {soundness_violations:?}"
     );
 
-    // The COMBINE-MECHANISMS hypothesis (the planner's raison d'être) — measured, not assumed,
-    // split by what actually TRANSFERS. A `*` in the table = the combined verdict is config-scoped.
+    // The COMBINE-MECHANISMS hypothesis (the planner's raison d'être) — measured, not assumed. The
+    // composed plan is the union of its SOUND component levers (exact-first ∪ scalable-cube), so a
+    // win here is a case every singleton leaves ⊥ that their sound composition decides + TRANSFERS.
     if combined_fullspace.is_empty() {
         println!(
-            "MEASURED: no genuine FULL-SPACE combination win on this set. The composed plan's only \
-             ⊥→decided cases are config-SCOPED (pins applied): {combined_scoped:?} — a valid but \
-             weaker 'recoverable under held inputs' sub-question that does NOT transfer (AG EF is \
-             not monotone under input-restriction; pinning `go`/`start`=0 hides the trap). The \
-             sound verdict-PRESERVING shrinkers (F1/F2/COI) save ~0 on the data-dependent ⊥, so \
-             composition adds no full-space decision here. Combination stays the right DEFAULT; \
-             this set simply has no combination-only full-space-decidable case yet."
+            "MEASURED: no genuine FULL-SPACE combination win on this set. Among the SOUND, \
+             transferable levers the composed plan is the union of exact-first and the scalable-cube \
+             path (cube+ranking+guard+Craig): every case is decided by a single sound lever, so \
+             composition adds only union COVERAGE, no synergy. (The earlier apparent 'win' — \
+             `staller` HOLDS* / `trap_uf_w48` HOLDS* — was the removed UNSOUND auto-input-pinning \
+             producing non-transferable scoped verdicts; AG EF is not monotone under \
+             input-restriction, so those never transferred.) Combination stays the right DEFAULT for \
+             COVERAGE + the soundness cross-check (exact corroborating/overturning cube); it is not a \
+             new decidability lever on this set."
         );
     } else {
         println!(
-            "COMBINATION WIN (full-space, transfers — decided with no pins where every singleton \
-             was ⊥): {combined_fullspace:?}   [config-scoped-only: {combined_scoped:?}]"
+            "COMBINATION WIN (full-space, transfers — every singleton was ⊥, the sound composition \
+             decided): {combined_fullspace:?}"
         );
     }
 


### PR DESCRIPTION
## What

`solve_recoverability_combined` config-pinned every in-cone free input to 0 as a "combination component", then returned the pinned verdict (with the pins as a side-channel). **This is unsound for `AG EF`:** recoverability is not monotone under input-restriction — pinning an input to a constant restricts *both* the reachable states (weakening the outer `AG`) *and* the recovery paths (strengthening the inner `EF`), so neither a pinned HOLDS nor a pinned VIOLATED transfers to the free design.

Measured on the wall-class matrix, this turned **`staller`** (a genuinely VIOLATED design — the input-pin hid the stall) into a scoped `HOLDS*`, and `trap_uf_w48` into a scoped `HOLDS*`. The config-scope rode only the side-channel `pins` return, so a caller reading just the verdict would get a **spurious bare HOLDS on a broken design.**

It was contained (matrix-only; **not** used by `verify-auto` / the shipped portfolio), but it is a latent spurious-verdict footgun the planner (P2.1) would inherit, and auto-config-value was already measured as 0 full-space payoff.

## Fix

- `solve_recoverability_combined` now runs only the **sound, transferable** levers — exact-first (COI) then the scalable-cube path (cube + ranking + guard-atoms + Craig) — and returns a plain `Result<PropertyVerdict, String>` (no side-channel pins). Every verdict it returns transfers. A caller wanting an operational sub-question pins RESET itself (sound scoping) and passes the model in.
- the wall-class matrix now includes `combined` in the **soundness invariant** (it was previously checked only for the single-lever columns — the gap that let the unsound scoped verdicts through).

Post-fix matrix: `staller`→VIOL, `trap_uf_w48`→⊥, and the composed plan is the union of its sound component levers (no contradiction, no synergy) on the set.

**Corrected finding:** among the sound levers there is no combination-only decidability win on the set; combination's genuine value is COVERAGE (the union) plus the soundness cross-check (exact corroborating/overturning cube), not a new decidability lever.

## Test plan

- `cargo test -p mununu-core --test wall_class_matrix -- --ignored` — passes with `combined` now in the soundness invariant; no spurious verdicts.
- `make ci` equivalent ran clean in the pre-commit hook (fmt + clippy -D warnings + full test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)