### PR TITLE
feat(planner): lift SV→BTOR2 once, shared across precision-ladder operators (P2.1 common-IR keystone)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1624,21 +1624,11 @@ pub fn verify_auto(
     yosys_opts: &YosysOptions,
     opts: &VerifyAutoOptions,
 ) -> Result<AutoVerifyReport, AdapterError> {
-    use crate::adapter::AdapterOptions;
-    use crate::adapter::btor2::cegar::{
-        CegarOptions, LiftStrategy, PredicateSource, cegar_refine_loop,
-    };
-    use crate::adapter::btor2::shadow::augment_with_past_shadows;
-    use crate::adapter::yosys::sv_to_btor2_with_blackboxes;
-    use crate::mu_calculus::Environment;
-    use crate::mu_calculus::parser as mu_parser;
-    use crate::mu_calculus::trit::Trit;
-
     // PORTFOLIO dispatch — when a portfolio mode is set, hand the task to the execution
     // planner (verification-execution-planner P2.1a): `plan()` emits the engine-operator
-    // ladder, `execute()` drives it, delegating each single-engine pass back here (each with
-    // `portfolio: None`, so no recursion) and merging under the runtime soundness guard.
-    // Verdict-equivalent to the former inline `verify_auto_portfolio`.
+    // ladder, `execute()` lifts SV → BTOR2 ONCE (the lift-once common-IR keystone, roadmap
+    // P2.1) and drives each operator over the shared lift, merging under the runtime
+    // soundness guard. Verdict-equivalent to the former inline `verify_auto_portfolio`.
     if opts.portfolio.is_some() {
         let task = crate::planner::VerificationTask {
             sources,
@@ -1648,7 +1638,97 @@ pub fn verify_auto(
         return crate::planner::execute(&crate::planner::plan(&task), &task);
     }
 
-    let (primary_name, primary_content) = sources.first().ok_or_else(|| AdapterError {
+    // Single-engine path: lift inline (`prelift = None`) then run the body.
+    verify_auto_impl(sources, yosys_opts, opts, None)
+}
+
+/// The SV → BTOR2 lift output (incl. the `auto_stub_flops` re-lift), factored out so the
+/// execution planner ([`crate::planner::execute`]) can run the lift **once** and share it
+/// across the precision-ladder operators. The yosys lift is the dominant redundant cost of
+/// the per-operator portfolio body — a 3-engine ladder otherwise re-elaborates the identical
+/// SV up to three times. The cheap Rust prep (SVA extraction, reset detection / pinning,
+/// BTOR2 parse, cube-atom classification) still re-runs per operator; only the lift is shared.
+#[derive(Clone)]
+pub(crate) struct PreLift {
+    /// The lifted BTOR2 (pre reset-pin / shadow / config-pin — those stay per-operator).
+    pub btor2: String,
+    /// Modules the lift black-boxed (instantiated, no body) — surfaced in diagnostics.
+    pub blackboxed_modules: Vec<String>,
+    /// Flop-primitive stubs auto-injected on the H.C re-lift (empty when none).
+    pub auto_provided_stubs: Vec<String>,
+}
+
+/// Run the SV → BTOR2 lift (yosys) with the `auto_stub_flops` re-lift. Pure function of
+/// `(sources, yosys_opts, opts)` — the same inputs every precision-ladder operator shares —
+/// so the planner calls it once and threads the [`PreLift`] into each [`verify_auto_impl`].
+pub(crate) fn lift_sv(
+    sources: &[(String, String)],
+    yosys_opts: &YosysOptions,
+    opts: &VerifyAutoOptions,
+) -> Result<PreLift, AdapterError> {
+    use crate::adapter::yosys::sv_to_btor2_with_blackboxes;
+    let (_, primary_content) = sources.first().ok_or_else(|| AdapterError {
+        kind: AdapterErrorKind::ParseError,
+        message: "adapter/slang/verify_auto: no SV sources provided".to_string(),
+        location: None,
+    })?;
+    // 2. SV → flattened BTOR2. The lift reports modules it black-boxed (instantiated, no
+    // body) — surfaced in `diagnostics.blackboxed_modules` so a cut FSM (the
+    // `prim_sparse_fsm_flop`-class root cause) is visible, not silent.
+    let (mut btor2, mut blackboxed_modules) =
+        sv_to_btor2_with_blackboxes(primary_content, yosys_opts).map_err(|mut e| {
+            e.message = format!("verify_auto: SV → BTOR2: {}", e.message);
+            e
+        })?;
+    // H.C — if the first lift cut a known flop primitive, inject a behavioral stub for it and
+    // re-lift so the register survives (e.g. OpenTitan's `prim_sparse_fsm_flop`). Only stubs
+    // ACTUALLY-cut modules (no collision with designs that provide their own body).
+    let mut auto_provided_stubs = Vec::new();
+    if opts.auto_stub_flops {
+        let stubs = crate::adapter::slang::prim_stubs::stubs_for_cut_modules(&blackboxed_modules);
+        if !stubs.is_empty() {
+            let mut yopts2 = yosys_opts.clone();
+            yopts2.additional_sources.extend(stubs.iter().cloned());
+            let (b2, bb2) =
+                sv_to_btor2_with_blackboxes(primary_content, &yopts2).map_err(|mut e| {
+                    e.message = format!("verify_auto: SV → BTOR2 (with flop stubs): {}", e.message);
+                    e
+                })?;
+            btor2 = b2;
+            blackboxed_modules = bb2;
+            auto_provided_stubs = stubs
+                .iter()
+                .map(|(name, _)| name.trim_end_matches(".sv").to_string())
+                .collect();
+        }
+    }
+    Ok(PreLift {
+        btor2,
+        blackboxed_modules,
+        auto_provided_stubs,
+    })
+}
+
+/// The single-engine verify body: extraction → lift → reset/pin → per-property engine →
+/// replan / rescue / notes. `prelift` is `Some` when the planner supplies a shared SV → BTOR2
+/// lift (the portfolio path lifts once), `None` to lift inline (the single-engine path).
+/// Verdict-equivalent either way — the only difference is whether the yosys lift is reused.
+pub(crate) fn verify_auto_impl(
+    sources: &[(String, String)],
+    yosys_opts: &YosysOptions,
+    opts: &VerifyAutoOptions,
+    prelift: Option<PreLift>,
+) -> Result<AutoVerifyReport, AdapterError> {
+    use crate::adapter::AdapterOptions;
+    use crate::adapter::btor2::cegar::{
+        CegarOptions, LiftStrategy, PredicateSource, cegar_refine_loop,
+    };
+    use crate::adapter::btor2::shadow::augment_with_past_shadows;
+    use crate::mu_calculus::Environment;
+    use crate::mu_calculus::parser as mu_parser;
+    use crate::mu_calculus::trit::Trit;
+
+    let (primary_name, _) = sources.first().ok_or_else(|| AdapterError {
         kind: AdapterErrorKind::ParseError,
         message: "adapter/slang/verify_auto: no SV sources provided".to_string(),
         location: None,
@@ -1758,38 +1838,24 @@ pub fn verify_auto(
         Vec::new()
     };
 
-    // 2. SV → flattened BTOR2, then 3. augment the `__past` shadow flops. The
-    // lift also reports modules it black-boxed (instantiated, no body) — those
-    // are surfaced in `diagnostics.blackboxed_modules` so a cut FSM (the
-    // `prim_sparse_fsm_flop`-class root cause) is visible, not silent.
-    let (mut btor2, mut blackboxed_modules) =
-        sv_to_btor2_with_blackboxes(primary_content, yosys_opts).map_err(|mut e| {
-            e.message = format!("verify_auto: SV → BTOR2: {}", e.message);
-            e
-        })?;
-    // H.C — if the first lift cut a known flop primitive, inject a behavioral
-    // stub for it and re-lift so the register survives (e.g. OpenTitan's
-    // `prim_sparse_fsm_flop`). Only stubs ACTUALLY-cut modules (no collision
-    // with designs that provide their own body).
-    if opts.auto_stub_flops {
-        let stubs = crate::adapter::slang::prim_stubs::stubs_for_cut_modules(&blackboxed_modules);
-        if !stubs.is_empty() {
-            let mut yopts2 = yosys_opts.clone();
-            yopts2.additional_sources.extend(stubs.iter().cloned());
-            let (b2, bb2) =
-                sv_to_btor2_with_blackboxes(primary_content, &yopts2).map_err(|mut e| {
-                    e.message = format!("verify_auto: SV → BTOR2 (with flop stubs): {}", e.message);
-                    e
-                })?;
-            btor2 = b2;
-            blackboxed_modules = bb2;
-            report.diagnostics.auto_provided_stubs = stubs
-                .iter()
-                .map(|(name, _)| name.trim_end_matches(".sv").to_string())
-                .collect();
-        }
-    }
+    // 2. SV → flattened BTOR2 (then 3. augment the `__past` shadow flops, below). Lift-once
+    // keystone (roadmap P2.1): the yosys lift is the dominant redundant cost when the
+    // portfolio runs this body once per engine operator. The planner (`execute`) lifts ONCE
+    // via `lift_sv` and threads the result in as `prelift`, so a 3-engine precision ladder
+    // does ONE yosys lift instead of up to three. On the single-engine path `prelift` is
+    // `None` and the lift runs inline — verdict-equivalent either way. The black-boxed
+    // modules + auto-injected flop stubs are surfaced in diagnostics (a cut FSM, the
+    // `prim_sparse_fsm_flop`-class root cause, is visible not silent).
+    let PreLift {
+        mut btor2,
+        blackboxed_modules,
+        auto_provided_stubs,
+    } = match prelift {
+        Some(p) => p,
+        None => lift_sv(sources, yosys_opts, opts)?,
+    };
     report.diagnostics.blackboxed_modules = blackboxed_modules;
+    report.diagnostics.auto_provided_stubs = auto_provided_stubs;
 
     // Structural reset auto-pin. When reset-gating is on but no `disable iff (reset)`
     // guard was recognized (`reset_pins` empty — the common case for a plain-RTL

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -22,8 +22,8 @@
 
 use crate::adapter::slang::verify_auto::{
     AutoVerifyReport, NoteLevel, PortfolioMode, VerificationNote, VerifyAutoOptions, VerifyOutcome,
-    escalate_bottom, merge_portfolio_reports, outcome_definite, rescue_skipped_via_exact,
-    verify_auto,
+    escalate_bottom, lift_sv, merge_portfolio_reports, outcome_definite, rescue_skipped_via_exact,
+    verify_auto_impl,
 };
 use crate::adapter::yosys::YosysOptions;
 use crate::adapter::{AdapterError, AdapterErrorKind};
@@ -141,13 +141,28 @@ pub fn execute(
         o
     };
 
+    // Lift-once common-IR keystone (roadmap P2.1): the SV → BTOR2 lift (yosys) is a pure
+    // function of `(sources, yosys_opts, opts)` — identical for every precision-ladder
+    // operator (`mk_opts` only flips the portfolio + engine flags, which the lift ignores).
+    // Lift it ONCE here and thread the shared result into each operator's `verify_auto_impl`
+    // pass, so a 3-engine ladder does ONE yosys elaboration instead of re-lifting per engine.
+    // Verdict-equivalent: each operator runs the identical body it did before, only reusing
+    // the lift instead of recomputing it. (The cheap Rust prep — extraction, reset/pin, parse,
+    // cube-atom classification — still re-runs per operator; only the yosys lift is shared.)
+    let prelift = lift_sv(task.sources, task.yosys_opts, task.opts)?;
+
     match plan.mode {
         PortfolioMode::Sequential => {
             let mut runs: Vec<(&str, Result<AutoVerifyReport, AdapterError>)> = Vec::new();
             for op in &plan.ops {
                 runs.push((
                     op.label,
-                    verify_auto(task.sources, task.yosys_opts, &mk_opts(op)),
+                    verify_auto_impl(
+                        task.sources,
+                        task.yosys_opts,
+                        &mk_opts(op),
+                        Some(prelift.clone()),
+                    ),
                 ));
                 // Early-exit as soon as the MERGE so far leaves no ⊥ property (the budget win).
                 let merged = merge_portfolio_reports(&runs, plan.mode);
@@ -163,7 +178,8 @@ pub fn execute(
             merge_portfolio_reports(&runs, plan.mode)
         }
         PortfolioMode::Parallel => {
-            // Scoped threads borrow the task's sources / yosys_opts; each owns its option clone.
+            // Scoped threads borrow the task's sources / yosys_opts; each owns its option clone
+            // AND its own clone of the shared lift (so no engine re-runs yosys).
             let runs: Vec<(&str, Result<AutoVerifyReport, AdapterError>)> =
                 std::thread::scope(|scope| {
                     let handles: Vec<(&str, _)> = plan
@@ -171,9 +187,12 @@ pub fn execute(
                         .iter()
                         .map(|op| {
                             let o = mk_opts(op);
+                            let pl = prelift.clone();
                             (
                                 op.label,
-                                scope.spawn(move || verify_auto(task.sources, task.yosys_opts, &o)),
+                                scope.spawn(move || {
+                                    verify_auto_impl(task.sources, task.yosys_opts, &o, Some(pl))
+                                }),
                             )
                         })
                         .collect();


### PR DESCRIPTION
## What

The verification-execution planner's portfolio path (`planner::execute`) re-entered `verify_auto` from the **SV sources** once per engine operator, so a 3-engine precision ladder re-ran the identical yosys **SV→BTOR2 lift up to 3–6×** — there is no lift cache. This PR makes the lift happen **once** and be shared across operators (the P2.1 "common-IR keystone").

- Factored the lift into `lift_sv()` returning a `PreLift { btor2, blackboxed_modules, auto_provided_stubs }` (derive `Clone`).
- Threaded an `Option<PreLift>` through a private `verify_auto_impl(…, prelift)`; the public `verify_auto` single-engine path passes `None` (lifts inline, unchanged).
- `planner::execute` now lifts once up front and hands each precision-ladder operator its own clone of the shared `PreLift` — Sequential **and** Parallel modes.

## Why this shape

An **STS-IR waist review** (gated this work) found the STS-IR (`adapter/sts_ir.rs`) is the *μ-abstraction-lift seam* — `bit_blast` (Enumerate→CLTS) and `predicate_cube_lift` (SmtImage→KMTS) — **not a universal engine waist**. The reachability portfolio (`decide_reach_portfolio(&Btor2File)` = native-BMC / spacer / interp), recoverability (`verify_recoverability(&str, …)`), and the symbolic-BDD `abstract_relation` all take BTOR2 directly and **bypass** the seam. So the common currency every engine actually funnels through is **BTOR2** (`Btor2File` + `ModelFacts`), and "lift once + share the BTOR2" is the correct first common-IR increment — the plan-doc's `Sts`-centric `VerificationTask` named a currency half the engines don't consume.

## Verdict-equivalence

By construction: only the yosys lift is shared. The cheap Rust prep (SVA extraction, reset detection/pinning, BTOR2 parse, cube-atom classification) still re-runs per operator, and every operator runs the identical body it did before — the change is purely *not recomputing the lift*.

## Validation

- `cargo clippy -p mununu-core --all-targets -D warnings` — clean
- `cargo test -p mununu-core --lib` — **2340 passed / 0 failed** (60 ignored)
- Portfolio SVA e2e in `mununu-sva-pono` (the CLAUDE.md rule for a verify-auto change): `e2e_csrng_real_sva_verdict_breakdown` (HOLDS=2 VIOLATED=0) + `e2e_oracle_gates_verify_auto_verdicts` + `e2e_h5gr1_csrng_recoverability_escalation_flip` — **3/3 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
