### PR TITLE
feat(planner): diameter cost estimation — structural proxy + sound reach-diameter probe

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/model_facts.rs
+++ b/crates/mununu-core/src/adapter/btor2/model_facts.rs
@@ -48,6 +48,7 @@ pub(crate) struct ModelFacts<'m> {
     theory: OnceLock<Theory>,
     total_bits: OnceLock<u32>,
     free_inputs: OnceLock<Vec<InputFact>>,
+    counters: OnceLock<Vec<crate::adapter::btor2::bit_blast::DownCounterMeta>>,
 }
 
 impl<'m> ModelFacts<'m> {
@@ -58,6 +59,7 @@ impl<'m> ModelFacts<'m> {
             theory: OnceLock::new(),
             total_bits: OnceLock::new(),
             free_inputs: OnceLock::new(),
+            counters: OnceLock::new(),
         }
     }
 
@@ -98,6 +100,44 @@ impl<'m> ModelFacts<'m> {
     pub(crate) fn cone_vs_cap(&self, seed_atoms: &[String]) -> (u32, u32) {
         let cb = self.cone_bits(seed_atoms);
         (cb, effective_bitblast_cap(cb))
+    }
+
+    /// Detected down-counters of the model (`detect_down_counter`), computed once.
+    pub(crate) fn counters(&self) -> &[crate::adapter::btor2::bit_blast::DownCounterMeta] {
+        self.counters
+            .get_or_init(|| crate::adapter::btor2::bit_blast::detect_down_counter(self.model))
+    }
+
+    /// P2.2c (2026-07-28) — the CHEAP **diameter proxy**. The exact μ-engine's fixpoint cost is
+    /// the state-space DIAMETER, not the cone bit-count: `compute_engine_wide` has a ~34-bit cone
+    /// (well under the cap, so `cone_vs_cap` says "admit, cheap") yet a 2³² diameter that grinds
+    /// ~20 s then abstains. Bit-count cannot see the diameter — `bit-count ≠ tractability`
+    /// (P2.5-A) — with ONE cheap exception: a detected **down-counter** of width `W` in the
+    /// property's cone bounds a reachable descent of up to 2^W steps. Returns the widest such
+    /// in-cone counter width (= log₂ of the diameter estimate); `None` when the cone carries no
+    /// detected counter.
+    ///
+    /// **SOUNDNESS / USE — this is a HEURISTIC upper bound, NOT a sound hard-skip predicate.** A
+    /// wide in-cone counter does *not* guarantee the engine grinds: a property whose target is a
+    /// NEARBY value (`EF(cnt == reachable_soon)`) converges in a few iterations regardless of `W`,
+    /// so the proxy OVER-predicts that case. It answers "*could* this fixpoint be diameter-bound?"
+    /// (yes iff a wide counter feeds the cone) — sound as an ADVISORY note and as a
+    /// deadline-shortening input (a genuine decision still finishes under a short deadline; only a
+    /// real grind is cut sooner), but UNSOUND as a hard skip. See `cone_counter_diameter_log2_*`.
+    pub(crate) fn cone_counter_diameter_log2(&self, seed_atoms: &[String]) -> Option<u32> {
+        let counters = self.counters();
+        if counters.is_empty() {
+            return None;
+        }
+        if seed_atoms.is_empty() {
+            return counters.iter().map(|c| c.width).max();
+        }
+        let cone = cone_leaf_nids(self.model, seed_atoms);
+        counters
+            .iter()
+            .filter(|c| cone.contains(&c.nid))
+            .map(|c| c.width)
+            .max()
     }
 
     /// The pinnable primary-input surface — all free `input` leaves, widest first. Memoized.
@@ -249,5 +289,71 @@ mod tests {
             vec!["cfg".to_string()]
         );
         assert!(facts.pinnable_cone_inputs(&["ctrl".to_string()]).is_empty());
+    }
+
+    // An 8-bit down-counter `cnt` (reload-at-0) plus an INDEPENDENT 1-bit toggle `flag`. The
+    // diameter proxy must return the counter width for a cone that reaches `cnt`, and `None` for
+    // one that does not (`flag`), and must ignore the sub-2-bit toggle (not a counter).
+    const COUNTER_FIXTURE: &str = "\
+1 sort bitvec 8
+2 sort bitvec 1
+3 state 1 cnt
+4 ones 1
+5 zero 1
+6 one 1
+7 eq 2 3 5
+8 sub 1 3 6
+9 ite 1 7 4 8
+10 next 1 3 9
+11 init 1 3 4
+12 state 2 flag
+13 not 2 12
+14 next 2 12 13
+15 zero 2
+16 init 2 12 15
+";
+
+    #[test]
+    fn cone_counter_diameter_log2_flags_in_cone_counter() {
+        let file = parser::parse(COUNTER_FIXTURE).expect("parse");
+        let facts = ModelFacts::new(&file);
+        // The 8-bit down-counter is detected and lies in its own cone ⇒ diameter proxy = 8.
+        assert_eq!(
+            facts.cone_counter_diameter_log2(&["cnt".to_string()]),
+            Some(8)
+        );
+        // Whole-design (empty atoms) also sees it.
+        assert_eq!(facts.cone_counter_diameter_log2(&[]), Some(8));
+        // Memoized detection agrees on a second read.
+        assert_eq!(facts.counters().len(), 1);
+    }
+
+    #[test]
+    fn cone_counter_diameter_log2_excludes_out_of_cone_counter() {
+        let file = parser::parse(COUNTER_FIXTURE).expect("parse");
+        let facts = ModelFacts::new(&file);
+        // `flag` toggles independently of `cnt`, so the counter is NOT in its cone ⇒ None.
+        // (The cone filter is what keeps the proxy property-specific, not design-global.)
+        assert_eq!(
+            facts.cone_counter_diameter_log2(&["flag".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn cone_counter_diameter_log2_none_without_counter() {
+        // COST_FIXTURE's `ctrl` is a free-running `+1` up-counter with no reload/threshold — not
+        // a `detect_down_counter` match — so the diameter proxy is None (the proxy only covers
+        // the reload-at-threshold down-counter shape, honestly not every wide register).
+        let file = parser::parse(COST_FIXTURE).expect("parse");
+        let facts = ModelFacts::new(&file);
+        assert_eq!(
+            facts.cone_counter_diameter_log2(&["ctrl".to_string()]),
+            None
+        );
+        assert_eq!(
+            facts.cone_counter_diameter_log2(&["other".to_string()]),
+            None
+        );
     }
 }

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -1772,6 +1772,23 @@ pub struct ExactModel {
     deadline: Option<std::time::Instant>,
 }
 
+/// P2.2c #4 — the outcome of the SOUND diameter pre-pass ([`ExactModel::reach_diameter_to`]).
+/// It MEASURES the exact engine's own bounded fixpoint, so it neither over-predicts (a near
+/// target saturates fast) nor under-predicts (a wide diameter of ANY counter shape ExceedsBound) —
+/// the failure modes of the structural [`ModelFacts::cone_counter_diameter_log2`] proxy.
+///
+/// [`ModelFacts::cone_counter_diameter_log2`]: crate::adapter::btor2::model_facts::ModelFacts::cone_counter_diameter_log2
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiameterEstimate {
+    /// The `EF(target)` preimage fixpoint saturated at this depth (≤ `k_max`) — the exact
+    /// distance the farthest state needs to reach `target`. The full exact fixpoint converges
+    /// here, so the property is cheap for the exact engine.
+    Saturated(usize),
+    /// Still growing at `k_max` ⇒ the backward-reach diameter to `target` EXCEEDS `k_max`; the
+    /// exact fixpoint needs > `k_max` iterations (the measured diameter signal).
+    ExceedsBound(usize),
+}
+
 /// The exact-engine fixpoint iteration budget: `MUNUNU_BDD_ITER_BUDGET` or a default sized to
 /// catch a wide-counter diameter (`2^W`) while admitting any control fixpoint (small diameter).
 fn fixpoint_iter_budget() -> usize {
@@ -2105,6 +2122,42 @@ impl ExactModel {
             }
             x = next;
         }
+    }
+
+    /// P2.2c #4 — the SOUND diameter PRE-PASS. Iterate the `EF(target)` least fixpoint
+    /// (`μX.(target ∨ ◇X)`) from `⊥` for up to `k_max` diamond-preimage steps and report where it
+    /// saturates. This runs the exact engine's OWN inner reachability fixpoint, bounded — so it
+    /// *measures* the backward-reach diameter to `target` rather than guessing it from structure.
+    ///
+    /// It is the sound superset of [`ModelFacts::cone_counter_diameter_log2`]: a near target
+    /// saturates in a few steps (`Saturated(small)`), and a wide-diameter recovery of ANY shape —
+    /// an up-counter, a down-drain, a deep sequential chain — `ExceedsBound(k_max)`, with no
+    /// over- or under-prediction (the counter proxy misses up-counters and over-fires on a
+    /// counter-in-cone whose property does not traverse it; this cannot, because it evaluates the
+    /// real transitions). Cheap: `k_max` preimages on the already-built relation, `k_max` small.
+    ///
+    /// USE: routing on the result is still a heuristic *cutoff* — `ExceedsBound(k_max)` soundly
+    /// means the diameter > `k_max`, but concluding "the exact engine will not decide" requires
+    /// `k_max` above the largest *decidable* diameter (empirically small; grinds run to the
+    /// `1<<20` budget). So it is a sound estimator + a deadline/early-abort input, and — because
+    /// `Saturated` means the `EF(target)` reach-set is now known — a decision short-cut on the
+    /// cheap path. Not memoized (varies per target).
+    ///
+    /// [`ModelFacts::cone_counter_diameter_log2`]: crate::adapter::btor2::model_facts::ModelFacts::cone_counter_diameter_log2
+    pub fn reach_diameter_to(&self, target: &BDDFunction, k_max: usize) -> DiameterEstimate {
+        let mut x = self.ff.clone();
+        for depth in 0..k_max {
+            // ◇x under the exact modal preimage (∃ inputs, constraint-respecting), then
+            // `target ∨ ◇x` — the monotone `EF(target)` step. Saturation `next == x` is exact
+            // (ROBDDs are canonical), and the depth at saturation IS the reach diameter.
+            let pre = self.diamond_pre(&x);
+            let next = target.or(&pre).unwrap();
+            if next == x {
+                return DiameterEstimate::Saturated(depth);
+            }
+            x = next;
+        }
+        DiameterEstimate::ExceedsBound(k_max)
     }
 }
 
@@ -3267,6 +3320,44 @@ mod tests {
                     tc.elapsed().as_millis()
                 );
             }
