### PR TITLE
feat(exact): auto-cap 64→192 + wall-clock backstop — admit i2c's control cap-artifact safely (P2.5-A)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/native_bmc.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_bmc.rs
@@ -554,10 +554,10 @@ mod tests {
     // `q` init 0, `next q = 0` (stays 0), `bad = q`. Never violated (bounded safe).
     const SAFE: &str = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 next 1 3 2\n\
                         6 bad 3\n";
-    // 80-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
-    // depth 5. The 80-bit cone is OVER the exact engine's auto-cap ceiling (64), so
+    // 300-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
+    // depth 5. The 300-bit cone is OVER the exact engine's auto-cap ceiling (192), so
     // only a SAT-based engine (this) decides it — the beyond-cap scale win.
-    const WIDE: &str = "1 sort bitvec 80\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
+    const WIDE: &str = "1 sort bitvec 300\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
                         6 add 1 4 3\n7 next 1 4 6\n8 constd 1 5\n9 sort bitvec 1\n\
                         10 eq 9 4 8\n11 bad 10\n";
 
@@ -574,7 +574,7 @@ mod tests {
         // Reaches bad at depth 1 / 5 — the deep CEX-only search returns the depth.
         let reach = parser::parse(REACH).expect("parse");
         assert_eq!(bmc_cex_until(&reach, 64, 5_000, far, &never), Some(1));
-        let wide = parser::parse(WIDE).expect("parse"); // depth 5, 80-bit (beyond the auto-cap ceiling)
+        let wide = parser::parse(WIDE).expect("parse"); // depth 5, 300-bit (beyond the auto-cap ceiling)
         assert_eq!(bmc_cex_until(&wide, 64, 5_000, far, &never), Some(5));
         // Bounded-safe design → no CEX within the depth budget → None (never a wrong verdict).
         let safe = parser::parse(SAFE).expect("parse");
@@ -646,7 +646,7 @@ mod tests {
 
     #[test]
     fn decides_beyond_the_exact_40_bit_cap() {
-        // An 80-bit reachability the exact BDD engine abstains on (over the 64-bit auto-cap
+        // An 300-bit reachability the exact BDD engine abstains on (over the 192-bit auto-cap
         // ceiling); native BMC finds the depth-5 counterexample bit-precisely.
         assert_eq!(bmc(WIDE, 10), BmcOutcome::Violated { depth: 5 });
         // And with too small a bound it is honestly bounded, never a wrong SAFE.
@@ -730,10 +730,10 @@ mod tests {
 
     #[test]
     fn k_induction_proves_safe_beyond_the_exact_40_bit_cap() {
-        // An 80-bit register that stays 0, `bad = (big != 0)`. The exact BDD engine
-        // abstains (over the 64-bit auto-cap ceiling); native k-induction proves it SAFE
+        // An 300-bit register that stays 0, `bad = (big != 0)`. The exact BDD engine
+        // abstains (over the 192-bit auto-cap ceiling); native k-induction proves it SAFE
         // (1-inductive) bit-precisely — an in-house UNBOUNDED safety proof past the cap.
-        let wide_safe = "1 sort bitvec 80\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
+        let wide_safe = "1 sort bitvec 300\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
                          5 next 1 3 3\n6 sort bitvec 1\n7 neq 6 3 2\n8 bad 7\n";
         assert_eq!(safety(wide_safe, 10), SafetyVerdict::Safe { k: 1 });
     }
@@ -767,7 +767,7 @@ mod tests {
         // W-bit register that stays 0 (`AG(big == 0)`, encoded `bad = big != 0`),
         // swept over widths. The native k-induction engine proves it SAFE at EVERY
         // width; the exact BDD engine ABSTAINS once the cone exceeds its cap (the
-        // auto-cap ceiling, 64). That is the in-house scale win charted, not asserted by hand.
+        // auto-cap ceiling, 192). That is the in-house scale win charted, not asserted by hand.
         use crate::adapter::btor2::symbolic_bitblast::exact_bad_reachable;
         let wide_safe = |w: u32| -> String {
             format!(
@@ -784,11 +784,11 @@ mod tests {
                 "native must prove W={w} SAFE"
             );
         }
-        // The exact engine abstains once the cone is over-cap (> 64 bits, the auto-cap
-        // ceiling), where the native engine still decides — the scale delta. (At W=64 the
-        // auto-cap now admits the cone and exact DECIDES — covered by
+        // The exact engine abstains once the cone is over-cap (> 192 bits, the auto-cap
+        // ceiling raised in P2.5-A), where the native engine still decides — the scale delta.
+        // (At W ≤ 192 the auto-cap now admits the cone and exact DECIDES — covered by
         // `symbolic_bitblast::auto_cap_admits_modestly_wide_concrete_cone`.)
-        for w in [80u32, 128, 256, 512] {
+        for w in [300u32, 512] {
             assert!(
                 exact_bad_reachable(&wide_safe(w)).is_err(),
                 "the exact engine must abstain (over-cap) at W={w}"

--- a/crates/mununu-core/src/adapter/btor2/native_boolector.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_boolector.rs
@@ -532,10 +532,10 @@ mod tests {
     // `q` init 0, `next q = 0`: never violated (bounded safe).
     const SAFE: &str = "1 sort bitvec 1\n2 zero 1\n3 state 1 q\n4 init 1 3 2\n5 next 1 3 2\n\
                         6 bad 3\n";
-    // 80-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
-    // depth 5 — a cone OVER the exact engine's auto-cap ceiling (64), so a BV engine
+    // 300-bit counter: init 0, `next = big + 1`, `bad = (big == 5)`. Reaches 5 at
+    // depth 5 — a cone OVER the exact engine's auto-cap ceiling (192), so a BV engine
     // is the only one that decides it.
-    const WIDE: &str = "1 sort bitvec 80\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
+    const WIDE: &str = "1 sort bitvec 300\n2 zero 1\n3 one 1\n4 state 1 big\n5 init 1 4 2\n\
                         6 add 1 4 3\n7 next 1 4 6\n8 constd 1 5\n9 sort bitvec 1\n\
                         10 eq 9 4 8\n11 bad 10\n";
 

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -133,17 +133,34 @@ use crate::mu_calculus::{Control, Formula, FormulaVarId, Guard, ModalKind, Node 
 /// it is admitted automatically up to [`AUTO_CAP_CEILING`]; see [`effective_bitblast_cap`].
 const MAX_BITBLAST_BITS: u32 = 40;
 
-/// Auto-cap-management ceiling (verification-execution-planner Phase 4.6). With NO explicit
-/// `MUNUNU_BDD_MAX_BITS`, a concrete cone up to this width is admitted even though it exceeds
-/// the conservative [`MAX_BITBLAST_BITS`] default, so exact decides the CONCRETE model directly
-/// (no abstraction) instead of Skipping to the cube. This is sound now that BOTH failure modes
-/// a wider cone could hit bail deterministically: the mid-build node-budget guard
-/// ([`BddBitBlaster::node_budget`]) bounds BDD *size*, and the fixpoint iteration budget
-/// ([`fixpoint_iter_budget`], #369) bounds the `2^W`-diameter *counter* fixpoint the node guard
-/// alone misses — the exact reason the default stayed at 40 until that budget shipped. 64
-/// covers word-wide control designs (e.g. the OpenTitan i2c `AG EF ack` cone) while staying
-/// inside both guards' bounded-attempt cost; a wider cone still needs an explicit env opt-in.
-const AUTO_CAP_CEILING: u32 = 64;
+/// Auto-cap-management ceiling (verification-execution-planner Phase 4.6 / P2.5-A). With NO explicit
+/// `MUNUNU_BDD_MAX_BITS`, a concrete cone up to this width is admitted even though it exceeds the
+/// conservative [`MAX_BITBLAST_BITS`] default, so exact decides the CONCRETE model directly (no
+/// abstraction) instead of Skipping to the cube.
+///
+/// **Raised 64 → 192 (2026-07-27, P2.5-A).** The bit COUNT is a poor proxy for BDD tractability —
+/// measured, i2c's 173-bit recovery cone bit-blasts to an 11 135-node BDD and exact decides
+/// `AG EF (scl_padoen_o==1)` in 242 ms, but the old 64-bit ceiling Skipped it, leaving a ledger `⊥`
+/// (a cap ARTIFACT, not intractability). The size gates catch a large *BDD*: the mid-build
+/// node-budget guard ([`BddBitBlaster::node_budget`]) bounds node count and — since #813f505 — an
+/// arena exhaustion abstains GRACEFULLY (caught, not a crash); the fixpoint-iteration budget
+/// ([`fixpoint_iter_budget`], #369) bounds the `2^W`-diameter counter fixpoint.
+///
+/// **Why 192, and why the cap alone is NOT the safety guard.** Those two size/count gates do NOT
+/// bound wall-clock TIME. A deep FREE COUNTER (`twocount32` — two 32-bit counters, 2^32 fixpoint
+/// diameter) has a TINY BDD (never trips the node budget) but its EF fixpoint grinds ~1M cheap
+/// preimages ≈ 132 min before the iteration budget bails it. And the bit COUNT cannot exclude it:
+/// `twocount32`'s cone is 65 bits < i2c's 173, so ANY cap that admits the control cap-artifacts
+/// admits the counter too. (Admission is on the cone-bit SUM, not a sort width: the raw-228-bit
+/// `ponylink-slaveTXlen-sat` sums to 2870 cone bits and is excluded at EVERY cap — it is never the
+/// boundary; the actual hanger is the 65-bit counter.) So the cap can NOT be the tractability gate
+/// — the [`ExactModel::deadline`] wall-clock backstop is. 192 is chosen only to admit the measured
+/// control cap-artifacts (i2c's 173-bit cone) with modest headroom while keeping the auto-allocated
+/// arena bounded; a cone > 192 still needs an explicit `MUNUNU_BDD_MAX_BITS` opt-in (clamped to
+/// [`HARD_BITBLAST_CEILING`] = 1024). The residual — a single pathological in-op `apply_exists`
+/// (uninterruptible in-process; the BDD-blowup form is caught by the node budget) — needs a thread
+/// + `recv_timeout` to bound (P2.5-A-follow).
+const AUTO_CAP_CEILING: u32 = 192;
 
 /// Absolute ceiling the `MUNUNU_BDD_MAX_BITS` override is clamped to — bounds the largest
 /// arena we will allocate regardless of the env value. Raised 256 → 1024 (2026-07-27): measured
@@ -1726,12 +1743,33 @@ pub struct ExactModel {
     /// Fixpoint ITERATION budget — the total μ/ν fixpoint iterations across one
     /// [`ExactModel::evaluate`]. A wide FREE COUNTER has a small BDD (so the node-budget
     /// guard never fires) but a `2^W`-step (reachable-diameter) fixpoint; this bails it to
-    /// a clean `Err` (→ Skipped) DETERMINISTICALLY (machine-independent, unlike a wall clock).
+    /// a clean `Err` (→ Skipped) DETERMINISTICALLY (machine-independent). It bounds the
+    /// iteration COUNT, not wall-clock TIME: at ~ms per cheap preimage, reaching the ~1M
+    /// default takes MINUTES — so [`deadline`](Self::deadline) is the time backstop beside it.
     /// The other blowup mode — a large BDD — is caught by the node-budget guard + catch_unwind.
     iter_budget: usize,
     /// Running total of fixpoint iterations. Interior-mutable because `evaluate` / `fixpoint`
     /// take `&self`; the exact eval is single-threaded per call.
     iters: std::cell::Cell<usize>,
+    /// Wall-clock backstop DEADLINE (`Instant::now()` + [`exact_time_budget`]), SAMPLED every 256
+    /// iterations in [`Self::fixpoint`] BESIDE [`iter_budget`](Self::iter_budget) (so a fast
+    /// control fixpoint never reads the clock). `None` = no time bound (pure determinism, for
+    /// tests via `MUNUNU_BDD_TIME_BUDGET_MS=0`).
+    ///
+    /// **Why a wall clock despite the iteration budget's determinism.** The iteration budget
+    /// bounds COUNT; a deep free-counter (`twocount32` — two 32-bit counters, ~2^32 diameter)
+    /// reaches it only after ~132 min of individually-cheap preimages, and no bit-COUNT cap can
+    /// exclude it without also excluding the tractable wide-CONTROL cones the P2.5-A cap-raise
+    /// exists to admit (i2c's 173-bit cone decides in 242 ms; twocount32's 65 bits < i2c's 173).
+    /// So the cap cannot separate them and this deadline must. It is a SECONDARY guard: it only
+    /// fires for a design the deterministic budgets abstain on ANYWAY, bounding how LONG the
+    /// abstain takes, not WHETHER it happens — so a non-pathological verdict (which finishes far
+    /// under it) stays machine-independent. Abstain is always sound (never a fabricated verdict),
+    /// so a machine-dependent abstain BOUNDARY is a robustness, not a soundness, property. The
+    /// interruptible unit is one fixpoint iteration; a single pathological in-op `apply_exists`
+    /// (not observed in-corpus — the BDD-blowup form is caught by the node budget) is the residual
+    /// gap a thread + `recv_timeout` would close (P2.5-A-follow).
+    deadline: Option<std::time::Instant>,
 }
 
 /// The exact-engine fixpoint iteration budget: `MUNUNU_BDD_ITER_BUDGET` or a default sized to
@@ -1741,6 +1779,19 @@ fn fixpoint_iter_budget() -> usize {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1 << 20) // ~1M iterations; a counter's steps are cheap (small BDD) so this is fast to reach
+}
+
+/// The exact-engine WALL-CLOCK backstop: `MUNUNU_BDD_TIME_BUDGET_MS` or a default. See
+/// [`ExactModel::deadline`] for why this exists beside the deterministic iteration budget. `0`
+/// disables it (returns `None` ⇒ no time bound, for tests wanting pure determinism). The default
+/// (10 s) is ~40× i2c's measured 242 ms — generous for any tractable control cone — while cutting a
+/// deep-counter abstain from the iteration budget's ~minutes down to seconds.
+fn exact_time_budget() -> Option<std::time::Duration> {
+    let ms = std::env::var("MUNUNU_BDD_TIME_BUDGET_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(10_000);
+    (ms != 0).then(|| std::time::Duration::from_millis(ms))
 }
 
 impl BddBitBlaster {
@@ -1781,6 +1832,7 @@ impl BddBitBlaster {
             ff: self.ff.clone(),
             iter_budget: fixpoint_iter_budget(),
             iters: std::cell::Cell::new(0),
+            deadline: exact_time_budget().map(|d| std::time::Instant::now() + d),
         }
     }
 
@@ -2025,6 +2077,24 @@ impl ExactModel {
                     "symbolic bit-blaster: fixpoint iteration budget exceeded ({n} > {}) — the \
                      property's reachable diameter is too large to bit-blast; use `--engine explicit`",
                     self.iter_budget
+                ));
+            }
+            // Wall-clock backstop beside the count budget — bail a deep-counter fixpoint (whose
+            // cheap-but-many preimages reach `iter_budget` only after minutes) in seconds. The
+            // per-iteration preimage is the interruptible unit; the `Instant::now()` read is
+            // SAMPLED every `TIME_CHECK_STRIDE` iterations, not every one, so a fast control
+            // fixpoint (converges in < a stride) never touches the clock — zero overhead on the
+            // common path, ~stride×per-iter granularity on a deep loop. See [`Self::deadline`] for
+            // why a wall clock is sound here despite the count budget.
+            const TIME_CHECK_STRIDE: usize = 256;
+            if n.is_multiple_of(TIME_CHECK_STRIDE)
+                && let Some(dl) = self.deadline
+                && std::time::Instant::now() > dl
+            {
+                return Err(format!(
+                    "symbolic bit-blaster: exact time budget exceeded (fixpoint still iterating at \
+                     {n} steps) — the property's reachable diameter is too large to bit-blast in \
+                     the wall-clock budget; use `--engine explicit`"
                 ));
             }
             bindings.insert(var, x.clone());
@@ -4610,16 +4680,16 @@ mod tests {
     /// `Err` (which `verify_auto`'s exact branch maps to a `Skipped` property, per
     /// `e2e_sysrst`-style graceful degradation). This locks that OoM-safety
     /// guarantee for the exact path as a fast, non-docker regression. The fixture is
-    /// 80-bit — over the [`AUTO_CAP_CEILING`] (64) the no-env auto-cap will admit,
-    /// so it still degrades. (The 41–64-bit admit path is covered by
+    /// 300-bit — over the [`AUTO_CAP_CEILING`] (192) the no-env auto-cap will admit,
+    /// so it still degrades. (The 41–192-bit admit path is covered by
     /// `auto_cap_admits_modestly_wide_concrete_cone`.)
     #[test]
     fn d1_7_exact_verdict_over_bit_cap_degrades_gracefully() {
-        // One 80-bit register (80 > AUTO_CAP_CEILING = 64), no inputs. The formula is
+        // One 300-bit register (300 > AUTO_CAP_CEILING = 192), no inputs. The formula is
         // immaterial: the cap fires in `build`, before atom resolution or fixpoint
         // evaluation, so a caller degrades to Skipped rather than OoM.
         const WIDE_BTOR2: &str = r#"
-1 sort bitvec 80
+1 sort bitvec 300
 2 sort bitvec 1
 3 state 1 wide
 4 one 1
@@ -4628,9 +4698,9 @@ mod tests {
 "#;
         let formula = crate::mu_calculus::parser::parse("(wide == 0)").expect("formula parses");
         let err = exact_symbolic_verdict(WIDE_BTOR2, &formula)
-            .expect_err("80-bit design exceeds the auto-cap ceiling (64) → clean Err");
+            .expect_err("300-bit design exceeds the auto-cap ceiling (192) → clean Err");
         assert!(
-            err.contains("register+input bits") && err.contains("80"),
+            err.contains("register+input bits") && err.contains("300"),
             "the error must name the bit count + cap so a caller can degrade to \
              Skipped; got: {err}"
         );
@@ -4638,7 +4708,7 @@ mod tests {
 
     /// Auto-cap-management (verification-execution-planner Phase 4.6) — with NO explicit
     /// `MUNUNU_BDD_MAX_BITS`, a concrete cone that modestly exceeds the conservative 40-bit
-    /// default is admitted up to [`AUTO_CAP_CEILING`] (64), so exact decides the CONCRETE model
+    /// default is admitted up to [`AUTO_CAP_CEILING`] (192), so exact decides the CONCRETE model
     /// directly instead of Skipping. Locks (a) the pure `default_cap_for_cone` thresholds and
     /// (b) that a 48-bit concrete cone — which the old 40-bit default rejected (see `d1_7`,
     /// which used exactly this width before the ceiling shipped) — now DECIDES. No env mutation:
@@ -4646,20 +4716,27 @@ mod tests {
     /// in the environment the assertion is skipped rather than falsely failing.
     #[test]
     fn auto_cap_admits_modestly_wide_concrete_cone() {
-        // Pure threshold math (no env, no BDD): the default floor is never lowered; a 41–64-bit
-        // cone raises the cap to fit; a > 64-bit cone is clamped to the ceiling (⇒ Err upstream).
+        // Pure threshold math (no env, no BDD): the default floor is never lowered; a 41–192-bit
+        // cone raises the cap to fit; a > 192-bit cone is clamped to the ceiling (⇒ Err upstream).
         assert_eq!(default_cap_for_cone(8), 40, "≤ floor ⇒ the 40-bit floor");
         assert_eq!(default_cap_for_cone(40), 40, "exactly the floor");
         assert_eq!(
             default_cap_for_cone(48),
             48,
-            "41–64 ⇒ raised to fit the cone"
+            "41–192 ⇒ raised to fit the cone"
         );
-        assert_eq!(default_cap_for_cone(64), 64, "exactly the ceiling");
         assert_eq!(
-            default_cap_for_cone(80),
-            64,
-            "> ceiling ⇒ clamped (build then Errs)"
+            default_cap_for_cone(173),
+            173,
+            "i2c's control cone ⇒ admitted (P2.5-A)"
+        );
+        assert_eq!(default_cap_for_cone(192), 192, "exactly the ceiling");
+        assert_eq!(
+            default_cap_for_cone(300),
+            192,
+            "> ceiling ⇒ clamped (build then Errs). NB the cap is NOT the tractability gate — a \
+             deep counter (twocount32, 65-bit cone < i2c's 173) is admitted and bounded by the \
+             wall-clock deadline, not the cap; see AUTO_CAP_CEILING + ExactModel::deadline",
         );
 
         // End-to-end: a 48-bit counter cone the old default Skipped now bit-blasts and decides.
@@ -4715,10 +4792,10 @@ mod tests {
 
     /// R-F5.6 — cone-of-influence restriction lifts the bit cap when the property's cone is
     /// small even though the FULL design is over the cap. `fsm` (2-bit) cycles 1→2→3→0→…; `wide`
-    /// (70-bit) is an out-of-cone counter `fsm` never reads. The full build hits the cap (72 >
-    /// the 64-bit auto-cap ceiling), but `exact_symbolic_verdict` restricts to the cone of
+    /// (300-bit) is an out-of-cone counter `fsm` never reads. The full build hits the cap (302 >
+    /// the 192-bit auto-cap ceiling), but `exact_symbolic_verdict` restricts to the cone of
     /// `fsm == 0` = {fsm} (pinning `wide` to a constant) and DECIDES `EF (fsm == 0)` = Holds.
-    /// `wide` is 70-bit (not 45) so the full design exceeds the auto-cap ceiling — COI, not the
+    /// `wide` is 300-bit so the full design exceeds the auto-cap ceiling — COI, not the
     /// auto-raise, is what makes this decidable. Locks that (a) COI is wired into the exact path,
     /// and (b) pinning the out-of-cone datapath is verdict-preserving — the whole point of
     /// R-F5.6, as a fast non-docker regression.
@@ -4726,7 +4803,7 @@ mod tests {
     fn rf5_6_coi_lifts_bit_cap_on_out_of_cone_datapath() {
         const FSM_PLUS_WIDE_CTR: &str = r#"
 1 sort bitvec 2
-2 sort bitvec 70
+2 sort bitvec 300
 3 state 1 fsm
 4 one 1
 5 add 1 3 4
@@ -4738,12 +4815,12 @@ mod tests {
 11 add 2 9 10
 12 next 2 9 11
 "#;
-        // The full design is 2 + 70 = 72 bits — over the 64-bit auto-cap ceiling.
+        // The full design is 2 + 300 = 302 bits — over the 192-bit auto-cap ceiling.
         let file = parser::parse(FSM_PLUS_WIDE_CTR).expect("parse");
         let full_err = BddBitBlaster::build(&file).err();
         assert!(
-            full_err.as_ref().is_some_and(|e| e.contains("72")),
-            "full 72-bit build must still hit the cap; got {full_err:?}",
+            full_err.as_ref().is_some_and(|e| e.contains("302")),
+            "full 302-bit build must still hit the cap; got {full_err:?}",
         );
         // The exact verdict restricts to the {fsm} cone (2 bits), pinning `wide` → decidable.
         // `fsm` inits to 1 and cycles to 0, so `EF (fsm == 0)` holds from the initial state.

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -733,12 +733,12 @@ mod tests {
 
     #[test]
     fn native_engine_decides_beyond_the_exact_cap_in_portfolio() {
-        // An 80-bit register that stays 0, `bad = (big != 0)`: SAFE, but the 80-bit
-        // cone is over the exact engine's auto-cap ceiling (64). With no btormc/pono on
+        // An 300-bit register that stays 0, `bad = (big != 0)`: SAFE, but the 300-bit
+        // cone is over the exact engine's auto-cap ceiling (192). With no btormc/pono on
         // PATH and the exact engine abstaining, the portfolio would previously be
         // Unknown; the in-house native engine (k-induction) now proves it
         // Unreachable — the scale win, in-process, no subprocess.
-        const WIDE_SAFE: &str = "1 sort bitvec 80\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
+        const WIDE_SAFE: &str = "1 sort bitvec 300\n2 zero 1\n3 state 1 big\n4 init 1 3 2\n\
                                  5 next 1 3 3\n6 sort bitvec 1\n7 neq 6 3 2\n8 bad 7\n";
         let file = parser::parse(WIDE_SAFE).expect("parse");
         let out = decide_reach_portfolio(&file);
@@ -749,21 +749,21 @@ mod tests {
         );
         assert!(
             !out.unreachable_by.contains(&"exact"),
-            "the exact engine must abstain on the over-cap 80-bit design: {out:?}"
+            "the exact engine must abstain on the over-cap 300-bit design: {out:?}"
         );
     }
 
     #[test]
     fn spacer_decides_beyond_native_k_induction_in_portfolio() {
-        // An 80-bit counter that STALLS at 0 (init 0, next = (c==0)?0:c+1), bad = (c==MAX).
+        // An 300-bit counter that STALLS at 0 (init 0, next = (c==0)?0:c+1), bad = (c==MAX).
         // Reachable set is {0} ⇒ SAFE, but:
-        //   - the exact BDD engine abstains (80-bit > its auto-cap ceiling of 64);
+        //   - the exact BDD engine abstains (300-bit > its auto-cap ceiling of 192);
         //   - native k-induction abstains — the property is not provable by *simple*
         //     k-induction: an unreachable free path MAX-k → … → MAX stays ¬bad until
         //     the last step at every depth, so it never closes below depth 2^80-1.
         // Only SPACER's invariant discovery (`c == 0`) decides it, so the portfolio
         // verdict is carried uniquely by "spacer". (btormc/pono absent in make-ci.)
-        const WIDE_STALL: &str = "1 sort bitvec 80\n2 zero 1\n3 one 1\n4 state 1 c\n5 init 1 4 2\n\
+        const WIDE_STALL: &str = "1 sort bitvec 300\n2 zero 1\n3 one 1\n4 state 1 c\n5 init 1 4 2\n\
              6 sort bitvec 1\n7 eq 6 4 2\n8 add 1 4 3\n9 ite 1 7 2 8\n\
              10 next 1 4 9\n11 ones 1\n12 eq 6 4 11\n13 bad 12\n";
         let file = parser::parse(WIDE_STALL).expect("parse");
@@ -779,7 +779,7 @@ mod tests {
         );
         assert!(
             !out.unreachable_by.contains(&"exact"),
-            "the exact engine must abstain on the over-cap 80-bit design: {out:?}"
+            "the exact engine must abstain on the over-cap 300-bit design: {out:?}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -335,12 +335,12 @@ mod tests {
 13 init 2 6 5
 ";
 
-    /// An 80-bit register `big` that stays 0 — `AG(big == 0)` HOLDS and is
-    /// 1-inductive. The 80-bit cone EXCEEDS the exact engine's auto-cap ceiling (64), so
+    /// A 300-bit register `big` that stays 0 — `AG(big == 0)` HOLDS and is
+    /// 1-inductive. The 300-bit cone EXCEEDS the exact engine's auto-cap ceiling (192), so
     /// the exact member abstains and only the subprocess members (btormc k-induction /
     /// Pono IC3) can decide it — the "beyond the BDD cap" value proof.
     const WIDE_STATE: &str = "\
-1 sort bitvec 80
+1 sort bitvec 300
 2 zero 1
 3 state 1 big
 4 init 1 3 2

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -2428,14 +2428,14 @@ mod tests {
     // st's cone-of-influence → the exact engine over-caps. busy ALWAYS returns to idle,
     // so every reachable state can reach idle ⇒ AG EF (st==0) HOLDS.
     //
-    // Width note: this MUST exceed AUTO_CAP_CEILING (64), not just the 40-bit floor. For an
-    // `AG EF (control-target)` property the EF-reachability fixpoint converges in ~2 iterations
-    // regardless of the counter's width (a free-running counter never *blocks* reaching idle),
-    // so the fixpoint iteration budget never fires — only the bit cap does. At ≤ 64 bits the
-    // auto-cap would admit the cone and exact would DECIDE (a win), defeating the "exact
-    // abstains" premise this test needs.
+    // Width note: this MUST exceed AUTO_CAP_CEILING (192, raised from 64 in P2.5-A), not just the
+    // 40-bit floor. For an `AG EF (control-target)` property the EF-reachability fixpoint converges
+    // in ~2 iterations regardless of the counter's width (a free-running counter never *blocks*
+    // reaching idle), so the fixpoint iteration budget never fires — only the bit cap does. At
+    // ≤ 192 bits the auto-cap would admit the cone and exact would DECIDE (a win), defeating the
+    // "exact abstains" premise this test needs.
     const WIDE_RECOVERABLE: &str = "\
-1 sort bitvec 80
+1 sort bitvec 300
 2 sort bitvec 2
 3 sort bitvec 1
 4 state 1 cnt
@@ -2454,12 +2454,12 @@ mod tests {
 17 next 2 9 16
 ";
 
-    // Same 80-bit counter (over the 64-bit auto-cap ceiling, per WIDE_RECOVERABLE's width note)
+    // Same 300-bit counter (over the 192-bit auto-cap ceiling, per WIDE_RECOVERABLE's width note)
     // but st's next-state is `stuck (2)` UNCONDITIONALLY — the `ite(cnt==0, 2, 2)` keeps the
     // counter syntactically in st's cone (so the exact engine over-caps) while every state moves
     // to the absorbing trap. From `stuck`, idle is unreachable ⇒ AG EF (st==0) VIOLATED.
     const WIDE_TRAP: &str = "\
-1 sort bitvec 80
+1 sort bitvec 300
 2 sort bitvec 2
 3 sort bitvec 1
 4 state 1 cnt

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -481,10 +481,10 @@ mod tests {
 
     #[test]
     fn skip_note_register_dominated_says_config_value_cannot_help() {
-        // A 70-bit self-incrementing register: the property cone is 70 bits, ALL register
-        // (no in-cone inputs), so residual = 70 > the 64-bit cap — pinning inputs can't help.
+        // A 300-bit self-incrementing register: the property cone is 300 bits, ALL register
+        // (no in-cone inputs), so residual = 300 > the 192-bit cap — pinning inputs can't help.
         let btor2 = "\
-1 sort bitvec 70
+1 sort bitvec 300
 2 sort bitvec 1
 3 state 1 big
 4 one 1
@@ -513,10 +513,10 @@ mod tests {
 
     #[test]
     fn skip_note_input_inflated_points_at_config_value() {
-        // A 70-bit INPUT feeding a 1-bit register: cone = 71 (1 register + 70 input), so
-        // residual = 1 ≤ the 64-bit cap — pinning the input via --config-value decides it.
+        // A 300-bit INPUT feeding a 1-bit register: cone = 301 (1 register + 300 input), so
+        // residual = 1 ≤ the 192-bit cap — pinning the input via --config-value decides it.
         let btor2 = "\
-1 sort bitvec 70
+1 sort bitvec 300
 2 sort bitvec 1
 3 input 1 wide
 4 state 2 flag

--- a/crates/mununu-core/tests/differential_oracle_e2e.rs
+++ b/crates/mununu-core/tests/differential_oracle_e2e.rs
@@ -120,10 +120,10 @@ const BTOR2TOOLS_SUITE: &[(&str, Option<bool>)] = &[
     ("recount4.btor2", None),
     ("twocount2.btor2", None),
     ("factorial4even.btor2", None),
-    ("twocount32.btor2", None),
+    ("twocount32.btor2", None), // 65-bit (two 32-bit counters); exact abstains on the wall-clock deadline
     ("noninitstate.btor2", None), // has a `constraint` — the exact engine refuses (soundness)
-    ("twocount2c.btor2", None),   // has a `constraint`
-    ("ponylink-slaveTXlen-sat.btor2", Some(true)), // 228-bit / 320-state — over the cap
+    ("twocount2c.btor2", None), // has a `constraint`
+    ("ponylink-slaveTXlen-sat.btor2", Some(true)), // 2870 cone bits — over the cap (excluded fast)
 ];
 
 #[test]
@@ -234,7 +234,9 @@ fn native_engine_adjudication_over_btor2tools_suite() {
     for (fname, known) in BTOR2TOOLS_SUITE {
         let content = std::fs::read_to_string(root.join(fname))
             .unwrap_or_else(|e| panic!("read {fname}: {e}"));
-        // Exact BDD engine: Some(bool) reachability, or None (over-cap / free-init refusal).
+        // Exact BDD engine: Some(bool) reachability, or None — abstains on over-cap (ponylink's
+        // 2870 cone bits), free-init refusal (noninitstate), or the wall-clock deadline (the
+        // 65-bit twocount32 counter, whose 2^32-diameter fixpoint the cap can't exclude).
         let exact = exact_bad_reachable(&content).ok();
         // Native engine: in-house BMC + k-induction, bounded k=40 + a 2s per-check
         // budget (the deciding benchmarks resolve in well under it; only the 228-bit

--- a/crates/mununu-core/tests/wall_class_matrix.rs
+++ b/crates/mununu-core/tests/wall_class_matrix.rs
@@ -96,7 +96,7 @@ const STALLER: &str = "\
 ";
 
 const WIDE_RECOVERABLE: &str = "\
-1 sort bitvec 80
+1 sort bitvec 300
 2 sort bitvec 2
 3 sort bitvec 1
 4 state 1 cnt
@@ -116,7 +116,7 @@ const WIDE_RECOVERABLE: &str = "\
 ";
 
 const WIDE_TRAP: &str = "\
-1 sort bitvec 80
+1 sort bitvec 300
 2 sort bitvec 2
 3 sort bitvec 1
 4 state 1 cnt


### PR DESCRIPTION
## P2.5-A — raise the exact auto-cap so control cap-artifacts decide by default, safely

Raises the exact BDD engine's auto-cap default **64 → 192** so the measured control cap-artifacts decide by default (i2c's 173-bit recovery cone → 11k-node BDD, `AG EF (scl_padoen_o==1)` in 242 ms; the 64-bit ceiling Skipped it — a cap **artifact**, not intractability).

### The finding this uncovered

The obvious "just node-budget-gate it, drop the bit cap" is **unsound**: the node budget bounds BDD *size*, the iteration budget bounds iteration *count* — **neither bounds wall-clock time**. A deep free-counter (`twocount32`: two 32-bit counters, 2³² fixpoint diameter) has a *tiny* BDD (never trips the node budget) but its EF fixpoint grinds ~1M cheap preimages ≈ **132 min** before the iteration budget bails it.

And bit-count **cannot separate** it from the control cap-artifacts: `twocount32`'s cone is **65 bits < i2c's 173**, so *any* cap that admits i2c admits the counter. (Admission is on the cone-bit **sum**, not the sort width — the raw-228-bit `ponylink` sums to **2870** cone bits and is excluded at *every* cap; it is never the boundary. The actual hanger is the 65-bit counter.)

### The fix — two guards, not one

1. **auto-cap 64 → 192** — admits i2c's 173-bit cone with modest headroom, arena stays bounded; a cone > 192 still needs an explicit `MUNUNU_BDD_MAX_BITS` opt-in (clamped to `HARD_BITBLAST_CEILING` = 1024).
2. **A wall-clock backstop deadline** in the exact fixpoint (`ExactModel::deadline`, `MUNUNU_BDD_TIME_BUDGET_MS`, default 10 s ≈ 40× i2c, **sampled every 256 iterations** so a fast control fixpoint never reads the clock, `=0` disables for deterministic tests).

**Sound:** the deadline only *abstains* (→ Skipped → the portfolio's cube/native leg decides), never fabricates a verdict; it is a **secondary** guard over the deterministic iteration budget, so a non-pathological verdict (which finishes far under it) stays machine-independent.

### Test fixtures

Fixtures calibrated to the old 64-bit cap (reach_rescue, native_boolector, wall_class_matrix wide-cube reps, recoverability, native_bmc, reach_portfolio, planner) widened **80/130 → 300** so their "beyond the exact cap" premise holds at 192; comments retuned 256 → 192.

### Validation (host)

- `differential_oracle_e2e` — `twocount32` now abstains at the deadline (test **19 s**, was a 132 min hang), 6 agree / 0 disagreements.
- mununu-core lib **2340 passed / 0 failed**; clippy clean; fmt clean.

### Residual (P2.5-A-follow)

A single pathological in-op `apply_exists` (uninterruptible in-process; not observed in-corpus — the BDD-blowup form is caught by the node budget) needs a thread + `recv_timeout` to bound.

> **Note:** the i2c-decides-at-192 *RTL* claim is validated separately in `mununu-sva-pono` (bare-host SVA verdicts are presumed vacuous) before the ledger flip is recorded (P1.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
