### PR TITLE
--refine surface across CLI + API + UI (refined-verdicts Phase 0b–0d)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -729,6 +729,12 @@ struct Btor2VerifyRecoverabilityArgs {
     /// with none.
     #[arg(long = "predicate", value_name = "NAME:REG=VALUE")]
     predicate: Vec<String>,
+    /// Also emit a structured `refinement` alongside the verdict: a `vacuous` witness when the target
+    /// is never reachable (the `AG EF` is degenerate), and a best-effort "why ⊥ / what would decide it"
+    /// hint. Diagnostic-only — it never changes the canonical verdict. (The config-partition +
+    /// discovered-assumption refinements arrive in later phases.)
+    #[arg(long = "refine")]
+    refine: bool,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -1806,6 +1812,11 @@ struct SvVerifyRecoverabilityArgs {
     /// escalation is automatic even with none.
     #[arg(long = "predicate", value_name = "NAME:REG=VALUE")]
     predicate: Vec<String>,
+    /// Also emit a structured `refinement` alongside the verdict: a `vacuous` witness when the target
+    /// is never reachable, and a best-effort "why ⊥ / what would decide it" hint. Diagnostic-only —
+    /// never changes the canonical verdict. (Config-partition + assumption discovery arrive later.)
+    #[arg(long = "refine")]
+    refine: bool,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2677,7 +2688,8 @@ fn btor2_check_fsm(args: Btor2CheckFsmArgs) -> Result<(), String> {
 /// `POST /api/v1/btor2/verify-recoverability`.
 fn btor2_verify_recoverability(args: Btor2VerifyRecoverabilityArgs) -> Result<(), String> {
     use mununu_core::adapter::recoverability::{
-        parse_extra_predicate, recoverability_property_str, verify_recoverability_with_predicates,
+        parse_extra_predicate, recoverability_property_str, verify_recoverability_refined,
+        verify_recoverability_with_predicates,
     };
 
     let content = std::fs::read_to_string(&args.file)
@@ -2687,13 +2699,23 @@ fn btor2_verify_recoverability(args: Btor2VerifyRecoverabilityArgs) -> Result<()
         .iter()
         .map(|s| parse_extra_predicate(s))
         .collect::<Result<Vec<_>, _>>()?;
-    let verdict = verify_recoverability_with_predicates(&content, &args.target, &extra)?;
 
-    let summary = serde_json::json!({
+    let mut summary = serde_json::json!({
         "file": args.file.display().to_string(),
         "property": recoverability_property_str(&args.target),
-        "verdict": verdict.as_str(),
     });
+    // `--refine` (refined-verdicts Phase 0): the canonical verdict PLUS a structured, diagnostic-only
+    // refinement carried alongside it (never changes the verdict). Without it, the plain verdict path.
+    let verdict = if args.refine {
+        let (verdict, refinement) = verify_recoverability_refined(&content, &args.target, &extra);
+        summary["refinement"] =
+            serde_json::to_value(&refinement).map_err(|e| format!("serialize refinement: {e}"))?;
+        verdict
+    } else {
+        verify_recoverability_with_predicates(&content, &args.target, &extra)?
+    };
+    summary["verdict"] = serde_json::Value::String(verdict.as_str().to_string());
+
     println!(
         "{}",
         serde_json::to_string_pretty(&summary).map_err(|e| format!("serialize summary: {e}"))?
@@ -5291,7 +5313,9 @@ fn sv_verify_recoverability(args: SvVerifyRecoverabilityArgs) -> Result<(), Stri
     use mununu_core::adapter::recoverability::{
         parse_extra_predicate, recoverability_property_str,
     };
-    use mununu_core::adapter::sv_verify::sv_verify_recoverability_with_predicates;
+    use mununu_core::adapter::sv_verify::{
+        sv_verify_recoverability_refined, sv_verify_recoverability_with_predicates,
+    };
 
     let file = args.lift.primary_display();
     let extra = args
@@ -5299,13 +5323,22 @@ fn sv_verify_recoverability(args: SvVerifyRecoverabilityArgs) -> Result<(), Stri
         .iter()
         .map(|s| parse_extra_predicate(s))
         .collect::<Result<Vec<_>, _>>()?;
-    let verdict =
-        sv_verify_recoverability_with_predicates(&read_sv_lift(&args.lift)?, &args.target, &extra)?;
-    let summary = serde_json::json!({
+    let lift = read_sv_lift(&args.lift)?;
+
+    let mut summary = serde_json::json!({
         "file": file,
         "property": recoverability_property_str(&args.target),
-        "verdict": verdict.as_str(),
     });
+    let verdict = if args.refine {
+        let (verdict, refinement) = sv_verify_recoverability_refined(&lift, &args.target, &extra)?;
+        summary["refinement"] =
+            serde_json::to_value(&refinement).map_err(|e| format!("serialize refinement: {e}"))?;
+        verdict
+    } else {
+        sv_verify_recoverability_with_predicates(&lift, &args.target, &extra)?
+    };
+    summary["verdict"] = serde_json::Value::String(verdict.as_str().to_string());
+
     print_json_summary(&summary)?;
     ci_gate_exit(verdict.as_str(), args.ci.fail_on);
     Ok(())

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1081,8 +1081,9 @@ pub fn verify_recoverability_with_predicates(
 pub fn verify_recoverability_refined(
     btor2_content: &str,
     good: &str,
+    extra_predicates: &[PredicateSpec],
 ) -> (PropertyVerdict, VerdictRefinement) {
-    let verdict = verify_recoverability_with_predicates(btor2_content, good, &[])
+    let verdict = verify_recoverability_with_predicates(btor2_content, good, extra_predicates)
         .unwrap_or(PropertyVerdict::Unknown);
     let mut refinement = VerdictRefinement::default();
 
@@ -3444,7 +3445,7 @@ mod tests {
     fn refined_verdict_holds_design_has_empty_refinement() {
         const TOGGLE: &str =
             "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 not 1 2\n6 next 1 2 5\n";
-        let (verdict, refinement) = verify_recoverability_refined(TOGGLE, "flag == 0");
+        let (verdict, refinement) = verify_recoverability_refined(TOGGLE, "flag == 0", &[]);
         assert_eq!(verdict, PropertyVerdict::Holds);
         assert!(
             refinement.is_empty(),
@@ -3459,7 +3460,7 @@ mod tests {
     fn refined_verdict_vacuous_target_is_flagged() {
         const STUCK: &str =
             "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 next 1 2 3\n";
-        let (verdict, refinement) = verify_recoverability_refined(STUCK, "flag == 1");
+        let (verdict, refinement) = verify_recoverability_refined(STUCK, "flag == 1", &[]);
         assert_ne!(
             verdict,
             PropertyVerdict::Holds,

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -134,6 +134,28 @@ pub fn sv_verify_recoverability_with_predicates(
     verify_recoverability_with_predicates(&btor2, target, extra_predicates)
 }
 
+/// `sv verify-recoverability --refine` — lift SV and decide `AG EF target`, returning the canonical
+/// verdict PLUS a structured [`VerdictRefinement`] (the `Vacuous`/`bot_diagnosis` today; the config
+/// partition and discovered assumptions in later phases). The refinement is diagnostic-only — it never
+/// changes the canonical verdict. Sidecar-free (operates on the same lift as the plain verb).
+pub fn sv_verify_recoverability_refined(
+    lift: &SvLift,
+    target: &str,
+    extra_predicates: &[PredicateSpec],
+) -> Result<(PropertyVerdict, crate::verdict::VerdictRefinement), String> {
+    parse_predicate_expr(target).map_err(|e| {
+        format!("recoverability target `{target}` is not a register-comparison atom: {e:?}")
+    })?;
+    let btor2 = lift.lift()?;
+    Ok(
+        crate::adapter::recoverability::verify_recoverability_refined(
+            &btor2,
+            target,
+            extra_predicates,
+        ),
+    )
+}
+
 /// `sv check-fsm` — lift SV and auto-scan every FSM-like state register for a reachable
 /// illegal encoding (no user input). The SV-direct peer of `btor2 check-fsm`.
 pub fn sv_check_fsm(

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -789,7 +789,8 @@ pub async fn btor2_verify_recoverability_handler(
     Json(request): Json<Btor2VerifyRecoverabilityRequest>,
 ) -> ApiResult<Json<Btor2VerifyRecoverabilityResponse>> {
     use crate::adapter::recoverability::{
-        parse_extra_predicate, recoverability_property_str, verify_recoverability_with_predicates,
+        parse_extra_predicate, recoverability_property_str, verify_recoverability_refined,
+        verify_recoverability_with_predicates,
     };
 
     let extra = request
@@ -801,15 +802,23 @@ pub async fn btor2_verify_recoverability_handler(
             message,
             details: None,
         })?;
-    let verdict = verify_recoverability_with_predicates(&request.content, &request.target, &extra)
-        .map_err(|message| ApiError::BadRequest {
-            message,
-            details: None,
-        })?;
+    // `refine` (refined-verdicts Phase 0): canonical verdict PLUS a diagnostic-only refinement.
+    let (verdict, refinement) = if request.refine {
+        let (v, r) = verify_recoverability_refined(&request.content, &request.target, &extra);
+        (v, Some(r))
+    } else {
+        let v = verify_recoverability_with_predicates(&request.content, &request.target, &extra)
+            .map_err(|message| ApiError::BadRequest {
+                message,
+                details: None,
+            })?;
+        (v, None)
+    };
 
     Ok(Json(Btor2VerifyRecoverabilityResponse {
         verdict: verdict.as_str().to_string(),
         property: recoverability_property_str(&request.target),
+        refinement,
     }))
 }
 
@@ -1000,7 +1009,9 @@ pub async fn sv_verify_recoverability_handler(
     Json(request): Json<SvVerifyRecoverabilityRequest>,
 ) -> ApiResult<Json<Btor2VerifyRecoverabilityResponse>> {
     use crate::adapter::recoverability::{parse_extra_predicate, recoverability_property_str};
-    use crate::adapter::sv_verify::{SvLift, sv_verify_recoverability_with_predicates};
+    use crate::adapter::sv_verify::{
+        SvLift, sv_verify_recoverability_refined, sv_verify_recoverability_with_predicates,
+    };
 
     let property = recoverability_property_str(&request.target);
     let extra = request
@@ -1031,14 +1042,27 @@ pub async fn sv_verify_recoverability_handler(
             crate::adapter::yosys::SvFrontend::Auto
         },
     };
-    let verdict = sv_verify_recoverability_with_predicates(&lift, &request.target, &extra)
-        .map_err(|message| ApiError::BadRequest {
-            message,
-            details: None,
-        })?;
+    let (verdict, refinement) = if request.refine {
+        let (v, r) = sv_verify_recoverability_refined(&lift, &request.target, &extra).map_err(
+            |message| ApiError::BadRequest {
+                message,
+                details: None,
+            },
+        )?;
+        (v, Some(r))
+    } else {
+        let v = sv_verify_recoverability_with_predicates(&lift, &request.target, &extra).map_err(
+            |message| ApiError::BadRequest {
+                message,
+                details: None,
+            },
+        )?;
+        (v, None)
+    };
     Ok(Json(Btor2VerifyRecoverabilityResponse {
         verdict: verdict.as_str().to_string(),
         property,
+        refinement,
     }))
 }
 
@@ -4421,12 +4445,35 @@ members = ["x"]
             content: LIVENESS_STALLER.to_string(),
             target: "st == 0".to_string(),
             predicates: Vec::new(),
+            refine: false,
         };
         let Json(out) = btor2_verify_recoverability_handler(Json(request))
             .await
             .expect("verify-recoverability runs");
         assert_eq!(out.verdict, "violated", "response: {out:?}");
         assert_eq!(out.property, "AG EF (st == 0)");
+        assert!(out.refinement.is_none(), "no refinement without `refine`");
+    }
+
+    /// `refine: true` carries a structured refinement alongside the verdict (refined-verdicts
+    /// Phase 0). A stuck-at-0 flag can never recover to 1, so the target is flagged `vacuous`.
+    #[tokio::test]
+    async fn btor2_verify_recoverability_refine_flags_vacuous_target() {
+        const STUCK: &str =
+            "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 next 1 2 3\n";
+        let request = Btor2VerifyRecoverabilityRequest {
+            content: STUCK.to_string(),
+            target: "flag == 1".to_string(),
+            predicates: Vec::new(),
+            refine: true,
+        };
+        let Json(out) = btor2_verify_recoverability_handler(Json(request))
+            .await
+            .expect("verify-recoverability --refine runs");
+        assert_ne!(out.verdict, "holds");
+        let refinement = out.refinement.expect("refine returns a refinement");
+        let vac = refinement.vacuous.expect("unreachable target is vacuous");
+        assert!(vac.good_unreachable);
     }
 
     #[tokio::test]
@@ -4435,6 +4482,7 @@ members = ["x"]
             content: LIVENESS_STALLER.to_string(),
             target: "definitely not an atom".to_string(),
             predicates: Vec::new(),
+            refine: false,
         };
         let err = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4528,6 +4576,7 @@ members = ["x"]
             use_slang: false,
             target: "not an atom !!".to_string(),
             predicates: Vec::new(),
+            refine: false,
         };
         let err = sv_verify_recoverability_handler(Json(request))
             .await

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1008,6 +1008,11 @@ pub struct Btor2VerifyRecoverabilityRequest {
     /// (over the ~40-bit cone cap); the escalation is automatic even with none.
     #[serde(default)]
     pub predicates: Vec<String>,
+    /// Also compute a structured [`crate::verdict::VerdictRefinement`] alongside the verdict — a
+    /// `vacuous` witness when the target is never reachable, and a "why ⊥" hint. Diagnostic-only:
+    /// it never changes the canonical verdict. (Mirrors the CLI `--refine`.)
+    #[serde(default)]
+    pub refine: bool,
 }
 
 /// Response for `POST /api/v1/btor2/verify-recoverability`.
@@ -1020,6 +1025,10 @@ pub struct Btor2VerifyRecoverabilityResponse {
     pub verdict: String,
     /// The decided property, echoed for provenance: `AG EF (<target>)`.
     pub property: String,
+    /// The structured refinement, when `refine` was requested and it produced one. `None` otherwise.
+    /// Diagnostic detail carried ALONGSIDE the verdict — never changes it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refinement: Option<crate::verdict::VerdictRefinement>,
 }
 
 /// Request for the auto FSM illegal-encoding scan
@@ -1163,6 +1172,10 @@ pub struct SvVerifyRecoverabilityRequest {
     /// `"NAME:REGISTER=VALUE"` (P2 Slice 1). Used only when the exact engine abstains.
     #[serde(default)]
     pub predicates: Vec<String>,
+    /// Also compute a structured `refinement` alongside the verdict (mirrors the CLI `--refine`).
+    /// Diagnostic-only — never changes the canonical verdict.
+    #[serde(default)]
+    pub refine: bool,
 }
 
 /// Request for `POST /api/v1/sv/check-fsm` — the SV lift fields plus the FSM width


### PR DESCRIPTION
Wires the Phase-0 `VerdictRefinement` producer (#414) to all three surfaces behind an opt-in `refine` flag — the **canonical verdict is unchanged**; the structured refinement (today: a `Vacuous` witness + the "why ⊥" hint) rides *alongside* it, never replacing it.

## Surfaces (parity, one pass)
- **CLI:** `--refine` on `btor2 verify-recoverability` and `sv verify-recoverability`; emits a `"refinement"` JSON object (`{}` when there's nothing to refine, e.g. a definite HOLDS).
- **API:** `refine: bool` on `Btor2VerifyRecoverabilityRequest` + `SvVerifyRecoverabilityRequest`; `refinement: Option<VerdictRefinement>` on the shared response; handlers route through the refined producer when set.
- **UI:** the typed client (`mununu-ui/src/api/endpoints.ts`) gains the `VerdictRefinement` type + the `refine`/`refinement` fields — **mununu-ui PR #56**.

## Core
`verify_recoverability_refined` now honours the same `--predicate` cube-escalation extras as the plain verb; new `sv_verify_recoverability_refined` lifts + calls it. **Sidecar-free** by construction (same lifted BTOR2 as the plain verb).

## Validation
- Smoke test (CLI): `STUCK`→`vacuous` witness; `TOGGLE`→`{}`; plain path (no `--refine`)→output unchanged.
- API handler test: `refine: true` on a stuck-at-0 target → `vacuous` flagged; plain path → no `refinement`.
- UI type-check + lint + prettier green.

Engine (§16): reachability portfolio / `exact-symbolic` for the `Vacuous` probe; no new external tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)