### PR TITLE
fix(soundness): content-verify context-cache hits + bounded straggler grace (state-mgmt audit)

### DIFF
--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -615,15 +615,37 @@ pub fn decide_reach_owned_only(file: &Btor2File, timeout_ms: u32) -> ReachOutcom
             Err(_) => break,
         }
     }
-    // A definite verdict is in — grab any members that ALSO already finished (so a
-    // co-completed contradiction is still surfaced) but do NOT wait for slow stragglers
-    // (e.g. the non-interruptible exact BDD engine on a wide datapath).
+    // A definite verdict is in. Give the OTHER members a SHORT bounded grace to finish so a
+    // co-completing CONTRADICTION (the inter-engine safety-net — one engine Reachable, another
+    // Unreachable ⇒ a latent single-engine bug) is still surfaced. We do NOT wait for the full
+    // deadline: a slow, non-interruptible straggler (the exact BDD engine on a wide datapath)
+    // would defeat the owned early-return. The grace catches the fast members (native / interp /
+    // boolector), which co-complete within ms; a genuinely-slow engine is simply not waited on.
+    // Bounded — the added latency past first-definite is at most `STRAGGLER_GRACE` (and the
+    // overall `deadline` still caps it). Was a non-blocking `try_recv` only, which missed a
+    // straggler that hadn't landed at the exact instant the first verdict arrived (DET-2).
     if definite {
-        while let Ok((name, v)) = rx.try_recv() {
-            match v {
-                Some(true) => reachable_by.push(name),
-                Some(false) => unreachable_by.push(name),
-                None => {}
+        const STRAGGLER_GRACE: Duration = Duration::from_millis(250);
+        let grace_deadline = (Instant::now() + STRAGGLER_GRACE).min(deadline);
+        while reports < N_MEMBERS {
+            let now = Instant::now();
+            if now >= grace_deadline {
+                break;
+            }
+            match rx.recv_timeout(grace_deadline - now) {
+                Ok((name, v)) => {
+                    reports += 1;
+                    match v {
+                        Some(true) => reachable_by.push(name),
+                        Some(false) => unreachable_by.push(name),
+                        None => {}
+                    }
+                    // Safety-net fired — a contradiction is now present; report it immediately.
+                    if !reachable_by.is_empty() && !unreachable_by.is_empty() {
+                        break;
+                    }
+                }
+                Err(_) => break, // grace elapsed or all members disconnected
             }
         }
     }

--- a/crates/mununu-core/src/api/cache.rs
+++ b/crates/mununu-core/src/api/cache.rs
@@ -28,10 +28,33 @@ const MAX_CACHE_SIZE: usize = 64;
 /// One cache entry: the parsed input documents AND the realized result.
 /// Caching both means the handler can read context_doc.automata without
 /// re-parsing, even though only the realized portion drives evaluation.
+///
+/// `context_src` / `sidecar_srcs` retain the RAW input strings so a lookup can
+/// verify the full content on a hit — the `u64` key alone (a 64-bit hash) could
+/// collide across two different designs and return the wrong realized model
+/// (a wrong-verdict path); the content check turns any collision into a miss.
 pub struct CacheEntry {
     pub context_doc: Arc<crate::context_dsl::ast::ContextDoc>,
     pub sidecar_docs: Arc<Vec<crate::context_dsl::ast::ContextDoc>>,
     pub realized: Arc<RealizedContext>,
+    /// The raw context source this entry was realized from (collision guard).
+    context_src: Arc<str>,
+    /// The raw sidecar sources, in order (collision guard).
+    sidecar_srcs: Arc<Vec<String>>,
+}
+
+impl CacheEntry {
+    /// True iff this entry was realized from EXACTLY these inputs — the guard
+    /// against a 64-bit-hash collision handing back a different design's model.
+    fn matches(&self, context: &str, sidecars: &[&str]) -> bool {
+        *self.context_src == *context
+            && self.sidecar_srcs.len() == sidecars.len()
+            && self
+                .sidecar_srcs
+                .iter()
+                .zip(sidecars.iter())
+                .all(|(a, b)| a.as_str() == *b)
+    }
 }
 
 impl Clone for CacheEntry {
@@ -40,6 +63,8 @@ impl Clone for CacheEntry {
             context_doc: Arc::clone(&self.context_doc),
             sidecar_docs: Arc::clone(&self.sidecar_docs),
             realized: Arc::clone(&self.realized),
+            context_src: Arc::clone(&self.context_src),
+            sidecar_srcs: Arc::clone(&self.sidecar_srcs),
         }
     }
 }
@@ -76,7 +101,12 @@ pub fn get_or_realize(context: &str, sidecars: &[&str]) -> Result<(CacheEntry, b
         let cache_guard = cache()
             .lock()
             .map_err(|e| format!("cache mutex poisoned: {e}"))?;
-        if let Some(entry) = cache_guard.get(&key) {
+        if let Some(entry) = cache_guard.get(&key)
+            && entry.matches(context, sidecars)
+        {
+            // Content-verified hit — the key AND the raw inputs match. A key-only
+            // match with differing content (a 64-bit-hash collision) falls through
+            // to a fresh realize below, which overwrites the colliding entry.
             return Ok((entry.clone(), true));
         }
     }
@@ -92,6 +122,8 @@ pub fn get_or_realize(context: &str, sidecars: &[&str]) -> Result<(CacheEntry, b
         context_doc: Arc::new(context_doc),
         sidecar_docs: Arc::new(sidecar_docs),
         realized: Arc::new(realized),
+        context_src: Arc::from(context),
+        sidecar_srcs: Arc::new(sidecars.iter().map(|s| s.to_string()).collect()),
     };
 
     {
@@ -155,6 +187,29 @@ context cache_test_same {
         let (_, hit_b2) = get_or_realize(ctx_b, &[]).unwrap();
         assert!(hit_a2, "ctx_a should hit on re-fetch");
         assert!(hit_b2, "ctx_b should hit on re-fetch");
+    }
+
+    #[test]
+    fn hash_collision_falls_through_to_realize() {
+        // Simulate a 64-bit-hash collision: force a DIFFERENT design's entry under the
+        // key that `ctx_correct` hashes to, then verify the lookup rejects it (content
+        // check) and realizes the CORRECT design instead — the GAP-1 guard.
+        let ctx_correct = r#"context cache_test_collision_correct { automata { automaton C { states { state s0 initial; } transitions {} } } }"#;
+        let ctx_other = r#"context cache_test_collision_other { automata { automaton O { states { state s0 initial; } transitions {} } } }"#;
+        let (other_entry, _) = get_or_realize(ctx_other, &[]).unwrap();
+        // Force the collision: the other design's entry stored under ctx_correct's key.
+        let key = cache_key(ctx_correct, &[]);
+        cache().lock().unwrap().insert(key, other_entry);
+        // The key hits the wrong entry, but `matches` must reject it and realize correctly.
+        let (got, _) = get_or_realize(ctx_correct, &[]).unwrap();
+        assert!(
+            got.matches(ctx_correct, &[]),
+            "must return the entry for ctx_correct, not the collided one"
+        );
+        assert!(
+            !got.matches(ctx_other, &[]),
+            "must NOT return ctx_other's realized model"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## State-management soundness audit — 2 fixes

Prompted by the keccak 1/8 verdict-flip anomaly, a full audit of **cache-clearing between checks** and **multi-threading hazards** in the verification pipeline. The audit came back **clean by construction** — two low-severity gaps found and fixed.

### GAP-1 — content-verify `CONTEXT_CACHE` hits
`CONTEXT_CACHE` returned a realized model on a **64-bit-hash key match with no content check** ([api/cache.rs](crates/mununu-core/src/api/cache.rs)). A hash collision between two different context documents would hand back the **wrong design's model → a wrong verdict**. Now `CacheEntry` retains the raw context + sidecar sources and `matches()` verifies them on a hit; a key-match with differing content falls through to a fresh realize (overwriting the colliding entry). New test `hash_collision_falls_through_to_realize` forces the collision and confirms the guard. **API-path only** — the btor2/SVA/verify-auto portfolio never touches this cache.

### DET-2 — bounded straggler grace in `decide_reach_owned_only`
The post-first-definite drain was a non-blocking `try_recv`, so a **co-completing contradiction** (the inter-engine safety-net) that hadn't landed at the exact instant the first verdict arrived was missed ([reach_portfolio.rs](crates/mununu-core/src/adapter/reach_portfolio.rs)). Now a **bounded 250 ms grace-drain** (capped by the deadline) gives the fast members a window to surface a contradiction, still WITHOUT waiting for a slow non-interruptible straggler (the exact BDD engine) — preserving the owned early-return. The full `_parallel_with_timeout` driver already kept the complete cross-check.

### Audit verdict (otherwise clean)
- **Caches: per-check-fresh by construction** — OxiDD manager + apply-cache per `BddBitBlaster::build` (dropped with it); `ExactModel`/`EvalContext` per-eval; `ModelFacts` anchored to an immutable model (cannot go stale). No explicit "clear" needed.
- **Threading:** no `static mut` / `lazy_static!` / `thread_local!`; no `env::set_var` during a parallel run; parallel threads share only read-only data + atomics/channels + thread-local Z3 contexts; no shared OxiDD manager.
- **Determinism:** all verdict-affecting structures use `Vec` / `BTreeSet` / `BTreeMap` / positional cube indexing — no HashMap-iteration order feeds a verdict.

The **keccak 1/8 anomaly is NOT explained by any cache/race/determinism issue here** → the lift pipeline (yosys/slang subprocess) determinism is the residual hypothesis (diff the lifted BTOR2 across runs if it recurs).

Validated: `mununu-core --features api` lib — 13/13 relevant tests pass; clippy `-D warnings` clean; fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
