### PR TITLE
VerdictRefinement type + refined recoverability producer (refined-verdicts Phase 0)

### DIFF
--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -49,7 +49,7 @@ use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
 use crate::mu_calculus::Environment;
 use crate::mu_calculus::parser as mu_parser;
 use crate::mu_calculus::trit::Trit;
-use crate::verdict::PropertyVerdict;
+use crate::verdict::{PropertyVerdict, VacuityWitness, VerdictRefinement};
 
 /// Max CEGAR refinement iterations for the scalable recoverability path — a sensible
 /// default: a pure state-atom `AG EF` target either decides at the seed abstraction or
@@ -1071,6 +1071,72 @@ pub fn verify_recoverability_with_predicates(
     }
 }
 
+/// Phase 0 of the refined-verdicts plan (`.claude/plans/refined-verdicts-assumption-discovery.md`):
+/// the recoverability verdict PLUS a structured [`VerdictRefinement`] carried alongside it. Today it
+/// attaches a `Vacuous` witness (the target is never reachable) and the best-effort `bot_diagnosis`
+/// "why ⊥" hint; later phases add the config partition (capability A) and discovered assumptions
+/// (capability B) to the SAME object. The canonical [`PropertyVerdict`] is UNCHANGED — the refinement
+/// is diagnostic-only and never turns a ⊥ into a bare `Holds` (an assumption/config scope is not a
+/// sound unconditional verdict). Sidecar-free: operates on the same BTOR2 content the plain verb uses.
+pub fn verify_recoverability_refined(
+    btor2_content: &str,
+    good: &str,
+) -> (PropertyVerdict, VerdictRefinement) {
+    let verdict = verify_recoverability_with_predicates(btor2_content, good, &[])
+        .unwrap_or(PropertyVerdict::Unknown);
+    let mut refinement = VerdictRefinement::default();
+
+    // Vacuity probe — only for a non-`Holds` verdict (a `Holds` target is trivially reachable). A
+    // sound `Unreachable` from the reachability portfolio (never emitted on free-init state) means
+    // the target is never entered ⇒ the `AG EF(good)` verdict is degenerate.
+    if verdict != PropertyVerdict::Holds
+        && let Some(vac) = probe_vacuous(btor2_content, good)
+    {
+        refinement.vacuous = Some(vac);
+    }
+
+    // Structural "why ⊥ / what would decide it" hint — only meaningful when genuinely undecided.
+    if verdict == PropertyVerdict::Unknown {
+        let diag = diagnose_recoverability_bot(btor2_content, good);
+        if !diag.is_empty() {
+            refinement.bot_diagnosis = Some(diag);
+        }
+    }
+    (verdict, refinement)
+}
+
+/// SOUND vacuity probe: is `good` (a `REG == VALUE` atom) reachable from the initial state? Emits a
+/// `bad = (REG == VALUE)` monitor — via the `AG(REG != VALUE)` monitor, whose `bad` is exactly
+/// `!(REG != VALUE) = (REG == VALUE) = good` — and asks the reachability portfolio. A sound
+/// `Unreachable` ⇒ `good` is never reached ⇒ vacuous. `None` when the atom is not a `REG == VALUE`
+/// equality, or the probe cannot run (a hint is never load-bearing — never changes a verdict).
+fn probe_vacuous(btor2_content: &str, good: &str) -> Option<VacuityWitness> {
+    use crate::adapter::btor2::bad_monitor::emit_ag_state_atom_monitor;
+    use crate::adapter::reach_portfolio::{ReachVerdict, decide_reach_portfolio};
+    let (register, value) = match parse_predicate_expr(good).ok()? {
+        PredicateExpr::Cmp {
+            register,
+            op: CmpOp::Eq,
+            value,
+        } => (register, value),
+        _ => return None, // relational / inequality target: no vacuity determination here
+    };
+    let monitored =
+        emit_ag_state_atom_monitor(btor2_content, &register, CmpOp::Ne, value as u128, false)
+            .ok()?;
+    let file = crate::adapter::btor2::parser::parse(&monitored).ok()?;
+    match decide_reach_portfolio(&file).verdict {
+        ReachVerdict::Unreachable => Some(VacuityWitness {
+            good_unreachable: true,
+            note: format!(
+                "`{good}` is never reachable from the initial state — `AG EF({good})` is degenerate \
+                 (the recovery target is never entered); the verdict is vacuous, not a meaningful decide"
+            ),
+        }),
+        _ => None, // Reachable, or Unknown/Contradiction ⇒ not (soundly) vacuous
+    }
+}
+
 /// Harness / attribution seam — run ONLY the SPCR pre-pass ([`array_prophecy::spcr`]), then the
 /// exact ROBDD on the array-free result. Isolates SPCR's contribution, which is otherwise embedded
 /// inside [`verify_recoverability_scalable`] (so a `dflt`/`wp` HOLDS on an array-content case cannot
