### PR TITLE
feat(planner): prepare_model common-IR hub + plan/verify_auto_impl unify

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1624,21 +1624,31 @@ pub fn verify_auto(
     yosys_opts: &YosysOptions,
     opts: &VerifyAutoOptions,
 ) -> Result<AutoVerifyReport, AdapterError> {
-    // PORTFOLIO dispatch — when a portfolio mode is set, hand the task to the execution
-    // planner (verification-execution-planner P2.1a): `plan()` emits the engine-operator
-    // ladder, `execute()` lifts SV → BTOR2 ONCE (the lift-once common-IR keystone, roadmap
-    // P2.1) and drives each operator over the shared lift, merging under the runtime
-    // soundness guard. Verdict-equivalent to the former inline `verify_auto_portfolio`.
+    // PORTFOLIO dispatch — when a portfolio mode is set, run the common-IR-hub pipeline:
+    // `prepare_model` once → `plan()` (the ladder + the per-property cost RATIONALE, computed from
+    // the shared prepared model) → `execute()` (drive each operator over the shared model, merge
+    // under the runtime soundness guard, attach the rationale telemetry). Verdict-equivalent to the
+    // former inline `verify_auto_portfolio`; the routing reasoning now lives in the planner.
     if opts.portfolio.is_some() {
-        let task = crate::planner::VerificationTask {
-            sources,
-            yosys_opts,
-            opts,
+        return match prepare_model(sources, yosys_opts, opts)? {
+            Prepared::Empty(report) => Ok(report),
+            Prepared::Model(m) => {
+                let m = *m;
+                let task = crate::planner::VerificationTask {
+                    sources,
+                    yosys_opts,
+                    opts,
+                };
+                let plan = crate::planner::plan(Some(&m), opts);
+                crate::planner::execute(&plan, &m, &task)
+            }
         };
-        return crate::planner::execute(&crate::planner::plan(&task), &task);
     }
 
-    // Single-engine path: lift inline (`prelift = None`) then run the body.
+    // Single-engine path (a user-picked `--engine`): the direct `verify_auto_impl(None)` form —
+    // it checks A.6 (exact + no-reset-gating rejection) at the top, BEFORE any lift, then builds
+    // the model inline and runs the one engine. No cost rationale — the predicted engine is
+    // trivially the one the user selected. (Only the portfolio uses the plan/execute pipeline.)
     verify_auto_impl(sources, yosys_opts, opts, None)
 }
 
@@ -1774,6 +1784,19 @@ pub(crate) struct PreparedModel {
     ann_scan: AnnotationScan,
     /// The config inputs actually pinned (`--config-value`), for the per-property substitution + note.
     applied_config_values: Vec<(String, u64)>,
+}
+
+impl PreparedModel {
+    /// The `(name, mu-formula)` of each translated property — the planner's input for the routing
+    /// rationale (`plan`). Pre-substitution formulas; the class + cone the rationale reads are
+    /// substitution-invariant, so this lines up with the post-run outcomes by name.
+    pub(crate) fn properties(&self) -> Vec<(String, String)> {
+        self.extraction
+            .translated
+            .iter()
+            .map(|t| (t.name.clone(), t.formula.clone()))
+            .collect()
+    }
 }
 
 /// The result of `prepare_model`: either a design with NO translated properties (the empty report is
@@ -2517,21 +2540,9 @@ pub(crate) fn verify_auto_impl(
     }
     report.notes.extend(rescue_notes);
     report.notes.extend(exact_skip_notes);
-
-    // P2.2d — cost-annotated plan telemetry: one `plan-cost` note per property (the planner's
-    // per-property cost prediction — class × cone-vs-cap × diameter → predicted engine + why) plus
-    // one `plan-accuracy` summary (predicted-decidable vs actually-decided). Additive telemetry,
-    // verdict-equivalent. Uses the verified formulas (post config-substitution) so it lines up with
-    // the outcomes. (2a: computed here; the 2b refactor moves the prediction half into `plan()`.)
-    let plan_cost_props: Vec<(String, String)> = report
-        .properties
-        .iter()
-        .map(|p| (p.name.clone(), p.formula.clone()))
-        .collect();
-    let plan_cost_notes =
-        crate::planner::routing_telemetry_notes(&btor2, &plan_cost_props, &report);
-    report.notes.extend(plan_cost_notes);
-
+    // The cost-annotated plan telemetry (`plan-cost` / `plan-accuracy`) is NO LONGER computed here:
+    // it is the planner's job now (`plan` builds the rationale from the shared prepared model,
+    // `execute` attaches it after the merge). This body is the pure per-engine leaf.
     Ok(report)
 }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1047,7 +1047,7 @@ fn counter_registers_in(seeded: &Seeded) -> std::collections::BTreeSet<String> {
 /// own SVA — recoverability, realizability, assume-guarantee liveness). The
 /// `guarantees` are appended to the translated property set and verified uniformly;
 /// `assumes` and `skipped` are surfaced as a provenance note.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct AnnotationScan {
     /// `@mununu_guarantee <mu-calculus>` properties that parsed, as
     /// `TranslatedAssertion`s ready to merge into `extraction.translated`.
@@ -1639,7 +1639,7 @@ pub fn verify_auto(
     }
 
     // Single-engine path: lift inline (`prelift = None`) then run the body.
-    verify_auto_impl(sources, yosys_opts, opts, None)
+    verify_auto_impl(sources, yosys_opts, opts, None, None)
 }
 
 /// The SV → BTOR2 lift output (incl. the `auto_stub_flops` re-lift), factored out so the
@@ -1709,6 +1709,51 @@ pub(crate) fn lift_sv(
     })
 }
 