+        }
+    }
+
+    /// P2.2c #4 — the SOUND diameter pre-pass MEASURES the backward-reach distance to the target,
+    /// so it neither over- nor under-predicts (the two failure modes of the structural counter
+    /// proxy). On a K-bit reloading down-counter draining to 0, the diameter to `cnt == 0` is
+    /// 2^K − 1: a `k_max` below it reports `ExceedsBound`; above it, `Saturated` at the true depth.
+    #[test]
+    fn reach_diameter_measures_the_true_counter_distance() {
+        // 4-bit reloading down-counter (init = 15, drains to 0, reloads) — diameter to cnt==0 = 15.
+        let src = "1 sort bitvec 1\n2 sort bitvec 4\n3 state 2 cnt\n4 zero 2\n5 one 2\n\
+                   6 constd 2 15\n7 init 2 3 6\n8 eq 1 3 4\n9 sub 2 3 5\n10 ite 2 8 6 9\n11 next 2 3 10\n";
+        let file = parser::parse(src).expect("parse");
+        let bb = BddBitBlaster::build(&file).expect("build");
+        let target = bb
+            .predicate_bdd(&PredicateExpr::Cmp {
+                register: "cnt".into(),
+                op: CmpOp::Eq,
+                value: 0,
+            })
+            .expect("target bdd");
+        let model = bb.exact_model();
+
+        // k_max BELOW the diameter → ExceedsBound (the measured diameter signal — this is what the
+        // structural counter proxy could only GUESS, and got wrong for up-counters / near targets).
+        assert_eq!(
+            model.reach_diameter_to(&target, 8),
+            DiameterEstimate::ExceedsBound(8),
+            "an 8-step bound cannot reach cnt==0 from the far end of a 4-bit drain"
+        );
+        // k_max ABOVE the diameter → Saturated at the TRUE distance (~15), and it is measured, not
+        // assumed — the pre-pass ran the exact engine's own EF fixpoint, bounded.
+        match model.reach_diameter_to(&target, 64) {
+            DiameterEstimate::Saturated(d) => assert!(
+                (12..=17).contains(&d),
+                "a 4-bit drain saturates at diameter ~15, measured: {d}"
+            ),
+            e => panic!("expected Saturated within the generous bound, got {e:?}"),
         }
     }
 

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -347,8 +347,16 @@ fn skip_over_cap_notes(report: &AutoVerifyReport, design_btor2: &str) -> Vec<Ver
         let atoms = formula_seed_atoms(&formula);
         let (cone_bits, cap) = facts.cone_vs_cap(&atoms);
         if cone_bits <= cap {
-            // Skipped for another reason (atom-less cube, unsupported op) — not a cap issue;
-            // leave it to the existing Skip provenance.
+            // Not a bit-CAP issue (the cone fits). Consult the DIAMETER proxy (P2.2c): an in-cone
+            // down-counter of width W means the fixpoint may need ~2^W iterations, so exact
+            // abstains on the ITERATION budget rather than the bit cap — a different, and more
+            // actionable, Skip reason than "cone too wide". Emit a diameter-bound note when the
+            // proxy can tell (it covers the reload-at-threshold down-counter shape only — up-
+            // counters and non-counter diameters are honestly out of its reach); otherwise leave
+            // it to the existing Skip provenance (atom-less cube, unsupported op).
+            if let Some(w) = facts.cone_counter_diameter_log2(&atoms) {
+                notes.push(diameter_bound_skip_note(&prop.name, w));
+            }
             continue;
         }
         let inputs = facts.pinnable_cone_inputs(&atoms);
