### PR TITLE
Harden the --design-dir source-manifest: comment/string masking + .sv/.v dedup

### DIFF
--- a/crates/mununu-core/src/adapter/yosys/source_manifest.rs
+++ b/crates/mununu-core/src/adapter/yosys/source_manifest.rs
@@ -41,6 +41,125 @@ fn is_ident_char(c: u8) -> bool {
     c.is_ascii_alphanumeric() || c == b'_' || c == b'$'
 }
 
+/// Blank out `//`-line and `/* */`-block comments (replacing them with whitespace so
+/// byte offsets and line structure are preserved) BEFORE any `module`/instantiation
+/// token scan. Without this, prose after `module` in a comment — `// the PWM module.
+/// Output is …` — is mis-read as a declared module name (`Output`, `is`, `body`),
+/// which then becomes a spurious un-instantiated top candidate. String literals are
+/// preserved (a `//`/`/*` inside `"…"` is not a comment), so `` `include "x.vh" ``
+/// targets survive; a `` `include `` that is itself commented out is correctly dropped.
+/// Verilog block comments do not nest.
+fn strip_comments(content: &str) -> String {
+    #[derive(PartialEq)]
+    enum St {
+        Normal,
+        Str,
+        Line,
+        Block,
+    }
+    let b = content.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(b.len());
+    let mut st = St::Normal;
+    let mut i = 0;
+    while i < b.len() {
+        let c = b[i];
+        let c2 = if i + 1 < b.len() { b[i + 1] } else { 0 };
+        match st {
+            St::Normal => {
+                if c == b'"' {
+                    st = St::Str;
+                    out.push(c);
+                    i += 1;
+                } else if c == b'/' && c2 == b'/' {
+                    st = St::Line;
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                } else if c == b'/' && c2 == b'*' {
+                    st = St::Block;
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                } else {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+            St::Str => {
+                // A backslash escape (`\"`) does not close the string.
+                if c == b'\\' && i + 1 < b.len() {
+                    out.push(c);
+                    out.push(b[i + 1]);
+                    i += 2;
+                } else {
+                    if c == b'"' {
+                        st = St::Normal;
+                    }
+                    out.push(c);
+                    i += 1;
+                }
+            }
+            St::Line => {
+                if c == b'\n' {
+                    st = St::Normal;
+                    out.push(c);
+                } else {
+                    out.push(b' ');
+                }
+                i += 1;
+            }
+            St::Block => {
+                if c == b'*' && c2 == b'/' {
+                    st = St::Normal;
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                } else {
+                    // Keep newlines so line numbers are preserved; blank everything else.
+                    out.push(if c == b'\n' { b'\n' } else { b' ' });
+                    i += 1;
+                }
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Replace the CONTENTS of `"…"` string literals with spaces (run on already
+/// comment-stripped text). Used for the `module`/instantiation scan so a string such as
+/// `$display("module foo started")` cannot inject a fake module name; the strings-KEPT
+/// [`strip_comments`] output is used separately for `` `include "target" `` extraction.
+fn blank_strings(content: &str) -> String {
+    let b = content.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(b.len());
+    let mut in_str = false;
+    let mut i = 0;
+    while i < b.len() {
+        let c = b[i];
+        if in_str {
+            if c == b'\\' && i + 1 < b.len() {
+                out.push(b' ');
+                out.push(b' ');
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_str = false;
+                out.push(c);
+            } else {
+                out.push(if c == b'\n' { b'\n' } else { b' ' });
+            }
+        } else if c == b'"' {
+            in_str = true;
+            out.push(c);
+        } else {
+            out.push(c);
+        }
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 /// Whole-word occurrences of `word` in `content` whose following text satisfies
 /// `after` (called with the byte slice immediately after the word). Skips
 /// occurrences that are part of a larger identifier (e.g. `endmodule` for
@@ -149,24 +268,34 @@ pub fn assemble_sv_design(
 ) -> AssembledDesign {
     let mut notes = Vec::new();
 
+    // Mask every file ONCE up front so token scans never read comment prose or string
+    // contents as code. Two levels: `stripped` (comments blanked, strings KEPT) feeds
+    // `` `include "target" `` extraction; `masked` (strings blanked too) feeds the
+    // `module`/instantiation scan (a comment or `$display("module x")` string can no
+    // longer inject a fake module name). Yosys still receives the ORIGINAL content so its
+    // error line numbers stay meaningful.
+    let stripped: Vec<String> = files.iter().map(|(_, c)| strip_comments(c)).collect();
+    let masked: Vec<String> = stripped.iter().map(|s| blank_strings(s)).collect();
+
     // Which basenames are `` `include ``d by some file → fragments, not units.
     let mut included: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for (_, content) in files {
-        for t in include_targets(content) {
+    for s in &stripped {
+        for t in include_targets(s) {
             included.insert(t);
         }
     }
 
     // Compilation units: files that declare ≥1 module AND are not `` `include ``d.
-    let mut units: Vec<(&PathBuf, &String, Vec<String>)> = Vec::new();
+    // Each carries (path, ORIGINAL content [for yosys], MASKED content [for scans], mods).
+    let mut units: Vec<(&PathBuf, &String, &str, Vec<String>)> = Vec::new();
     let mut fragment_dirs: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
-    for (path, content) in files {
+    for ((path, content), m) in files.iter().zip(masked.iter()) {
         let base = path
             .file_name()
             .and_then(|s| s.to_str())
             .unwrap_or_default()
             .to_string();
-        let mods = declared_modules(content);
+        let mods = declared_modules(m);
         if included.contains(&base) {
             if let Some(d) = path.parent() {
                 fragment_dirs.insert(d.to_path_buf());
@@ -184,27 +313,52 @@ pub fn assemble_sv_design(
                 "{base}: no module declaration → header/define, include-dir only"
             ));
         } else {
-            units.push((path, content, mods));
+            units.push((path, content, m.as_str(), mods));
         }
     }
+
+    // DEDUP `.sv`/`.v` twins: many corpora ship both a `.v` and a `.sv` copy of the same
+    // module(s) (or a flattened `work.sv` duplicating per-module files). Staging both is a
+    // guaranteed `duplicate definition` lift failure. Drop any later unit whose declared
+    // modules are ALL already staged by an earlier unit — the input is path-sorted
+    // (`discover_sv_files`), so `foo.sv` (`.sv` < `.v`) is kept and `foo.v` dropped. A unit
+    // that declares at least one NEW module is always kept (never drop unique RTL).
+    let mut seen_modules: std::collections::HashSet<String> = std::collections::HashSet::new();
+    units.retain(|(path, _, _, mods)| {
+        if mods.iter().all(|m| seen_modules.contains(m)) {
+            let base = path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default();
+            notes.push(format!(
+                "{base}: module(s) {mods:?} already staged → skipped (.sv/.v twin / duplicate)"
+            ));
+            return false;
+        }
+        for m in mods {
+            seen_modules.insert(m.clone());
+        }
+        true
+    });
 
     // Include dirs: the parents of every unit (so their `` `include ``s resolve)
     // plus every fragment dir.
     let mut include_dirs: std::collections::BTreeSet<PathBuf> = fragment_dirs;
-    for (path, _, _) in &units {
+    for (path, _, _, _) in &units {
         if let Some(d) = path.parent() {
             include_dirs.insert(d.to_path_buf());
         }
     }
 
-    // Top = a declared module no OTHER unit instantiates.
+    // Top = a declared module no OTHER unit instantiates. Scan the STRIPPED contents so a
+    // module name appearing in a comment never registers as an instantiation.
     let all_content: String = units
         .iter()
-        .map(|(_, c, _)| c.as_str())
+        .map(|(_, _, s, _)| *s)
         .collect::<Vec<_>>()
         .join("\n");
     let mut top_candidates: Vec<(String, &PathBuf)> = Vec::new();
-    for (path, _, mods) in &units {
+    for (path, _, _, mods) in &units {
         for m in mods {
             if !is_instantiated(&all_content, m) {
                 top_candidates.push((m.clone(), path));
@@ -240,8 +394,8 @@ pub fn assemble_sv_design(
     let top_path: Option<PathBuf> = top.as_ref().and_then(|t| {
         units
             .iter()
-            .find(|(_, _, mods)| mods.contains(t))
-            .map(|(p, _, _)| (*p).clone())
+            .find(|(_, _, _, mods)| mods.contains(t))
+            .map(|(p, _, _, _)| (*p).clone())
     });
     let named = |p: &PathBuf, c: &String| {
         (
@@ -255,14 +409,14 @@ pub fn assemble_sv_design(
     let (primary, additional): ((String, String), Vec<(String, String)>) = {
         let idx = top_path
             .as_ref()
-            .and_then(|tp| units.iter().position(|(p, _, _)| *p == tp))
+            .and_then(|tp| units.iter().position(|(p, _, _, _)| *p == tp))
             .unwrap_or(0);
         let primary = named(units[idx].0, units[idx].1);
         let additional = units
             .iter()
             .enumerate()
             .filter(|(i, _)| *i != idx)
-            .map(|(_, (p, c, _))| named(p, c))
+            .map(|(_, (p, c, _, _))| named(p, c))
             .collect();
         (primary, additional)
     };
@@ -390,6 +544,113 @@ mod tests {
             assemble_sv_design(&files, Some("zzz")).top,
             None,
             "no match → Yosys auto-detect"
+        );
+    }
+
+    #[test]
+    fn declared_modules_ignores_comments_and_strings() {
+        // The mis-tokenization bug: `module` in a comment or string must NOT be a decl.
+        let src = "// module fake_line here\n\
+                   /* the module body is here; module also_fake */\n\
+                   module real1(input a); endmodule\n\
+                   initial $display(\"module in_a_string running\");\n\
+                   module real2; endmodule\n";
+        let scan = blank_strings(&strip_comments(src));
+        assert_eq!(
+            declared_modules(&scan),
+            vec!["real1".to_string(), "real2".to_string()],
+            "only real `module` declarations count — not comment prose / string contents"
+        );
+    }
+
+    #[test]
+    fn comment_prose_after_module_is_not_a_top_candidate() {
+        // End-to-end: a design whose ONLY real module is `PWM`, but whose comments say
+        // "… the PWM module. Output is …" (the exact `Output`/`is`/`body` mis-tokenization
+        // seen on the AssertLLM2 pwm/PIT designs). The top must be unambiguously `PWM`.
+        let files = vec![f(
+            "d/PWM.v",
+            "// This is the PWM module. Output is driven here.\n\
+             /* module body: the down-clocking is below; module foo is fake */\n\
+             module PWM(input clk, output reg pwm_out);\n  reg [1:0] state;\nendmodule\n",
+        )];
+        let a = assemble_sv_design(&files, Some("PWM"));
+        assert_eq!(
+            a.top.as_deref(),
+            Some("PWM"),
+            "the only real module is the top; comment words (is/body/Output/foo) are not modules"
+        );
+        assert!(
+            !a.notes.iter().any(|n| n.contains("top candidates")),
+            "no spurious ambiguity from comment prose: {:?}",
+            a.notes
+        );
+    }
+
+    #[test]
+    fn sv_v_twin_modules_are_deduped() {
+        // The duplicate-definition bug: a design ships BOTH `foo.sv` and `foo.v` for the
+        // same module (path-sorted → `.sv` before `.v`). Only the `.sv` copy is staged;
+        // the `.v` twin is dropped so Yosys does not see a redefinition.
+        let files = vec![
+            f("d/top.sv", "module top; sub s0 (); endmodule\n"),
+            f("d/sub.sv", "module sub; endmodule\n"),
+            f("d/sub.v", "module sub; endmodule\n"), // the `.v` twin of sub.sv
+        ];
+        let a = assemble_sv_design(&files, Some("top"));
+        assert_eq!(a.top.as_deref(), Some("top"));
+        let staged: Vec<&str> = std::iter::once(a.primary.0.as_str())
+            .chain(a.additional.iter().map(|(n, _)| n.as_str()))
+            .collect();
+        assert!(
+            staged.contains(&"sub.sv") && !staged.contains(&"sub.v"),
+            "the `.sv` copy is kept and the `.v` twin dropped: {staged:?}"
+        );
+        assert!(
+            a.notes.iter().any(|n| n.contains(".sv/.v twin")),
+            "the dedup is noted: {:?}",
+            a.notes
+        );
+    }
+
+    #[test]
+    fn unique_module_in_a_v_file_is_never_dropped() {
+        // Dedup must NOT drop a `.v` file that declares a module absent from the `.sv` set.
+        let files = vec![
+            f("d/top.sv", "module top; a a0(); b b0(); endmodule\n"),
+            f("d/a.sv", "module a; endmodule\n"),
+            f("d/b.v", "module b; endmodule\n"), // unique — no `.sv` twin
+        ];
+        let a = assemble_sv_design(&files, Some("top"));
+        let staged: Vec<&str> = std::iter::once(a.primary.0.as_str())
+            .chain(a.additional.iter().map(|(n, _)| n.as_str()))
+            .collect();
+        assert!(staged.contains(&"b.v"), "unique .v RTL is kept: {staged:?}");
+    }
+
+    #[test]
+    fn strip_comments_preserves_include_string_but_drops_commented_include() {
+        // A real `` `include `` survives (its dir is on the search path); a commented-out
+        // one does not create a spurious fragment.
+        let files = vec![
+            f(
+                "d/top.v",
+                "`include \"real.vh\"\n// `include \"commented.vh\"\nmodule top; endmodule\n",
+            ),
+            f("d/real.vh", "`define W 8\n"),
+        ];
+        let a = assemble_sv_design(&files, Some("top"));
+        assert!(
+            a.notes
+                .iter()
+                .any(|n| n.contains("real.vh") && n.contains("fragment")),
+            "the real `include target is a fragment: {:?}",
+            a.notes
+        );
+        assert!(
+            !a.notes.iter().any(|n| n.contains("commented.vh")),
+            "a commented-out `include is not detected: {:?}",
+            a.notes
         );
     }
 }


### PR DESCRIPTION
The E6 `--design-dir` auto-assembler ([source_manifest.rs](crates/mununu-core/src/adapter/yosys/source_manifest.rs)) had two systematic failures that blocked much of the un-measured AssertLLM2 corpus (surfaced by the P1.1 lift sweep, ledger §3.10). Both are fixed and **differential-validated against the pre-fix binary** in the `mununu-sva-pono` image — no regression.

## The two bugs

**1. Top-module mis-tokenization.** The `module`/instantiation token scan ran over raw file content, so prose after `module` in a *comment* — `// … the PWM module. Output is …` — was read as a declared module name. These fakes (`is`, `body`, `in`, `Output`, `has`, `implementation`, `inputs`, …) are never instantiated → they became spurious un-instantiated top candidates → "ambiguous top" or `error: 'to' is not a valid top-level module`.
*Fix:* `strip_comments` (blank `//` and `/* */`, preserving strings + line structure) + `blank_strings` (blank `"…"` contents for the module scan). `` `include "target" `` extraction still uses the strings-kept text.

**2. `.sv`/`.v` twin duplicates.** Many designs ship both a `.v` and a `.sv` copy of each module → the scan staged both → guaranteed yosys `duplicate definition` failure (cop, versatile_fifo, sd_fifo).
*Fix:* dedup — drop any later unit whose declared modules are all already staged (path-sorted, so `.sv` is kept, `.v` twin dropped); a unit with ≥1 new module is always kept, so unique RTL is never dropped.

## Validation (mununu-sva-pono, differential vs baseline `main`)

- **No regression:** baseline and post-fix both lift `sdspi` (15 regs) identically; the `uart`/`i2c_slave` `OutOfMemory` panic is **pre-existing** (an engine OOM in the FSM bit-blast, present on baseline too — a separate issue, not assembly).
- **Improvement:** baseline `uart` top candidates were garbage `["has","implementation","input",…]`; post-fix they are the real module names (or a clean cyclic → Yosys auto-detect). `cop`/`versatile_fifo`/`sd_fifo` now skip their `.sv`/`.v` twins (dedup notes emitted).
- Designs that remain blocked now fail for **genuine** reasons (yosys-slang inout #143, mixed blocking/nonblocking, `` `SYN `` macro, true multi-variant-library ambiguity needing explicit `--top`).

5 new unit tests (comment/string masking, twin dedup, unique-`.v` kept, commented-`` `include `` dropped) + 3 existing green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)