+/// P-3 (common-IR hub) — the SVA + annotation extraction result, factored out so the execution
+/// planner can run the slang `extract_sva` subprocess ONCE and share it across the precision-ladder
+/// operators — exactly as [`PreLift`] does for the yosys lift. Without this the portfolio
+/// re-extracts per engine operator (a slang subprocess apiece). Clone so each operator owns a copy.
+#[derive(Clone)]
+pub(crate) struct SharedExtraction {
+    /// The translated SVA with the `@mununu_guarantee` properties merged in.
+    extraction: crate::adapter::slang::translate::TranslationReport,
+    /// The `@mununu_*` annotation scan (drives the annotation note).
+    ann_scan: AnnotationScan,
+    /// Abstraction-predicate hints (in-source `@mununu_predicate` + CLI/API `--predicate`).
+    predicate_hints: Vec<String>,
+}
+
+/// Run the SVA + annotation extraction (the slang subprocess + the source annotation scan), merging
+/// the `@mununu_guarantee` properties into the translated set. Pure function of `(sources, opts)` —
+/// the same inputs every precision-ladder operator shares — so the planner calls it once and threads
+/// the [`SharedExtraction`] into each [`verify_auto_impl`].
+pub(crate) fn extract_front(
+    sources: &[(String, String)],
+    opts: &VerifyAutoOptions,
+) -> Result<SharedExtraction, AdapterError> {
+    let mut extraction = extract_sva_with_options(
+        sources,
+        &TranslateOptions {
+            gate_reset: opts.gate_reset,
+        },
+    )?;
+    let ann_scan = scan_annotation_properties(sources);
+    let predicate_hints: Vec<String> = ann_scan
+        .predicates
+        .iter()
+        .chain(opts.predicate_hints.iter())
+        .cloned()
+        .collect();
+    extraction
+        .translated
+        .extend(ann_scan.guarantees.iter().cloned());
+    Ok(SharedExtraction {
+        extraction,
+        ann_scan,
+        predicate_hints,
+    })
+}
+
 /// The single-engine verify body: extraction → lift → reset/pin → per-property engine →
 /// replan / rescue / notes. `prelift` is `Some` when the planner supplies a shared SV → BTOR2
 /// lift (the portfolio path lifts once), `None` to lift inline (the single-engine path).
@@ -1718,6 +1763,7 @@ pub(crate) fn verify_auto_impl(
     yosys_opts: &YosysOptions,
     opts: &VerifyAutoOptions,
     prelift: Option<PreLift>,
+    shared_extraction: Option<SharedExtraction>,
 ) -> Result<AutoVerifyReport, AdapterError> {
     use crate::adapter::AdapterOptions;
     use crate::adapter::btor2::cegar::{
@@ -1767,34 +1813,22 @@ pub(crate) fn verify_auto_impl(
         });
     }
 
-    // 1. Extract + translate the SVA. When reset-gating, the `disable iff`
-    // guards are dropped from the formulas and the recognized reset signals are
-    // reported (we pin them inactive in the lift below).
-    let mut extraction = extract_sva_with_options(
-        sources,
-        &TranslateOptions {
-            gate_reset: opts.gate_reset,
-        },
-    )?;
-
-    // H.5-GR1 — merge any `@mununu_guarantee` annotation properties (the
-    // mununu-exclusive properties an author adds beyond the design's own SVA)
-    // into the translated set, so they are verified through the same pipeline.
-    // Merged BEFORE the empty-check so a design with no SVA but annotation-only
-    // properties still verifies.
-    let ann_scan = scan_annotation_properties(sources);
-    // W1/W2 — the abstraction-predicate hints seeded into every property's cube:
-    // in-source `@mununu_predicate` annotations MERGED with CLI `--predicate` / API
-    // `predicate` hints. Sound by monotonicity (a hint only refines the cube).
-    let predicate_hints: Vec<String> = ann_scan
-        .predicates
-        .iter()
-        .chain(opts.predicate_hints.iter())
-        .cloned()
-        .collect();
-    extraction
-        .translated
-        .extend(ann_scan.guarantees.iter().cloned());
+    // 1. Extract + translate the SVA (slang subprocess) and merge any `@mununu_guarantee`
+    // annotation properties. When reset-gating, the `disable iff` guards are dropped from the
+    // formulas and the recognized reset signals are reported (pinned inactive in the lift below).
+    // P-3 common-IR hub: `shared_extraction` is `Some` on the portfolio path (the planner extracted
+    // ONCE and shares it across the precision-ladder operators, so the slang subprocess runs once
+    // not per-engine), `None` on the single-engine path (extract inline). Verdict-equivalent either
+    // way. `predicate_hints` (W1/W2) merge in-source `@mununu_predicate` with CLI/API hints — sound
+    // by monotonicity. The merge happens BEFORE the empty-check so an annotation-only design verifies.
+    let SharedExtraction {
+        extraction,
+        ann_scan,
+        predicate_hints,
+    } = match shared_extraction {
+        Some(s) => s,
+        None => extract_front(sources, opts)?,
+    };
 
     let mut report = AutoVerifyReport {
         unsupported: extraction

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1639,7 +1639,7 @@ pub fn verify_auto(
     }
 
     // Single-engine path: lift inline (`prelift = None`) then run the body.
-    verify_auto_impl(sources, yosys_opts, opts, None, None)
+    verify_auto_impl(sources, yosys_opts, opts, None)
 }
 
 /// The SV → BTOR2 lift output (incl. the `auto_stub_flops` re-lift), factored out so the
@@ -1754,6 +1754,178 @@ pub(crate) fn extract_front(
     })
 }
 