@@ -405,6 +413,33 @@ fn skip_over_cap_notes(report: &AutoVerifyReport, design_btor2: &str) -> Vec<Ver
         });
     }
     notes
+}
+
+/// P2.2c — the diameter-proxy Skip note: a property Skipped with its cone UNDER the bit cap, whose
+/// cone carries a `W`-bit down-counter (⟹ up to 2^W fixpoint iterations). It tells the user the
+/// abstention was the ITERATION budget (the reachable DIAMETER), not the bit cap — the sound lever
+/// here is a well-founded RANKING certificate (a `verify-recoverability` escalation / the
+/// recoverability rescue), not register reduction. Advisory only (a note, never a verdict change).
+fn diameter_bound_skip_note(name: &str, counter_log2: u32) -> VerificationNote {
+    VerificationNote {
+        kind: "skip-diameter-bound".into(),
+        level: NoteLevel::ScopeCaveat,
+        summary: format!(
+            "`{name}`: Skipped — the cone fits the bit cap, but an in-cone {counter_log2}-bit \
+             counter gives a ~2^{counter_log2} state-space DIAMETER, so the exact fixpoint \
+             abstains on the iteration budget (not the bit cap)."
+        ),
+        detail: "The exact μ-engine decides by fixpoint iteration; its cost is the reachable \
+                 DIAMETER, which bit-count cannot see (`bit-count ≠ tractability`). A wide in-cone \
+                 down-counter bounds a descent of up to 2^W steps past the iteration budget, so the \
+                 engine abstains after grinding rather than on admission. The decidable lever for a \
+                 well-founded descent is a RANKING certificate (a `verify-recoverability` \
+                 escalation / the recoverability rescue), not register reduction or input \
+                 concretization — and if the descent is not well-founded toward the target, the \
+                 property is a genuine diameter wall (an honest ⊥)."
+            .into(),
+        items: Vec::new(),
+    }
 }
 
 #[cfg(test)]
