### PR TITLE
docs(examples): recoverability differentiator contrast — a lockup safety checkers miss

### DIFF
--- a/examples/recoverability/README.md
+++ b/examples/recoverability/README.md
@@ -2,10 +2,17 @@
 
 > Concept: what a *recoverability* property is and why a safety-only tool cannot express it.
 
-`compute_engine.sv` is a small, self-contained `load → busy → done` compute core. It exists to
-demonstrate — reproducibly, on RTL this repository owns — the class of property that separates
-mununu's 3-valued KMTS μ-calculus engine from a bit-level safety checker (SVA assertions, plain
-BMC/k-induction).
+This directory holds a **contrast pair** of small, self-contained `load → busy → done` compute
+cores that demonstrate — reproducibly, on RTL this repository owns — the class of property that
+separates mununu's 3-valued KMTS μ-calculus engine from a bit-level safety checker (SVA assertions,
+plain BMC/k-induction):
+
+- [`compute_engine.sv`](compute_engine.sv) — **recovers**: `AG EF(busy==0)` **HOLDS**.
+- [`compute_engine_faulty.sv`](compute_engine_faulty.sv) — the same core with one missing recovery
+  edge, so it **locks up**: `AG EF(busy==0)` is **VIOLATED**, and mununu returns the trap trace.
+
+Same command, same core, opposite verdict — the [execution planner](../../crates/mununu-core/src/planner/mod.rs)
+routes both to the exact-symbolic engine and returns a *definite* answer (a trace, not a shrug).
 
 ## The property
 
@@ -35,10 +42,11 @@ its inactive value so recovery is proved via the design's own logic, not a reset
 
 ```console
 $ mununu sv verify-auto examples/recoverability/compute_engine.sv \
-      --top compute_engine --engine exact-symbolic --config-value rst_n=1
+      --top compute_engine --config-value rst_n=1
 ```
 
-Expected verdict (exact full-state model checking — a definite verdict transfers to the RTL):
+No `--engine` flag: the default is the **execution planner's portfolio**, which routes this small
+control cone to the exact-symbolic engine automatically (a definite verdict transfers to the RTL):
 
 ```
   reset-gated (pinned inactive): rst_n=1
@@ -46,10 +54,89 @@ Expected verdict (exact full-state model checking — a definite verdict transfe
   [assert] ann_guarantee_1: HOLDS
   [assert] ann_guarantee_2: HOLDS
   [coverage-summary] 3 assertion(s): 3 definite (HOLDS), 0 violated, 0 unknown, 0 skipped
+  [portfolio] portfolio-sequential: 3/3 properties decided (ran: exact-symbolic)
 ```
 
 The `busy`/`done` cone is the small FSM (`state`, `cnt`); the 32-bit `result` datapath is out of