@@ -1194,7 +1260,7 @@ fn verify_recoverability_counter_abstracted(
 /// so a ⊥ becomes ACTIONABLE ("what would it take to decide this?") instead of a bare "don't know".
 /// Purely a diagnostic: it NEVER produces or changes a verdict. Localizes the structural obstacles in
 /// the good's recovery cone that the predicate abstraction cannot cross.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RecoverabilityBotDiagnosis {
     /// Down-counters that GATE the recovery (in the good's cone, not read by the good) whose descent
     /// is NOT ranking-certified — a fairness-gated reload or a non-affine descent: `(name, width)`.
@@ -3369,6 +3435,41 @@ mod tests {
         );
         assert!(diag.hint().contains("wide data/config state"));
         assert!(!diag.is_empty());
+    }
+
+    /// Refined verdict (Phase 0) — a HOLDS design carries an EMPTY refinement: the target is
+    /// recoverable (so not vacuous) and the verdict is definite (so no ⊥ hint). `flag` toggles, so
+    /// `AG EF(flag==0)` HOLDS.
+    #[test]
+    fn refined_verdict_holds_design_has_empty_refinement() {
+        const TOGGLE: &str =
+            "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 not 1 2\n6 next 1 2 5\n";
+        let (verdict, refinement) = verify_recoverability_refined(TOGGLE, "flag == 0");
+        assert_eq!(verdict, PropertyVerdict::Holds);
+        assert!(
+            refinement.is_empty(),
+            "a definite, recoverable HOLDS needs no refinement: {refinement:?}"
+        );
+    }
+
+    /// Refined verdict (Phase 0) — a design whose target is NEVER reachable is flagged `Vacuous`:
+    /// `flag` is init 0 and stuck at 0 (`next = 0`), so `flag == 1` is unreachable and `AG EF(flag==1)`
+    /// is degenerate. The canonical verdict is NOT Holds; the refinement carries the vacuity witness.
+    #[test]
+    fn refined_verdict_vacuous_target_is_flagged() {
+        const STUCK: &str =
+            "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 next 1 2 3\n";
+        let (verdict, refinement) = verify_recoverability_refined(STUCK, "flag == 1");
+        assert_ne!(
+            verdict,
+            PropertyVerdict::Holds,
+            "a stuck-at-0 flag can never recover to 1"
+        );
+        let vac = refinement
+            .vacuous
+            .expect("an unreachable target must be flagged Vacuous");
+        assert!(vac.good_unreachable);
+        assert!(vac.note.contains("never reachable"));
     }
 
     /// Actionable-⊥ diagnosis — a recovery target riding only NARROW control state localizes NO

--- a/crates/mununu-core/src/verdict.rs
+++ b/crates/mununu-core/src/verdict.rs
@@ -32,6 +32,110 @@ pub enum PropertyVerdict {
     Skipped,
 }
 