@@ -560,6 +595,56 @@ mod tests {
             n.detail.contains("--config-value") && n.detail.contains("INPUT-inflated"),
             "detail must point at --config-value on an input-inflated cone: {}",
             n.detail
+        );
+    }
+
+    // ---- P2.2c: the diameter-proxy Skip note --------------------------------------------------
+
+    #[test]
+    fn skip_note_diameter_bound_flags_in_cone_down_counter() {
+        // A recoverability property Skipped whose cone FITS the cap (an 8-bit counter) but carries
+        // a down-counter → the abstention is attributed to the ITERATION budget (2^8 diameter),
+        // NOT the bit cap. This is the compute_engine_drain shape (proxy fires, exact abstained).
+        let btor2 = "\
+1 sort bitvec 8
+2 sort bitvec 1
+3 state 1 cnt
+4 ones 1
+5 zero 1
+6 one 1
+7 eq 2 3 5
+8 sub 1 3 6
+9 ite 1 7 4 8
+10 next 1 3 9
+11 init 1 3 4
+";
+        let report = skipped_report("p_drain", "nu Y.((mu X.(cnt == 0 || <> X)) && [] Y)");
+        let notes = skip_over_cap_notes(&report, btor2);
+        assert_eq!(notes.len(), 1, "the diameter-bound note fires: {notes:?}");
+        assert_eq!(notes[0].kind, "skip-diameter-bound");
+        assert!(
+            notes[0].summary.contains("DIAMETER") && notes[0].summary.contains("8-bit"),
+            "summary must attribute the Skip to the 8-bit-counter diameter: {}",
+            notes[0].summary
+        );
+        assert!(
+            notes[0].detail.contains("RANKING"),
+            "detail must point at the ranking lever, not register reduction: {}",
+            notes[0].detail
+        );
+    }
+
+    #[test]
+    fn skip_note_no_diameter_claim_without_a_counter() {
+        // A Skipped property over a plain toggle (no counter, cone under cap) gets NO diameter
+        // note — the proxy honestly says nothing when it cannot tell (no over-claiming).
+        let btor2 =
+            "1 sort bitvec 1\n2 state 1 flag\n3 not 1 2\n4 next 1 2 3\n5 zero 1\n6 init 1 2 5\n";
+        let report = skipped_report("p_flag", "nu Y.((mu X.(flag == 1 || <> X)) && [] Y)");
+        let notes = skip_over_cap_notes(&report, btor2);
+        assert!(
+            notes.is_empty(),
+            "no counter in cone ⇒ no diameter note (honest silence): {notes:?}"
         );
     }
 }