+/// P-3b/P-4 (common-IR hub) — the operator-INDEPENDENT prepared model: the fully-prepared BTOR2
+/// (lifted + reset/init/shadow/config-pinned) plus everything the per-property loop needs that does
+/// NOT depend on the engine choice. `prepare_model` builds it ONCE; `plan` reads it (facts-aware
+/// routing rationale) and `verify_from_prepared` runs each engine operator over it. This makes the
+/// slang extraction + yosys lift + reset/pin prep run once per portfolio run, not per operator, and
+/// gives `plan()` the fully-prepared model to reason about cost. Clone so each operator owns a copy.
+#[derive(Clone)]
+pub(crate) struct PreparedModel {
+    /// The fully-prepared BTOR2 (lift + reset-init + shadow + reset/config pins).
+    pub btor2: String,
+    /// The report skeleton — carries `unsupported` + the lift/reset diagnostics.
+    report: AutoVerifyReport,
+    /// The translated properties (+ merged `@mununu_guarantee`).
+    extraction: crate::adapter::slang::translate::TranslationReport,
+    /// Abstraction-predicate hints (W1/W2).
+    predicate_hints: Vec<String>,
+    /// The `@mununu_*` annotation scan (drives the annotation note).
+    ann_scan: AnnotationScan,
+    /// The config inputs actually pinned (`--config-value`), for the per-property substitution + note.
+    applied_config_values: Vec<(String, u64)>,
+}
+
+/// The result of `prepare_model`: either a design with NO translated properties (the empty report is
+/// final) or a fully-prepared [`PreparedModel`].
+pub(crate) enum Prepared {
+    /// No properties to verify — the report (posture + annotation note) is complete.
+    Empty(AutoVerifyReport),
+    /// The prepared model, ready for `plan` + `verify_from_prepared`. Boxed — it is much larger
+    /// than the `Empty` report, and `Prepared` is returned by value.
+    Model(Box<PreparedModel>),
+}
+
+/// P-3b/P-4 — the operator-INDEPENDENT prep: extract the SVA (slang), lift to BTOR2 (yosys),
+/// reset/init/shadow/config-pin. Pure function of `(sources, yosys_opts, opts)` — identical for
+/// every precision-ladder operator — so the planner calls it ONCE. Returns [`Prepared::Empty`] for a
+/// design with no properties, else [`Prepared::Model`]. (The engine-flag-dependent A.6 check is the
+/// caller's — it belongs with the per-operator run, not the shared prep.)
+pub(crate) fn prepare_model(
+    sources: &[(String, String)],
+    yosys_opts: &YosysOptions,
+    opts: &VerifyAutoOptions,
+) -> Result<Prepared, AdapterError> {
+    use crate::adapter::btor2::shadow::augment_with_past_shadows;
+
+    // 1. Extract + translate the SVA (slang) + merge `@mununu_guarantee` annotations.
+    let SharedExtraction {
+        extraction,
+        ann_scan,
+        predicate_hints,
+    } = extract_front(sources, opts)?;
+
+    let mut report = AutoVerifyReport {
+        unsupported: extraction
+            .unsupported
+            .iter()
+            .map(|u| (u.name.clone(), u.reason.clone()))
+            .collect(),
+        ..Default::default()
+    };
+    if extraction.translated.is_empty() {
+        // No properties: the posture note is informational; reflect the engine.
+        let posture = if opts.exact_symbolic {
+            NotePosture::Exact
+        } else {
+            NotePosture::Cube
+        };
+        report.notes = build_notes(
+            &report,
+            opts.must_edge_inference,
+            &[],
+            &[],
+            &yosys_opts.cutpoint_signals,
+            &posture,
+        );
+        if let Some(n) = annotation_note(&ann_scan) {
+            report.notes.push(n);
+        }
+        return Ok(Prepared::Empty(report));
+    }
+
+    // Reset inputs to pin inactive (reset-gating). Empty when gating is off or no `disable iff`
+    // reset was recognized.
+    let mut reset_pins: Vec<(String, u64)> = if opts.gate_reset {
+        extraction
+            .reset_signals
+            .iter()
+            .map(|rs| (rs.signal.clone(), rs.inactive_value))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // 2. SV → flattened BTOR2 (yosys), + auto-stub re-lift. Surfaces black-boxed modules + stubs.
+    let PreLift {
+        mut btor2,
+        blackboxed_modules,
+        auto_provided_stubs,
+    } = lift_sv(sources, yosys_opts, opts)?;
+    report.diagnostics.blackboxed_modules = blackboxed_modules;
+    report.diagnostics.auto_provided_stubs = auto_provided_stubs;
+
+    // Structural reset auto-pin: when gating is on but no `disable iff` guard was recognized, detect
+    // the async-reset input from the lifted BTOR2's reset-mux structure and pin it inactive (else a
+    // free reset-edge spuriously VIOLATES every box/AF property). `disable iff` always wins.
+    if opts.gate_reset
+        && reset_pins.is_empty()
+        && let Ok(file) = crate::adapter::btor2::parser::parse(&btor2)
+    {
+        let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
+        reset_pins.extend(crate::adapter::fsm_scan::detect_resets(&file, &symbols));
+    }
+
+    // Inject `init` at the post-reset state (a reset-gated async-reset FSM starts in its real reset
+    // state, not the init-less 0). Runs on the reset-FREE BTOR2 (before the pin below).
+    btor2 = crate::adapter::btor2::reset_init::inject_reset_init(&btor2, &reset_pins)?;
+
+    // Complete the init to the `setundef -zero` power-up for a RESET-LESS design, so every engine
+    // starts from the same state (the portfolio otherwise leaves an init-less cell free → engine
+    // disagreement). Scoped to reset-less designs; a reset-based design's free-init is real behavior.
+    if opts.gate_reset && reset_pins.is_empty() {
+        btor2 = crate::adapter::btor2::reset_init::inject_zero_init(&btor2)?;
+    }
+
+    // Augment only the `__past` shadows whose base resolves to a BTOR2 state cell (a renamed base is
+    // skipped → its properties are SKIPPED below, not an abort).
+    let pre_file = crate::adapter::btor2::parser::parse(&btor2).map_err(|mut e| {
+        e.message = format!("verify_auto: parse lifted BTOR2: {}", e.message);
+        e
+    })?;
+    let shadow_bases: Vec<&str> = extraction
+        .required_shadows
+        .iter()
+        .map(|s| s.base.as_str())
+        .filter(|b| crate::adapter::btor2::parser::resolve_state_by_symbol(&pre_file, b).is_some())
+        .collect();
+    let btor2 = augment_with_past_shadows(&btor2, &shadow_bases)?;
+
+    // Pin recognized reset inputs inactive (the model-level half of reset-gating).
+    let (btor2, pinned_resets) =
+        crate::adapter::btor2::pin::pin_inputs_to_constants(&btor2, &reset_pins);
+    report.diagnostics.gated_resets = pinned_resets;
+
+    // H.J.b — pin user-supplied config inputs to constants (same mechanism as reset-gating).
+    let config_pins: Vec<(String, u64)> = {
+        let mut v: Vec<(String, u64)> = opts
+            .config_values
+            .iter()
+            .map(|(k, val)| (k.clone(), *val))
+            .collect();
+        v.sort();
+        v
+    };
+    let (btor2, pinned_configs) =
+        crate::adapter::btor2::pin::pin_inputs_to_constants(&btor2, &config_pins);
+    let applied_config_values: Vec<(String, u64)> = pinned_configs
+        .iter()
+        .filter_map(|s| {
+            let (n, val) = s.split_once('=')?;
+            Some((n.to_string(), val.trim().parse::<u64>().ok()?))
+        })
+        .collect();
+
+    Ok(Prepared::Model(Box::new(PreparedModel {
+        btor2,
+        report,
+        extraction,
+        predicate_hints,
+        ann_scan,
+        applied_config_values,
+    })))
+}
+
 /// The single-engine verify body: extraction → lift → reset/pin → per-property engine →
 /// replan / rescue / notes. `prelift` is `Some` when the planner supplies a shared SV → BTOR2
 /// lift (the portfolio path lifts once), `None` to lift inline (the single-engine path).
@@ -1762,24 +1934,15 @@ pub(crate) fn verify_auto_impl(
     sources: &[(String, String)],
     yosys_opts: &YosysOptions,
     opts: &VerifyAutoOptions,
-    prelift: Option<PreLift>,
-    shared_extraction: Option<SharedExtraction>,
+    prepared: Option<PreparedModel>,
 ) -> Result<AutoVerifyReport, AdapterError> {
     use crate::adapter::AdapterOptions;
     use crate::adapter::btor2::cegar::{
         CegarOptions, LiftStrategy, PredicateSource, cegar_refine_loop,
     };
-    use crate::adapter::btor2::shadow::augment_with_past_shadows;
     use crate::mu_calculus::Environment;
     use crate::mu_calculus::parser as mu_parser;
     use crate::mu_calculus::trit::Trit;
-
-    let (primary_name, _) = sources.first().ok_or_else(|| AdapterError {
-        kind: AdapterErrorKind::ParseError,
-        message: "adapter/slang/verify_auto: no SV sources provided".to_string(),
-        location: None,
-    })?;
-    let _ = primary_name;
 
     // A.6 (soundness-ledger, 2026-07-05) — reject `--engine exact-symbolic` with
     // `--no-gate-reset`. The exact full-state engine is built for the reset-GATED
@@ -1813,192 +1976,25 @@ pub(crate) fn verify_auto_impl(
         });
     }
 