-cone, so the exact BDD engine decides all three in milliseconds.
+cone, so the planner's exact BDD engine decides all three in milliseconds.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> IDLE
+    IDLE --> WORK: start
+    WORK --> WORK: cnt++
+    WORK --> FINISH: cnt == WORK_CYCLES-1
+    FINISH --> IDLE: done pulse
+    note right of IDLE: busy == 0 (the recovery target)
+```
+
+## The contrast — a lockup a safety checker misses
+
+> Source of truth: [`compute_engine_faulty.sv`](compute_engine_faulty.sv) — surface: CLI (`sv verify-auto`) + API + UI
+
+[`compute_engine_faulty.sv`](compute_engine_faulty.sv) is the **same core with one realistic
+defect**: an `err` strobe during `WORK` sends the FSM to a `FAULT` state that has **no edge back to
+`IDLE`** — the designer forgot the recovery transition. Nothing short of a reset clears it, so once
+faulted the core is **busy forever**.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> IDLE
+    IDLE --> WORK: start
+    WORK --> WORK: cnt++
+    WORK --> FINISH: cnt == WORK_CYCLES-1
+    WORK --> FAULT: err
+    FINISH --> IDLE: done pulse
+    FAULT --> FAULT: (no way back — the bug)
+    note right of FAULT: busy == 1 forever
+```
+
+Verified reset-pinned (recovery must be via the design's *own* logic, not the reset escape):
+
+```console
+$ mununu sv verify-auto examples/recoverability/compute_engine_faulty.sv \
+      --top compute_engine_faulty --config-value rst_n=1
+```
+
+```
+  [assert] ann_guarantee_0: VIOLATED (1 cell(s))
+        formula: nu Y.((mu X.(busy==0 || <> X)) && [] Y)
+        counterexample (stall lasso):
+          -> cnt=0, state=0   (IDLE)
+          -> cnt=0, state=1   (WORK)
+          (*) cnt=0, state=3  (FAULT)
+          (cycle repeats forever - the property is avoided)
+  [assert] ann_guarantee_1: HOLDS
+```
+
+mununu returns the **exact trap path** `IDLE → WORK → FAULT` and proves `busy==0` is unreachable
+from there. The non-vacuity witness (`EF(busy==1)`) still HOLDS, so this is a *real* lockup, not a
+stuck-signal artifact.
+
+### Why a safety / linear-time checker cannot state this
+
+| you want to say | in SVA / LTL | problem |
+|---|---|---|
+| "`busy` drops within N cycles" | `assert property (busy \|-> ##[1:N] !busy)` | needs a **bound** `N`; a genuine lockup has none, and guessing `N` turns a proof into a heuristic |
+| "`busy` eventually drops" | `s_eventually !busy` | **linear** liveness — fairness-sensitive, and over an over-approximation it is unsound or undecidable |
+| "from **every** reachable state, idle is **still reachable**" | *(not expressible)* | this is **branching** (`AG EF`): a `∀`-states, `∃`-path claim no single linear trace can express |
+
+`AG EF(busy==0)` is a `μ` inside a `ν` — an alternating fixpoint that collapses under plain over- or
+under-approximation. mununu's 3-valued KMTS engine decides it soundly at every alternation depth
+(Bruns–Godefroid), and the **execution planner** routes it: the portfolio's exact-symbolic engine
+takes the small `busy` cone and returns a *definite* VIOLATED with the trap trace.
+
+<!-- [TODO: prose] Lead the article HERE — open with the two-line contrast (recovers vs. locks up)
+     and the trap trace, before any mention of engines or fixpoints. The reader should feel the bug
+     first. -->
+<!-- [TODO: prose] One paragraph on WHY this bug class matters in real silicon: sticky error states
+     with a missing recovery edge are a common RTL defect; a safety regression suite that only
+     checks "bad never asserts" sails right past a core that is merely stuck. -->
+<!-- [TODO: prose] Close the loop back to the planner: same command, same core, opposite verdict —
+     the planner picked the right engine (exact over a small cone) and produced a trace, not a
+     shrug. Tie to the "lift once, route by structure" narrative. -->
 
 ## Why isolation is enough here
 

--- a/examples/recoverability/compute_engine_faulty.sv
+++ b/examples/recoverability/compute_engine_faulty.sv
@@ -1,0 +1,88 @@
+// compute_engine_faulty.sv — the RECOVERABILITY-BUG contrast to compute_engine.sv.
+//
+// Authored for mununu as a PUBLIC, permissively-licensed (this repo's license) demonstration of
+// the branching-time RECOVERABILITY differentiator CATCHING A REAL BUG — a lockup a bit-level,
+// safety-only checker (SVA assertion, plain BMC) cannot express.
+//
+// This is the same "load → busy → done" core as compute_engine.sv, with ONE realistic defect: an
+// `err` strobe from the environment during WORK drives the FSM into a FAULT state that has no
+// transition back to IDLE — the designer forgot the recovery edge. Nothing SHORT OF A RESET gets
+// the core out of FAULT, so once faulted it is BUSY FOREVER.
+//
+// The differentiator, in one line:
+//     AG EF (busy == 0)   — "from EVERY reachable state, the core can STILL return to idle"
+// On this design that property is *VIOLATED*: FAULT is a reachable state from which `busy==0` is
+// unreachable (a trap). mununu returns a concrete counterexample path reset → … → FAULT.
+//
+// Why a safety/linear checker misses this:
+//   - A bounded SVA `assert property (busy |-> ##[1:N] !busy)` needs a bound N; a genuine lockup
+//     has no N, and picking one is guesswork. An unbounded `s_eventually !busy` is a LINEAR
+//     liveness property (fairness-sensitive, often undecidable on an over-approximation).
+//   - `AG EF !busy` is BRANCHING: "from every reachable state, there EXISTS a path back to idle."
+//     A single failing linear trace cannot state it; only a branching-time engine can. mununu
+//     decides it exactly over the bit-blasted state space (3-valued KMTS mu-calculus), soundly.
+//
+// Verified reset-pinned (`--config-value rst_n=1`) on purpose: recovery must be via the design's
+// OWN logic, not the reset escape. "Can it get unstuck WITHOUT a power-cycle?" — here, no.
+//
+// The properties are carried as `@mununu_guarantee` mu-calculus annotations (verified by
+// `mununu sv verify-auto`). See README.md for the invocation and the verdict contrast.
+
+// AG EF(idle): from every reachable state, can the core still return to idle?  VIOLATED (FAULT trap).
+// @mununu_guarantee nu Y.((mu X.(busy==0 || <> X)) && [] Y)
+// Non-vacuity witness: busy is genuinely reachable, so the VIOLATED above is a real trap, not vacuity.
+// @mununu_guarantee mu Z.(busy==1 || <> Z)
+module compute_engine_faulty #(
+    parameter int WORK_CYCLES = 8
+) (
+    input  logic        clk,
+    input  logic        rst_n,        // async, active-low
+    input  logic        start,        // pulse to begin a computation
+    input  logic        err,          // fault strobe from a sub-unit (drives the lockup)
+    input  logic [31:0] data_in,
+    output logic        busy,         // high while a computation is in flight
+    output logic        done,         // one-cycle pulse when a result is ready
+    output logic [31:0] result
+);
+    typedef enum logic [1:0] { IDLE, WORK, FINISH, FAULT } state_t;
+    state_t     state;
+    logic [7:0] cnt;
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state  <= IDLE;
+            cnt    <= '0;
+            result <= '0;
+            done   <= 1'b0;
+        end else begin
+            done <= 1'b0;                       // default: a single-cycle pulse
+            case (state)
+                IDLE:
+                    if (start) begin
+                        state  <= WORK;
+                        cnt    <= '0;
+                        result <= data_in;
+                    end
+                WORK: begin
+                    result <= result ^ (result << 1) ^ {24'b0, cnt};  // self-contained "processing"
+                    if (err)
+                        state <= FAULT;          // THE BUG: a fault during WORK locks the core...
+                    else if (cnt == WORK_CYCLES[7:0] - 8'd1)
+                        state <= FINISH;
+                    else
+                        cnt <= cnt + 8'd1;
+                end
+                FINISH: begin
+                    done  <= 1'b1;               // result is ready this cycle
+                    state <= IDLE;               // ... the good path returns to idle (the recovery)
+                end
+                FAULT: begin
+                    state <= FAULT;              // ... and there is NO edge back to IDLE (the defect).
+                end
+                default: state <= IDLE;
+            endcase
+        end
+    end
+
+    assign busy = (state != IDLE);
+endmodule


### PR DESCRIPTION
## What

Adds the **buggy contrast** to the recovering `compute_engine.sv` (#404): [`compute_engine_faulty.sv`](examples/recoverability/compute_engine_faulty.sv) — the same `load → busy → done` core with **one missing recovery edge**. An `err` strobe during `WORK` drives the FSM to a `FAULT` state that has no path back to `IDLE`, so once faulted the core is busy forever (a realistic sticky-error lockup).

Together the two files are the **branching-time recoverability differentiator**, the article's lead example: same command, same core, opposite verdict.

## The contrast (both through the execution planner's default portfolio → exact-symbolic)

| core | `AG EF(busy==0)` | witness |
|---|---|---|
| `compute_engine.sv` | **HOLDS** (recovers) | 3/3 `@mununu_guarantee` HOLDS |
| `compute_engine_faulty.sv` | **VIOLATED** | counterexample `IDLE → WORK → FAULT` (stuck forever); `EF(busy==1)` HOLDS (non-vacuity — a real trap, not a stuck signal) |

## Why a safety / linear checker misses it

`AG EF(busy==0)` — "from **every** reachable state, idle is **still reachable**" — is a branching (`∀`-states, `∃`-path) property. A single failing linear SVA/LTL trace cannot state it; a bounded `busy |-> ##[1:N] !busy` needs a bound a genuine lockup has none of; `s_eventually !busy` is linear/fairness-sensitive. mununu decides it exactly over the bit-blasted state (3-valued KMTS μ-calculus, sound at every alternation depth) and returns the trap trace.

## Deliverable shape (article division of labor)

The README grows into the article-grade writeup — I build the harness, diagrams, code, and prose *placeholders*; the prose is authored separately:
- contrast pair + mermaid FSM diagrams (recovering vs. faulty)
- runnable harness for both verdicts (verbatim planner output)
- an "SVA can't express this" table
- `<!-- [TODO: prose] -->` placeholders for the article narrative

## Validation

Both verdicts reproduced reset-pinned in `mununu-sva-pono` via the default planner portfolio (no `--engine` flag — the planner routes both to exact-symbolic). Clean-room, permissively licensed. No Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