### PR DESCRIPTION
## What

Two increments of the planner's **diameter cost estimation** — the cost that separates *exact decides fast* from *exact grinds then abstains*, which bit-count cannot see (`compute_engine_wide`: a 34-bit cone but a 2³² diameter that grinds ~20 s).

### 1. The cheap structural proxy (`ModelFacts::cone_counter_diameter_log2`)
The one cheap **static** handle on the diameter: a detected down-counter of width `W` → diameter ≈ 2^W. Consumed by a diameter-bound Skip note that distinguishes a bit-**CAP** abstention (`cone > cap` → register reduction) from a **DIAMETER** abstention (`cone ≤ cap` but a wide counter → the iteration budget → a *ranking certificate*). Advisory only.

**Validated as deliberately PARTIAL** — down-drain → `Some(W)` (correct), up-counter → `None` (**under**-predicts, detector is down-only), near-target → over-predicts. So it's a sound *advisory*, not a hard-skip trigger.

### 2. The sound measured probe (`ExactModel::reach_diameter_to`)
The fix for the proxy's guesswork: run the exact engine's **own** inner `EF(target)` fixpoint (`μX.(target ∨ ◇X)`) bounded to `k_max` preimage steps → `Saturated(depth)` or `ExceedsBound(k_max)`. Because it evaluates the **real transitions**, it *measures* the backward-reach diameter — no over- or under-prediction, any counter shape (up/down/deep-chain). On `Saturated` the reach-set **is** `EF(target)`, so on the cheap path it doubles as the decision.

**Validated:** a 4-bit reloading down-counter (diameter 15 to `cnt==0`) → `ExceedsBound(8)`, `Saturated(~15)` at `k_max=64`.

## The relationship

The structural proxy becomes the cheap **pre-filter** (when to bother running the probe); the bounded fixpoint is the **measurement**. Routing on either is still a heuristic *cutoff* (`k_max` must exceed the largest *decidable* diameter — empirically small, while grinds run to the `1<<20` budget), so both land as sound estimators + deadline/early-abort inputs, not hard skips.

## Tests

`cone_counter_diameter_log2_{flags,excludes,none}` + `skip_note_diameter_bound_*` + `reach_diameter_measures_the_true_counter_distance`. clippy `-D warnings` clean; verdict-equivalent (advisory + a new pure estimator, no dispatch change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