-    // 1. Extract + translate the SVA (slang subprocess) and merge any `@mununu_guarantee`
-    // annotation properties. When reset-gating, the `disable iff` guards are dropped from the
-    // formulas and the recognized reset signals are reported (pinned inactive in the lift below).
-    // P-3 common-IR hub: `shared_extraction` is `Some` on the portfolio path (the planner extracted
-    // ONCE and shares it across the precision-ladder operators, so the slang subprocess runs once
-    // not per-engine), `None` on the single-engine path (extract inline). Verdict-equivalent either
-    // way. `predicate_hints` (W1/W2) merge in-source `@mununu_predicate` with CLI/API hints — sound
-    // by monotonicity. The merge happens BEFORE the empty-check so an annotation-only design verifies.
-    let SharedExtraction {
+    // The operator-INDEPENDENT prepared model (P-3b common-IR hub): the fully-prepared BTOR2 (slang
+    // extract + yosys lift + reset/init/shadow/config-pin) + the properties + diagnostics. Built
+    // ONCE by the planner (`prepare_model`) and shared across the precision-ladder operators (so the
+    // two subprocesses + the prep run once, not per engine); `None` on the single-engine path, where
+    // it is built inline here. A design with no properties returns its (complete) empty report.
+    let PreparedModel {
+        btor2,
+        mut report,
         extraction,
-        ann_scan,
         predicate_hints,
-    } = match shared_extraction {
-        Some(s) => s,
-        None => extract_front(sources, opts)?,
+        ann_scan,
+        applied_config_values,
+    } = match prepared {
+        Some(m) => m,
+        None => match prepare_model(sources, yosys_opts, opts)? {
+            Prepared::Empty(r) => return Ok(r),
+            Prepared::Model(m) => *m,
+        },
     };
-
-    let mut report = AutoVerifyReport {
-        unsupported: extraction
-            .unsupported
-            .iter()
-            .map(|u| (u.name.clone(), u.reason.clone()))
-            .collect(),
-        ..Default::default()
-    };
-    if extraction.translated.is_empty() {
-        // No properties: the posture note is informational; reflect the engine.
-        let posture = if opts.exact_symbolic {
-            NotePosture::Exact
-        } else {
-            NotePosture::Cube
-        };
-        report.notes = build_notes(
-            &report,
-            opts.must_edge_inference,
-            &[],
-            &[],
-            &yosys_opts.cutpoint_signals,
-            &posture,
-        );
-        if let Some(n) = annotation_note(&ann_scan) {
-            report.notes.push(n);
-        }
-        return Ok(report);
-    }
-
-    // Reset inputs to pin inactive (reset-gating) — applied to the lifted BTOR2
-    // below via `pin_inputs_to_constants`. Empty when gating is off or no
-    // `disable iff` reset was recognized.
-    let mut reset_pins: Vec<(String, u64)> = if opts.gate_reset {
-        extraction
-            .reset_signals
-            .iter()
-            .map(|rs| (rs.signal.clone(), rs.inactive_value))
-            .collect()
-    } else {
-        Vec::new()
-    };
-
-    // 2. SV → flattened BTOR2 (then 3. augment the `__past` shadow flops, below). Lift-once
-    // keystone (roadmap P2.1): the yosys lift is the dominant redundant cost when the
-    // portfolio runs this body once per engine operator. The planner (`execute`) lifts ONCE
-    // via `lift_sv` and threads the result in as `prelift`, so a 3-engine precision ladder
-    // does ONE yosys lift instead of up to three. On the single-engine path `prelift` is
-    // `None` and the lift runs inline — verdict-equivalent either way. The black-boxed
-    // modules + auto-injected flop stubs are surfaced in diagnostics (a cut FSM, the
-    // `prim_sparse_fsm_flop`-class root cause, is visible not silent).
-    let PreLift {
-        mut btor2,
-        blackboxed_modules,
-        auto_provided_stubs,
-    } = match prelift {
-        Some(p) => p,
-        None => lift_sv(sources, yosys_opts, opts)?,
-    };
-    report.diagnostics.blackboxed_modules = blackboxed_modules;
-    report.diagnostics.auto_provided_stubs = auto_provided_stubs;
-
-    // Structural reset auto-pin. When reset-gating is on but no `disable iff (reset)`
-    // guard was recognized (`reset_pins` empty — the common case for a plain-RTL
-    // `@mununu_guarantee` design with no SVA), detect the async-reset input from the
-    // lifted BTOR2's reset-mux structure (`next(state) = ite(reset, RESET_CONST, normal)`
-    // / active-low branch-swap) and pin it inactive. Without this the reset input stays a
-    // free primary input, so the transition relation carries a reset-edge from every
-    // state to the reset state — and every `[]`/`AF`/box-universal property is then
-    // spuriously VIOLATED (it would have to hold at the reset state too). Diamond/`EF`/
-    // `AG EF` properties are immune (existential), which is why they verified correctly
-    // even without this. The detected reset flows through `inject_reset_init` and
-    // `pin_inputs_to_constants` exactly like a `disable iff`-recognized one, and is
-    // surfaced in `diagnostics.gated_resets`. The `disable iff` path always wins (guard
-    // on `reset_pins.is_empty()`), mirroring the fsm-encoding scan's reset handling.
-    if opts.gate_reset
-        && reset_pins.is_empty()
-        && let Ok(file) = crate::adapter::btor2::parser::parse(&btor2)
-    {
-        let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
-        reset_pins.extend(crate::adapter::fsm_scan::detect_resets(&file, &symbols));
-    }
-
-    // Inject `init` lines at the post-reset state so a reset-gated async-reset
-    // FSM starts in its real reset state (e.g. an OpenTitan sparse-FSM's non-zero
-    // `MainSmIdle = 6'b110111`) rather than the init-less power-on default 0.
-    // Zero is an illegal sparse encoding: the FSM's `default` arm traps it into
-    // its error state, so without this the reset-gated model starts in a state
-    // the real design never occupies, silently corrupting every reset-dependent
-    // verdict (recoverability `AG EF idle`, liveness-from-reset). Runs on the
-    // reset-FREE BTOR2 (before the pin below) so it can assert the reset to
-    // derive the post-reset state; no-op unless reset-gating is on (`reset_pins`
-    // non-empty) and the design carries no authoritative `init` line.
-    btor2 = crate::adapter::btor2::reset_init::inject_reset_init(&btor2, &reset_pins)?;
-
-    // Complete the init to the `setundef -zero` power-up for a RESET-LESS design:
-    // every init-less bitvec state cell gets an explicit `init … 0`. A design with
-    // no reset (`reset_pins` empty) has no reset mechanism to establish its start
-    // state — its init is fixed ONLY by `initial` values plus the FPGA/`setundef
-    // -zero` power-up (0) for the rest, which is exactly what the cube and exact
-    // engines already assume (`state_cell_init_values` / `initial_state_bdd`). The
-    // reachability portfolio (native BMC / spacer / Boolector) otherwise leaves an
-    // init-less cell FREE (BTOR2's nondeterministic-init semantics), so a
-    // reset-less design with a partial `initial` (a Xilinx wrapper: `initial state
-    // = IDLE` but an init-less status flop) hands the portfolio a spurious
-    // power-up counterexample the exact engine never sees — an engine verdict
-    // disagreement. Making the 0 power-up explicit puts every engine on the same
-    // start state.
-    //
-    // Scoped to reset-LESS designs on purpose: a RESET-based design establishes
-    // its operational init through the reset (`inject_reset_init`), and the
-    // portfolio's free-init for any cell the reset does not pin is the existing,
-    // real-RTL-validated behavior (`e2e_btormc_confirms_sysrst_real_rtl_verdict`
-    // et al.) — a free-init counterexample there is a genuine run of the model, so
-    // it must not be clamped. Raw `btor2 verify` (no reset-gating) also keeps
-    // BTOR2's free-init semantics.
-    if opts.gate_reset && reset_pins.is_empty() {
-        btor2 = crate::adapter::btor2::reset_init::inject_zero_init(&btor2)?;
-    }
-
-    // Augment only the `__past` shadows whose base resolves to a BTOR2 state
-    // cell. A base the lift renamed away (the SVA name not matching the lifted
-    // register) would hard-error `augment_with_past_shadows`, aborting the whole
-    // run; instead we skip it here and the properties that need its `__past`
-    // atom are SKIPPED below (the atom finds no state cell). Graceful per-design
-    // degradation, not an abort.
-    let pre_file = crate::adapter::btor2::parser::parse(&btor2).map_err(|mut e| {
-        e.message = format!("verify_auto: parse lifted BTOR2: {}", e.message);
-        e
-    })?;
-    let shadow_bases: Vec<&str> = extraction
-        .required_shadows
-        .iter()
-        .map(|s| s.base.as_str())
-        .filter(|b| crate::adapter::btor2::parser::resolve_state_by_symbol(&pre_file, b).is_some())
-        .collect();
-    let btor2 = augment_with_past_shadows(&btor2, &shadow_bases)?;
-
-    // Pin recognized reset inputs inactive so the (un-guarded) bodies are
-    // verified only while not in reset (the model-level half of reset-gating).
-    // `gated_resets` records only the resets actually found + pinned in the
-    // BTOR2 — a recognized reset that the lift renamed/optimized away is left
-    // unpinned rather than misreported.
-    let (btor2, pinned_resets) =
-        crate::adapter::btor2::pin::pin_inputs_to_constants(&btor2, &reset_pins);
-    report.diagnostics.gated_resets = pinned_resets;
-
-    // H.J.b — pin user-supplied config inputs to constants (scope-reduced
-    // concretization; same mechanism as reset-gating). Only signals that are
-    // actual inputs are pinned; `pinned_configs` is the applied set, which drives
-    // both the per-property formula substitution below and the
-    // `config-concretization` ScopeCaveat note. Sorted for a deterministic order.
-    let config_pins: Vec<(String, u64)> = {
-        let mut v: Vec<(String, u64)> = opts
-            .config_values
-            .iter()
-            .map(|(k, val)| (k.clone(), *val))
-            .collect();
-        v.sort();
-        v
-    };
-    let (btor2, pinned_configs) =
-        crate::adapter::btor2::pin::pin_inputs_to_constants(&btor2, &config_pins);
-    let applied_config_values: Vec<(String, u64)> = pinned_configs
-        .iter()
-        .filter_map(|s| {
-            let (n, val) = s.split_once('=')?;
-            Some((n.to_string(), val.trim().parse::<u64>().ok()?))
-        })
-        .collect();
 
     // State-cell symbols of the augmented design — the seedable-atom universe.
     let file = crate::adapter::btor2::parser::parse(&btor2).map_err(|mut e| {

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -21,8 +21,8 @@
 //! See `.claude/plans/verification-execution-planner.md` §4.2/§4.5.
 
 use crate::adapter::slang::verify_auto::{
-    AutoVerifyReport, NoteLevel, PortfolioMode, VerificationNote, VerifyAutoOptions, VerifyOutcome,
-    escalate_bottom, extract_front, lift_sv, merge_portfolio_reports, outcome_definite,
+    AutoVerifyReport, NoteLevel, PortfolioMode, Prepared, VerificationNote, VerifyAutoOptions,
+    VerifyOutcome, escalate_bottom, merge_portfolio_reports, outcome_definite, prepare_model,
     rescue_skipped_via_exact, verify_auto_impl,
 };
 use crate::adapter::yosys::YosysOptions;
@@ -147,14 +147,15 @@ pub fn execute(
     // Lift it ONCE here and thread the shared result into each operator's `verify_auto_impl`
     // pass, so a 3-engine ladder does ONE yosys elaboration instead of re-lifting per engine.
     // Verdict-equivalent: each operator runs the identical body it did before, only reusing
-    // the lift instead of recomputing it. (The cheap Rust prep — reset/pin, parse, cube-atom
-    // classification — still re-runs per operator; the two subprocess costs are shared.)
-    let prelift = lift_sv(task.sources, task.yosys_opts, task.opts)?;
-
-    // P-3 common-IR hub: the SVA extraction (the slang subprocess) is likewise a pure function of
-    // `(sources, opts)` — identical for every operator — so extract it ONCE and share it, so a
-    // 3-engine ladder runs slang once, not per engine (the second subprocess, after the yosys lift).
-    let shared_extraction = extract_front(task.sources, task.opts)?;
+    // the prep instead of recomputing it. P-3b common-IR hub: build the operator-INDEPENDENT model
+    // ONCE — the slang extract + yosys lift + reset/init/shadow/config-pin — and share it across the
+    // precision-ladder operators (`mk_opts` only flips the engine flags, which the prep ignores), so
+    // a 3-engine ladder runs both subprocesses + the prep ONCE, not per engine. A design with no
+    // properties returns its complete empty report here.
+    let prepared = match prepare_model(task.sources, task.yosys_opts, task.opts)? {
+        Prepared::Empty(report) => return Ok(report),
+        Prepared::Model(m) => *m,
+    };
 
     match plan.mode {
         PortfolioMode::Sequential => {
@@ -166,8 +167,7 @@ pub fn execute(
                         task.sources,
                         task.yosys_opts,
                         &mk_opts(op),
-                        Some(prelift.clone()),
-                        Some(shared_extraction.clone()),
+                        Some(prepared.clone()),
                     ),
                 ));
                 // Early-exit as soon as the MERGE so far leaves no ⊥ property (the budget win).
@@ -193,18 +193,11 @@ pub fn execute(
                         .iter()
                         .map(|op| {
                             let o = mk_opts(op);
-                            let pl = prelift.clone();
-                            let se = shared_extraction.clone();
+                            let pm = prepared.clone();
                             (
                                 op.label,
                                 scope.spawn(move || {
-                                    verify_auto_impl(
-                                        task.sources,
-                                        task.yosys_opts,
-                                        &o,
-                                        Some(pl),
-                                        Some(se),
-                                    )
+                                    verify_auto_impl(task.sources, task.yosys_opts, &o, Some(pm))
                                 }),
                             )
                         })

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -22,8 +22,8 @@
 
 use crate::adapter::slang::verify_auto::{
     AutoVerifyReport, NoteLevel, PortfolioMode, VerificationNote, VerifyAutoOptions, VerifyOutcome,
-    escalate_bottom, lift_sv, merge_portfolio_reports, outcome_definite, rescue_skipped_via_exact,
-    verify_auto_impl,
+    escalate_bottom, extract_front, lift_sv, merge_portfolio_reports, outcome_definite,
+    rescue_skipped_via_exact, verify_auto_impl,
 };
 use crate::adapter::yosys::YosysOptions;
 use crate::adapter::{AdapterError, AdapterErrorKind};
@@ -147,9 +147,14 @@ pub fn execute(
     // Lift it ONCE here and thread the shared result into each operator's `verify_auto_impl`
     // pass, so a 3-engine ladder does ONE yosys elaboration instead of re-lifting per engine.
     // Verdict-equivalent: each operator runs the identical body it did before, only reusing
-    // the lift instead of recomputing it. (The cheap Rust prep — extraction, reset/pin, parse,
-    // cube-atom classification — still re-runs per operator; only the yosys lift is shared.)
+    // the lift instead of recomputing it. (The cheap Rust prep — reset/pin, parse, cube-atom
+    // classification — still re-runs per operator; the two subprocess costs are shared.)
     let prelift = lift_sv(task.sources, task.yosys_opts, task.opts)?;
+
+    // P-3 common-IR hub: the SVA extraction (the slang subprocess) is likewise a pure function of
+    // `(sources, opts)` — identical for every operator — so extract it ONCE and share it, so a
+    // 3-engine ladder runs slang once, not per engine (the second subprocess, after the yosys lift).
+    let shared_extraction = extract_front(task.sources, task.opts)?;
 
     match plan.mode {
         PortfolioMode::Sequential => {
@@ -162,6 +167,7 @@ pub fn execute(
                         task.yosys_opts,
                         &mk_opts(op),
                         Some(prelift.clone()),
+                        Some(shared_extraction.clone()),
                     ),
                 ));
                 // Early-exit as soon as the MERGE so far leaves no ⊥ property (the budget win).
@@ -188,10 +194,17 @@ pub fn execute(
                         .map(|op| {
                             let o = mk_opts(op);
                             let pl = prelift.clone();
+                            let se = shared_extraction.clone();
                             (
                                 op.label,
                                 scope.spawn(move || {
-                                    verify_auto_impl(task.sources, task.yosys_opts, &o, Some(pl))
+                                    verify_auto_impl(
+                                        task.sources,
+                                        task.yosys_opts,
+                                        &o,
+                                        Some(pl),
+                                        Some(se),
+                                    )
                                 }),
                             )
                         })

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -1,28 +1,28 @@
-//! Verification execution planner (verification-execution-planner Phase 3 / roadmap P2.1).
+//! Verification execution planner (verification-execution-planner Phase 3 / roadmap P2.1–P2.2).
 //!
-//! **P2.1a — the planner seam.** A [`VerificationTask`] is turned by [`plan`] into a
-//! [`PhysicalPlan`] (an ordered set of engine operators + a scheduling mode), which
-//! [`execute`] drives — delegating each operator to the existing single-engine
-//! [`verify_auto`](crate::adapter::slang::verify_auto::verify_auto) pass and merging under
-//! the existing runtime soundness guard
-//! ([`merge_portfolio_reports`](crate::adapter::slang::verify_auto::merge_portfolio_reports)).
+//! The portfolio `verify-auto` path runs a four-stage pipeline (the common-IR hub):
 //!
-//! This re-expresses today's `verify_auto` portfolio dispatch as an explicit plan/execute
-//! pair **without changing any verdict** — it is verdict-equivalent by construction (same
-//! operators, same precision order, same merge, same early-exit; the driver body is
-//! relocated verbatim from the former `verify_auto_portfolio`). What it buys is the *seam*:
-//! one place where the "which engines, in what order/mode" decision lives, ready for the
-//! later phases to make cost-based.
+//! 1. [`prepare_model`](crate::adapter::slang::verify_auto::prepare_model) — build the shared
+//!    prepared model ONCE (slang extract + yosys lift + reset/pin), an operator-independent IR.
+//! 2. [`plan`] — the ladder (exact → cube → explicit) **plus** the per-property COST RATIONALE:
+//!    from the model's facts (`property_class` × cone-vs-cap × diameter proxy) predict which engine
+//!    will decide each property, and why (the decision table). This is where the planner's
+//!    reasoning lives.
+//! 3. [`execute`] — drive each operator over the shared model, merge under the runtime soundness
+//!    guard ([`merge_portfolio_reports`](crate::adapter::slang::verify_auto::merge_portfolio_reports)),
+//!    and attach the rationale as `plan-cost` / `plan-accuracy` telemetry ONCE (never a verdict change).
+//! 4. `verify_auto_impl` — the pure per-engine leaf; runs one engine, no planning.
 //!
-//! Not yet here (deliberately): cost-based operator selection off `ModelFacts` (P2.2), the
-//! ⊥-reactive re-plan edges that generalise `escalate_bottom` (P2.1b), and the soundness
-//! plan-invariants — cube-νμ exact-corroboration, property-class transfer gating (P2.1c).
+//! **Verdict-equivalent by construction:** the plan is a fixed precision ladder + reactive rescue
+//! (`escalate_bottom`) + early-exit; the rationale is a telemetry hint, not a dispatch decision (a
+//! sound faster-abstain on the diameter case is un-achievable — see the plan doc). The single-engine
+//! path (a user-picked `--engine`) skips plan/execute and runs `verify_auto_impl` directly.
 //!
-//! See `.claude/plans/verification-execution-planner.md` §4.2/§4.5.
+//! See `.claude/plans/verification-execution-planner.md` + `.claude/plans/cost-annotated-plan-telemetry.md`.
 
 use crate::adapter::slang::verify_auto::{
-    AutoVerifyReport, NoteLevel, PortfolioMode, Prepared, VerificationNote, VerifyAutoOptions,
-    VerifyOutcome, escalate_bottom, merge_portfolio_reports, outcome_definite, prepare_model,
+    AutoVerifyReport, NoteLevel, PortfolioMode, PreparedModel, VerificationNote, VerifyAutoOptions,
+    VerifyOutcome, escalate_bottom, merge_portfolio_reports, outcome_definite,
     rescue_skipped_via_exact, verify_auto_impl,
 };
 use crate::adapter::yosys::YosysOptions;
@@ -43,7 +43,10 @@ pub struct EngineOp {
     pub exact_symbolic: bool,
 }
 
-/// The physical plan — the ordered engine operators plus how to schedule them.
+/// The physical plan — the ordered engine operators, how to schedule them, and the per-property
+/// COST RATIONALE (which engine the planner predicts will decide each property, and why). The
+/// rationale is the planner's reasoning made explicit; it is attached as `plan-cost` /
+/// `plan-accuracy` telemetry by [`execute`], never a verdict change.
 #[derive(Debug, Clone)]
 pub struct PhysicalPlan {
     /// Operators in precision order (exact first).
@@ -52,6 +55,9 @@ pub struct PhysicalPlan {
     /// budget win); `Parallel` = run all concurrently, merge once. A single-op plan runs the
     /// same under either mode.
     pub mode: PortfolioMode,
+    /// Per-property routing rationale (empty when the plan was built without a prepared model —
+    /// e.g. the plan unit-tests). Computed by [`plan`] from the prepared model's facts.
+    pub rationale: Vec<RoutingRationale>,
 }
 
 /// The logical verification task — the planner's input.
@@ -96,20 +102,28 @@ const PRECISION_LADDER: [EngineOp; 3] = [
 /// emits the full precision ladder in the requested mode; a single-engine intent emits just
 /// that operator. (P2.2 makes this cost-based off `ModelFacts` — cone-vs-cap, property-class
 /// → verdict requirement.)
-pub fn plan(task: &VerificationTask) -> PhysicalPlan {
-    match task.opts.portfolio {
-        Some(mode) => PhysicalPlan {
-            ops: PRECISION_LADDER.to_vec(),
-            mode,
-        },
-        None => PhysicalPlan {
-            ops: vec![EngineOp {
-                label: single_engine_label(task.opts),
-                symbolic_engine: task.opts.symbolic_engine,
-                exact_symbolic: task.opts.exact_symbolic,
+pub(crate) fn plan(prepared: Option<&PreparedModel>, opts: &VerifyAutoOptions) -> PhysicalPlan {
+    let (ops, mode) = match opts.portfolio {
+        Some(mode) => (PRECISION_LADDER.to_vec(), mode),
+        None => (
+            vec![EngineOp {
+                label: single_engine_label(opts),
+                symbolic_engine: opts.symbolic_engine,
+                exact_symbolic: opts.exact_symbolic,
             }],
-            mode: PortfolioMode::Sequential,
-        },
+            PortfolioMode::Sequential,
+        ),
+    };
+    // The planner's cost reasoning, made explicit: from the prepared model's facts, predict the
+    // deciding engine + why for each property (the decision table). Empty when no model is supplied
+    // (the plan unit-tests build the ladder alone). This is what `execute` attaches as telemetry.
+    let rationale = prepared
+        .map(|m| annotate_routing(&m.btor2, &m.properties()))
+        .unwrap_or_default();
+    PhysicalPlan {
+        ops,
+        mode,
+        rationale,
     }
 }
 
@@ -126,8 +140,9 @@ fn single_engine_label(opts: &VerifyAutoOptions) -> &'static str {
 /// Execute the plan: run each engine operator as a single-engine [`verify_auto`] pass and
 /// merge under the runtime soundness guard. Relocated verbatim from the former
 /// `verify_auto_portfolio` — behaviour-identical, so the portfolio's verdicts are unchanged.
-pub fn execute(
+pub(crate) fn execute(
     plan: &PhysicalPlan,
+    prepared: &PreparedModel,
     task: &VerificationTask,
 ) -> Result<AutoVerifyReport, AdapterError> {
     // A single-engine option set derived from `task.opts` with the portfolio disabled and the
@@ -141,20 +156,19 @@ pub fn execute(
         o
     };
 
-    // Lift-once common-IR keystone (roadmap P2.1): the SV → BTOR2 lift (yosys) is a pure
-    // function of `(sources, yosys_opts, opts)` — identical for every precision-ladder
-    // operator (`mk_opts` only flips the portfolio + engine flags, which the lift ignores).
-    // Lift it ONCE here and thread the shared result into each operator's `verify_auto_impl`
-    // pass, so a 3-engine ladder does ONE yosys elaboration instead of re-lifting per engine.
-    // Verdict-equivalent: each operator runs the identical body it did before, only reusing
-    // the prep instead of recomputing it. P-3b common-IR hub: build the operator-INDEPENDENT model
-    // ONCE — the slang extract + yosys lift + reset/init/shadow/config-pin — and share it across the
-    // precision-ladder operators (`mk_opts` only flips the engine flags, which the prep ignores), so
-    // a 3-engine ladder runs both subprocesses + the prep ONCE, not per engine. A design with no
-    // properties returns its complete empty report here.
-    let prepared = match prepare_model(task.sources, task.yosys_opts, task.opts)? {
-        Prepared::Empty(report) => return Ok(report),
-        Prepared::Model(m) => *m,
+    // Attach the plan's cost RATIONALE as telemetry on the final report — one `plan-cost` note per
+    // property + one `plan-accuracy` self-check. The precision ladder + reactive rescue decided the
+    // verdicts; this only explains + checks the routing (never a verdict change). Computed ONCE by
+    // `plan()` from the shared prepared model, so it is not recomputed per operator (the reasoning
+    // lives in the planner now, not in `verify_auto_impl`).
+    let attach = |mut rep: AutoVerifyReport| -> AutoVerifyReport {
+        for r in &plan.rationale {
+            rep.notes.push(routing_rationale_note(r));
+        }
+        if let Some(a) = plan_accuracy_note(&plan.rationale, &rep) {
+            rep.notes.push(a);
+        }
+        rep
     };
 
     match plan.mode {
@@ -178,14 +192,14 @@ pub fn execute(
                         .iter()
                         .all(|p| outcome_definite(&p.outcome).is_some())
                 {
-                    return merged;
+                    return merged.map(&attach);
                 }
             }
-            merge_portfolio_reports(&runs, plan.mode)
+            merge_portfolio_reports(&runs, plan.mode).map(&attach)
         }
         PortfolioMode::Parallel => {
             // Scoped threads borrow the task's sources / yosys_opts; each owns its option clone
-            // AND its own clone of the shared lift (so no engine re-runs yosys).
+            // AND its own clone of the shared prepared model (so no engine re-runs the prep).
             let runs: Vec<(&str, Result<AutoVerifyReport, AdapterError>)> =
                 std::thread::scope(|scope| {
                     let handles: Vec<(&str, _)> = plan
@@ -216,7 +230,7 @@ pub fn execute(
                         })
                         .collect()
                 });
-            merge_portfolio_reports(&runs, plan.mode)
+            merge_portfolio_reports(&runs, plan.mode).map(&attach)
         }
     }
 }
@@ -672,22 +686,6 @@ fn plan_accuracy_note(
     })
 }
 
-/// P2.2d entry — the full cost telemetry for a run: one `plan-cost` note per property plus one
-/// `plan-accuracy` summary. Additive telemetry (verdict-equivalent). Called from `verify_auto_impl`
-/// after the verdicts are in; in the 2b architecture the prediction half moves into `plan()`.
-pub fn routing_telemetry_notes(
-    design_btor2: &str,
-    properties: &[(String, String)],
-    report: &AutoVerifyReport,
-) -> Vec<VerificationNote> {
-    let rationales = annotate_routing(design_btor2, properties);
-    let mut notes: Vec<VerificationNote> = rationales.iter().map(routing_rationale_note).collect();
-    if let Some(acc) = plan_accuracy_note(&rationales, report) {
-        notes.push(acc);
-    }
-    notes
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -704,14 +702,8 @@ mod tests {
     #[test]
     fn plan_portfolio_sequential_emits_the_precision_ladder() {
         let o = opts_with(Some(PortfolioMode::Sequential), false, false);
-        let sources: Vec<(String, String)> = vec![];
-        let yopts = YosysOptions::default();
-        let task = VerificationTask {
-            sources: &sources,
-            yosys_opts: &yopts,
-            opts: &o,
-        };
-        let p = plan(&task);
+        // No prepared model in the unit test → the ladder alone (empty rationale).
+        let p = plan(None, &o);
         assert_eq!(p.mode, PortfolioMode::Sequential);
         assert_eq!(
             p.ops.iter().map(|e| e.label).collect::<Vec<_>>(),
@@ -723,35 +715,20 @@ mod tests {
     #[test]
     fn plan_portfolio_parallel_keeps_the_ladder_and_mode() {
         let o = opts_with(Some(PortfolioMode::Parallel), false, false);
-        let sources: Vec<(String, String)> = vec![];
-        let yopts = YosysOptions::default();
-        let task = VerificationTask {
-            sources: &sources,
-            yosys_opts: &yopts,
-            opts: &o,
-        };
-        let p = plan(&task);
+        let p = plan(None, &o);
         assert_eq!(p.mode, PortfolioMode::Parallel);
         assert_eq!(p.ops.len(), 3);
     }
 
     #[test]
     fn plan_single_engine_emits_one_op() {
-        // exact-symbolic
-        let sources: Vec<(String, String)> = vec![];
-        let yopts = YosysOptions::default();
         for (sym, exact, label) in [
             (false, true, "exact-symbolic"),
             (true, false, "symbolic"),
             (false, false, "explicit"),
         ] {
             let o = opts_with(None, sym, exact);
-            let task = VerificationTask {
-                sources: &sources,
-                yosys_opts: &yopts,
-                opts: &o,
-            };
-            let p = plan(&task);
+            let p = plan(None, &o);
             assert_eq!(p.ops.len(), 1, "single-engine intent → one operator");
             assert_eq!(p.ops[0].label, label);
         }


### PR DESCRIPTION
## What

The **`prepare_model` common-IR hub** + the **plan/verify_auto_impl unify** — completing the planner's clean pipeline for the portfolio `verify-auto` path:

```
prepare_model(sources, opts) -> Prepared          the shared IR (slang extract + yosys lift + reset/pin), built ONCE
plan(Some(&model), opts)     -> PhysicalPlan       the ladder + the per-property cost RATIONALE (the decision table)
execute(&plan, &model, task) -> report             drive each operator over the shared model, merge, attach the
                                                    rationale as plan-cost / plan-accuracy telemetry ONCE
verify_auto_impl(&model)     -> report             the pure per-engine leaf
```

Three commits:
1. **P-3a** — share the slang extraction across operators (`extract_front`).
2. **P-3b** — hoist the whole operator-independent prefix into `prepare_model`; both subprocesses (yosys + slang) **and** the reset/pin/parse prep now run once per portfolio run, not per engine.
3. **unify** — `plan()` now genuinely owns the routing rationale; `verify_auto_impl` is reduced to the pure engine leaf. Resolves the redundancy where a vestigial `plan()` co-existed with the reasoning buried in `verify_auto_impl`.

## Why

Before this, `execute()` re-entered `verify_auto_impl` per operator, re-running yosys + slang + the prep three times; and the actual cost *reasoning* lived inside the engine body while the named `plan()` did nothing. Now the planner (`plan`/`execute`) owns the shared IR **and** the reasoning, and the engine leaf just runs.

## Soundness

**Verdict-equivalent by construction** — the prefix moved *verbatim* into `prepare_model` (a pure, deterministic function of `(sources, yosys_opts, opts)`); the verdicts (loop + merge + reactive rescue + early-exit) are untouched; the telemetry only moved from per-op (deduped by the merge) to once-after-merge. The single-engine path stays direct (`verify_auto_impl(None)`, A.6-before-lift). `plan`/`execute` narrowed to `pub(crate)`.

## Validation

- `cargo test -p mununu-core --lib` — **2349 passed / 0 failed**
- clippy `-D warnings` + fmt clean; 10 planner/telemetry tests green
- SVA e2e in `mununu-sva-pono` — verdicts + `plan-cost` notes unchanged on the compute_engine pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)