+/// A structured elaboration of a [`PropertyVerdict`], carried ALONGSIDE the canonical verdict —
+/// never replacing it. `None`/empty on the common path. This is how a bare `⊥`/`violated` becomes an
+/// *actionable* result: which configs hold, under what assumption it would hold, or that the target is
+/// simply never reachable. It follows the same contract as the cube-cell / countertrace detail Track I
+/// already carries: **a refinement is a diagnostic and NEVER changes the canonical verdict** — a
+/// config-scoped or assumption-scoped result keeps the canonical verdict `Unknown` (the honest
+/// unconditional answer; an assumption is not monotone for `AG EF`, so it cannot soundly transfer).
+///
+/// Phases (see `.claude/plans/refined-verdicts-assumption-discovery.md`): Phase 0 populates
+/// [`Self::vacuous`] + [`Self::bot_diagnosis`]; Phase 1 populates [`Self::config_partition`]; Phase 2
+/// populates [`Self::holds_under`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VerdictRefinement {
+    /// The recovery target is never reachable from the initial state — `AG EF(good)` is degenerate
+    /// (the target is never entered), so the plain verdict is misleading. A SOUND witness (the
+    /// reachability portfolio proved `good` unreachable; only emitted when that proof is sound —
+    /// i.e. not on free-init state, per `ReachVerdict::Unreachable`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub vacuous: Option<VacuityWitness>,
+    /// A config-scoped partition: the property depends on config values (Phase 1 / capability A).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub config_partition: Option<ConfigPartition>,
+    /// Environment assumption(s) under which the property holds (Phase 2 / capability B). Each is a
+    /// CONDITIONAL result (`HoldsUnder(φ)`) — the canonical verdict stays `Unknown`.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub holds_under: Vec<DiscoveredAssumption>,
+    /// The best-effort structural "why ⊥ / what would decide it" hint (promoted from the standalone
+    /// [`crate::adapter::recoverability::diagnose_recoverability_bot`]).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub bot_diagnosis: Option<crate::adapter::recoverability::RecoverabilityBotDiagnosis>,
+}
+
+impl VerdictRefinement {
+    /// True when no refinement was produced — the bare canonical verdict stands.
+    pub fn is_empty(&self) -> bool {
+        self.vacuous.is_none()
+            && self.config_partition.is_none()
+            && self.holds_under.is_empty()
+            && self.bot_diagnosis.is_none()
+    }
+}
+
+/// See [`VerdictRefinement::vacuous`]. The recovery target is never reached.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VacuityWitness {
+    /// `good` is unreachable from the initial state (a sound reachability-portfolio `Unreachable`).
+    pub good_unreachable: bool,
+    /// A one-line, user-facing explanation.
+    pub note: String,
+}
+
+/// A concrete assignment of config leaves to values — one point in the config space.
+pub type ConfigValuation = Vec<(String, u64)>;
+
+/// See [`VerdictRefinement::config_partition`]. The property's verdict partitioned over the config
+/// leaves the recovery rides on. Sound per cell (each is a concrete pinned model decided by
+/// exact-symbolic); `exhaustive` is true ONLY when the enumerated config set is the complete reachable
+/// set. (Populated in Phase 1.)
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ConfigPartition {
+    /// The config leaves case-split on: `(name, width)`.
+    pub config_atoms: Vec<(String, u32)>,
+    /// Config valuations for which the property HOLDS.
+    pub holds: Vec<ConfigValuation>,
+    /// … for which it is VIOLATED.
+    pub violated: Vec<ConfigValuation>,
+    /// … for which it stayed ⊥ even pinned.
+    pub unknown: Vec<ConfigValuation>,
+    /// … for which the target is vacuous (never reached under that config).
+    pub vacuous: Vec<ConfigValuation>,
+    /// True iff the enumerated config set is the COMPLETE reachable config set (else the partition is
+    /// over the enumerated/reachable subset only).
+    pub exhaustive: bool,
+    /// The deciding engine, for provenance (e.g. `"exact-symbolic per-config pin"`).
+    pub engine: String,
+}
+
+/// The shape of a discovered environment assumption.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum AssumptionKind {
+    /// An input held at a constant value (`en = 1`).
+    InputHold,
+    /// A finite input schedule (a command sequence).
+    InputSchedule,
+    /// "Reset is eventually asserted."
+    ResetEventually,
+    /// A synthesized environment strategy (Mealy contract).
+    EnvStrategy,
+}
+
+/// See [`VerdictRefinement::holds_under`]. A CONDITIONAL result: the property holds under `phi`.
+/// (Populated in Phase 2.)
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DiscoveredAssumption {
+    /// A human-readable predicate over named inputs (Phase 2b may carry a typed schedule/strategy).
+    pub phi: String,
+    /// The assumption's shape.
+    pub kind: AssumptionKind,
+    /// True iff `good` is genuinely reached under `phi` (the non-vacuity gate passed).
+    pub non_vacuous: bool,
+    /// The engine that discovered it, for provenance.
+    pub engine: String,
+}
+
 impl PropertyVerdict {
     /// The stable lowercase label — identical across CLI, HTTP API, and UI.
     pub fn as_str(self) -> &'static str {
@@ -82,6 +186,46 @@ impl From<ExactVerdict> for PropertyVerdict {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn verdict_refinement_default_is_empty_and_serde_round_trips() {
+        // Common path: an empty refinement serializes to `{}` (every field is skip-if-empty) so it is
+        // a zero-cost optional detail on the surfaces.
+        let empty = VerdictRefinement::default();
+        assert!(empty.is_empty());
+        assert_eq!(serde_json::to_string(&empty).unwrap(), "{}");
+
+        // A populated refinement (vacuity + a config partition + an assumption) round-trips.
+        let full = VerdictRefinement {
+            vacuous: Some(VacuityWitness {
+                good_unreachable: true,
+                note: "never reached".into(),
+            }),
+            config_partition: Some(ConfigPartition {
+                config_atoms: vec![("cfg".into(), 4)],
+                holds: vec![vec![("cfg".into(), 15)]],
+                violated: vec![vec![("cfg".into(), 0)]],
+                unknown: vec![],
+                vacuous: vec![],
+                exhaustive: true,
+                engine: "exact-symbolic per-config pin".into(),
+            }),
+            holds_under: vec![DiscoveredAssumption {
+                phi: "rst eventually".into(),
+                kind: AssumptionKind::ResetEventually,
+                non_vacuous: true,
+                engine: "native-bmc".into(),
+            }],
+            bot_diagnosis: None,
+        };
+        assert!(!full.is_empty());
+        let json = serde_json::to_string(&full).unwrap();
+        let back: VerdictRefinement = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            full, back,
+            "VerdictRefinement must survive a JSON round-trip"
+        );
+    }
 
     #[test]
     fn labels_are_the_canonical_vocabulary() {


### PR DESCRIPTION
**Phase 0 (slice 1) of the refined-verdicts plan** ([.claude/plans/refined-verdicts-assumption-discovery.md](.claude/plans/refined-verdicts-assumption-discovery.md)) — the foundation that turns a flat ⊥/violated into a **structured, actionable result**, built first so the two analyses (config-partition = capability A; assumption discovery = capability B) plug into a stable contract.

## What this adds
- **`VerdictRefinement`** (+ `VacuityWitness`, `ConfigPartition`, `DiscoveredAssumption`, `AssumptionKind`) in [verdict.rs](crates/mununu-core/src/verdict.rs), serde-ready. Carried **alongside** the canonical `PropertyVerdict` (never replaces it) — the same "detail rides with the verdict" contract verdict.rs already documents and Track I already uses (cube cells / countertraces). Empty on the common path (serializes to `{}`).
- serde on `RecoverabilityBotDiagnosis` (it becomes a refinement field; the API slice needs it).
- **`verify_recoverability_refined(btor2, good) -> (PropertyVerdict, VerdictRefinement)`**: canonical verdict **unchanged**, plus (a) a **sound `Vacuous` probe** — emit `bad = (reg==value)` via `emit_ag_state_atom_monitor(reg, Ne, value)` (whose `bad` is exactly the target) and ask `decide_reach_portfolio`; a sound `Unreachable` (never on free-init) ⇒ the target is never entered ⇒ the `AG EF` verdict is degenerate — and (b) the existing `diagnose_recoverability_bot` "why ⊥" hint when Unknown.

## Soundness
The refinement is **diagnostic-only and never changes the canonical verdict** (a config/assumption scope is not a sound unconditional Holds — assumptions aren't monotone for `AG EF`). `Vacuous` is emitted only on a sound `ReachVerdict::Unreachable`.

## Scope / surface
**Internal foundation — no user-visible surface yet** (so no surface-parity obligation this PR; surfaces land in the follow-up slices: CLI `--refine`, API model + handler, UI type + renderer, ledger §D actionable-⊥ % metric). Sidecar-free by construction: operates on the same lifted BTOR2 the plain verb uses.

## Tests
HOLDS design → empty refinement; stuck-at-0 target → `Vacuous` flagged; `VerdictRefinement` serde round-trip (empty→`{}`, populated→identity). Full mununu-core lib suite green (pre-commit hook).

Engine (§16): `exact-symbolic` / reachability portfolio for the `Vacuous` probe; no new external tool (capability A stays tool-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)