### PR TITLE
SPCR: selective prophecy-cell registerization decides array-content-gated νμ recoverability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@
 13. [Available Agents and Skills](#available-agents-and-skills) `[REFERENCE]`
 14. [Private Files Policy](#private-files-policy) `[RULE]`
 15. [Reasoning & Recommendation Honesty](#reasoning--recommendation-honesty) `[RULE]`
-16. [Reference Docs Index](#reference-docs-index) `[REFERENCE]`
+16. [Engine Specificity in Proposals](#engine-specificity-in-proposals) `[RULE]`
+17. [Reference Docs Index](#reference-docs-index) `[REFERENCE]`
 
 ---
 
@@ -399,6 +400,20 @@ Sensitive or unpublished materials live in the sibling private repo, not here: `
 - **Intrinsic task difficulty / soundness-criticality** — some work (e.g. SMT quantifier placement) demands care *regardless of when it is done*. The correct response is procedural rigor (differential tests, oracles, validation), not postponement. "This is hard and must be validated" is a real reason; "this is hard and the session is long" is not.
 
 **How to apply.** When tempted to defer or hedge, state the *actual* reason. If the only reason is genuinely "the user should make this call," say exactly that — do not pad it with a fabricated fatigue rationale. Build/cache state (warm `target/`, warm docker volumes) typically *improves* over a session, so longer-running work is often cheaper to iterate, not riskier.
+
+## Engine Specificity in Proposals
+
+**Rule.** Whenever you propose a solution — an experiment, an approach, a design, or an implementation — state in **brief, explicit prose which engine(s) it uses and how**. Never write "the verifier decides it" or "the engine handles it": name the concrete engine and, for each, its structure, technique, and configuration.
+
+- **Name the engine.** `exact-symbolic` (full-state ROBDD, OxiDD) · `symbolic` / `explicit` (predicate-cube KMTS) · native BMC / k-induction · McMillan interpolation · SPACER · btormc / pono · ranking certificate.
+- **Structure** — the IR/abstraction it runs over: full-state ROBDD · predicate cube + may/must KMTS · QF_BV / QF_AUFBV relation · CHC.
+- **Technique** — bit-blast μ-fixpoint · 3-valued modal-μ + CEGAR · k-induction · CEG-prophecy (arrays) · well-founded ranking.
+- **Configuration** — bit cap (40→192→1024), theory (BvOnly / BvUfArray), must-edge inference (`SmtHyperMust`), timeout / rlimit / BDD deadline, owned vs subprocess.
+- **Role** — decider · differential oracle · cross-check.
+
+**Why.** mununu is a portfolio and "engine" spans three unrelated axes (reachability / μ-calculus / safety-abstraction). An unnamed engine makes a proposal unreviewable: the reader cannot judge **soundness** (which engine transfers for which property class — see [Soundness Guarantees](#soundness-guarantees)), **scale** (ROBDD bit-cap vs SMT), or even **applicability** (arrays go to the SMT predicate-cube, never to ROBDD). Naming the engine + config makes the soundness posture and the cost checkable at a glance, and ties the proposal to the engine roster (`docs/design/engine-routing.md`, `verification-execution-planner.md`).
+
+**How to apply.** One `engine:` line per step, kept succinct. Example: *"shot ②: `symbolic` predicate-cube KMTS — 3-valued may/must, `SmtHyperMust` (Z3 QF_AUFBV must-side), CEGAR-refined; `exact-symbolic` ROBDD is the differential oracle where the cone fits the cap."* Applies to plan docs under `.claude/plans/`, design notes, experiment writeups, and any recommendation you give the user.
 
 ## Reference Docs Index
 

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -1,0 +1,557 @@
+//! SPCR — Selective Prophecy-Cell Registerization (owned shot ①b of the array-νμ program).
+//!
+//! Removes the ∀-quantified array from the recoverability MUST-query by registerizing exactly
+//! the property-ACCESSED array cells (one prophecy register per read index) and DROPPING the
+//! array. The must-edge `∀ s ⊨ src. ∃ in, s'. …` then becomes pure QF_BV (decidable by
+//! bit-blasting) at `O(#accessed-cells)` cost — instead of `AUFBV + ∀-over-an-array` (undecidable
+//! → Z3 `Unknown` → no must-edges → the νµ abstains: the wall mechanized in
+//! `recoverability::tests::p1a_array_gated_recovery_hits_must_edge_quantifier_wall`).
+//! Plan: `.claude/plans/spcr-selective-prophecy-cell-registerization.md`.
+//!
+//! **P-A1 scope (SOUND, conservative — abstains (returns `None`) otherwise).** For EVERY array
+//! state in the design: a single UNCONDITIONAL full-width write `mem' = write(mem, waddr, wdata)`,
+//! read only at bare-register indices whose next-value moves only within `{itself, waddr}`
+//! (stable / move-to-write-address). Under that shape the frame
+//!
+//! ```text
+//! pv' = ite(waddr == idx', wdata, pv)          (idx' = the index register's next-value)
+//! ```
+//!
+//! reproduces `mem'[idx']` EXACTLY: when `idx' = idx` (held) the else-branch is `mem[idx] = pv`;
+//! when `idx' = waddr` (moved to the written cell) the `waddr == idx'` guard is true so it is
+//! `wdata = mem'[waddr]`. So SPCR is a verdict-PRESERVING reformulation (not an abstraction): the
+//! KMTS of the SPCR'd design has the same may/must edges as the original on the property-relevant
+//! projection ⇒ definite νµ verdicts transfer at every alternation depth (Bruns–Godefroid).
+
+use crate::adapter::btor2::ast::{Btor2File, Line, Nid, Node, Op, Operand, Sort};
+use crate::adapter::btor2::parser::find_next_value_operand;
+use std::collections::{HashMap, HashSet};
+
+/// A per-array elimination plan (the sound P-A1 shape, or `None` from [`plan_for_array`]).
+struct ArrayPlan {
+    array_nid: Nid,
+    elem_sort: Nid,
+    waddr: Operand,
+    wdata: Operand,
+    /// Broadcast init value (a const operand) if the array is initialised; else free at reset.
+    init_value: Option<Operand>,
+    /// `(read node nid, index register nid)` for every read of this array.
+    reads: Vec<(Nid, Nid)>,
+    /// distinct index register nid → its next-value operand (`None` = a never-written index).
+    index_next: HashMap<Nid, Option<Operand>>,
+    array_next_nid: Option<Nid>,
+    array_init_nid: Option<Nid>,
+    write_nid: Nid,
+}
+
+fn sort_of(file: &Btor2File, nid: Nid) -> Option<Sort> {
+    match &file.lookup(nid)?.node {
+        Node::Sort { sort } => Some(sort.clone()),
+        _ => None,
+    }
+}
+
+fn node_refs_array(node: &Node, array_nid: Nid) -> bool {
+    match node {
+        Node::Op { args, .. } => args.iter().any(|a| a.nid() == array_nid),
+        Node::Next { state, value, .. } | Node::Init { state, value, .. } => {
+            *state == array_nid || value.nid() == array_nid
+        }
+        Node::Bad { signal }
+        | Node::Constraint { signal }
+        | Node::Fair { signal }
+        | Node::Output { signal, .. } => signal.nid() == array_nid,
+        Node::Justice { signals } => signals.iter().any(|s| s.nid() == array_nid),
+        _ => false,
+    }
+}
+
+/// Detect the sound P-A1 SPCR shape for one array state. `None` ⇒ abstain (leave the array).
+fn plan_for_array(file: &Btor2File, array_nid: Nid) -> Option<ArrayPlan> {
+    let array_sort_nid = match &file.lookup(array_nid)?.node {
+        Node::State { sort, .. } => *sort,
+        _ => return None,
+    };
+    let Sort::Array { element, .. } = sort_of(file, array_sort_nid)? else {
+        return None;
+    };
+    let elem_sort = element;
+
+    // The array's next MUST be a single unconditional Write(array, waddr, wdata).
+    let next_op = find_next_value_operand(file, array_nid)?;
+    let array_next_nid = file.lines.iter().find_map(|l| match &l.node {
+        Node::Next { state, .. } if *state == array_nid => Some(l.nid),
+        _ => None,
+    });
+    let write_line = file.lookup(next_op.nid())?;
+    let (waddr, wdata, write_nid) = match &write_line.node {
+        Node::Op {
+            op: Op::Write,
+            args,
+            ..
+        } if args.len() == 3 && args[0].nid() == array_nid => (args[1], args[2], write_line.nid),
+        // write-mux / chain / non-write next → P-A1 abstains.
+        _ => return None,
+    };
+
+    // Broadcast init (a const operand) if present.
+    let (init_value, array_init_nid) = file
+        .lines
+        .iter()
+        .find_map(|l| match &l.node {
+            Node::Init { state, value, .. } if *state == array_nid => {
+                Some((Some(*value), Some(l.nid)))
+            }
+            _ => None,
+        })
+        .unwrap_or((None, None));
+
+    // Reads of the array; each index must be a bare state register.
+    let mut reads: Vec<(Nid, Nid)> = Vec::new();
+    for l in &file.lines {
+        if let Node::Op {
+            op: Op::Read, args, ..
+        } = &l.node
+            && args.len() == 2
+            && args[0].nid() == array_nid
+        {
+            let idx = args[1].nid();
+            if !matches!(file.lookup(idx)?.node, Node::State { .. }) {
+                return None; // non-register index → P-A1 abstains
+            }
+            reads.push((l.nid, idx));
+        }
+    }
+    if reads.is_empty() {
+        return None;
+    }
+
+    // Stability: each index register's next-value moves only within {itself, waddr}.
+    let mut index_next: HashMap<Nid, Option<Operand>> = HashMap::new();
+    for &(_, idx) in &reads {
+        if index_next.contains_key(&idx) {
+            continue;
+        }
+        let nx = find_next_value_operand(file, idx);
+        if let Some(nxop) = nx {
+            let mut vis: HashSet<Nid> = HashSet::new();
+            let mut st = vec![nxop.nid()];
+            while let Some(n) = st.pop() {
+                if !vis.insert(n) {
+                    continue;
+                }
+                if n == idx || n == waddr.nid() {
+                    continue; // an allowed leaf (hold / move-to-write-address)
+                }
+                match &file.lookup(n)?.node {
+                    Node::Op {
+                        op: Op::Ite, args, ..
+                    } if args.len() == 3 => {
+                        st.push(args[1].nid());
+                        st.push(args[2].nid());
+                    }
+                    // a leaf other than {idx, waddr} ⇒ the index moves to an arbitrary cell
+                    // whose old content `pv` does not hold ⇒ frame is not exact ⇒ abstain.
+                    _ => return None,
+                }
+            }
+        }
+        index_next.insert(idx, nx);
+    }
+
+    // No OTHER reference to the array beyond the reads + the write + next-array + init-array.
+    let mut expected: HashSet<Nid> = reads.iter().map(|&(r, _)| r).collect();
+    expected.insert(write_nid);
+    if let Some(n) = array_next_nid {
+        expected.insert(n);
+    }
+    if let Some(n) = array_init_nid {
+        expected.insert(n);
+    }
+    for l in &file.lines {
+        if !expected.contains(&l.nid) && node_refs_array(&l.node, array_nid) {
+            return None; // an unexpected use of the array ⇒ cannot eliminate soundly
+        }
+    }
+
+    Some(ArrayPlan {
+        array_nid,
+        elem_sort,
+        waddr,
+        wdata,
+        init_value,
+        reads,
+        index_next,
+        array_next_nid,
+        array_init_nid,
+        write_nid,
+    })
+}
+
+fn remap_node(node: &Node, f: &impl Fn(Operand) -> Operand) -> Node {
+    match node {
+        Node::Op {
+            sort,
+            op,
+            args,
+            symbol,
+        } => Node::Op {
+            sort: *sort,
+            op: *op,
+            args: args.iter().map(|a| f(*a)).collect(),
+            symbol: symbol.clone(),
+        },
+        Node::Next { sort, state, value } => Node::Next {
+            sort: *sort,
+            state: *state,
+            value: f(*value),
+        },
+        Node::Init { sort, state, value } => Node::Init {
+            sort: *sort,
+            state: *state,
+            value: f(*value),
+        },
+        Node::Bad { signal } => Node::Bad { signal: f(*signal) },
+        Node::Constraint { signal } => Node::Constraint { signal: f(*signal) },
+        Node::Fair { signal } => Node::Fair { signal: f(*signal) },
+        Node::Output { signal, symbol } => Node::Output {
+            signal: f(*signal),
+            symbol: symbol.clone(),
+        },
+        Node::Justice { signals } => Node::Justice {
+            signals: signals.iter().map(|s| f(*s)).collect(),
+        },
+        other => other.clone(),
+    }
+}
+
+/// SPCR entry: if EVERY in-cone array matches the sound P-A1 shape, return the array-FREE
+/// equivalent design (prophecy registers + exact frames, arrays dropped); else `None`
+/// (the caller keeps the original and falls through to its honest abstain).
+///
+/// **Engine:** owned BTOR2→BTOR2 rewrite (no solver). The result is consumed by the array-free
+/// deciders — `exact-symbolic` ROBDD (small cone) or the `symbolic` predicate-cube (QF_BV must).
+pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
+    let array_states: Vec<Nid> = file
+        .lines
+        .iter()
+        .filter_map(|l| match &l.node {
+            Node::State { sort, .. }
+                if matches!(sort_of(file, *sort), Some(Sort::Array { .. })) =>
+            {
+                Some(l.nid)
+            }
+            _ => None,
+        })
+        .collect();
+    if array_states.is_empty() {
+        return None; // no arrays ⇒ nothing for SPCR to do (caller uses the normal path)
+    }
+    // P-A1: every array must be soundly eliminable, else abstain wholesale.
+    let plans: Vec<ArrayPlan> = array_states
+        .iter()
+        .map(|&a| plan_for_array(file, a))
+        .collect::<Option<Vec<_>>>()?;
+
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut alloc = || {
+        let n = next_nid;
+        next_nid += 1;
+        n
+    };
+
+    // A 1-bit sort for the `eq(waddr, idx')` guards (reuse an existing one, else create it).
+    let mut prelude: Vec<Line> = Vec::new();
+    let bool_sort = file
+        .lines
+        .iter()
+        .find_map(|l| match &l.node {
+            Node::Sort {
+                sort: Sort::BitVec { width: 1 },
+            } => Some(l.nid),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            let n = alloc();
+            prelude.push(Line {
+                nid: n,
+                node: Node::Sort {
+                    sort: Sort::BitVec { width: 1 },
+                },
+                immediates: Vec::new(),
+                source_line: 0,
+            });
+            n
+        });
+
+    let mut tail: Vec<Line> = Vec::new();
+    let mut read_to_pv: HashMap<Nid, Nid> = HashMap::new();
+    let mut drop_nodes: HashSet<Nid> = HashSet::new();
+
+    for plan in &plans {
+        drop_nodes.insert(plan.array_nid);
+        drop_nodes.insert(plan.write_nid);
+        if let Some(n) = plan.array_next_nid {
+            drop_nodes.insert(n);
+        }
+        if let Some(n) = plan.array_init_nid {
+            drop_nodes.insert(n);
+        }
+        for &(r, _) in &plan.reads {
+            drop_nodes.insert(r);
+        }
+
+        let mut idx_to_pv: HashMap<Nid, Nid> = HashMap::new();
+        for (&idx, idx_next) in &plan.index_next {
+            let pv = alloc();
+            idx_to_pv.insert(idx, pv);
+            // pv state (element sort).
+            prelude.push(Line {
+                nid: pv,
+                node: Node::State {
+                    sort: plan.elem_sort,
+                    symbol: Some(format!("spcr_pv_{}_{}", plan.array_nid, idx)),
+                },
+                immediates: Vec::new(),
+                source_line: 0,
+            });
+            // pv init (broadcast) if the array is initialised.
+            if let Some(iv) = plan.init_value {
+                tail.push(Line {
+                    nid: alloc(),
+                    node: Node::Init {
+                        sort: plan.elem_sort,
+                        state: pv,
+                        value: iv,
+                    },
+                    immediates: Vec::new(),
+                    source_line: 0,
+                });
+            }
+            // frame: pv' = ite(eq(waddr, idx'), wdata, pv). A never-written index holds (idx' = idx).
+            let idx_next_op = idx_next.unwrap_or(Operand(idx));
+            let eq = alloc();
+            tail.push(Line {
+                nid: eq,
+                node: Node::Op {
+                    sort: bool_sort,
+                    op: Op::Eq,
+                    args: vec![plan.waddr, idx_next_op],
+                    symbol: None,
+                },
+                immediates: Vec::new(),
+                source_line: 0,
+            });
+            let ite = alloc();
+            tail.push(Line {
+                nid: ite,
+                node: Node::Op {
+                    sort: plan.elem_sort,
+                    op: Op::Ite,
+                    args: vec![Operand(eq), plan.wdata, Operand(pv)],
+                    symbol: None,
+                },
+                immediates: Vec::new(),
+                source_line: 0,
+            });
+            tail.push(Line {
+                nid: alloc(),
+                node: Node::Next {
+                    sort: plan.elem_sort,
+                    state: pv,
+                    value: Operand(ite),
+                },
+                immediates: Vec::new(),
+                source_line: 0,
+            });
+        }
+        for &(r, idx) in &plan.reads {
+            read_to_pv.insert(r, idx_to_pv[&idx]);
+        }
+    }
+
+    // Rewrite: references to a dropped read node → its prophecy register (sign-preserving).
+    let remap = |o: Operand| -> Operand {
+        match read_to_pv.get(&o.nid()) {
+            Some(&pv) => Operand(if o.0 < 0 { -pv } else { pv }),
+            None => o,
+        }
+    };
+    let mut out: Vec<Line> = Vec::with_capacity(file.lines.len() + prelude.len() + tail.len());
+    out.extend(prelude); // pv states (+ maybe the bool sort) — only forward-ref a SORT (nid-resolved)
+    for line in &file.lines {
+        if drop_nodes.contains(&line.nid) {
+            continue;
+        }
+        out.push(Line {
+            nid: line.nid,
+            node: remap_node(&line.node, &remap),
+            immediates: line.immediates.clone(),
+            source_line: line.source_line,
+        });
+    }
+    out.extend(tail); // eq / ite / next-pv / init — all backward refs
+    let by_nid = out.iter().enumerate().map(|(i, l)| (l.nid, i)).collect();
+    Some(Btor2File { lines: out, by_nid })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Clean P-A1 fixture: full-width write `mem[waddr]=wdata`, latched index
+    /// `key' ∈ {key, waddr}`, recovery gated on `mem[key]==3`; `AG EF(busy==0)` HOLDS.
+    const AGR_SPCR: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 sort array 2 2
+4 input 1 start
+5 input 2 waddr
+6 input 2 wdata
+7 state 1 busy
+8 state 2 key
+9 state 3 mem
+10 const 1 0
+11 init 1 7 10
+12 const 2 00
+13 init 2 8 12
+14 const 2 11
+15 read 2 9 8
+16 eq 1 15 14
+17 not 1 7
+18 and 1 4 17
+19 const 1 1
+20 and 1 7 16
+21 ite 1 20 10 7
+22 ite 1 18 19 21
+23 next 1 7 22
+24 ite 2 18 5 8
+25 next 2 8 24
+26 write 3 9 5 6
+27 next 3 9 26
+";
+
+    fn has_array(file: &Btor2File) -> bool {
+        file.lines.iter().any(|l| {
+            matches!(
+                &l.node,
+                Node::State { sort, .. } if matches!(sort_of(file, *sort), Some(Sort::Array { .. }))
+            )
+        })
+    }
+
+    #[test]
+    fn spcr_eliminates_the_array_on_the_clean_shape() {
+        let file = crate::adapter::btor2::parser::parse(AGR_SPCR).expect("parse");
+        assert!(has_array(&file), "fixture must have an array");
+        let out = super::spcr(&file).expect("SPCR applies to the clean shape");
+        assert!(!has_array(&out), "SPCR output must be array-free");
+        // The read `mem[key]` must be gone; a prophecy register must exist.
+        assert!(
+            !out.lines
+                .iter()
+                .any(|l| matches!(&l.node, Node::Op { op: Op::Read, .. })),
+            "no array reads should remain"
+        );
+        assert!(
+            out.lines.iter().any(|l| matches!(&l.node, Node::State { symbol: Some(s), .. } if s.starts_with("spcr_pv_"))),
+            "a prophecy register must be synthesized"
+        );
+    }
+
+    #[test]
+    fn spcr_decides_array_gated_recovery_holds_via_exact() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        use crate::mu_calculus::parser as mu_parser;
+        let file = crate::adapter::btor2::parser::parse(AGR_SPCR).expect("parse");
+        let f = mu_parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").unwrap();
+        // Guard: the ORIGINAL (array-bearing) design makes the exact ROBDD SKIP (in-cone array).
+        assert!(
+            exact_symbolic_verdict(AGR_SPCR, &f).is_err(),
+            "original must SKIP on the in-cone array"
+        );
+        // After SPCR the design is array-free ⇒ the exact ROBDD decides HOLDS.
+        let out = super::spcr(&file).expect("SPCR applies");
+        let src = crate::adapter::btor2::emit::emit_btor2(&out);
+        assert_eq!(
+            exact_symbolic_verdict(&src, &f).expect("array-free ⇒ exact decides"),
+            ExactVerdict::Holds,
+            "SPCR'd design must decide AG EF(busy==0) = Holds (matches registerized oracle)"
+        );
+    }
+
+    /// 8-bit twin (AW=8/DW=8, 256-cell array): SPCR must still yield exactly ONE prophecy
+    /// register (O(#accessed-cells), array-size-INDEPENDENT). Whole-array registerization would be
+    /// 256·8 = 2048 array bits (over the exact cap → SKIP); SPCR's `busy(1)+key(8)+pv(8)=17` bits
+    /// bit-blast, so the exact ROBDD decides — the scaling that beats registerization.
+    const AGR_SPCR_LARGE: &str = "\
+1 sort bitvec 1
+2 sort bitvec 8
+3 sort array 2 2
+4 input 1 start
+5 input 2 waddr
+6 input 2 wdata
+7 state 1 busy
+8 state 2 key
+9 state 3 mem
+10 const 1 0
+11 init 1 7 10
+12 const 2 00000000
+13 init 2 8 12
+14 const 2 11111111
+15 read 2 9 8
+16 eq 1 15 14
+17 not 1 7
+18 and 1 4 17
+19 const 1 1
+20 and 1 7 16
+21 ite 1 20 10 7
+22 ite 1 18 19 21
+23 next 1 7 22
+24 ite 2 18 5 8
+25 next 2 8 24
+26 write 3 9 5 6
+27 next 3 9 26
+";
+
+    #[test]
+    fn spcr_scales_array_size_independent_one_pv_and_exact_decides() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        use crate::mu_calculus::parser as mu_parser;
+        let file = crate::adapter::btor2::parser::parse(AGR_SPCR_LARGE).expect("parse");
+        let out = super::spcr(&file).expect("SPCR applies to the 8-bit clean shape");
+        // O(#accessed-cells): exactly ONE prophecy register regardless of the 256-cell array.
+        let pvs = out
+            .lines
+            .iter()
+            .filter(|l| matches!(&l.node, Node::State { symbol: Some(s), .. } if s.starts_with("spcr_pv_")))
+            .count();
+        assert_eq!(
+            pvs, 1,
+            "one prophecy register per read index, array-size-independent"
+        );
+        assert!(!has_array(&out), "SPCR output must be array-free");
+        let f = mu_parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").unwrap();
+        // Whole-array registerization (256·8 bits) would exceed the exact cap; SPCR's 17 state
+        // bits bit-blast → the exact ROBDD decides Holds.
+        let src = crate::adapter::btor2::emit::emit_btor2(&out);
+        assert_eq!(
+            exact_symbolic_verdict(&src, &f).expect("array-free 17-bit cone ⇒ exact decides"),
+            ExactVerdict::Holds,
+        );
+    }
+
+    #[test]
+    fn spcr_abstains_when_no_array() {
+        // A BV-only design: SPCR is a no-op (None) so the caller keeps the original.
+        let bv_only = "\
+1 sort bitvec 1
+2 state 1 busy
+3 const 1 0
+4 init 1 2 3
+5 next 1 2 2
+";
+        let file = crate::adapter::btor2::parser::parse(bv_only).expect("parse");
+        assert!(super::spcr(&file).is_none(), "no array ⇒ SPCR is a no-op");
+    }
+}

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -112,6 +112,15 @@ impl Elim<'_> {
         if let Some(&n) = self.pv_of.get(&cell) {
             return n;
         }
+        // SOUNDNESS: a registerized STATE index must be a real LATCH — it MUST have a `next`. A BTOR2
+        // state with NO `next` is HAVOC every cycle (an unconstrained/free index), so `pv = mem[state]`
+        // cannot be tracked by a single register (the index jumps arbitrarily) — abstain. (Const index
+        // cells never havoc.) Missing this is unsound: it treats a free index as a held constant.
+        if let Cell::State(s) = cell
+            && find_next_value_operand(self.file, s).is_none()
+        {
+            self.ok = false;
+        }
         let symbol = match cell {
             Cell::State(s) => format!("spcr_pv_{}_{}", self.array_nid, s),
             Cell::Const(c) => format!("spcr_pv_{}_c{}", self.array_nid, c),
@@ -772,6 +781,161 @@ fn fold_and_dce(file: &Btor2File) -> Btor2File {
     Btor2File { lines: out, by_nid }
 }
 
+/// The nids a node references (operands + sort + state/value + signals) — for topological ordering.
+fn node_dep_nids(node: &Node) -> Vec<Nid> {
+    match node {
+        Node::Sort {
+            sort: Sort::Array { index, element },
+        } => vec![*index, *element],
+        Node::Sort { .. } => Vec::new(),
+        Node::Op { sort, args, .. } => {
+            let mut v: Vec<Nid> = args.iter().map(|a| a.nid()).collect();
+            v.push(*sort);
+            v
+        }
+        Node::State { sort, .. } | Node::Input { sort, .. } | Node::Const { sort, .. } => {
+            vec![*sort]
+        }
+        Node::Init { sort, state, value } | Node::Next { sort, state, value } => {
+            vec![*sort, *state, value.nid()]
+        }
+        Node::Bad { signal }
+        | Node::Constraint { signal }
+        | Node::Fair { signal }
+        | Node::Output { signal, .. } => vec![signal.nid()],
+        Node::Justice { signals } => signals.iter().map(|s| s.nid()).collect(),
+    }
+}
+
+/// Topologically sort lines so every referenced nid precedes its use (iterative post-order DFS).
+/// The graph is a DAG — BTOR2 forbids combinational cycles, and a `state` is a leaf declaration
+/// whose `next` is a separate node (so `next(s, f(s))` is acyclic: s, then f(s), then next).
+fn topo_sort_lines(lines: Vec<Line>) -> Vec<Line> {
+    let idx_of: HashMap<Nid, usize> = lines.iter().enumerate().map(|(i, l)| (l.nid, i)).collect();
+    let mut mark = vec![0u8; lines.len()]; // 0 unvisited, 1 in-progress, 2 done
+    let mut order: Vec<usize> = Vec::with_capacity(lines.len());
+    for start in 0..lines.len() {
+        if mark[start] != 0 {
+            continue;
+        }
+        let mut stack = vec![(start, false)];
+        while let Some((i, processed)) = stack.pop() {
+            if processed {
+                if mark[i] != 2 {
+                    mark[i] = 2;
+                    order.push(i);
+                }
+                continue;
+            }
+            if mark[i] != 0 {
+                continue;
+            }
+            mark[i] = 1;
+            stack.push((i, true));
+            for d in node_dep_nids(&lines[i].node) {
+                if let Some(&j) = idx_of.get(&d)
+                    && mark[j] == 0
+                {
+                    stack.push((j, false));
+                }
+            }
+        }
+    }
+    let mut slots: Vec<Option<Line>> = lines.into_iter().map(Some).collect();
+    order
+        .into_iter()
+        .map(|i| slots[i].take().unwrap())
+        .collect()
+}
+
+/// Renumber lines to MONOTONIC 1-based nids (their line position) and remap EVERY nid reference —
+/// producing valid BTOR2 (`btormc`/`pono` require strictly-increasing ids in line order). Preserves
+/// operand signs; remaps sort refs (incl. `Array{index,element}`), state/value refs, and signals.
+fn renumber_monotonic(lines: Vec<Line>) -> Vec<Line> {
+    let map: HashMap<Nid, Nid> = lines
+        .iter()
+        .enumerate()
+        .map(|(i, l)| (l.nid, i as Nid + 1))
+        .collect();
+    let m = |old: Nid| -> Nid { map.get(&old).copied().unwrap_or(old) };
+    let mop = |o: Operand| -> Operand {
+        let n = m(o.nid());
+        Operand(if o.0 < 0 { -n } else { n })
+    };
+    lines
+        .into_iter()
+        .enumerate()
+        .map(|(i, l)| {
+            let node = match l.node {
+                Node::Sort {
+                    sort: Sort::Array { index, element },
+                } => Node::Sort {
+                    sort: Sort::Array {
+                        index: m(index),
+                        element: m(element),
+                    },
+                },
+                s @ Node::Sort { .. } => s, // BitVec width is not a nid
+                Node::Op {
+                    sort,
+                    op,
+                    args,
+                    symbol,
+                } => Node::Op {
+                    sort: m(sort),
+                    op,
+                    args: args.into_iter().map(mop).collect(),
+                    symbol,
+                },
+                Node::State { sort, symbol } => Node::State {
+                    sort: m(sort),
+                    symbol,
+                },
+                Node::Input { sort, symbol } => Node::Input {
+                    sort: m(sort),
+                    symbol,
+                },
+                Node::Const { sort, value } => Node::Const {
+                    sort: m(sort),
+                    value,
+                },
+                Node::Init { sort, state, value } => Node::Init {
+                    sort: m(sort),
+                    state: m(state),
+                    value: mop(value),
+                },
+                Node::Next { sort, state, value } => Node::Next {
+                    sort: m(sort),
+                    state: m(state),
+                    value: mop(value),
+                },
+                Node::Bad { signal } => Node::Bad {
+                    signal: mop(signal),
+                },
+                Node::Constraint { signal } => Node::Constraint {
+                    signal: mop(signal),
+                },
+                Node::Fair { signal } => Node::Fair {
+                    signal: mop(signal),
+                },
+                Node::Output { signal, symbol } => Node::Output {
+                    signal: mop(signal),
+                    symbol,
+                },
+                Node::Justice { signals } => Node::Justice {
+                    signals: signals.into_iter().map(mop).collect(),
+                },
+            };
+            Line {
+                nid: i as Nid + 1,
+                node,
+                immediates: l.immediates,
+                source_line: l.source_line,
+            }
+        })
+        .collect()
+}
+
 /// SPCR entry: if EVERY in-cone array matches the sound P-A1 shape (after the P-A1c fold), return
 /// the array-FREE equivalent design (prophecy registers + exact frames, arrays dropped); else
 /// `None` (the caller keeps the original and falls through to its honest abstain).
@@ -862,30 +1026,24 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
             None => o,
         }
     };
-    // Topological layout: fresh DECLARATIONS (sorts / prophecy states / consts — they reference at
-    // most a sort) first, then the original lines (minus drops, remapped), then the fresh
-    // COMBINATIONAL/next nodes (in push order = dependency order). This keeps every data operand a
-    // backward reference (only sort references may be forward — resolved by NID).
-    let (decls, rest): (Vec<Line>, Vec<Line>) = new_nodes.into_iter().partition(|l| {
-        matches!(
-            l.node,
-            Node::Sort { .. } | Node::State { .. } | Node::Const { .. }
-        )
-    });
-    let mut out: Vec<Line> = Vec::with_capacity(file.lines.len() + decls.len() + rest.len());
-    out.extend(decls);
-    for line in &file.lines {
-        if drops.contains(&line.nid) {
-            continue;
-        }
-        out.push(Line {
+    // Combine the surviving original lines (remapped, minus drops) with the fresh SPCR nodes, then
+    // TOPOLOGICALLY SORT (declaration-before-use) — a fixed partition is not enough because a read
+    // reconstructed as `ite(cond, pv_a, pv_b)` is a fresh op that an ORIGINAL node references AND
+    // that itself references an original condition, so new/old nodes interleave in dependency order.
+    let mut combined: Vec<Line> = Vec::with_capacity(file.lines.len() + new_nodes.len());
+    for line in file.lines.iter().filter(|l| !drops.contains(&l.nid)) {
+        combined.push(Line {
             nid: line.nid,
             node: remap_node(&line.node, &remap),
             immediates: line.immediates.clone(),
             source_line: line.source_line,
         });
     }
-    out.extend(rest);
+    combined.extend(new_nodes);
+    let out = topo_sort_lines(combined);
+    // Canonicalize to MONOTONIC nids (1-based line position), remapping every nid reference — valid
+    // BTOR2 requires strictly-increasing ids in line order (btormc/pono reject otherwise).
+    let out = renumber_monotonic(out);
     let by_nid = out.iter().enumerate().map(|(i, l)| (l.nid, i)).collect();
     // Observability (attribution): report that SPCR fired + its O(#accessed-cells) footprint.
     let pvs = out
@@ -1048,9 +1206,11 @@ mod tests {
         );
     }
 
-    /// P-A1b — write-ENABLE mux `mem' = ite(we, write(mem,waddr,wdata), mem)` with a STABLE
-    /// (never-moving) config index `key`. Recovery via the env asserting `we ∧ waddr==key ∧
-    /// wdata==3`; `AG EF(busy==0)` HOLDS. SPCR frame = `pv' = ite(we ∧ waddr==key, wdata, pv)`.
+    /// P-A1b — write-ENABLE mux `mem' = ite(we, write(mem,waddr,wdata), mem)` with a STABLE config
+    /// index `key`. Recovery via the env asserting `we ∧ waddr==key ∧ wdata==3`; `AG EF(busy==0)`
+    /// HOLDS. SPCR frame = `pv' = ite(we ∧ waddr==key, wdata, pv)`. NOTE `key` has an EXPLICIT
+    /// self-`next` (node 28: `next key key`) — a REAL latch. (A no-`next` state is HAVOC in BTOR2,
+    /// not a held constant, and SPCR correctly abstains on it — see `spcr_abstains_on_havoc_no_next_index`.)
     const AGR_SPCR_WE: &str = "\
 1 sort bitvec 1
 2 sort bitvec 2
@@ -1079,6 +1239,7 @@ mod tests {
 25 write 3 10 5 6
 26 ite 3 7 25 10
 27 next 3 10 26
+28 next 2 9 9
 ";
 
     #[test]
@@ -1371,6 +1532,126 @@ mod tests {
         assert_eq!(
             exact_symbolic_verdict(&src, &f).expect("array-free ⇒ exact decides"),
             ExactVerdict::Holds,
+        );
+    }
+
+    /// Measurement probe (not CI): run SPCR over every `*.btor`/`*.btor2` under
+    /// `MUNUNU_SPCR_PROBE_DIR` and report how many array-bearing designs SPCR's mechanism ELIMINATES
+    /// (becomes array-free) vs abstains on. Used to measure SPCR's applicability to real corpora
+    /// (e.g. the HWMCC20 arrays track). `#[ignore]` — run explicitly with the env var set.
+    #[test]
+    #[ignore]
+    fn spcr_applicability_probe_over_dir() {
+        let dir = std::env::var("MUNUNU_SPCR_PROBE_DIR").expect("set MUNUNU_SPCR_PROBE_DIR");
+        let mut total = 0usize;
+        let mut no_array = 0usize;
+        let mut applied: Vec<(String, usize)> = Vec::new();
+        let mut abstained: Vec<String> = Vec::new();
+        let mut parse_fail = 0usize;
+        // Recursively collect every *.btor / *.btor2 under `dir`.
+        let mut entries: Vec<std::path::PathBuf> = Vec::new();
+        let mut stack = vec![std::path::PathBuf::from(&dir)];
+        while let Some(d) = stack.pop() {
+            let Ok(rd) = std::fs::read_dir(&d) else {
+                continue;
+            };
+            for e in rd.filter_map(|e| e.ok()) {
+                let p = e.path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if p.extension().is_some_and(|x| x == "btor" || x == "btor2") {
+                    entries.push(p);
+                }
+            }
+        }
+        entries.sort();
+        for path in entries {
+            total += 1;
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(file) = crate::adapter::btor2::parser::parse(&content) else {
+                parse_fail += 1;
+                continue;
+            };
+            if !has_array(&file) {
+                no_array += 1;
+                continue;
+            }
+            match super::spcr(&file) {
+                Some(out) => {
+                    let pvs = out
+                        .lines
+                        .iter()
+                        .filter(|l| matches!(&l.node, Node::State { symbol: Some(s), .. } if s.starts_with("spcr_pv_")))
+                        .count();
+                    // Optionally emit the array-free design (for a manual `btor2 verify` marginal-reach check).
+                    if let Ok(out_dir) = std::env::var("MUNUNU_SPCR_OUT_DIR") {
+                        let stem = path.file_stem().unwrap().to_string_lossy();
+                        let dst = std::path::Path::new(&out_dir).join(format!("{stem}.spcr.btor2"));
+                        let _ = std::fs::write(dst, crate::adapter::btor2::emit::emit_btor2(&out));
+                    }
+                    applied.push((name, pvs));
+                }
+                None => abstained.push(name),
+            }
+        }
+        eprintln!(
+            "[SPCR-PROBE] dir={dir}\n  total={total} parse_fail={parse_fail} no_array={no_array} \
+             applied={} abstained={}",
+            applied.len(),
+            abstained.len()
+        );
+        for (n, pv) in &applied {
+            eprintln!("[SPCR-PROBE]   APPLIED  pv={pv:<3} {n}");
+        }
+        for n in abstained.iter().take(20) {
+            eprintln!("[SPCR-PROBE]   abstain      {n}");
+        }
+    }
+
+    /// SOUNDNESS regression — the HWMCC20 `easy_zero_array` benchmark. The read index `idx` (node 9)
+    /// has NO `next` line, so in BTOR2 it is HAVOC every cycle (a free index), NOT a held constant.
+    /// SPCR must ABSTAIN (registerizing `mem[idx]` for a havoc `idx` is unsound — btormc found a
+    /// spurious `sat`/violation on the earlier buggy elimination). Caught by an external
+    /// cross-check; this locks in the fix.
+    const EASY_ZERO_ARRAY: &str = "\
+1 sort bitvec 1
+2 sort bitvec 10
+3 sort bitvec 32
+4 sort array 2 3
+5 const 1 0
+6 const 1 1
+7 const 2 0000000000
+8 const 3 00000000000000000000000000000000
+9 state 2 idx
+10 state 4 mem
+11 state 2 i
+12 const 2 0000000000
+13 const 2 0000000001
+14 add 2 11 13
+15 const 2 0000100000
+16 ulte 1 11 15 i_lt_const
+17 ite 2 16 14 11 i_ite_res
+18 next 2 11 17
+19 write 4 10 11 8
+20 init 2 11 7
+21 ult 1 9 11
+22 read 3 10 9
+23 neq 1 22 8
+24 and 1 21 23
+25 next 4 10 19
+26 bad 24
+";
+
+    #[test]
+    fn spcr_abstains_on_havoc_no_next_index() {
+        let file = crate::adapter::btor2::parser::parse(EASY_ZERO_ARRAY).expect("parse");
+        assert!(has_array(&file), "fixture has an array");
+        assert!(
+            super::spcr(&file).is_none(),
+            "a no-next (HAVOC) read index must make SPCR abstain — registerizing mem[havoc] is unsound"
         );
     }
 

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -859,6 +859,18 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
     }
     out.extend(rest);
     let by_nid = out.iter().enumerate().map(|(i, l)| (l.nid, i)).collect();
+    // Observability (attribution): report that SPCR fired + its O(#accessed-cells) footprint.
+    let pvs = out
+        .iter()
+        .filter(
+            |l| matches!(&l.node, Node::State { symbol: Some(s), .. } if s.starts_with("spcr_pv_")),
+        )
+        .count();
+    tracing::info!(
+        arrays = array_states.len(),
+        prophecy_registers = pvs,
+        "SPCR: eliminated array(s) via selective prophecy-cell registerization"
+    );
     Some(Btor2File { lines: out, by_nid })
 }
 

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -36,28 +36,233 @@ use crate::adapter::btor2::ast::{Btor2File, Line, Nid, Node, Op, Operand, Sort};
 use crate::adapter::btor2::parser::find_next_value_operand;
 use std::collections::{HashMap, HashSet};
 
-/// A per-array elimination plan (the sound P-A1 shape, or `None` from [`plan_for_array`]).
-struct ArrayPlan {
+/// P-A1d — an index LEAF: a state cell (a moving index, tracked by its current value) or a
+/// constant index. SPCR registerizes one prophecy register `pv = mem[Cell]` per distinct cell.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum Cell {
+    State(Nid),
+    Const(u64),
+}
+
+/// P-A1d — the recursive array-elimination context for ONE array. Registerizes `pv_L = mem[L]`
+/// for every index leaf `L` reachable from a read index or (transitively) the next-value of a
+/// registerized index-state. A read `mem[E]` is reconstructed as [`Elim::read_at`] (the index
+/// `ite`-tree rebuilt over the `pv`s); each frame `pv_L' = mem'[L']` is built by
+/// [`Elim::mem_next_at`], substituting `mem'[leaf]` recursively. `ok` is cleared (⇒ SPCR abstains)
+/// on any leaf that is not a state / const / (the write address under an UNCONDITIONAL write) —
+/// e.g. an input-indexed read or an RMW read in a next-value. This subsumes P-A1/A1b/A1c (the
+/// single-state-leaf special case) and adds reset-mux `ite(rst, key, 0)` indices (P-A1d).
+struct Elim<'a> {
+    file: &'a Btor2File,
     array_nid: Nid,
     elem_sort: Nid,
+    bool_sort: Nid,
     waddr: Operand,
     wdata: Operand,
-    /// Broadcast init value (a const operand) if the array is initialised; else free at reset.
-    init_value: Option<Operand>,
-    /// `(read node nid, index register nid)` for every read of this array.
-    reads: Vec<(Nid, Nid)>,
-    /// distinct index register nid → its next-value operand (`None` = a never-written index).
-    index_next: HashMap<Nid, Option<Operand>>,
-    array_next_nid: Option<Nid>,
-    array_init_nid: Option<Nid>,
-    write_nid: Nid,
-    /// The write-enable mux node `ite(cond, write, array)` (P-A1b), if the write is conditional.
-    mux_nid: Option<Nid>,
-    /// The write-enable condition (`None` = unconditional / a tautological enable). When `Some`,
-    /// the write only fires under `cond`, so the frame guards `wdata` by `cond ∧ (waddr==idx')`
-    /// AND the index is required to be STABLE (never moves) — see the soundness note in
-    /// [`plan_for_array`].
+    /// `None` = unconditional write (so `mem'[waddr] = wdata`); `Some(cond)` = write-enable
+    /// (guards each cell frame, and forbids a `waddr` leaf in a next-value — that would need the
+    /// un-registerizable `mem[waddr]`).
     write_cond: Option<Operand>,
+    /// Broadcast init value (a const operand) if the array is initialised; else pv is free at reset.
+    init_value: Option<Operand>,
+    next_nid: &'a mut Nid,
+    new_nodes: &'a mut Vec<Line>,
+    const_of: &'a mut HashMap<(u64, Nid), Nid>,
+    pv_of: HashMap<Cell, Nid>,
+    frame_done: HashSet<Cell>,
+    ok: bool,
+    depth: u32,
+}
+
+impl Elim<'_> {
+    /// A hard recursion bound (index `ite`-trees are shallow; a runaway ⇒ abstain).
+    const DEPTH_CAP: u32 = 64;
+
+    fn alloc(&mut self) -> Nid {
+        let n = *self.next_nid;
+        *self.next_nid += 1;
+        n
+    }
+
+    fn push(&mut self, node: Node) -> Nid {
+        let n = self.alloc();
+        self.new_nodes.push(Line {
+            nid: n,
+            node,
+            immediates: Vec::new(),
+            source_line: 0,
+        });
+        n
+    }
+
+    fn const_node(&mut self, v: u64) -> Nid {
+        if let Some(&n) = self.const_of.get(&(v, self.elem_sort)) {
+            return n;
+        }
+        let n = self.push(Node::Const {
+            sort: self.elem_sort,
+            value: crate::adapter::btor2::ast::ConstValue::Dec(v as i128),
+        });
+        self.const_of.insert((v, self.elem_sort), n);
+        n
+    }
+
+    /// The prophecy register for a cell (lazily created, with the array's broadcast init if any).
+    fn pv_for(&mut self, cell: Cell) -> Nid {
+        if let Some(&n) = self.pv_of.get(&cell) {
+            return n;
+        }
+        let symbol = match cell {
+            Cell::State(s) => format!("spcr_pv_{}_{}", self.array_nid, s),
+            Cell::Const(c) => format!("spcr_pv_{}_c{}", self.array_nid, c),
+        };
+        let pv = self.push(Node::State {
+            sort: self.elem_sort,
+            symbol: Some(symbol),
+        });
+        self.pv_of.insert(cell, pv);
+        if let Some(iv) = self.init_value {
+            self.push(Node::Init {
+                sort: self.elem_sort,
+                state: pv,
+                value: iv,
+            });
+        }
+        pv
+    }
+
+    /// The index VALUE operand of a cell (for `waddr == cell`): a state's current value, or a const.
+    fn cell_value(&mut self, cell: Cell) -> Operand {
+        match cell {
+            Cell::State(s) => Operand(s),
+            Cell::Const(c) => Operand(self.const_node(c)),
+        }
+    }
+
+    /// The write guard for a cell: `(waddr == cell)` [∧ write_cond].
+    fn write_guard(&mut self, cell: Cell) -> Operand {
+        let idxval = self.cell_value(cell);
+        let eq = self.push(Node::Op {
+            sort: self.bool_sort,
+            op: Op::Eq,
+            args: vec![self.waddr, idxval],
+            symbol: None,
+        });
+        match self.write_cond {
+            None => Operand(eq),
+            Some(cond) => Operand(self.push(Node::Op {
+                sort: self.bool_sort,
+                op: Op::And,
+                args: vec![cond, Operand(eq)],
+                symbol: None,
+            })),
+        }
+    }
+
+    /// `mem'[cell]` = `ite((waddr == cell)[∧cond], wdata, pv_cell)`.
+    fn leaf_frame(&mut self, cell: Cell) -> Operand {
+        let g = self.write_guard(cell);
+        let pv = self.pv_for(cell);
+        Operand(self.push(Node::Op {
+            sort: self.elem_sort,
+            op: Op::Ite,
+            args: vec![g, self.wdata, Operand(pv)],
+            symbol: None,
+        }))
+    }
+
+    /// See through a width-preserving `uext`/`sext(x, 0)` alias to the underlying node (yosys puts
+    /// the visible name on such a copy — e.g. `u.key`).
+    fn see_through(&self, nid: Nid) -> Nid {
+        if let Some(l) = self.file.lookup(nid)
+            && let Node::Op { op, args, .. } = &l.node
+            && matches!(op, Op::Uext | Op::Sext)
+            && l.immediates.first().copied() == Some(0)
+            && let Some(a) = args.first()
+        {
+            return self.see_through(a.nid());
+        }
+        nid
+    }
+
+    /// The CURRENT-cycle value read at index expression `E`, rebuilt over the `pv`s. Clears `ok`
+    /// on a leaf that cannot be registerized (an input index / a complex op).
+    fn read_at(&mut self, nid: Nid) -> Operand {
+        if !self.ok || self.depth > Self::DEPTH_CAP {
+            self.ok = false;
+            return Operand(0);
+        }
+        let nid = self.see_through(nid);
+        if let Some(c) = crate::adapter::btor2::bit_blast::resolve_btor2_constant(self.file, nid) {
+            return Operand(self.pv_for(Cell::Const(c)));
+        }
+        match self.file.lookup(nid).map(|l| &l.node) {
+            Some(Node::State { .. }) => Operand(self.pv_for(Cell::State(nid))),
+            Some(Node::Op {
+                op: Op::Ite, args, ..
+            }) if args.len() == 3 => {
+                let (c, a, b) = (args[0], args[1].nid(), args[2].nid());
+                self.depth += 1;
+                let ra = self.read_at(a);
+                let rb = self.read_at(b);
+                self.depth -= 1;
+                Operand(self.push(Node::Op {
+                    sort: self.elem_sort,
+                    op: Op::Ite,
+                    args: vec![c, ra, rb],
+                    symbol: None,
+                }))
+            }
+            _ => {
+                self.ok = false;
+                Operand(0)
+            }
+        }
+    }
+
+    /// `mem'[value-of(E)]` — the NEXT-cycle memory content at index expression `E`. Substitutes
+    /// `mem'[leaf]` recursively: a state/const leaf → [`Elim::leaf_frame`]; the write address (under
+    /// an unconditional write) → `wdata`; an `ite` → the reconstructed `ite`. Clears `ok` otherwise.
+    fn mem_next_at(&mut self, nid: Nid) -> Operand {
+        if !self.ok || self.depth > Self::DEPTH_CAP {
+            self.ok = false;
+            return Operand(0);
+        }
+        let nid = self.see_through(nid);
+        if nid == self.waddr.nid() {
+            if self.write_cond.is_none() {
+                return self.wdata;
+            }
+            self.ok = false;
+            return Operand(0);
+        }
+        if let Some(c) = crate::adapter::btor2::bit_blast::resolve_btor2_constant(self.file, nid) {
+            return self.leaf_frame(Cell::Const(c));
+        }
+        match self.file.lookup(nid).map(|l| &l.node) {
+            Some(Node::State { .. }) => self.leaf_frame(Cell::State(nid)),
+            Some(Node::Op {
+                op: Op::Ite, args, ..
+            }) if args.len() == 3 => {
+                let (c, a, b) = (args[0], args[1].nid(), args[2].nid());
+                self.depth += 1;
+                let ma = self.mem_next_at(a);
+                let mb = self.mem_next_at(b);
+                self.depth -= 1;
+                Operand(self.push(Node::Op {
+                    sort: self.elem_sort,
+                    op: Op::Ite,
+                    args: vec![c, ma, mb],
+                    symbol: None,
+                }))
+            }
+            // an RMW read in a next-value, or any other op ⇒ cannot registerize soundly.
+            _ => {
+                self.ok = false;
+                Operand(0)
+            }
+        }
+    }
 }
 
 fn sort_of(file: &Btor2File, nid: Nid) -> Option<Sort> {
@@ -106,61 +311,63 @@ fn node_refs_array(node: &Node, array_nid: Nid) -> bool {
     }
 }
 
-/// Detect the sound P-A1 SPCR shape for one array state. `None` ⇒ abstain (leave the array).
-fn plan_for_array(file: &Btor2File, array_nid: Nid) -> Option<ArrayPlan> {
-    let array_sort_nid = match &file.lookup(array_nid)?.node {
-        Node::State { sort, .. } => *sort,
-        _ => return None,
+/// P-A1d — eliminate ONE array via the recursive [`Elim`], accumulating the fresh prophecy nodes
+/// (`new_nodes`), the `read_nid → reconstruction` map, and the drop set. Returns `false` (⇒ SPCR
+/// abstains) on any unsound shape: a write-chain / write in the else-branch, an unexpected
+/// reference to the array, a direct-read write-enable, or an un-registerizable index leaf.
+#[allow(clippy::too_many_arguments)]
+fn eliminate_array(
+    file: &Btor2File,
+    array_nid: Nid,
+    next_nid: &mut Nid,
+    new_nodes: &mut Vec<Line>,
+    const_of: &mut HashMap<(u64, Nid), Nid>,
+    bool_sort: Nid,
+    read_repl: &mut HashMap<Nid, Operand>,
+    drops: &mut HashSet<Nid>,
+) -> bool {
+    let array_sort_nid = match file.lookup(array_nid).map(|l| &l.node) {
+        Some(Node::State { sort, .. }) => *sort,
+        _ => return false,
     };
-    let Sort::Array { element, .. } = sort_of(file, array_sort_nid)? else {
-        return None;
+    let Some(Sort::Array { element, .. }) = sort_of(file, array_sort_nid) else {
+        return false;
     };
     let elem_sort = element;
 
-    // The array's next is either a single unconditional `Write(array, waddr, wdata)` (P-A1) or a
-    // write-ENABLE mux `ite(cond, write(array, …), array)` (P-A1b). A tautological `cond` collapses
-    // to unconditional. Anything else (write-chain, write in the else-branch, nested mux) abstains.
-    let next_op = find_next_value_operand(file, array_nid)?;
+    // Write shape: unconditional `Write(array, waddr, wdata)` (P-A1) or a write-ENABLE mux
+    // `ite(cond, write, array)` (P-A1b; tautological `cond` collapses to unconditional).
+    let Some(next_op) = find_next_value_operand(file, array_nid) else {
+        return false;
+    };
     let array_next_nid = file.lines.iter().find_map(|l| match &l.node {
         Node::Next { state, .. } if *state == array_nid => Some(l.nid),
         _ => None,
     });
-    let next_line = file.lookup(next_op.nid())?;
     let (write_nid, mux_nid, write_cond): (Nid, Option<Nid>, Option<Operand>) =
-        match &next_line.node {
-            Node::Op { op: Op::Write, .. } => (next_op.nid(), None, None),
-            Node::Op {
+        match file.lookup(next_op.nid()).map(|l| &l.node) {
+            Some(Node::Op { op: Op::Write, .. }) => (next_op.nid(), None, None),
+            Some(Node::Op {
                 op: Op::Ite, args, ..
-            } if args.len() == 3 && args[2].nid() == array_nid => {
-                // ite(cond, write(array,…), array) — write in the THEN branch, hold in the else.
+            }) if args.len() == 3 && args[2].nid() == array_nid => {
                 let cond = args[0];
-                let eff_cond = if is_tautology(file, cond.nid()) {
+                let eff = if is_tautology(file, cond.nid()) {
                     None
                 } else {
                     Some(cond)
                 };
-                (args[1].nid(), Some(next_op.nid()), eff_cond)
+                (args[1].nid(), Some(next_op.nid()), eff)
             }
-            _ => return None,
+            _ => return false,
         };
-    let write_line = file.lookup(write_nid)?;
-    let (waddr, wdata) = match &write_line.node {
-        Node::Op {
+    let (waddr, wdata) = match file.lookup(write_nid).map(|l| &l.node) {
+        Some(Node::Op {
             op: Op::Write,
             args,
             ..
-        } if args.len() == 3 && args[0].nid() == array_nid => (args[1], args[2]),
-        _ => return None,
+        }) if args.len() == 3 && args[0].nid() == array_nid => (args[1], args[2]),
+        _ => return false,
     };
-    // SOUNDNESS: the frame `pv' = ite(cond ∧ waddr==idx', wdata, pv)` is exact iff `idx' ≠ idx ⟹
-    // cond` (the index moves to `waddr` only when the write fires). Two sound, checkable cases:
-    //   (U) `write_cond == None` (unconditional / tautological) ⇒ the move-to-`waddr` guard is
-    //       trivially satisfied ⇒ a MOVING index (`idx' ∈ {idx, waddr}`) is fine.
-    //   (S) `write_cond == Some` (a real enable) ⇒ require a STABLE index (never moves), so the
-    //       `idx' = waddr` case never arises and the frame is exact for any `cond`.
-    let allow_waddr = write_cond.is_none();
-
-    // Broadcast init (a const operand) if present.
     let (init_value, array_init_nid) = file
         .lines
         .iter()
@@ -172,107 +379,114 @@ fn plan_for_array(file: &Btor2File, array_nid: Nid) -> Option<ArrayPlan> {
         })
         .unwrap_or((None, None));
 
-    // Reads of the array; each index must be a bare state register.
-    let mut reads: Vec<(Nid, Nid)> = Vec::new();
-    for l in &file.lines {
-        if let Node::Op {
-            op: Op::Read, args, ..
-        } = &l.node
-            && args.len() == 2
-            && args[0].nid() == array_nid
-        {
-            let idx = args[1].nid();
-            if !matches!(file.lookup(idx)?.node, Node::State { .. }) {
-                return None; // non-register index → P-A1 abstains
-            }
-            reads.push((l.nid, idx));
-        }
-    }
+    let reads: Vec<(Nid, Nid)> = file
+        .lines
+        .iter()
+        .filter_map(|l| match &l.node {
+            Node::Op {
+                op: Op::Read, args, ..
+            } if args.len() == 2 && args[0].nid() == array_nid => Some((l.nid, args[1].nid())),
+            _ => None,
+        })
+        .collect();
     if reads.is_empty() {
-        return None;
+        return false;
     }
-    // The write-enable condition must not itself BE an array read (else the frame's guard would
-    // dangle when the read is dropped). A cond that merely CONTAINS a read via an op node is fine
-    // — that op is kept and remapped to `pv`. Direct-read-as-enable is bizarre; abstain.
+    // A write-enable that is itself an array read would dangle when the read is dropped; abstain.
     if let Some(cond) = write_cond
         && reads.iter().any(|&(r, _)| r == cond.nid())
     {
-        return None;
+        return false;
     }
-
-    // Stability: each index register's next-value moves only within {itself, waddr}.
-    let mut index_next: HashMap<Nid, Option<Operand>> = HashMap::new();
-    for &(_, idx) in &reads {
-        if index_next.contains_key(&idx) {
-            continue;
-        }
-        let nx = find_next_value_operand(file, idx);
-        if let Some(nxop) = nx {
-            let mut vis: HashSet<Nid> = HashSet::new();
-            let mut st = vec![nxop.nid()];
-            while let Some(n) = st.pop() {
-                if !vis.insert(n) {
-                    continue;
-                }
-                if n == idx {
-                    continue; // held — always allowed
-                }
-                if n == waddr.nid() {
-                    // move-to-write-address — allowed ONLY for an unconditional/tautological write
-                    // (case U); a conditional write requires a stable index (case S).
-                    if allow_waddr {
-                        continue;
-                    }
-                    return None;
-                }
-                match &file.lookup(n)?.node {
-                    Node::Op {
-                        op: Op::Ite, args, ..
-                    } if args.len() == 3 => {
-                        st.push(args[1].nid());
-                        st.push(args[2].nid());
-                    }
-                    // a leaf other than {idx, waddr} ⇒ the index moves to an arbitrary cell
-                    // whose old content `pv` does not hold ⇒ frame is not exact ⇒ abstain.
-                    _ => return None,
-                }
-            }
-        }
-        index_next.insert(idx, nx);
-    }
-
     // No OTHER reference to the array beyond the reads + the write + the enable-mux + next + init.
     let mut expected: HashSet<Nid> = reads.iter().map(|&(r, _)| r).collect();
     expected.insert(write_nid);
-    if let Some(n) = mux_nid {
-        expected.insert(n);
-    }
-    if let Some(n) = array_next_nid {
-        expected.insert(n);
-    }
-    if let Some(n) = array_init_nid {
+    for n in [mux_nid, array_next_nid, array_init_nid]
+        .into_iter()
+        .flatten()
+    {
         expected.insert(n);
     }
     for l in &file.lines {
         if !expected.contains(&l.nid) && node_refs_array(&l.node, array_nid) {
-            return None; // an unexpected use of the array ⇒ cannot eliminate soundly
+            return false;
         }
     }
 
-    Some(ArrayPlan {
+    let mut elim = Elim {
+        file,
         array_nid,
         elem_sort,
+        bool_sort,
         waddr,
         wdata,
-        init_value,
-        reads,
-        index_next,
-        array_next_nid,
-        array_init_nid,
-        write_nid,
-        mux_nid,
         write_cond,
-    })
+        init_value,
+        next_nid,
+        new_nodes,
+        const_of,
+        pv_of: HashMap::new(),
+        frame_done: HashSet::new(),
+        ok: true,
+        depth: 0,
+    };
+    // Reconstruct each read `mem[E]` as the index `ite`-tree over the prophecy registers.
+    for &(read_nid, index_nid) in &reads {
+        let recon = elim.read_at(index_nid);
+        read_repl.insert(read_nid, recon);
+    }
+    // Build each prophecy register's frame `pv_L' = mem'[L']` (fixpoint — a frame may pull in more
+    // cells via `mem_next_at`).
+    let mut worklist: Vec<Cell> = elim.pv_of.keys().copied().collect();
+    while let Some(cell) = worklist.pop() {
+        if !elim.frame_done.insert(cell) {
+            continue;
+        }
+        let frame = match cell {
+            // A const index never moves: pv_c' = mem'[c].
+            Cell::Const(_) => elim.leaf_frame(cell),
+            // A state index: pv_s' = mem'[s'] where s' is the state's next-value (self if none).
+            Cell::State(s) => {
+                let nn = find_next_value_operand(file, s)
+                    .map(|o| o.nid())
+                    .unwrap_or(s);
+                elim.mem_next_at(nn)
+            }
+        };
+        let pv = elim.pv_of[&cell];
+        let n = elim.alloc();
+        elim.new_nodes.push(Line {
+            nid: n,
+            node: Node::Next {
+                sort: elem_sort,
+                state: pv,
+                value: frame,
+            },
+            immediates: Vec::new(),
+            source_line: 0,
+        });
+        for c in elim.pv_of.keys().copied().collect::<Vec<_>>() {
+            if !elim.frame_done.contains(&c) {
+                worklist.push(c);
+            }
+        }
+    }
+    if !elim.ok {
+        return false;
+    }
+
+    drops.insert(array_nid);
+    drops.insert(write_nid);
+    for n in [mux_nid, array_next_nid, array_init_nid]
+        .into_iter()
+        .flatten()
+    {
+        drops.insert(n);
+    }
+    for &(r, _) in &reads {
+        drops.insert(r);
+    }
+    true
 }
 
 fn remap_node(node: &Node, f: &impl Fn(Operand) -> Operand) -> Node {
@@ -561,21 +775,13 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
     if array_states.is_empty() {
         return None; // no arrays ⇒ nothing for SPCR to do (caller uses the normal path)
     }
-    // P-A1: every array must be soundly eliminable, else abstain wholesale.
-    let plans: Vec<ArrayPlan> = array_states
-        .iter()
-        .map(|&a| plan_for_array(file, a))
-        .collect::<Option<Vec<_>>>()?;
-
     let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
-    let mut alloc = || {
-        let n = next_nid;
-        next_nid += 1;
-        n
-    };
+    let mut new_nodes: Vec<Line> = Vec::new();
+    let mut const_of: HashMap<(u64, Nid), Nid> = HashMap::new();
+    let mut read_repl: HashMap<Nid, Operand> = HashMap::new();
+    let mut drops: HashSet<Nid> = HashSet::new();
 
-    // A 1-bit sort for the `eq(waddr, idx')` guards (reuse an existing one, else create it).
-    let mut prelude: Vec<Line> = Vec::new();
+    // A 1-bit sort for the `eq(waddr, idx)` guards (reuse an existing one, else create it).
     let bool_sort = file
         .lines
         .iter()
@@ -586,8 +792,9 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
             _ => None,
         })
         .unwrap_or_else(|| {
-            let n = alloc();
-            prelude.push(Line {
+            let n = next_nid;
+            next_nid += 1;
+            new_nodes.push(Line {
                 nid: n,
                 node: Node::Sort {
                     sort: Sort::BitVec { width: 1 },
@@ -598,126 +805,49 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
             n
         });
 
-    let mut tail: Vec<Line> = Vec::new();
-    let mut read_to_pv: HashMap<Nid, Nid> = HashMap::new();
-    let mut drop_nodes: HashSet<Nid> = HashSet::new();
-
-    for plan in &plans {
-        drop_nodes.insert(plan.array_nid);
-        drop_nodes.insert(plan.write_nid);
-        if let Some(n) = plan.mux_nid {
-            drop_nodes.insert(n);
-        }
-        if let Some(n) = plan.array_next_nid {
-            drop_nodes.insert(n);
-        }
-        if let Some(n) = plan.array_init_nid {
-            drop_nodes.insert(n);
-        }
-        for &(r, _) in &plan.reads {
-            drop_nodes.insert(r);
-        }
-
-        let mut idx_to_pv: HashMap<Nid, Nid> = HashMap::new();
-        for (&idx, idx_next) in &plan.index_next {
-            let pv = alloc();
-            idx_to_pv.insert(idx, pv);
-            // pv state (element sort).
-            prelude.push(Line {
-                nid: pv,
-                node: Node::State {
-                    sort: plan.elem_sort,
-                    symbol: Some(format!("spcr_pv_{}_{}", plan.array_nid, idx)),
-                },
-                immediates: Vec::new(),
-                source_line: 0,
-            });
-            // pv init (broadcast) if the array is initialised.
-            if let Some(iv) = plan.init_value {
-                tail.push(Line {
-                    nid: alloc(),
-                    node: Node::Init {
-                        sort: plan.elem_sort,
-                        state: pv,
-                        value: iv,
-                    },
-                    immediates: Vec::new(),
-                    source_line: 0,
-                });
-            }
-            // frame: pv' = ite(GUARD, wdata, pv), GUARD = (waddr == idx') [∧ write_cond].
-            // Unconditional/tautological write ⇒ GUARD = eq (index may move). Conditional write ⇒
-            // GUARD = write_cond ∧ eq, and the index is stable (idx' = idx) by the plan gate.
-            let idx_next_op = idx_next.unwrap_or(Operand(idx));
-            let eq = alloc();
-            tail.push(Line {
-                nid: eq,
-                node: Node::Op {
-                    sort: bool_sort,
-                    op: Op::Eq,
-                    args: vec![plan.waddr, idx_next_op],
-                    symbol: None,
-                },
-                immediates: Vec::new(),
-                source_line: 0,
-            });
-            let guard = match plan.write_cond {
-                None => Operand(eq),
-                Some(cond) => {
-                    let and = alloc();
-                    tail.push(Line {
-                        nid: and,
-                        node: Node::Op {
-                            sort: bool_sort,
-                            op: Op::And,
-                            args: vec![cond, Operand(eq)],
-                            symbol: None,
-                        },
-                        immediates: Vec::new(),
-                        source_line: 0,
-                    });
-                    Operand(and)
-                }
-            };
-            let ite = alloc();
-            tail.push(Line {
-                nid: ite,
-                node: Node::Op {
-                    sort: plan.elem_sort,
-                    op: Op::Ite,
-                    args: vec![guard, plan.wdata, Operand(pv)],
-                    symbol: None,
-                },
-                immediates: Vec::new(),
-                source_line: 0,
-            });
-            tail.push(Line {
-                nid: alloc(),
-                node: Node::Next {
-                    sort: plan.elem_sort,
-                    state: pv,
-                    value: Operand(ite),
-                },
-                immediates: Vec::new(),
-                source_line: 0,
-            });
-        }
-        for &(r, idx) in &plan.reads {
-            read_to_pv.insert(r, idx_to_pv[&idx]);
+    // Every array must be soundly eliminable (P-A1d recursive prophecy), else abstain wholesale.
+    for &a in &array_states {
+        if !eliminate_array(
+            file,
+            a,
+            &mut next_nid,
+            &mut new_nodes,
+            &mut const_of,
+            bool_sort,
+            &mut read_repl,
+            &mut drops,
+        ) {
+            return None;
         }
     }
 
-    // Rewrite: references to a dropped read node → its prophecy register (sign-preserving).
+    // Rewrite: references to a dropped read node → its reconstruction (sign-combining).
     let remap = |o: Operand| -> Operand {
-        match read_to_pv.get(&o.nid()) {
-            Some(&pv) => Operand(if o.0 < 0 { -pv } else { pv }),
+        match read_repl.get(&o.nid()) {
+            Some(&r) => {
+                if (o.0 < 0) ^ (r.0 < 0) {
+                    Operand(-r.nid())
+                } else {
+                    Operand(r.nid())
+                }
+            }
             None => o,
         }
     };
-    let mut out: Vec<Line> = Vec::with_capacity(file.lines.len() + prelude.len() + tail.len());
-    out.extend(prelude); // pv states (+ maybe the bool sort) — only forward-ref a SORT (nid-resolved)
+    // Topological layout: fresh DECLARATIONS (sorts / prophecy states / consts — they reference at
+    // most a sort) first, then the original lines (minus drops, remapped), then the fresh
+    // COMBINATIONAL/next nodes (in push order = dependency order). This keeps every data operand a
+    // backward reference (only sort references may be forward — resolved by NID).
+    let (decls, rest): (Vec<Line>, Vec<Line>) = new_nodes.into_iter().partition(|l| {
+        matches!(
+            l.node,
+            Node::Sort { .. } | Node::State { .. } | Node::Const { .. }
+        )
+    });
+    let mut out: Vec<Line> = Vec::with_capacity(file.lines.len() + decls.len() + rest.len());
+    out.extend(decls);
     for line in &file.lines {
-        if drop_nodes.contains(&line.nid) {
+        if drops.contains(&line.nid) {
             continue;
         }
         out.push(Line {
@@ -727,7 +857,7 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
             source_line: line.source_line,
         });
     }
-    out.extend(tail); // eq / ite / next-pv / init — all backward refs
+    out.extend(rest);
     let by_nid = out.iter().enumerate().map(|(i, l)| (l.nid, i)).collect();
     Some(Btor2File { lines: out, by_nid })
 }
@@ -1055,6 +1185,100 @@ mod tests {
                 ExactVerdict::Holds,
             );
         }
+    }
+
+    /// P-A1d — the REAL yosys async-reset lift of `array_gates_recovery.sv` (module _small): the
+    /// read index is a reset-mux `ite(rst_n, key, 0)` (node 16), `key`'s next carries reset-value
+    /// `const 0` leaves (nodes 35/36), and the write is the masked RMW (nodes 38-45, P-A1c folds
+    /// it). The recursive prophecy registerizes BOTH `mem[key]` and `mem[0]` and reconstructs the
+    /// read as `ite(rst_n, pv_key, pv_0)`. SPCR must produce an array-free design.
+    const AGR_RESETMUX_LIFT: &str = "\
+1 sort bitvec 1
+2 input 1 clk
+3 input 1 rst_n
+4 input 1 start
+5 sort bitvec 2
+6 input 5 waddr
+7 input 5 wdata
+8 const 1 0
+9 state 1
+10 ite 1 3 9 8
+11 output 10 busy
+12 uext 1 10 0 u.busy
+13 uext 1 2 0 u.clk
+14 const 5 00
+15 state 5
+16 ite 5 3 15 14
+17 uext 5 16 0 u.key
+18 uext 1 3 0 u.rst_n
+19 uext 1 4 0 u.start
+20 uext 5 6 0 u.waddr
+21 uext 5 7 0 u.wdata
+22 sort array 5 5
+23 state 22 u.mem
+24 read 5 23 16
+25 const 5 11
+26 eq 1 24 25
+27 ite 1 26 8 10
+28 ite 1 10 27 10
+29 const 1 1
+30 not 1 10
+31 and 1 4 30
+32 ite 1 31 29 28
+33 ite 1 3 32 8
+34 next 1 9 33
+35 ite 5 31 6 16
+36 ite 5 3 35 14
+37 next 5 15 36
+38 read 5 23 6
+39 not 5 25
+40 and 5 38 39
+41 and 5 7 25
+42 or 5 41 40
+43 write 22 23 6 42
+44 redor 1 25
+45 ite 22 44 43 23
+46 next 22 23 45
+";
+
+    #[test]
+    fn spcr_pa1d_real_async_reset_lift_decides_holds_e2e() {
+        // End-to-end through the wired recoverability path (which runs SPCR): the REAL async-reset
+        // yosys lift decides Holds — the DIFFERENTIAL ORACLE (matches the whole-array-registerized
+        // ROBDD, which independently gives Holds). Was `unknown` before P-A1d.
+        use crate::verdict::PropertyVerdict;
+        assert_eq!(
+            crate::adapter::recoverability::verify_recoverability_scalable(
+                AGR_RESETMUX_LIFT,
+                "busy == 0",
+                &[],
+            )
+            .expect("decides"),
+            PropertyVerdict::Holds,
+        );
+    }
+
+    #[test]
+    fn spcr_pa1d_resetmux_lift_eliminates_array_two_cells() {
+        let file = crate::adapter::btor2::parser::parse(AGR_RESETMUX_LIFT).expect("parse");
+        let out = super::spcr(&file).expect("SPCR (P-A1c fold + P-A1d recursive prophecy) applies");
+        assert!(
+            !has_array(&out),
+            "the async-reset lift must become array-free"
+        );
+        assert!(
+            !out.lines
+                .iter()
+                .any(|l| matches!(&l.node, Node::Op { op: Op::Read, .. })),
+            "no array reads remain (reconstructed over prophecy registers)"
+        );
+        // The reset-mux index `ite(rst_n, key, 0)` has TWO leaves ⇒ two prophecy cells (mem[key], mem[0]).
+        let pvs = out
+            .lines
+            .iter()
+            .filter(|l| matches!(&l.node, Node::State { symbol: Some(s), .. } if s.starts_with("spcr_pv_")))
+            .count();
+        assert_eq!(pvs, 2, "reset-mux index registerizes mem[key] AND mem[0]");
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -1307,6 +1307,58 @@ mod tests {
         );
     }
 
+    /// Boundary of the SPCR fragment (found via the OpenTitan config-table synthetic, 2026-07-29):
+    /// identical to the clean `AGR_SPCR` decide case EXCEPT the recovery index `key` latches a FREE
+    /// INPUT `sel` (nid 28) that is INDEPENDENT of the write address `waddr` (nid 5). On a new latch
+    /// the index jumps to an arbitrary cell whose content was set by past writes to a different
+    /// address, so no finite set of prophecy registers tracks it — `mem_next_at` hits `sel` (an
+    /// input ≠ `waddr`) as an index leaf and clears `ok`. SPCR must SOUNDLY ABSTAIN (fall to the
+    /// cube → honest ⊥), never registerize spuriously. Contrast
+    /// `spcr_pb1_latch_last_written_addr_under_we_decides_holds`, where the index tracks `waddr` and
+    /// SPCR decides. This is exactly the OT `ot_cfgtable_recovery` (index←`req_chan_i`, abstains) vs
+    /// `ot_lastcfg_recovery` (index←`cfg_addr_i`=waddr, decides) split.
+    const AGR_SPCR_INDEP_INDEX: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 sort array 2 2
+4 input 1 start
+5 input 2 waddr
+6 input 2 wdata
+7 state 1 busy
+8 state 2 key
+9 state 3 mem
+10 const 1 0
+11 init 1 7 10
+12 const 2 00
+13 init 2 8 12
+14 const 2 11
+15 read 2 9 8
+16 eq 1 15 14
+17 not 1 7
+18 and 1 4 17
+19 const 1 1
+20 and 1 7 16
+21 ite 1 20 10 7
+22 ite 1 18 19 21
+23 next 1 7 22
+24 ite 2 18 28 8
+25 next 2 8 24
+26 write 3 9 5 6
+27 next 3 9 26
+28 input 2 sel
+";
+
+    #[test]
+    fn spcr_abstains_when_index_moves_to_independent_free_input() {
+        let file = crate::adapter::btor2::parser::parse(AGR_SPCR_INDEP_INDEX).expect("parse");
+        assert!(has_array(&file), "fixture must have an array");
+        assert!(
+            super::spcr(&file).is_none(),
+            "a recovery index that latches a free input independent of waddr is outside SPCR's \
+             fragment ⇒ SPCR must abstain (no spurious registerization)"
+        );
+    }
+
     /// P-A1c — the yosys per-bit-write-ENABLE modeling of a plain full write `mem[waddr] <= wdata`:
     /// `write(mem, waddr, (wdata & allones) | (mem[waddr] & ~allones))`. The `mem[waddr]` read is
     /// DEAD (`& ~allones = & 0`). Without the fold, SPCR abstains (the RMW read's index is the INPUT

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -312,13 +312,240 @@ fn remap_node(node: &Node, f: &impl Fn(Operand) -> Operand) -> Node {
     }
 }
 
-/// SPCR entry: if EVERY in-cone array matches the sound P-A1 shape, return the array-FREE
-/// equivalent design (prophecy registers + exact frames, arrays dropped); else `None`
-/// (the caller keeps the original and falls through to its honest abstain).
+/// P-A1c — a small SOUND constant-fold + dead-code-elimination pass, run BEFORE SPCR. Its purpose
+/// is to collapse the yosys per-bit-write-ENABLE modeling of a plain full write:
+///
+/// ```text
+/// mem' = write(mem, a, (wdata & mask) | (mem[a] & ~mask))     with mask = all-ones
+/// ```
+///
+/// With `mask` all-ones, `mem[a] & ~mask = mem[a] & 0 = 0`, so the read-modify-write read `mem[a]`
+/// is DEAD. Folding `not(allones)→0`, `and(x,0)→0`, `or(x,0)→x`, `and(x,allones)→x` collapses the
+/// value to `wdata` and DCE removes the dead read — so SPCR (`plan_for_array`) then sees a single
+/// clean `write(mem, a, wdata)`. Every fold is width-aware and semantics-preserving; DCE removes
+/// only nodes unreachable from the roots (next/init/bad/constraint/fair/justice/output). Nodes
+/// wider than 64 bits are left un-folded (conservative — SPCR then simply abstains).
+fn fold_and_dce(file: &Btor2File) -> Btor2File {
+    use crate::adapter::btor2::ast::ConstValue;
+    use crate::adapter::btor2::bit_blast::resolve_btor2_constant;
+    use crate::adapter::btor2::parser::bv_width;
+
+    // Phase 1 — constant values (u64 fixpoint over not/and/or/xor + and-0 / or-allones).
+    let mut cval: HashMap<Nid, u64> = HashMap::new();
+    for l in &file.lines {
+        if let Some(v) = resolve_btor2_constant(file, l.nid) {
+            cval.insert(l.nid, v);
+        }
+    }
+    loop {
+        let mut changed = false;
+        for l in &file.lines {
+            let Node::Op { op, args, sort, .. } = &l.node else {
+                continue;
+            };
+            if cval.contains_key(&l.nid) {
+                continue;
+            }
+            let Some(w) = bv_width(file, *sort) else {
+                continue;
+            };
+            if w > 64 {
+                continue;
+            }
+            let m: u64 = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
+            let a = args.first().and_then(|o| cval.get(&o.nid()).copied());
+            let b = args.get(1).and_then(|o| cval.get(&o.nid()).copied());
+            let r = match op {
+                Op::Not => a.map(|x| !x & m),
+                Op::And => {
+                    if a == Some(0) || b == Some(0) {
+                        Some(0)
+                    } else if let (Some(x), Some(y)) = (a, b) {
+                        Some(x & y)
+                    } else {
+                        None
+                    }
+                }
+                Op::Or => {
+                    if a == Some(m) || b == Some(m) {
+                        Some(m)
+                    } else if let (Some(x), Some(y)) = (a, b) {
+                        Some(x | y)
+                    } else {
+                        None
+                    }
+                }
+                Op::Xor => match (a, b) {
+                    (Some(x), Some(y)) => Some(x ^ y),
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(v) = r {
+                cval.insert(l.nid, v);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // Phase 2 — replacement operands: a const-folded op → a materialized const; a structural
+    // identity `and(x, allones)→x` / `or(x, 0)→x` → the surviving operand.
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut extra_consts: Vec<Line> = Vec::new();
+    let mut const_of: HashMap<(u64, Nid), Nid> = HashMap::new();
+    let mut repl: HashMap<Nid, Operand> = HashMap::new();
+    for l in &file.lines {
+        let Node::Op { op, args, sort, .. } = &l.node else {
+            continue;
+        };
+        // A non-Const op that resolved to a constant → materialize / reuse a const node.
+        if let Some(&v) = cval.get(&l.nid) {
+            let nid = *const_of.entry((v, *sort)).or_insert_with(|| {
+                let n = next_nid;
+                next_nid += 1;
+                extra_consts.push(Line {
+                    nid: n,
+                    node: Node::Const {
+                        sort: *sort,
+                        value: ConstValue::Dec(v as i128),
+                    },
+                    immediates: Vec::new(),
+                    source_line: 0,
+                });
+                n
+            });
+            repl.insert(l.nid, Operand(nid));
+            continue;
+        }
+        let Some(w) = bv_width(file, *sort) else {
+            continue;
+        };
+        if w > 64 || args.len() != 2 {
+            continue;
+        }
+        let m: u64 = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
+        let (av, bv) = (
+            cval.get(&args[0].nid()).copied(),
+            cval.get(&args[1].nid()).copied(),
+        );
+        let pass = match op {
+            Op::And => {
+                if av == Some(m) {
+                    Some(args[1])
+                } else if bv == Some(m) {
+                    Some(args[0])
+                } else {
+                    None
+                }
+            }
+            Op::Or => {
+                if av == Some(0) {
+                    Some(args[1])
+                } else if bv == Some(0) {
+                    Some(args[0])
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if let Some(o) = pass {
+            repl.insert(l.nid, o);
+        }
+    }
+
+    // Resolve a (non-negated) operand through the replacement chain. Negated operands are left
+    // untouched (yosys emits explicit `not` nodes, not operand negation — conservative + sound).
+    let resolve = |o: Operand| -> Operand {
+        if o.0 < 0 {
+            return o;
+        }
+        let mut cur = o;
+        for _ in 0..=file.lines.len() {
+            match repl.get(&cur.nid()) {
+                Some(&r) if r.0 >= 0 => cur = r,
+                _ => break,
+            }
+        }
+        cur
+    };
+
+    // Rewrite every operand through `resolve`, then append the fresh const nodes.
+    let mut rewritten: Vec<Line> = file
+        .lines
+        .iter()
+        .map(|l| Line {
+            nid: l.nid,
+            node: remap_node(&l.node, &resolve),
+            immediates: l.immediates.clone(),
+            source_line: l.source_line,
+        })
+        .collect();
+    rewritten.extend(extra_consts);
+
+    // Phase 3 — DCE. Keep sorts/states/inputs + the root lines always; keep Op/Const iff reachable
+    // from a root (next/init/bad/constraint/fair/justice/output) through op args.
+    let by_nid: HashMap<Nid, usize> = rewritten
+        .iter()
+        .enumerate()
+        .map(|(i, l)| (l.nid, i))
+        .collect();
+    let mut reachable: HashSet<Nid> = HashSet::new();
+    let mut stack: Vec<Nid> = Vec::new();
+    for l in &rewritten {
+        match &l.node {
+            Node::Next { state, value, .. } | Node::Init { state, value, .. } => {
+                stack.push(*state);
+                stack.push(value.nid());
+            }
+            Node::Bad { signal }
+            | Node::Constraint { signal }
+            | Node::Fair { signal }
+            | Node::Output { signal, .. } => stack.push(signal.nid()),
+            Node::Justice { signals } => stack.extend(signals.iter().map(|s| s.nid())),
+            _ => {}
+        }
+    }
+    while let Some(n) = stack.pop() {
+        if !reachable.insert(n) {
+            continue;
+        }
+        if let Some(&i) = by_nid.get(&n)
+            && let Node::Op { args, .. } = &rewritten[i].node
+        {
+            stack.extend(args.iter().map(|a| a.nid()));
+        }
+    }
+    let out: Vec<Line> = rewritten
+        .into_iter()
+        .filter(|l| match &l.node {
+            Node::Op { .. } | Node::Const { .. } => reachable.contains(&l.nid),
+            _ => true, // sorts, states, inputs, and root lines are always kept
+        })
+        .collect();
+    let by_nid = out.iter().enumerate().map(|(i, l)| (l.nid, i)).collect();
+    Btor2File { lines: out, by_nid }
+}
+
+/// SPCR entry: if EVERY in-cone array matches the sound P-A1 shape (after the P-A1c fold), return
+/// the array-FREE equivalent design (prophecy registers + exact frames, arrays dropped); else
+/// `None` (the caller keeps the original and falls through to its honest abstain).
 ///
 /// **Engine:** owned BTOR2→BTOR2 rewrite (no solver). The result is consumed by the array-free
 /// deciders — `exact-symbolic` ROBDD (small cone) or the `symbolic` predicate-cube (QF_BV must).
 pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
+    // Cheap guard: SPCR (and the fold) are only for array-bearing designs.
+    if !file.lines.iter().any(|l| {
+        matches!(&l.node, Node::State { sort, .. } if matches!(sort_of(file, *sort), Some(Sort::Array { .. })))
+    }) {
+        return None;
+    }
+    // P-A1c: fold the yosys write-mask RMW into a clean write so `plan_for_array` can apply.
+    let folded = fold_and_dce(file);
+    let file = &folded;
     let array_states: Vec<Nid> = file
         .lines
         .iter()
@@ -747,6 +974,87 @@ mod tests {
             super::spcr(&file).is_none(),
             "moving index under a conditional write is unsound to registerize ⇒ SPCR must abstain"
         );
+    }
+
+    /// P-A1c — the yosys per-bit-write-ENABLE modeling of a plain full write `mem[waddr] <= wdata`:
+    /// `write(mem, waddr, (wdata & allones) | (mem[waddr] & ~allones))`. The `mem[waddr]` read is
+    /// DEAD (`& ~allones = & 0`). Without the fold, SPCR abstains (the RMW read's index is the INPUT
+    /// `waddr`, not a register). `fold_and_dce` collapses it to a clean `write(mem, waddr, wdata)`
+    /// and DCE removes the dead read, so SPCR applies and decides HOLDS.
+    const AGR_MASKED: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 sort array 2 2
+4 input 1 start
+5 input 2 waddr
+6 input 2 wdata
+7 state 1 busy
+8 state 2 key
+9 state 3 mem
+10 const 1 0
+11 init 1 7 10
+12 const 2 00
+13 init 2 8 12
+14 const 2 11
+15 read 2 9 8
+16 eq 1 15 14
+17 not 1 7
+18 and 1 4 17
+19 const 1 1
+20 and 1 7 16
+21 ite 1 20 10 7
+22 ite 1 18 19 21
+23 next 1 7 22
+24 ite 2 18 5 8
+25 next 2 8 24
+26 read 2 9 5
+27 not 2 14
+28 and 2 26 27
+29 and 2 6 14
+30 or 2 29 28
+31 write 3 9 5 30
+32 next 3 9 31
+";
+
+    #[test]
+    fn spcr_pa1c_fold_removes_dead_rmw_read_then_decides_holds() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        use crate::mu_calculus::parser as mu_parser;
+        let file = crate::adapter::btor2::parser::parse(AGR_MASKED).expect("parse");
+        // Without folding, the raw shape has the masked-RMW read at an INPUT index → SPCR would
+        // see a non-register read index. `fold_and_dce` inside `spcr` collapses it first.
+        let out = super::spcr(&file).expect("SPCR applies after the P-A1c fold");
+        assert!(!has_array(&out), "SPCR output must be array-free");
+        assert!(
+            !out.lines
+                .iter()
+                .any(|l| matches!(&l.node, Node::Op { op: Op::Read, .. })),
+            "the dead RMW read must be folded + DCE'd away"
+        );
+        let f = mu_parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").unwrap();
+        let src = crate::adapter::btor2::emit::emit_btor2(&out);
+        assert_eq!(
+            exact_symbolic_verdict(&src, &f).expect("array-free ⇒ exact decides"),
+            ExactVerdict::Holds,
+        );
+    }
+
+    #[test]
+    fn spcr_pa1c_fold_is_verdict_preserving_on_masked_vs_clean() {
+        // The masked-write fixture and the clean-write fixture (`AGR_SPCR`) are the SAME design —
+        // SPCR must give the same array-free structure (both decide Holds via exact).
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        use crate::mu_calculus::parser as mu_parser;
+        let f = mu_parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").unwrap();
+        for src in [AGR_MASKED, AGR_SPCR] {
+            let file = crate::adapter::btor2::parser::parse(src).expect("parse");
+            let out = super::spcr(&file).expect("SPCR applies");
+            let emitted = crate::adapter::btor2::emit::emit_btor2(&out);
+            assert_eq!(
+                exact_symbolic_verdict(&emitted, &f).expect("decides"),
+                ExactVerdict::Holds,
+            );
+        }
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -8,20 +8,29 @@
 //! `recoverability::tests::p1a_array_gated_recovery_hits_must_edge_quantifier_wall`).
 //! Plan: `.claude/plans/spcr-selective-prophecy-cell-registerization.md`.
 //!
-//! **P-A1 scope (SOUND, conservative — abstains (returns `None`) otherwise).** For EVERY array
-//! state in the design: a single UNCONDITIONAL full-width write `mem' = write(mem, waddr, wdata)`,
-//! read only at bare-register indices whose next-value moves only within `{itself, waddr}`
-//! (stable / move-to-write-address). Under that shape the frame
+//! **Scope (SOUND, conservative — abstains (returns `None`) otherwise).** For EVERY array state in
+//! the design, the next-state is a write to `waddr`/`wdata` (P-A1 an UNCONDITIONAL
+//! `mem' = write(mem, waddr, wdata)`; P-A1b a write-ENABLE mux `ite(cond, write, mem)`, with a
+//! tautological `cond` collapsing to unconditional), read only at bare-register indices. The frame
 //!
 //! ```text
-//! pv' = ite(waddr == idx', wdata, pv)          (idx' = the index register's next-value)
+//! pv' = ite(cond ∧ (waddr == idx'), wdata, pv)   (idx' = the index register's next-value)
 //! ```
 //!
-//! reproduces `mem'[idx']` EXACTLY: when `idx' = idx` (held) the else-branch is `mem[idx] = pv`;
-//! when `idx' = waddr` (moved to the written cell) the `waddr == idx'` guard is true so it is
-//! `wdata = mem'[waddr]`. So SPCR is a verdict-PRESERVING reformulation (not an abstraction): the
-//! KMTS of the SPCR'd design has the same may/must edges as the original on the property-relevant
-//! projection ⇒ definite νµ verdicts transfer at every alternation depth (Bruns–Godefroid).
+//! reproduces `mem'[idx']` EXACTLY under two sound, checkable index disciplines:
+//!   - **(U) unconditional / tautological write** — `idx'` may MOVE within `{idx, waddr}`: when
+//!     `idx' = idx` the else-branch is `mem[idx] = pv`; when `idx' = waddr` the write always fires
+//!     so the guard is true and it is `wdata = mem'[waddr]`.
+//!   - **(S) conditional write** — `idx'` must be STABLE (`= idx` always): then `mem'[idx] =
+//!     ite(cond ∧ waddr==idx, wdata, mem[idx]) = ite(cond ∧ waddr==idx, wdata, pv)`, exact for any
+//!     `cond`. (A moving index under a conditional write is UNSOUND — the index could move to
+//!     `waddr` while the write is disabled, leaving `mem[waddr] ≠ pv` — so it abstains.)
+//!
+//! So SPCR is a verdict-PRESERVING reformulation (not an abstraction): the KMTS of the SPCR'd design
+//! has the same may/must edges as the original on the property-relevant projection ⇒ definite νµ
+//! verdicts transfer at every alternation depth (Bruns–Godefroid). Residual (abstain): a
+//! read-modify-write / input-indexed read (needs the array or a dead-code fold), a moving index
+//! under a conditional write, write-chains, or a non-register index.
 
 use crate::adapter::btor2::ast::{Btor2File, Line, Nid, Node, Op, Operand, Sort};
 use crate::adapter::btor2::parser::find_next_value_operand;
@@ -42,12 +51,43 @@ struct ArrayPlan {
     array_next_nid: Option<Nid>,
     array_init_nid: Option<Nid>,
     write_nid: Nid,
+    /// The write-enable mux node `ite(cond, write, array)` (P-A1b), if the write is conditional.
+    mux_nid: Option<Nid>,
+    /// The write-enable condition (`None` = unconditional / a tautological enable). When `Some`,
+    /// the write only fires under `cond`, so the frame guards `wdata` by `cond ∧ (waddr==idx')`
+    /// AND the index is required to be STABLE (never moves) — see the soundness note in
+    /// [`plan_for_array`].
+    write_cond: Option<Operand>,
 }
 
 fn sort_of(file: &Btor2File, nid: Nid) -> Option<Sort> {
     match &file.lookup(nid)?.node {
         Node::Sort { sort } => Some(sort.clone()),
         _ => None,
+    }
+}
+
+/// A syntactic tautology — a write-enable that always fires, so the mux is really an
+/// unconditional write (`const 1`, `redor(nonzero const)`, `not(const 0)`). Yosys emits e.g.
+/// `ite(redor(K), write, mem)` for a `for`-style always-write; treating it as unconditional
+/// lets the moving-index (P-A1) frame apply.
+fn is_tautology(file: &Btor2File, nid: Nid) -> bool {
+    use crate::adapter::btor2::bit_blast::resolve_btor2_constant;
+    if resolve_btor2_constant(file, nid).is_some_and(|v| v != 0) {
+        return true;
+    }
+    match file.lookup(nid).map(|l| &l.node) {
+        Some(Node::Op {
+            op: Op::Redor,
+            args,
+            ..
+        }) if args.len() == 1 => {
+            resolve_btor2_constant(file, args[0].nid()).is_some_and(|v| v != 0)
+        }
+        Some(Node::Op {
+            op: Op::Not, args, ..
+        }) if args.len() == 1 => resolve_btor2_constant(file, args[0].nid()) == Some(0),
+        _ => false,
     }
 }
 
@@ -77,22 +117,48 @@ fn plan_for_array(file: &Btor2File, array_nid: Nid) -> Option<ArrayPlan> {
     };
     let elem_sort = element;
 
-    // The array's next MUST be a single unconditional Write(array, waddr, wdata).
+    // The array's next is either a single unconditional `Write(array, waddr, wdata)` (P-A1) or a
+    // write-ENABLE mux `ite(cond, write(array, …), array)` (P-A1b). A tautological `cond` collapses
+    // to unconditional. Anything else (write-chain, write in the else-branch, nested mux) abstains.
     let next_op = find_next_value_operand(file, array_nid)?;
     let array_next_nid = file.lines.iter().find_map(|l| match &l.node {
         Node::Next { state, .. } if *state == array_nid => Some(l.nid),
         _ => None,
     });
-    let write_line = file.lookup(next_op.nid())?;
-    let (waddr, wdata, write_nid) = match &write_line.node {
+    let next_line = file.lookup(next_op.nid())?;
+    let (write_nid, mux_nid, write_cond): (Nid, Option<Nid>, Option<Operand>) =
+        match &next_line.node {
+            Node::Op { op: Op::Write, .. } => (next_op.nid(), None, None),
+            Node::Op {
+                op: Op::Ite, args, ..
+            } if args.len() == 3 && args[2].nid() == array_nid => {
+                // ite(cond, write(array,…), array) — write in the THEN branch, hold in the else.
+                let cond = args[0];
+                let eff_cond = if is_tautology(file, cond.nid()) {
+                    None
+                } else {
+                    Some(cond)
+                };
+                (args[1].nid(), Some(next_op.nid()), eff_cond)
+            }
+            _ => return None,
+        };
+    let write_line = file.lookup(write_nid)?;
+    let (waddr, wdata) = match &write_line.node {
         Node::Op {
             op: Op::Write,
             args,
             ..
-        } if args.len() == 3 && args[0].nid() == array_nid => (args[1], args[2], write_line.nid),
-        // write-mux / chain / non-write next → P-A1 abstains.
+        } if args.len() == 3 && args[0].nid() == array_nid => (args[1], args[2]),
         _ => return None,
     };
+    // SOUNDNESS: the frame `pv' = ite(cond ∧ waddr==idx', wdata, pv)` is exact iff `idx' ≠ idx ⟹
+    // cond` (the index moves to `waddr` only when the write fires). Two sound, checkable cases:
+    //   (U) `write_cond == None` (unconditional / tautological) ⇒ the move-to-`waddr` guard is
+    //       trivially satisfied ⇒ a MOVING index (`idx' ∈ {idx, waddr}`) is fine.
+    //   (S) `write_cond == Some` (a real enable) ⇒ require a STABLE index (never moves), so the
+    //       `idx' = waddr` case never arises and the frame is exact for any `cond`.
+    let allow_waddr = write_cond.is_none();
 
     // Broadcast init (a const operand) if present.
     let (init_value, array_init_nid) = file
@@ -125,6 +191,14 @@ fn plan_for_array(file: &Btor2File, array_nid: Nid) -> Option<ArrayPlan> {
     if reads.is_empty() {
         return None;
     }
+    // The write-enable condition must not itself BE an array read (else the frame's guard would
+    // dangle when the read is dropped). A cond that merely CONTAINS a read via an op node is fine
+    // — that op is kept and remapped to `pv`. Direct-read-as-enable is bizarre; abstain.
+    if let Some(cond) = write_cond
+        && reads.iter().any(|&(r, _)| r == cond.nid())
+    {
+        return None;
+    }
 
     // Stability: each index register's next-value moves only within {itself, waddr}.
     let mut index_next: HashMap<Nid, Option<Operand>> = HashMap::new();
@@ -140,8 +214,16 @@ fn plan_for_array(file: &Btor2File, array_nid: Nid) -> Option<ArrayPlan> {
                 if !vis.insert(n) {
                     continue;
                 }
-                if n == idx || n == waddr.nid() {
-                    continue; // an allowed leaf (hold / move-to-write-address)
+                if n == idx {
+                    continue; // held — always allowed
+                }
+                if n == waddr.nid() {
+                    // move-to-write-address — allowed ONLY for an unconditional/tautological write
+                    // (case U); a conditional write requires a stable index (case S).
+                    if allow_waddr {
+                        continue;
+                    }
+                    return None;
                 }
                 match &file.lookup(n)?.node {
                     Node::Op {
@@ -159,9 +241,12 @@ fn plan_for_array(file: &Btor2File, array_nid: Nid) -> Option<ArrayPlan> {
         index_next.insert(idx, nx);
     }
 
-    // No OTHER reference to the array beyond the reads + the write + next-array + init-array.
+    // No OTHER reference to the array beyond the reads + the write + the enable-mux + next + init.
     let mut expected: HashSet<Nid> = reads.iter().map(|&(r, _)| r).collect();
     expected.insert(write_nid);
+    if let Some(n) = mux_nid {
+        expected.insert(n);
+    }
     if let Some(n) = array_next_nid {
         expected.insert(n);
     }
@@ -185,6 +270,8 @@ fn plan_for_array(file: &Btor2File, array_nid: Nid) -> Option<ArrayPlan> {
         array_next_nid,
         array_init_nid,
         write_nid,
+        mux_nid,
+        write_cond,
     })
 }
 
@@ -291,6 +378,9 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
     for plan in &plans {
         drop_nodes.insert(plan.array_nid);
         drop_nodes.insert(plan.write_nid);
+        if let Some(n) = plan.mux_nid {
+            drop_nodes.insert(n);
+        }
         if let Some(n) = plan.array_next_nid {
             drop_nodes.insert(n);
         }
@@ -328,7 +418,9 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
                     source_line: 0,
                 });
             }
-            // frame: pv' = ite(eq(waddr, idx'), wdata, pv). A never-written index holds (idx' = idx).
+            // frame: pv' = ite(GUARD, wdata, pv), GUARD = (waddr == idx') [∧ write_cond].
+            // Unconditional/tautological write ⇒ GUARD = eq (index may move). Conditional write ⇒
+            // GUARD = write_cond ∧ eq, and the index is stable (idx' = idx) by the plan gate.
             let idx_next_op = idx_next.unwrap_or(Operand(idx));
             let eq = alloc();
             tail.push(Line {
@@ -342,13 +434,31 @@ pub(crate) fn spcr(file: &Btor2File) -> Option<Btor2File> {
                 immediates: Vec::new(),
                 source_line: 0,
             });
+            let guard = match plan.write_cond {
+                None => Operand(eq),
+                Some(cond) => {
+                    let and = alloc();
+                    tail.push(Line {
+                        nid: and,
+                        node: Node::Op {
+                            sort: bool_sort,
+                            op: Op::And,
+                            args: vec![cond, Operand(eq)],
+                            symbol: None,
+                        },
+                        immediates: Vec::new(),
+                        source_line: 0,
+                    });
+                    Operand(and)
+                }
+            };
             let ite = alloc();
             tail.push(Line {
                 nid: ite,
                 node: Node::Op {
                     sort: plan.elem_sort,
                     op: Op::Ite,
-                    args: vec![Operand(eq), plan.wdata, Operand(pv)],
+                    args: vec![guard, plan.wdata, Operand(pv)],
                     symbol: None,
                 },
                 immediates: Vec::new(),
@@ -538,6 +648,104 @@ mod tests {
         assert_eq!(
             exact_symbolic_verdict(&src, &f).expect("array-free 17-bit cone ⇒ exact decides"),
             ExactVerdict::Holds,
+        );
+    }
+
+    /// P-A1b — write-ENABLE mux `mem' = ite(we, write(mem,waddr,wdata), mem)` with a STABLE
+    /// (never-moving) config index `key`. Recovery via the env asserting `we ∧ waddr==key ∧
+    /// wdata==3`; `AG EF(busy==0)` HOLDS. SPCR frame = `pv' = ite(we ∧ waddr==key, wdata, pv)`.
+    const AGR_SPCR_WE: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 sort array 2 2
+4 input 1 start
+5 input 2 waddr
+6 input 2 wdata
+7 input 1 we
+8 state 1 busy
+9 state 2 key
+10 state 3 mem
+11 const 1 0
+12 init 1 8 11
+13 const 2 00
+14 init 2 9 13
+15 const 2 11
+16 read 2 10 9
+17 eq 1 16 15
+18 not 1 8
+19 and 1 4 18
+20 const 1 1
+21 and 1 8 17
+22 ite 1 21 11 8
+23 ite 1 19 20 22
+24 next 1 8 23
+25 write 3 10 5 6
+26 ite 3 7 25 10
+27 next 3 10 26
+";
+
+    #[test]
+    fn spcr_pa1b_write_enable_mux_stable_index_decides_holds() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        use crate::mu_calculus::parser as mu_parser;
+        let file = crate::adapter::btor2::parser::parse(AGR_SPCR_WE).expect("parse");
+        let out =
+            super::spcr(&file).expect("SPCR applies to the write-enable + stable-index shape");
+        assert!(!has_array(&out), "SPCR output must be array-free");
+        let f = mu_parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").unwrap();
+        assert!(
+            exact_symbolic_verdict(AGR_SPCR_WE, &f).is_err(),
+            "the array-bearing design must SKIP on the exact ROBDD"
+        );
+        let src = crate::adapter::btor2::emit::emit_btor2(&out);
+        assert_eq!(
+            exact_symbolic_verdict(&src, &f).expect("array-free ⇒ exact decides"),
+            ExactVerdict::Holds,
+            "write-enable SPCR (guard we ∧ waddr==key) must decide AG EF(busy==0) = Holds"
+        );
+    }
+
+    /// SOUNDNESS gate: a MOVING index (`key' = ite(arm, waddr, key)`) under a CONDITIONAL write
+    /// must ABSTAIN — the index could move to `waddr` while `we` is low, leaving `mem[waddr] ≠ pv`
+    /// (the frame would be unsound). `AGR_SPCR_WE` + a move-to-waddr `next` for `key`.
+    const AGR_SPCR_WE_MOVING: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 sort array 2 2
+4 input 1 start
+5 input 2 waddr
+6 input 2 wdata
+7 input 1 we
+8 state 1 busy
+9 state 2 key
+10 state 3 mem
+11 const 1 0
+12 init 1 8 11
+13 const 2 00
+14 init 2 9 13
+15 const 2 11
+16 read 2 10 9
+17 eq 1 16 15
+18 not 1 8
+19 and 1 4 18
+20 const 1 1
+21 and 1 8 17
+22 ite 1 21 11 8
+23 ite 1 19 20 22
+24 next 1 8 23
+25 write 3 10 5 6
+26 ite 3 7 25 10
+27 next 3 10 26
+28 ite 2 19 5 9
+29 next 2 9 28
+";
+
+    #[test]
+    fn spcr_pa1b_conditional_write_moving_index_abstains_soundly() {
+        let file = crate::adapter::btor2::parser::parse(AGR_SPCR_WE_MOVING).expect("parse");
+        assert!(
+            super::spcr(&file).is_none(),
+            "moving index under a conditional write is unsound to registerize ⇒ SPCR must abstain"
         );
     }
 

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -223,16 +223,25 @@ impl Elim<'_> {
     /// `mem'[value-of(E)]` — the NEXT-cycle memory content at index expression `E`. Substitutes
     /// `mem'[leaf]` recursively: a state/const leaf → [`Elim::leaf_frame`]; the write address (under
     /// an unconditional write) → `wdata`; an `ite` → the reconstructed `ite`. Clears `ok` otherwise.
-    fn mem_next_at(&mut self, nid: Nid) -> Operand {
+    ///
+    /// `we_on_path` (P-B.1) tracks whether the path from a registerized index-state's next-value to
+    /// THIS node passed through the THEN-branch of an `ite` guarded by (a conjunction including) the
+    /// write-enable `write_cond`. When it did, a `waddr` leaf resolves to `wdata` even under a
+    /// conditional write — the "latch the last-written address" pattern `idx' = ite(we, waddr, idx)`
+    /// — because on every reachable path to that leaf the write fired, so `mem'[waddr] = wdata`.
+    fn mem_next_at(&mut self, nid: Nid, we_on_path: bool) -> Operand {
         if !self.ok || self.depth > Self::DEPTH_CAP {
             self.ok = false;
             return Operand(0);
         }
         let nid = self.see_through(nid);
         if nid == self.waddr.nid() {
-            if self.write_cond.is_none() {
+            // mem'[waddr] = wdata when the write fires: unconditional, or the path guarantees `we`.
+            if self.write_cond.is_none() || we_on_path {
                 return self.wdata;
             }
+            // conditional write with no guarantee ⇒ mem'[waddr] = ite(we, wdata, mem[waddr]) and the
+            // old mem[waddr] is input-indexed (un-registerizable) ⇒ abstain (P-B.2 / index-prophecy).
             self.ok = false;
             return Operand(0);
         }
@@ -245,9 +254,12 @@ impl Elim<'_> {
                 op: Op::Ite, args, ..
             }) if args.len() == 3 => {
                 let (c, a, b) = (args[0], args[1].nid(), args[2].nid());
+                // Descending into the THEN branch under a guard that implies `write_cond` guarantees
+                // the write fired on that sub-path.
+                let then_we = we_on_path || self.guard_implies_write_cond(c);
                 self.depth += 1;
-                let ma = self.mem_next_at(a);
-                let mb = self.mem_next_at(b);
+                let ma = self.mem_next_at(a, then_we);
+                let mb = self.mem_next_at(b, we_on_path);
                 self.depth -= 1;
                 Operand(self.push(Node::Op {
                     sort: self.elem_sort,
@@ -262,6 +274,22 @@ impl Elim<'_> {
                 Operand(0)
             }
         }
+    }
+
+    /// SOUND sufficient check that an `ite` condition `c` (taken positively) implies the write-enable
+    /// `write_cond`: `c` is syntactically `write_cond` (same nid, same sign), or `c = and(.., write_cond, ..)`.
+    fn guard_implies_write_cond(&self, c: Operand) -> bool {
+        let Some(wc) = self.write_cond else {
+            return false;
+        };
+        if c.0 == wc.0 {
+            return true; // same node, same sign
+        }
+        // `c = and(x, y, …)` where some conjunct is exactly `write_cond`.
+        matches!(
+            self.file.lookup(c.nid()).map(|l| &l.node),
+            Some(Node::Op { op: Op::And, args, .. }) if c.0 >= 0 && args.iter().any(|a| a.0 == wc.0)
+        )
     }
 }
 
@@ -450,7 +478,7 @@ fn eliminate_array(
                 let nn = find_next_value_operand(file, s)
                     .map(|o| o.nid())
                     .unwrap_or(s);
-                elim.mem_next_at(nn)
+                elim.mem_next_at(nn, false)
             }
         };
         let pv = elim.pv_of[&cell];
@@ -1291,6 +1319,59 @@ mod tests {
             .filter(|l| matches!(&l.node, Node::State { symbol: Some(s), .. } if s.starts_with("spcr_pv_")))
             .count();
         assert_eq!(pvs, 2, "reset-mux index registerizes mem[key] AND mem[0]");
+    }
+
+    /// P-B.1 — "latch the last-written address under `we`": `key' = ite(we, waddr, key)` with a
+    /// CONDITIONAL write `mem' = ite(we, write, mem)`. The move-to-`waddr` guard IS `we`, so on every
+    /// reachable path where `key` moves to `waddr` the write fired ⇒ `mem'[waddr] = wdata`. The
+    /// path-condition tracking (`we_on_path`) makes SPCR decide this (P-A1b's plain moving+conditional
+    /// case correctly abstains because there the move guard `arm ≠ we`).
+    const AGR_LATCH_WE: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 sort array 2 2
+4 input 1 start
+5 input 2 waddr
+6 input 2 wdata
+7 input 1 we
+8 state 1 busy
+9 state 2 key
+10 state 3 mem
+11 const 1 0
+12 init 1 8 11
+13 const 2 00
+14 init 2 9 13
+15 const 2 11
+16 read 2 10 9
+17 eq 1 16 15
+18 not 1 8
+19 and 1 4 18
+20 const 1 1
+21 and 1 8 17
+22 ite 1 21 11 8
+23 ite 1 19 20 22
+24 next 1 8 23
+25 ite 2 7 5 9
+26 next 2 9 25
+27 write 3 10 5 6
+28 ite 3 7 27 10
+29 next 3 10 28
+";
+
+    #[test]
+    fn spcr_pb1_latch_last_written_addr_under_we_decides_holds() {
+        use crate::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_symbolic_verdict};
+        use crate::mu_calculus::parser as mu_parser;
+        let file = crate::adapter::btor2::parser::parse(AGR_LATCH_WE).expect("parse");
+        let out = super::spcr(&file)
+            .expect("P-B.1: move-to-waddr guard implies write-enable ⇒ SPCR applies");
+        assert!(!has_array(&out), "array-free");
+        let f = mu_parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").unwrap();
+        let src = crate::adapter::btor2::emit::emit_btor2(&out);
+        assert_eq!(
+            exact_symbolic_verdict(&src, &f).expect("array-free ⇒ exact decides"),
+            ExactVerdict::Holds,
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -20,6 +20,7 @@
 //! - Multi-clock designs.
 
 pub mod abs_safety;
+pub mod array_prophecy;
 pub mod ast;
 pub mod bad_monitor;
 pub mod bit_blast;

--- a/crates/mununu-core/src/adapter/btor2/predicate_expr.rs
+++ b/crates/mununu-core/src/adapter/btor2/predicate_expr.rs
@@ -101,6 +101,30 @@ pub enum PredicateExpr {
         /// `width == 0` leaf is a caller error (production never evals it).
         width: u32,
     },
+    /// SEL (P1-a, shot ①b) — an **array-content** predicate
+    /// `array[index] <op> value`: a Z3 `select` over an array-sorted state cell,
+    /// compared to a literal. `array` names an in-cone `$mem` state cell; `index`
+    /// is a BV register whose value chooses the cell; `value` is the literal.
+    ///
+    /// **SMT-ONLY** (like [`PredicateExpr::CmpReg`] / [`PredicateExpr::CmpRegAddend`]):
+    /// the concrete sampler tracks BV registers only, not array *contents*, so
+    /// this leaf can never be [`eval`]'d — it is gated to `SmtAllPairs` via
+    /// [`has_select`]. It is realised only by [`build_constraint_arr`], which
+    /// emits `select(arr, idx) <op> value` over Z3's **exact** array theory
+    /// (QF_AUFBV). Soundness therefore rests on the exactness of `select`, NOT on
+    /// an eval/SMT agreement (there is no eval counterpart) — the array image is
+    /// the precise must-side oracle (`btor2_encode` §Phase 10), so a definite
+    /// verdict transfers.
+    ///
+    /// [`eval`]: PredicateExpr::eval
+    /// [`has_select`]: PredicateExpr::has_select
+    /// [`build_constraint_arr`]: PredicateExpr::build_constraint_arr
+    Select {
+        array: String,
+        index: String,
+        op: CmpOp,
+        value: u64,
+    },
     And(Box<PredicateExpr>, Box<PredicateExpr>),
     Or(Box<PredicateExpr>, Box<PredicateExpr>),
     Not(Box<PredicateExpr>),
@@ -154,9 +178,46 @@ impl PredicateExpr {
     pub fn has_addend(&self) -> bool {
         match self {
             PredicateExpr::CmpRegAddend { .. } => true,
-            PredicateExpr::Cmp { .. } | PredicateExpr::CmpReg { .. } => false,
+            PredicateExpr::Cmp { .. }
+            | PredicateExpr::CmpReg { .. }
+            | PredicateExpr::Select { .. } => false,
             PredicateExpr::And(a, b) | PredicateExpr::Or(a, b) => a.has_addend() || b.has_addend(),
             PredicateExpr::Not(a) => a.has_addend(),
+        }
+    }
+
+    /// SEL — true if the expression contains an array-content leaf
+    /// ([`PredicateExpr::Select`]). Like [`has_addend`], such an expression is
+    /// routed **SMT-only** (`SmtAllPairs`): the literal-based sampler cannot read
+    /// array content, so [`eval`] must never see it — only
+    /// [`build_constraint_arr`] realises it, over Z3's exact array theory.
+    ///
+    /// [`has_addend`]: PredicateExpr::has_addend
+    /// [`eval`]: PredicateExpr::eval
+    /// [`build_constraint_arr`]: PredicateExpr::build_constraint_arr
+    pub fn has_select(&self) -> bool {
+        match self {
+            PredicateExpr::Select { .. } => true,
+            PredicateExpr::Cmp { .. }
+            | PredicateExpr::CmpReg { .. }
+            | PredicateExpr::CmpRegAddend { .. } => false,
+            PredicateExpr::And(a, b) | PredicateExpr::Or(a, b) => a.has_select() || b.has_select(),
+            PredicateExpr::Not(a) => a.has_select(),
+        }
+    }
+
+    /// SEL — an array-content atom `array[index] <op> value`. SMT-only.
+    pub fn select(
+        array: impl Into<String>,
+        index: impl Into<String>,
+        op: CmpOp,
+        value: u64,
+    ) -> Self {
+        PredicateExpr::Select {
+            array: array.into(),
+            index: index.into(),
+            op,
+            value,
         }
     }
 
@@ -203,6 +264,18 @@ impl PredicateExpr {
                 };
                 cmp_apply(*op, l, sum)
             }
+            PredicateExpr::Select { .. } => {
+                // SMT-only: the concrete sampler tracks BV registers, not array
+                // contents. `has_select` gates a Select-bearing predicate to
+                // `SmtAllPairs`, so this is never reached in production — a
+                // debug-assert catches a mis-route; release returns `false`
+                // (a conservative label, not relied upon).
+                debug_assert!(
+                    false,
+                    "eval on a Select leaf (array-content, SMT-only) — production must use build_constraint_arr"
+                );
+                false
+            }
             PredicateExpr::And(a, b) => a.eval(regs) && b.eval(regs),
             PredicateExpr::Or(a, b) => a.eval(regs) || b.eval(regs),
             PredicateExpr::Not(a) => !a.eval(regs),
@@ -228,11 +301,42 @@ impl PredicateExpr {
                 out.insert(lhs.clone());
                 out.insert(rhs.clone());
             }
+            PredicateExpr::Select { index, .. } => {
+                // The BV INDEX register (resolved via the BV lookup); the array
+                // itself is resolved separately via the array lookup (see
+                // `arrays()` / `build_constraint_arr`).
+                out.insert(index.clone());
+            }
             PredicateExpr::And(a, b) | PredicateExpr::Or(a, b) => {
                 a.collect_registers(out);
                 b.collect_registers(out);
             }
             PredicateExpr::Not(a) => a.collect_registers(out),
+        }
+    }
+
+    /// SEL — all distinct ARRAY names referenced by [`PredicateExpr::Select`]
+    /// leaves, sorted. The caller resolves each to an array-sorted state cell
+    /// (via the encoded view's `state_curr_arr`) and confirms it is in-cone.
+    pub fn arrays(&self) -> Vec<String> {
+        let mut set = BTreeSet::new();
+        self.collect_arrays(&mut set);
+        set.into_iter().collect()
+    }
+
+    fn collect_arrays(&self, out: &mut BTreeSet<String>) {
+        match self {
+            PredicateExpr::Select { array, .. } => {
+                out.insert(array.clone());
+            }
+            PredicateExpr::Cmp { .. }
+            | PredicateExpr::CmpReg { .. }
+            | PredicateExpr::CmpRegAddend { .. } => {}
+            PredicateExpr::And(a, b) | PredicateExpr::Or(a, b) => {
+                a.collect_arrays(out);
+                b.collect_arrays(out);
+            }
+            PredicateExpr::Not(a) => a.collect_arrays(out),
         }
     }
 
@@ -247,18 +351,42 @@ impl PredicateExpr {
     where
         F: Fn(&str) -> Option<z3::ast::BV>,
     {
+        // No array lookup supplied — a `Select` (array-content) leaf therefore
+        // resolves to `None`, which the caller treats as an `Unknown` must-edge
+        // (the conservative direction). Array-aware callers use
+        // [`build_constraint_arr`].
+        self.build_constraint_arr(lookup, &|_: &str| None)
+    }
+
+    /// SEL — the array-aware SMT encoding. Identical to [`build_constraint`] for
+    /// every BV leaf, and additionally realises [`PredicateExpr::Select`] as
+    /// `select(arr_lookup(array), bv_lookup(index)) <op> value` over Z3's exact
+    /// array theory (QF_AUFBV). `arr_lookup` maps an array-sorted state-cell name
+    /// to its `state_curr`/`state_next` [`z3::ast::Array`] from the encoded view.
+    /// Returns `None` (⇒ conservative `Unknown`) if any referenced register OR
+    /// array is absent from the view, matching the missing-register behaviour of
+    /// the simple-atom path.
+    ///
+    /// **Caller must hold a [`z3::with_z3_config`] scope.**
+    ///
+    /// [`build_constraint`]: PredicateExpr::build_constraint
+    pub fn build_constraint_arr<F, G>(&self, bv_lookup: &F, arr_lookup: &G) -> Option<z3::ast::Bool>
+    where
+        F: Fn(&str) -> Option<z3::ast::BV>,
+        G: Fn(&str) -> Option<z3::ast::Array>,
+    {
         match self {
             PredicateExpr::Cmp {
                 register,
                 op,
                 value,
             } => {
-                let bv = lookup(register)?;
+                let bv = bv_lookup(register)?;
                 Some(cmp_constraint(&bv, *op, *value))
             }
             PredicateExpr::CmpReg { lhs, op, rhs } => {
-                let lbv = lookup(lhs)?;
-                let rbv = lookup(rhs)?;
+                let lbv = bv_lookup(lhs)?;
+                let rbv = bv_lookup(rhs)?;
                 Some(cmp_constraint_bv(&lbv, *op, &rbv))
             }
             PredicateExpr::CmpRegAddend {
@@ -271,25 +399,40 @@ impl PredicateExpr {
                 // `lhs <op> (rhs + addend)` in BV — `bvadd` wraps at `rhs`'s real
                 // width (the RTL semantics). `width` is the eval-side modulus
                 // only; here the operand BVs carry the authoritative width.
-                let lbv = lookup(lhs)?;
-                let rbv = lookup(rhs)?;
+                let lbv = bv_lookup(lhs)?;
+                let rbv = bv_lookup(rhs)?;
                 let w = rbv.get_size();
                 let mask: u64 = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
                 let addend_bv = z3::ast::BV::from_u64(*addend & mask, w);
                 let sum = rbv.bvadd(&addend_bv);
                 Some(cmp_constraint_bv(&lbv, *op, &sum))
             }
+            PredicateExpr::Select {
+                array,
+                index,
+                op,
+                value,
+            } => {
+                // SEL — `select(arr, idx) <op> value`. Exact array read (mirrors
+                // the encoder's `Op::Read`, `btor2_encode.rs:762`). `None` (⇒
+                // conservative Unknown) if the array/index is absent from the view
+                // or the element is not a bit-vector.
+                let arr = arr_lookup(array)?;
+                let idx = bv_lookup(index)?;
+                let elem = arr.select(&idx).as_bv()?;
+                Some(cmp_constraint(&elem, *op, *value))
+            }
             PredicateExpr::And(a, b) => {
-                let ca = a.build_constraint(lookup)?;
-                let cb = b.build_constraint(lookup)?;
+                let ca = a.build_constraint_arr(bv_lookup, arr_lookup)?;
+                let cb = b.build_constraint_arr(bv_lookup, arr_lookup)?;
                 Some(z3::ast::Bool::and(&[&ca, &cb]))
             }
             PredicateExpr::Or(a, b) => {
-                let ca = a.build_constraint(lookup)?;
-                let cb = b.build_constraint(lookup)?;
+                let ca = a.build_constraint_arr(bv_lookup, arr_lookup)?;
+                let cb = b.build_constraint_arr(bv_lookup, arr_lookup)?;
                 Some(z3::ast::Bool::or(&[&ca, &cb]))
             }
-            PredicateExpr::Not(a) => Some(a.build_constraint(lookup)?.not()),
+            PredicateExpr::Not(a) => Some(a.build_constraint_arr(bv_lookup, arr_lookup)?.not()),
         }
     }
 }
@@ -400,6 +543,10 @@ enum Token {
     Plus,
     LParen,
     RParen,
+    /// SEL — `[` / `]` delimiting the index of an array-content atom
+    /// `array[index] <op> value`.
+    LBracket,
+    RBracket,
 }
 
 fn tokenize(s: &str) -> Result<Vec<Token>, PredicateExprParseError> {
@@ -419,6 +566,14 @@ fn tokenize(s: &str) -> Result<Vec<Token>, PredicateExprParseError> {
             }
             ')' => {
                 tokens.push(Token::RParen);
+                i += 1;
+            }
+            '[' => {
+                tokens.push(Token::LBracket);
+                i += 1;
+            }
+            ']' => {
+                tokens.push(Token::RBracket);
                 i += 1;
             }
             '&' if chars.get(i + 1) == Some(&'&') => {
@@ -580,6 +735,50 @@ impl Parser<'_> {
             Some(Token::Ident(s)) => s,
             other => return Err(perr(format!("expected a register name, found {other:?}"))),
         };
+        // SEL — `array[index] <op> value` (array-content atom). An `[` after the
+        // first identifier means it names an array; parse the index register + `]`,
+        // then a comparison against an integer literal → `PredicateExpr::Select`.
+        if matches!(self.peek(), Some(Token::LBracket)) {
+            self.pos += 1; // consume `[`
+            let index = match self.next() {
+                Some(Token::Ident(s)) => s,
+                other => {
+                    return Err(perr(format!(
+                        "expected an index register in `{register}[…]`, found {other:?}"
+                    )));
+                }
+            };
+            match self.next() {
+                Some(Token::RBracket) => {}
+                other => {
+                    return Err(perr(format!(
+                        "expected `]` after `{register}[{index}`, found {other:?}"
+                    )));
+                }
+            }
+            let op = match self.next() {
+                Some(Token::Op(o)) => o,
+                other => {
+                    return Err(perr(format!(
+                        "expected a comparison operator after `{register}[{index}]`, found {other:?}"
+                    )));
+                }
+            };
+            let value = match self.next() {
+                Some(Token::Int(v)) => v,
+                other => {
+                    return Err(perr(format!(
+                        "expected an integer value after `{register}[{index}] <op>`, found {other:?}"
+                    )));
+                }
+            };
+            return Ok(PredicateExpr::Select {
+                array: register,
+                index,
+                op,
+                value,
+            });
+        }
         let op = match self.next() {
             Some(Token::Op(o)) => o,
             other => {

--- a/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
+++ b/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
@@ -310,7 +310,21 @@ fn build_pred_constraint<P: PredicateLike>(
                 };
                 Some(bv.clone())
             };
-            let raw = e.build_constraint(&lookup)?;
+            // SEL — array-content lookup: array cells are absent from the BV
+            // `nid_map` (not cube dimensions), so resolve by name via
+            // `array_name_nid` to the curr/next Z3 `Array` handle, so a `Select`
+            // seed's `select(arr, idx)` binds against the same source/target frame
+            // as the BV atoms.
+            let arr_lookup = |arr: &str| -> Option<z3::ast::Array> {
+                let nid = *view.array_name_nid.get(arr)?;
+                let a = if slot_next {
+                    view.state_next_arr.get(&nid)?
+                } else {
+                    view.state_curr_arr.get(&nid)?
+                };
+                Some(a.clone())
+            };
+            let raw = e.build_constraint_arr(&lookup, &arr_lookup)?;
             Some(if polarity { raw } else { raw.not() })
         }
     }
@@ -412,7 +426,19 @@ fn build_pred_constraint_uniform<P: PredicateLike>(
                     term_source_bv(view, nid).cloned()
                 }
             };
-            let raw = e.build_constraint(&term_bv)?;
+            // SEL — array-content lookup. Array cells are absent from the BV `nid_map`
+            // (not cube dimensions), so resolve the array by name via `array_name_nid`;
+            // arrays have no primed cache, so the next-cycle array is `state_next_arr`.
+            let arr_lookup = |arr: &str| -> Option<z3::ast::Array> {
+                let nid = *view.array_name_nid.get(arr)?;
+                let a = if slot_next {
+                    view.state_next_arr.get(&nid)?
+                } else {
+                    view.state_curr_arr.get(&nid)?
+                };
+                Some(a.clone())
+            };
+            let raw = e.build_constraint_arr(&term_bv, &arr_lookup)?;
             Some(if polarity { raw } else { raw.not() })
         }
     }
@@ -547,6 +573,19 @@ fn universal_bound_bvs(view: &Btor2SmtView) -> Vec<z3::ast::BV> {
     bvs
 }
 
+/// SEL — the next-step ARRAY handles that must ALSO be universally bound in the ∀∃
+/// must-edge check. The transition constrains each memory cell's next value
+/// (`s_next_arr == write(s_arr, …)` / `ite(…)`), so the `state_next_arr` variable is a
+/// next-state component exactly like a `state_next` BV. Omitting it leaves the array's
+/// next-state FREE under the `∀`, which lets the solver pick an array that falsifies the
+/// transition — trivially satisfying `¬(transition ∧ tgt)` and spuriously reporting
+/// `NotMust` for EVERY array-bearing source. Binding it makes the `∀` range over the full
+/// next-state (a sound completeness fix: it can only turn spurious `NotMust` into a
+/// Z3-proven `Must`). Empty under `Theory::BvOnly`.
+fn universal_bound_arrays(view: &Btor2SmtView) -> Vec<z3::ast::Array> {
+    view.state_next_arr.values().cloned().collect()
+}
+
 /// R.2.5b session-2 follow-up (2026-06-09) — standard ∀∃ form of
 /// the SMT must-edge query for one (source-cube, target-cube) pair.
 ///
@@ -603,8 +642,10 @@ where
     // universally quantifying over both is equivalent semantically
     // and is the cleanest encoding given the view's BV vocabulary.
     let bound_bvs = universal_bound_bvs(view);
-    let bound_refs: Vec<&dyn z3::ast::Ast> =
+    let bound_arrs = universal_bound_arrays(view);
+    let mut bound_refs: Vec<&dyn z3::ast::Ast> =
         bound_bvs.iter().map(|bv| bv as &dyn z3::ast::Ast).collect();
+    bound_refs.extend(bound_arrs.iter().map(|a| a as &dyn z3::ast::Ast));
     let universal = z3::ast::forall_const(&bound_refs, &[], &inner_body);
 
     let solver = z3::Solver::new();
@@ -695,8 +736,10 @@ where
     let inner_body = z3::ast::Bool::and(&[&view.transition, &any_tgt]).not();
 
     let bound_bvs = universal_bound_bvs(view);
-    let bound_refs: Vec<&dyn z3::ast::Ast> =
+    let bound_arrs = universal_bound_arrays(view);
+    let mut bound_refs: Vec<&dyn z3::ast::Ast> =
         bound_bvs.iter().map(|bv| bv as &dyn z3::ast::Ast).collect();
+    bound_refs.extend(bound_arrs.iter().map(|a| a as &dyn z3::ast::Ast));
     let universal = z3::ast::forall_const(&bound_refs, &[], &inner_body);
 
     let solver = z3::Solver::new();
@@ -926,8 +969,10 @@ where
     let tgt_conj = conj_bool(&tgt_constraints);
     let inner_body = z3::ast::Bool::and(&[&view.transition, &tgt_conj]).not();
     let bound_bvs = universal_bound_bvs(view);
-    let bound_refs: Vec<&dyn z3::ast::Ast> =
+    let bound_arrs = universal_bound_arrays(view);
+    let mut bound_refs: Vec<&dyn z3::ast::Ast> =
         bound_bvs.iter().map(|bv| bv as &dyn z3::ast::Ast).collect();
+    bound_refs.extend(bound_arrs.iter().map(|a| a as &dyn z3::ast::Ast));
     let universal = z3::ast::forall_const(&bound_refs, &[], &inner_body);
 
     let solver = z3::Solver::new();
@@ -987,8 +1032,10 @@ where
     let any_tgt = z3::ast::Bool::or(&tgt_disjuncts_refs);
     let inner_body = z3::ast::Bool::and(&[&view.transition, &any_tgt]).not();
     let bound_bvs = universal_bound_bvs(view);
-    let bound_refs: Vec<&dyn z3::ast::Ast> =
+    let bound_arrs = universal_bound_arrays(view);
+    let mut bound_refs: Vec<&dyn z3::ast::Ast> =
         bound_bvs.iter().map(|bv| bv as &dyn z3::ast::Ast).collect();
+    bound_refs.extend(bound_arrs.iter().map(|a| a as &dyn z3::ast::Ast));
     let universal = z3::ast::forall_const(&bound_refs, &[], &inner_body);
 
     let solver = z3::Solver::new();
@@ -1170,7 +1217,13 @@ pub fn smt_combinational_label<P: PredicateLike>(
             let lookup = |reg: &str| -> Option<z3::ast::BV> {
                 derived_source_bv(view, nid_map, reg).cloned()
             };
-            match e.build_constraint(&lookup) {
+            // SEL — current-cycle array lookup for a derived Select predicate.
+            // Array cells resolve by name via `array_name_nid` (absent from `nid_map`).
+            let arr_lookup = |arr: &str| -> Option<z3::ast::Array> {
+                let nid = *view.array_name_nid.get(arr)?;
+                view.state_curr_arr.get(&nid).cloned()
+            };
+            match e.build_constraint_arr(&lookup, &arr_lookup) {
                 Some(b) => b,
                 None => return Tristate::KleeneBot,
             }

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -818,6 +818,11 @@ impl BddBitBlaster {
                 Ok(self.predicate_bdd(a)?.or(&self.predicate_bdd(b)?).unwrap())
             }
             PredicateExpr::Not(a) => Ok(self.predicate_bdd(a)?.not().unwrap()),
+            PredicateExpr::Select { .. } => Err(
+                "exact-symbolic ROBDD cannot bit-blast an array-content (Select) predicate — it is \
+                 SMT-only (predicate-cube path); the exact engine abstains on it"
+                    .to_string(),
+            ),
         }
     }
 
@@ -2214,6 +2219,17 @@ fn resolve_predicate_expr_registers(
             Box::new(resolve_predicate_expr_registers(a, resolve)),
             Box::new(resolve_predicate_expr_registers(b, resolve)),
         ),
+        PredicateExpr::Select {
+            array,
+            index,
+            op,
+            value,
+        } => PredicateExpr::Select {
+            array: resolve(array),
+            index: resolve(index),
+            op: *op,
+            value: *value,
+        },
         PredicateExpr::Not(a) => {
             PredicateExpr::Not(Box::new(resolve_predicate_expr_registers(a, resolve)))
         }
@@ -2239,6 +2255,11 @@ pub(crate) fn collect_predicate_registers(
         PredicateExpr::And(a, b) | PredicateExpr::Or(a, b) => {
             collect_predicate_registers(a, out);
             collect_predicate_registers(b, out);
+        }
+        PredicateExpr::Select { array, index, .. } => {
+            // Both the array cell AND the index register must be kept in-cone.
+            out.insert(array.clone());
+            out.insert(index.clone());
         }
         PredicateExpr::Not(a) => collect_predicate_registers(a, out),
     }

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1424,8 +1424,37 @@ pub fn verify_recoverability_scalable_with_source(
 
     // Parse the design early — needed both for the reset valuation and for the auto-seed candidate
     // values below.
-    let file = crate::adapter::btor2::parser::parse(btor2_content)
+    let file0 = crate::adapter::btor2::parser::parse(btor2_content)
         .map_err(|e| format!("recoverability cube path: parsing BTOR2: {}", e.message))?;
+
+    // SPCR (shot ①b) — Selective Prophecy-Cell Registerization. If every in-cone array matches the
+    // sound P-A1 shape (single unconditional full-width write, read at stable/move-to-write indices),
+    // eliminate the arrays by registerizing exactly the accessed cells (a prophecy register + exact
+    // frame). The result is array-FREE, so the must-edge ∀∃ becomes pure QF_BV (decidable) instead of
+    // the undecidable AUFBV+∀-array that leaves the νµ at ⊥. Verdict-preserving reformulation, so a
+    // definite exact verdict on the array-free design transfers. `None` ⇒ no array / not the sound
+    // shape ⇒ keep the original (honest ⊥ downstream). See `array_prophecy` + the plan doc.
+    let spcr_src;
+    let (file, btor2_content): (crate::adapter::btor2::ast::Btor2File, &str) =
+        match crate::adapter::btor2::array_prophecy::spcr(&file0) {
+            Some(af) => {
+                spcr_src = crate::adapter::btor2::emit::emit_btor2(&af);
+                // The array-free cone often now bit-blasts — retry the EXACT ROBDD first (a small
+                // array-free design decides definitively; the array-gated recovery the wall blocked).
+                let formula_str = format!("nu Y. ((mu X. (({good}) || <> X)) && [] Y)");
+                if let Ok(formula) = mu_parser::parse(&formula_str)
+                    && let Ok(v) = crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict(
+                        &spcr_src, &formula,
+                    )
+                {
+                    return Ok(PropertyVerdict::from(v));
+                }
+                // Cone still too wide for exact even array-free → fall through to the cube on the
+                // array-free design (the guard `pv == K` is now a plain BV predicate; QF_BV must).
+                (af, spcr_src.as_str())
+            }
+            None => (file0, btor2_content),
+        };
     let init_values: BTreeMap<String, u128> =
         crate::adapter::btor2::concrete_oracle::init_valuation(&file);
 
@@ -3847,40 +3876,37 @@ mod tests {
 ";
 
     #[test]
-    fn p1a_array_gated_recovery_hits_must_edge_quantifier_wall() {
-        // (b) THE WALL (P1-a finding): the array-content `Select` seed IS discovered, resolves
-        //     (`array_name_nid`), and CONSTRAINS the may-relation — but the cube still ABSTAINS
-        //     (`Unknown`) on `AG EF(busy==0)`. Why: a definite recoverability verdict needs the
-        //     diamond `<>X` to be True, which needs a MUST (hyper) edge. The must-edge is a ∀∃
-        //     query — `∀ s ⊨ src. ∃ inputs, s'. (T(s,in,s') ∧ s' ⊨ tgt)` — whose negation
-        //     universally quantifies EVERY next-state component, including the next-state ARRAY
-        //     (`universal_bound_arrays`). That puts it in quantified array logic (AUFBV + ∀
-        //     over an array), which Z3 cannot decide → it returns `Unknown` → NO must-edges →
-        //     the νμ stays `Unknown`. The MAY side (∃, QF_AUFBV) is decidable and works.
-        //
-        //     ⇒ An array-content cube predicate is NECESSARY but NOT SUFFICIENT: the array axis
-        //     needs a dedicated abstraction (prophecy à la Mann TACAS'21 / array-aware IC3-CEG)
-        //     that ELIMINATES the universally-quantified array from the must-query. This test
-        //     locks in the honest wall; a future engine that decides it should flip this to
-        //     `Holds` (matching the registerized ROBDD oracle) — a real capability gain.
+    fn p1a_spcr_decides_array_gated_recovery_holds() {
+        // (b) THE WALL, REMOVED by SPCR (shot ①b). BACKGROUND: a definite recoverability verdict
+        //     needs the diamond `<>X` = True, hence a MUST (hyper) edge; the must-edge ∀∃ —
+        //     `∀ s ⊨ src. ∃ in, s'. (T ∧ s' ⊨ tgt)` — universally quantifies EVERY next-state
+        //     component including the next-state ARRAY (`universal_bound_arrays`), which is
+        //     quantified array logic (AUFBV + ∀-over-array), UNDECIDABLE for Z3 → no must-edges →
+        //     the raw cube abstains. FIX: SPCR (`array_prophecy`) registerizes the property-
+        //     ACCESSED cell (`pv = mem[key]`, exact frame) and DROPS the array, so the must-query
+        //     is pure QF_BV (decidable). The design is then array-free and the exact ROBDD decides.
+        //     Verdict-preserving reformulation ⇒ the `Holds` transfers (Bruns–Godefroid), matching
+        //     the whole-array-registerized ROBDD oracle — but at O(#accessed-cells), the scaling
+        //     that beats whole-array registerization (see `array_gates_recovery_large`).
         use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
-        // Discovery fires on the clean fixture (direct symbol, no see-through needed).
+        // Discovery still fires on the array-bearing form (the SPCR read-set detector).
         let file = crate::adapter::btor2::parser::parse(AGR_CLEAN).expect("parse");
         assert!(
             select_guard_atoms(&file).contains(&("mem".to_string(), "key".to_string(), 3)),
             "clean fixture must discover mem[key]==3"
         );
         let f = mu_parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").unwrap();
+        // The ARRAY-BEARING design makes the exact ROBDD SKIP (in-cone array) — the raw wall.
         assert!(
             exact_symbolic_verdict(AGR_CLEAN, &f).is_err(),
-            "the in-cone array must make the exact ROBDD SKIP (else the cube path is untested)"
+            "the in-cone array must make the raw exact ROBDD SKIP"
         );
+        // SPCR eliminates it → the escalating scalable entry now DECIDES Holds.
         assert_eq!(
-            verify_recoverability_scalable(AGR_CLEAN, "busy == 0", &[]).expect("scalable runs"),
-            PropertyVerdict::Unknown,
-            "array-gated recovery: the ∀∃ must-query over a universally-bound array is undecidable \
-             for Z3 → no must-edges → cube abstains (the array-must wall; needs a dedicated \
-             array abstraction, not a cube predicate)"
+            verify_recoverability_scalable(AGR_CLEAN, "busy == 0", &[]).expect("scalable decides"),
+            PropertyVerdict::Holds,
+            "SPCR removes the array-must wall: registerize the accessed cell, drop the array, \
+             the QF_BV must-query decides AG EF(busy==0) = Holds"
         );
     }
 }

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -172,6 +172,118 @@ fn counter_gate_of(
 /// that only pushes toward `⊥` (sound, per PR #302's universal ◇). Pairs are ordered (`lhs <= rhs`) for
 /// deterministic dedup (`data == target` and `target == data` are the same predicate); reflexive
 /// `r == r` is dropped (no information). Deduped.
+/// SEL (P1-a, shot ①b) — discover **array-content** guard atoms `array[index] == K`:
+/// an `Eq` comparing a memory `Read(array, index)` against a constant `K` — the
+/// design's own array-content decision condition (e.g. `busy → idle` gated on
+/// `mem[key] == unlock`). Returns `(array_symbol, index_symbol, value)`; the caller
+/// lifts each to a `PredicateExpr::Select` COMPOUND seed. Mirrors [`eq_guard_atoms`]
+/// (register-vs-constant) for the array-read case — the property-directed discovery
+/// of the array-content predicate the predicate-cube KMTS needs to decide a
+/// content-gated recovery (the ROBDD exact engine cannot, since arrays are not
+/// bit-blastable). Bounded by the number of `Eq(Read, const)` nodes; deduped.
+fn select_guard_atoms(file: &crate::adapter::btor2::ast::Btor2File) -> Vec<(String, String, u64)> {
+    use crate::adapter::btor2::ast::{Node, Op};
+    let symbols = crate::adapter::btor2::parser::collect_symbols(file);
+    // nid → (array_nid, index_nid) for every memory `Read` op.
+    let reads: std::collections::HashMap<i64, (i64, i64)> = file
+        .lines
+        .iter()
+        .filter_map(|l| match &l.node {
+            Node::Op {
+                op: Op::Read, args, ..
+            } if args.len() == 2 => Some((l.nid, (args[0].0.abs(), args[1].0.abs()))),
+            _ => None,
+        })
+        .collect();
+    let state_nids: std::collections::HashSet<i64> = file
+        .lines
+        .iter()
+        .filter(|l| matches!(l.node, Node::State { .. }))
+        .map(|l| l.nid)
+        .collect();
+    // Resolve a read-index nid to a symboled register. yosys routinely reset-muxes the
+    // addressing FF (`read(mem, ite(rst, key, 0))`) and — crucially — `collect_symbols`
+    // attaches the visible name (`u.key`) to the underlying STATE cell, NOT to the `ite`/
+    // `uext` chain. So a bare `symbols.get(idx_nid)` on the reset-mux node misses it; walk
+    // the index cone to the first symboled STATE instead (collecting only states skips the
+    // reset-CONDITION input the `ite` branches on). That symboled state name is a real
+    // `Node::State` symbol, so it resolves in the states-only cube `nid_map` AND is pinned
+    // in `init_values` (the reset-cube gate) — the seeded `select(arr, key)` then reads
+    // exactly the cell the design reads, over the same state frame as the BV atoms.
+    let idx_symbol = |idx_nid: i64| -> Option<String> {
+        if let Some(s) = symbols.get(&idx_nid) {
+            return Some(s.clone());
+        }
+        let mut seen = std::collections::HashSet::new();
+        let mut queue = std::collections::VecDeque::from([idx_nid]);
+        while let Some(nid) = queue.pop_front() {
+            if !seen.insert(nid) {
+                continue;
+            }
+            let Some(line) = file.lookup(nid) else {
+                continue;
+            };
+            match &line.node {
+                Node::State { .. } => {
+                    if let Some(s) = symbols.get(&nid) {
+                        return Some(s.clone());
+                    }
+                }
+                Node::Op { args, .. } => {
+                    for o in args {
+                        queue.push_back(o.0.abs());
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    };
+    let mut out: Vec<(String, String, u64)> = Vec::new();
+    for line in &file.lines {
+        let Node::Op {
+            op: Op::Eq, args, ..
+        } = &line.node
+        else {
+            continue;
+        };
+        if args.len() != 2 {
+            continue;
+        }
+        // Either operand may be the array `Read` vs the constant.
+        for (read_nid, const_nid) in [
+            (args[0].0.abs(), args[1].0.abs()),
+            (args[1].0.abs(), args[0].0.abs()),
+        ] {
+            let Some(&(arr_nid, idx_nid)) = reads.get(&read_nid) else {
+                continue;
+            };
+            // The array must be an array-sorted state cell (a `$mem`) with a symbol; the
+            // index resolves to a symboled alias (see-through above) so the Select binds.
+            if !state_nids.contains(&arr_nid) {
+                continue;
+            }
+            let Some(arr_sym) = symbols.get(&arr_nid) else {
+                continue;
+            };
+            let Some(idx_sym) = idx_symbol(idx_nid) else {
+                continue;
+            };
+            let Some(k) = crate::adapter::btor2::bit_blast::resolve_btor2_constant(file, const_nid)
+            else {
+                continue;
+            };
+            if !out
+                .iter()
+                .any(|(a, i, v)| a == arr_sym && *i == idx_sym && *v == k)
+            {
+                out.push((arr_sym.clone(), idx_sym, k));
+            }
+        }
+    }
+    out
+}
+
 fn eq_reg_guard_atoms(file: &crate::adapter::btor2::ast::Btor2File) -> Vec<(String, String)> {
     use crate::adapter::btor2::ast::{Node, Op};
     let symbols = crate::adapter::btor2::parser::collect_symbols(file);
@@ -1519,6 +1631,36 @@ pub fn verify_recoverability_scalable_with_source(
         compound_seeds.push((name, expr_str, expr));
     }
 
+    // SEL (P1-a, shot ①b) — ARRAY-CONTENT return: seed the design's `array[index] == K` guard atoms
+    // (`select_guard_atoms`) as COMPOUND `PredicateExpr::Select` predicates. When the must-return reads an
+    // in-cone MEMORY (`busy → idle` only when `mem[key] == unlock`), control/register seeding leaves
+    // `EF good` at ⊥ — the array merges into one cube cell — so the deciding predicate is `mem[key] == K`.
+    // SMT-only (like the relational seeds): the `SmtHyperMust` seam decides each cube's truth via the exact
+    // transition over Z3's array `select` (QF_AUFBV), never bit-blasting the array. Cone-filtered + capped.
+    for (arr, idx, k) in select_guard_atoms(&file) {
+        if specs.len() + compound_seeds.len() > MAX_AUTO_SEED {
+            break;
+        }
+        // Property-directed filter keys on the ARRAY (a state cell in the good's cone-of-
+        // influence, per `good_register_coi`'s state traversal): a `mem[·]` predicate is
+        // relevant iff the array's content flows into recovery. The index is a combinational
+        // reset-mux alias (`u.key`, not a state) so it is absent from the states-only cone
+        // set — checking `in_coi(idx)` would spuriously drop every valid array-content seed.
+        // The index only selects which cell; it needs no independent cone membership.
+        if !in_coi(&arr) {
+            continue;
+        }
+        let name = format!("sel_{arr}_{idx}_eq_{k}");
+        if compound_seeds.iter().any(|(n, _, _)| n == &name) {
+            continue;
+        }
+        let expr_str = format!("{arr}[{idx}] == {k}");
+        let Ok(expr) = parse_predicate_expr(&expr_str) else {
+            continue;
+        };
+        compound_seeds.push((name, expr_str, expr));
+    }
+
     // N1 EMERGENT-K — inductive relational-invariant discovery. The frontiers above lift relations from
     // syntactic `eq`/`add` nodes; a design that decides its control return through inequalities or
     // arithmetic carries the deciding relation (`data == target`, `target == data + 1`) only semantically,
@@ -1751,20 +1893,61 @@ pub fn verify_recoverability_scalable_with_source(
     let init_map: std::collections::HashMap<String, u128> =
         init_values.iter().map(|(k, v)| (k.clone(), *v)).collect();
     let mut init_cube = 0usize;
+    // SEL — a Select's reset truth (`mem[key] == K` at cycle 0) depends on the array's reset
+    // CONTENT, which `init_values` (BV-only) does not model. Rather than read one arbitrary
+    // content (unsound) or abstain outright, treat the array as FREE at reset: the initial
+    // state ranges over ALL array contents, so this bit is enumerated over both truth values
+    // (`free_select_bits`) below. The index register IS pinned (guarded above), so only the
+    // content is free.
+    let mut free_select_bits: Vec<usize> = Vec::new();
     for (i, spec) in trace.final_predicates.iter().enumerate() {
-        let holds = match compound_map.get(&spec.name) {
-            Some(expr) => expr.eval(&init_map),
-            None => init_values.get(&spec.register).copied() == Some(spec.value as u128),
-        };
-        if holds {
-            init_cube |= 1 << i;
+        match compound_map.get(&spec.name) {
+            Some(expr) if expr.has_select() => free_select_bits.push(i),
+            Some(expr) => {
+                if expr.eval(&init_map) {
+                    init_cube |= 1 << i;
+                }
+            }
+            None => {
+                if init_values.get(&spec.register).copied() == Some(spec.value as u128) {
+                    init_cube |= 1 << i;
+                }
+            }
         }
     }
 
-    Ok(match trace.final_verdict.verdict_at(init_cube) {
-        Trit::False => PropertyVerdict::Violated,
-        Trit::Unknown => PropertyVerdict::Unknown,
-        Trit::True => PropertyVerdict::Holds,
+    if free_select_bits.is_empty() {
+        // Pinned reset cube — the exact-input-independent verdict (all three values trusted).
+        return Ok(match trace.final_verdict.verdict_at(init_cube) {
+            Trit::False => PropertyVerdict::Violated,
+            Trit::Unknown => PropertyVerdict::Unknown,
+            Trit::True => PropertyVerdict::Holds,
+        });
+    }
+    // Free array content at reset over-APPROXIMATES the initial set (a superset of the real
+    // reachable initial states). `AG EF good` holding over the superset implies it over the
+    // real set, so a UNANIMOUS `True` across every flavour is a sound `Holds`. A `False` /
+    // `Unknown` flavour could correspond to an initial array content the concrete design
+    // never has (a spurious violation from an unreachable init), so we do NOT emit `Violated`
+    // here — we abstain (the recoverability path's "trust only Holds from an over-approx"
+    // posture). Bounded to keep the 2^f enumeration small; a wider free set abstains.
+    const MAX_FREE_SELECT_BITS: usize = 4;
+    if free_select_bits.len() > MAX_FREE_SELECT_BITS {
+        return Ok(PropertyVerdict::Unknown);
+    }
+    let all_true = (0..(1usize << free_select_bits.len())).all(|mask| {
+        let mut cube = init_cube;
+        for (b, &bit) in free_select_bits.iter().enumerate() {
+            if (mask >> b) & 1 == 1 {
+                cube |= 1 << bit;
+            }
+        }
+        matches!(trace.final_verdict.verdict_at(cube), Trit::True)
+    });
+    Ok(if all_true {
+        PropertyVerdict::Holds
+    } else {
+        PropertyVerdict::Unknown
     })
 }
 
@@ -1892,6 +2075,12 @@ fn atomic_expr_string(expr: &PredicateExpr) -> Option<String> {
             addend,
             ..
         } => Some(format!("{lhs} {} {rhs} + {addend}", op(*o))),
+        PredicateExpr::Select {
+            array,
+            index,
+            op: o,
+            value,
+        } => Some(format!("{array}[{index}] {} {value}", op(*o))),
         PredicateExpr::And(..) | PredicateExpr::Or(..) | PredicateExpr::Not(..) => None,
     }
 }
@@ -3552,6 +3741,146 @@ mod tests {
         assert_eq!(
             verify_recoverability(&wide, "fsm == 2").expect("b2 decides the wide design"),
             PropertyVerdict::Holds,
+        );
+    }
+
+    /// P1-a shot-①b — the array-content Select seed on a yosys-lifted keep-`$mem` design whose
+    /// recovery is gated on array content (`mem[key] == all-ones`). The read index is a reset-mux
+    /// `ite(rst, key, 0)` over an UNNAMED FF, with the symbol on a width-preserving observable copy
+    /// `uext(idx, 0) = u.key` — so `select_guard_atoms` must SEE THROUGH the uext to resolve the
+    /// index. Isolates discovery (does the Select seed get produced?) from decision (can the cube
+    /// use it?). The exact ROBDD SKIPs (in-cone array), so this is the escalated cube path.
+    const AGR_SMALL_MEM: &str = "\
+1 sort bitvec 1
+2 input 1 clk
+3 input 1 rst_n
+4 input 1 start
+5 sort bitvec 2
+6 input 5 waddr
+7 input 5 wdata
+8 const 1 0
+9 state 1
+10 ite 1 3 9 8
+11 output 10 busy
+12 uext 1 10 0 u.busy
+13 uext 1 2 0 u.clk
+14 const 5 00
+15 state 5
+16 ite 5 3 15 14
+17 uext 5 16 0 u.key
+18 uext 1 3 0 u.rst_n
+19 uext 1 4 0 u.start
+20 uext 5 6 0 u.waddr
+21 uext 5 7 0 u.wdata
+22 sort array 5 5
+23 state 22 u.mem
+24 read 5 23 16
+25 const 5 11
+26 eq 1 24 25
+27 ite 1 26 8 10
+28 ite 1 10 27 10
+29 const 1 1
+30 not 1 10
+31 and 1 4 30
+32 ite 1 31 29 28
+33 ite 1 3 32 8
+34 next 1 9 33
+35 ite 5 31 6 16
+36 ite 5 3 35 14
+37 next 5 15 36
+38 read 5 23 6
+39 not 5 25
+40 and 5 38 39
+41 and 5 7 25
+42 or 5 41 40
+43 write 22 23 6 42
+44 redor 1 25
+45 ite 22 44 43 23
+46 next 22 23 45 u.mem
+";
+
+    #[test]
+    fn p1a_select_guard_discovery_sees_through_resetmux_uext() {
+        // (a) DISCOVERY: the index (`16 ite …`, unsymboled) resolves to `u.key` via the
+        //     `17 uext 5 16 0 u.key` observable-copy see-through; array is the `$mem` state.
+        let file = crate::adapter::btor2::parser::parse(AGR_SMALL_MEM).expect("parse");
+        let atoms = select_guard_atoms(&file);
+        assert!(
+            atoms.contains(&("u.mem".to_string(), "u.key".to_string(), 3)),
+            "select_guard_atoms must discover mem[key]==3 (via reset-mux/uext see-through); got {atoms:?}"
+        );
+    }
+
+    /// Hand-authored twin of `AGR_SMALL_MEM` with NAMED state FFs and a DIRECT `mem[key]`
+    /// read (no yosys reset-mux / observable-copy artifacts), so the reset-cube gate pins
+    /// every register and the ONLY hard axis is the in-cone array content. Recovery: busy→0
+    /// iff mem[key]==all-ones(3); mem is freely env-writable (mem[waddr]=wdata), so from any
+    /// busy state the env can write mem[key]=3 and recover ⇒ AG EF(busy==0) HOLDS.
+    const AGR_CLEAN: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 sort array 2 2
+4 input 1 start
+5 input 2 waddr
+6 input 2 wdata
+7 state 1 busy
+8 state 2 key
+9 state 3 mem
+10 const 1 0
+11 init 1 7 10
+12 const 2 00
+13 init 2 8 12
+14 const 2 11
+15 read 2 9 8
+16 eq 1 15 14
+17 not 1 7
+18 and 1 4 17
+19 const 1 1
+20 and 1 7 16
+21 ite 1 20 10 7
+22 ite 1 18 19 21
+23 next 1 7 22
+24 ite 2 18 5 8
+25 next 2 8 24
+26 write 3 9 5 6
+27 next 3 9 26
+";
+
+    #[test]
+    fn p1a_array_gated_recovery_hits_must_edge_quantifier_wall() {
+        // (b) THE WALL (P1-a finding): the array-content `Select` seed IS discovered, resolves
+        //     (`array_name_nid`), and CONSTRAINS the may-relation — but the cube still ABSTAINS
+        //     (`Unknown`) on `AG EF(busy==0)`. Why: a definite recoverability verdict needs the
+        //     diamond `<>X` to be True, which needs a MUST (hyper) edge. The must-edge is a ∀∃
+        //     query — `∀ s ⊨ src. ∃ inputs, s'. (T(s,in,s') ∧ s' ⊨ tgt)` — whose negation
+        //     universally quantifies EVERY next-state component, including the next-state ARRAY
+        //     (`universal_bound_arrays`). That puts it in quantified array logic (AUFBV + ∀
+        //     over an array), which Z3 cannot decide → it returns `Unknown` → NO must-edges →
+        //     the νμ stays `Unknown`. The MAY side (∃, QF_AUFBV) is decidable and works.
+        //
+        //     ⇒ An array-content cube predicate is NECESSARY but NOT SUFFICIENT: the array axis
+        //     needs a dedicated abstraction (prophecy à la Mann TACAS'21 / array-aware IC3-CEG)
+        //     that ELIMINATES the universally-quantified array from the must-query. This test
+        //     locks in the honest wall; a future engine that decides it should flip this to
+        //     `Holds` (matching the registerized ROBDD oracle) — a real capability gain.
+        use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
+        // Discovery fires on the clean fixture (direct symbol, no see-through needed).
+        let file = crate::adapter::btor2::parser::parse(AGR_CLEAN).expect("parse");
+        assert!(
+            select_guard_atoms(&file).contains(&("mem".to_string(), "key".to_string(), 3)),
+            "clean fixture must discover mem[key]==3"
+        );
+        let f = mu_parser::parse("nu Y. ((mu X. ((busy == 0) || <> X)) && [] Y)").unwrap();
+        assert!(
+            exact_symbolic_verdict(AGR_CLEAN, &f).is_err(),
+            "the in-cone array must make the exact ROBDD SKIP (else the cube path is untested)"
+        );
+        assert_eq!(
+            verify_recoverability_scalable(AGR_CLEAN, "busy == 0", &[]).expect("scalable runs"),
+            PropertyVerdict::Unknown,
+            "array-gated recovery: the ∀∃ must-query over a universally-bound array is undecidable \
+             for Z3 → no must-edges → cube abstains (the array-must wall; needs a dedicated \
+             array abstraction, not a cube predicate)"
         );
     }
 }

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
@@ -132,6 +132,11 @@ pub struct Btor2SmtView {
     /// value of each array-sorted state cell. Mirror of
     /// `state_curr_arr` over `s_next`.
     pub state_next_arr: HashMap<Nid, z3::ast::Array>,
+    /// SEL — array-cell NAME → NID, for array-content (`Select`) predicates. Memory cells
+    /// are intentionally absent from `signals` (they are not BV cube dimensions), so the
+    /// BV `nid_map` cannot resolve an array name; this map lets a `select(arr, idx)` atom
+    /// bind the array by its symbol. Populated under `Theory::BvUfArray`, empty under BvOnly.
+    pub array_name_nid: HashMap<String, Nid>,
     /// Per-signal metadata for callers that need to round-trip
     /// names / widths back to the sidecar. Includes State, Input, and
     /// (H.E.1) named Combinational nodes.
@@ -225,6 +230,7 @@ pub fn encode_design_with_theory(
     let mut state_next: HashMap<Nid, z3::ast::BV> = HashMap::new();
     let mut state_curr_arr: HashMap<Nid, z3::ast::Array> = HashMap::new();
     let mut state_next_arr: HashMap<Nid, z3::ast::Array> = HashMap::new();
+    let mut array_name_nid: HashMap<String, Nid> = HashMap::new();
     let mut inputs: HashMap<Nid, z3::ast::BV> = HashMap::new();
     let mut signals = Vec::new();
 
@@ -264,10 +270,14 @@ pub fn encode_design_with_theory(
                         z3::ast::Array::new_const(format!("a_next_{label}").as_str(), &dom, &rng);
                     state_curr_arr.insert(line.nid, curr);
                     state_next_arr.insert(line.nid, next);
+                    if let Some(s) = &sym {
+                        array_name_nid.insert(s.clone(), line.nid);
+                    }
                     // Memory cells are tracked in the array maps, not
                     // the BV `signals` vector (which feeds bit-vector
                     // cube enumeration). The predicate-cube lift's
-                    // cube predicates reference BV registers only.
+                    // cube predicates reference BV registers only; the
+                    // `array_name_nid` map lets a `Select` atom bind them.
                 } else {
                     return Err(EncodeError::ArraySortUnsupportedInBvOnly { nid: line.nid });
                 }
@@ -314,6 +324,7 @@ pub fn encode_design_with_theory(
         state_next,
         state_curr_arr,
         state_next_arr,
+        array_name_nid,
         inputs,
         signals,
         signal_bvs: HashMap::new(),
@@ -453,6 +464,7 @@ pub(crate) fn encode_primed(
         state_next: view.state_next.clone(),
         state_curr_arr: view.state_next_arr.clone(),
         state_next_arr: view.state_next_arr.clone(),
+        array_name_nid: view.array_name_nid.clone(),
         inputs: primed_inputs.clone(),
         signals: view.signals.clone(),
         signal_bvs: HashMap::new(),


### PR DESCRIPTION
## What this is

Adds an **owned decider for the array-content νμ recoverability wall** — `AG EF good` where recovery is gated on array content read at a *latched* index. The predicate-cube KMTS's must-edge for this shape is an `AUFBV + ∀-over-array` query → Z3 `Unknown` → 0 must-edges → the νμ abstains (⊥). SPCR (Selective Prophecy-Cell Registerization) removes the wall by registerizing exactly the property-accessed cells and dropping the array, so the must-query becomes pure **QF_BV** (decidable) at `O(#accessed-cells)`, independent of array size.

**Engine (§16):** `symbolic` predicate-cube KMTS (Z3 QF_AUFBV may / AUFBV must) is the wall; the fix is an owned **BTOR2→BTOR2 pre-pass** (`array_prophecy::spcr`, sibling of `counter_may_abstract`) wired into `verify_recoverability_scalable`, after which `exact-symbolic` ROBDD (OxiDD) decides the array-free design. It is a **verdict-preserving reformulation** (trusts both Holds and Violated), sound at every alternation depth (Bruns–Godefroid).

## The arc (10 commits)

1. **`0c0a5d1`** — array-content `Select` predicate + array-aware may/must edges; mechanizes the wall. Two independently-valuable bug fixes: `array_name_nid` (arrays absent from the BV nid-map → degenerate complete-may, `may 256→12`) and `universal_bound_arrays` (the ∀∃ must-check didn't bind the next-state array → spurious `NotMust` for every array source).
2. **`16945c2`** — CLAUDE.md §16 Engine Specificity rule.
3. **`d54b968` P-A1 / `719518c` P-A1b / `42ed8af` P-A1c / `84b5dae` P-A1d** — the SPCR ladder: unconditional write; write-enable mux + soundness gate; const-fold+DCE of the yosys write-mask RMW; **recursive index-expression prophecy** (decides the real async-reset yosys lift `agr_small_mem`, differential-ROBDD-oracle-confirmed).
4. **`5b5f5da`** — attribution log (`SPCR: eliminated arrays=N prophecy_registers=M`) + P-A3 e2e validation.
5. **`4127e22` P-B.1** — latch-last-written-address (`idx' = ite(we, waddr, idx)`) under a conditional write.
6. **`f299310`** — **soundness fix**: a read-index STATE with no `next` line is HAVOC in BTOR2 (a free index), not a held constant — registerizing it is unsound (spurious `violated` on HWMCC `easy_zero_array`; btormc confirmed the design is safe). Now abstains unless the state index is a real latch. Also fixes an invalid-BTOR2 emit (forward/out-of-order nids → topo-sort + monotonic renumber; btormc/pono now parse the output).
7. **`46e007e`** — regression test for the fragment boundary.

## Fragment boundary (the precise characterization)

SPCR decides **iff the recovery index tracks the write address** (stable, or moves only to `waddr`); it **soundly abstains** when the index is a free input independent of the write port. Validated on an OpenTitan-shaped config-register-file synthetic: latch the *just-configured* channel → decides (small + 2048-array-bit large, oracle-agreed); latch an *independent* request channel → abstains (`unknown`). Locked in by `spcr_abstains_when_index_moves_to_independent_free_input`.

## Measurement (measure-first)

The target class — array-content-gated recovery at a latched index — is **absent from real corpora**: 0/135 AssertLLM2 arrays, 0/315 HWMCC20 array-track, and a full OpenTitan `hw/ip` sweep (1727 SV, 190 array decls) found no strong candidate (the OTBN loop stack near-miss recovers via a down-counter + PC-address match, not a stored-content value-test). SPCR ships as the **sound decidable-fragment mechanism** with a sharply-characterized boundary; no corpus row moves, and it is **not** wired into safety (measured 0 marginal reach).

## Tests

13 `array_prophecy` unit tests (incl. 3 soundness-abstention tests + array-size-independence + the real async-reset lift + differential oracle) + the recoverability wall test. Full mununu-core lib suite green (the 3 known env failures — cvc5/sv2v absent — are pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)