### PR TITLE
docs(examples): clean-room compute_engine recoverability example

### DIFF
--- a/examples/recoverability/README.md
+++ b/examples/recoverability/README.md
@@ -1,0 +1,67 @@
+# Recoverability — the branching-time differentiator
+
+> Concept: what a *recoverability* property is and why a safety-only tool cannot express it.
+
+`compute_engine.sv` is a small, self-contained `load → busy → done` compute core. It exists to
+demonstrate — reproducibly, on RTL this repository owns — the class of property that separates
+mununu's 3-valued KMTS μ-calculus engine from a bit-level safety checker (SVA assertions, plain
+BMC/k-induction).
+
+## The property
+
+> Source of truth: [`compute_engine.sv`](compute_engine.sv) — surface: CLI (`sv verify-auto`) + API + UI
+
+The core carries three `@mununu_guarantee` annotations (μ-calculus, verified through the same
+pipeline as translated SVA):
+
+| # | formula | meaning |
+|---|---|---|
+| 0 | `nu Y.((mu X.(busy==0 \|\| <> X)) && [] Y)` | **`AG EF(busy==0)`** — from *every* reachable state, the core can return to idle |
+| 1 | `mu Z.(busy==1 \|\| <> Z)` | **`EF(busy==1)`** — *non-vacuity witness*: `busy` is genuinely reachable |
+| 2 | `nu Y.((mu X.(done==1 \|\| <> X)) && [] Y)` | **`AG EF(done==1)`** — the core can *always* complete a computation |
+
+Property 0 is the differentiator. A safety checker can only say *"`busy` is low on this trace"*;
+only a branching-time engine says *"idle is **always re-reachable**, from anywhere"* — an `AG EF`
+(a `μ` inside a `ν`) that collapses under plain over- or under-approximation. Property 1 is the
+**non-vacuity gate**: without it, `AG EF(busy==0)` would hold trivially if `busy` were stuck at 0
+(a signal that never leaves the target is "recoverable" for free). Because `busy` genuinely toggles
+(0 on idle, 1 on `start`) and the FSM always returns to `IDLE`, the HOLDS is a *real* recoverability
+claim.
+
+## Run it
+
+The properties are verified out of reset (the standard formal reset discipline — pin the reset to
+its inactive value so recovery is proved via the design's own logic, not a reset escape):
+
+```console
+$ mununu sv verify-auto examples/recoverability/compute_engine.sv \
+      --top compute_engine --engine exact-symbolic --config-value rst_n=1
+```
+
+Expected verdict (exact full-state model checking — a definite verdict transfers to the RTL):
+
+```
+  reset-gated (pinned inactive): rst_n=1
+  [assert] ann_guarantee_0: HOLDS
+  [assert] ann_guarantee_1: HOLDS
+  [assert] ann_guarantee_2: HOLDS
+  [coverage-summary] 3 assertion(s): 3 definite (HOLDS), 0 violated, 0 unknown, 0 skipped
+```
+
+The `busy`/`done` cone is the small FSM (`state`, `cnt`); the 32-bit `result` datapath is out of
+cone, so the exact BDD engine decides all three in milliseconds.
+
+## Why isolation is enough here
+
+Unlike a *bus controller* (I2C/SPI), whose activity needs an external protocol partner and is
+therefore unreachable in module isolation (its "recoverability" is vacuous when verified alone),
+this core's `WORK` phase advances on its **own clock with no external handshake**. So the whole
+`busy ↔ idle` cycle is reachable in isolation, and the recoverability is genuinely exercised — the
+design-selection criterion for a *meaningful* self-contained recoverability check.
+
+## Provenance
+
+Authored in this repository (clean-room, under the repo's license) specifically as a public
+reproducer. It is a minimal analog of the same property class mununu decides on real compute cores
+(crypto round-FSMs, DSP pipelines) — those measurements live in the project's private benchmark
+ledger; this example is the runnable demonstration of the capability.

--- a/examples/recoverability/compute_engine.sv
+++ b/examples/recoverability/compute_engine.sv
@@ -1,0 +1,77 @@
+// compute_engine.sv — a self-contained "load → busy → done" compute core.
+//
+// Authored for mununu as a PUBLIC, permissively-licensed (this repo's license) reproducer of
+// the branching-time RECOVERABILITY differentiator — the class of property no bit-level,
+// safety-only tool (SVA assertion checker, plain BMC) can express.
+//
+// The differentiator, in one line:
+//     AG EF (busy == 0)   — "from EVERY reachable state, the core can return to idle"
+// paired with its non-vacuity witness  EF (busy == 1)  ("the core genuinely goes busy", so the
+// recovery is not trivially true). A safety checker can only say "busy is low on THIS trace";
+// only a branching-time engine says "idle is ALWAYS re-reachable, from anywhere". mununu decides
+// it exactly over the bit-blasted state space (3-valued KMTS mu-calculus), soundly.
+//
+// Why this design is a *meaningful* (non-vacuous) example — the property gate mununu's own work
+// applies (see the benchmark-property discipline): the recovery target `busy==0` is genuinely
+// LEFT (busy goes high on `start`) and always re-reached (the FSM returns to IDLE), so the HOLDS
+// is a real recoverability claim, not a stuck-signal vacuity. Its activity is self-contained: the
+// WORK phase advances on its own clock with no external handshake, so the whole busy↔idle cycle is
+// reachable in module isolation.
+//
+// The properties are carried as `@mununu_guarantee` mu-calculus annotations (verified by
+// `mununu sv verify-auto`). Run out-of-reset (`--config-value rst_n=1`) — see README.md.
+
+// AG EF(idle): from every reachable state, the core can return to idle (the recovery).
+// @mununu_guarantee nu Y.((mu X.(busy==0 || <> X)) && [] Y)
+// Non-vacuity witness: busy is genuinely reachable, so the recovery above is not trivially true.
+// @mununu_guarantee mu Z.(busy==1 || <> Z)
+// AG EF(done): from every reachable state, the core can always complete a computation.
+// @mununu_guarantee nu Y.((mu X.(done==1 || <> X)) && [] Y)
+module compute_engine #(
+    parameter int WORK_CYCLES = 8
+) (
+    input  logic        clk,
+    input  logic        rst_n,        // async, active-low
+    input  logic        start,        // pulse to begin a computation
+    input  logic [31:0] data_in,
+    output logic        busy,         // high while a computation is in flight
+    output logic        done,         // one-cycle pulse when a result is ready
+    output logic [31:0] result
+);
+    typedef enum logic [1:0] { IDLE, WORK, FINISH } state_t;
+    state_t     state;
+    logic [7:0] cnt;
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state  <= IDLE;
+            cnt    <= '0;
+            result <= '0;
+            done   <= 1'b0;
+        end else begin
+            done <= 1'b0;                       // default: a single-cycle pulse
+            case (state)
+                IDLE:
+                    if (start) begin
+                        state  <= WORK;
+                        cnt    <= '0;
+                        result <= data_in;
+                    end
+                WORK: begin
+                    result <= result ^ (result << 1) ^ {24'b0, cnt};  // self-contained "processing"
+                    if (cnt == WORK_CYCLES[7:0] - 8'd1)
+                        state <= FINISH;
+                    else
+                        cnt <= cnt + 8'd1;
+                end
+                FINISH: begin
+                    done  <= 1'b1;               // result is ready this cycle
+                    state <= IDLE;               // ... and the core returns to idle (the recovery)
+                end
+                default: state <= IDLE;
+            endcase
+        end
+    end
+
+    assign busy = (state != IDLE);
+endmodule


### PR DESCRIPTION
## Clean-room recoverability example — the branching-time differentiator

Adds `examples/recoverability/compute_engine.sv` — a small, self-contained `load → busy → done` compute core, authored in-repo (permissive) as a **public runnable reproducer** of the property class that separates mununu from a bit-level safety checker:

| formula | meaning | verdict |
|---|---|---|
| `AG EF(busy==0)` | from every reachable state, the core can return to idle | **HOLDS** |
| `EF(busy==1)` | non-vacuity witness — busy genuinely toggles | **HOLDS** |
| `AG EF(done==1)` | the core can always complete a computation | **HOLDS** |

```console
$ mununu sv verify-auto examples/recoverability/compute_engine.sv \
      --top compute_engine --engine exact-symbolic --config-value rst_n=1
  → 3 definite (HOLDS), 0 violated, 0 unknown, 0 skipped
```

`AG EF(busy==0)` is the differentiator — a `μ` inside a `ν` that no SVA assertion / plain BMC can express (a safety checker says "busy is low on *this* trace"; only a branching engine says "idle is *always* re-reachable"). `EF(busy==1)` is the **non-vacuity gate**: because `busy` genuinely leaves 0, the HOLDS is a real recoverability claim, not a stuck-signal vacuity. The `busy`/`done` cone is the small FSM (`state`, `cnt`); the 32-bit `result` datapath is out-of-cone, so exact decides in ms.

**Why isolation suffices:** the `WORK` phase advances on its own clock with no external handshake, so the `busy ↔ idle` cycle is reachable in module isolation — unlike a bus controller (I2C/SPI), whose activity needs an external protocol partner and is *vacuous* when verified alone. This is the design-selection criterion for a meaningful self-contained recoverability check.

Clean-room (this repo's license) — the runnable capability demo; real compute-core measurements live in the private benchmark ledger. Feeds the planned planner demo + article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
