### PR TITLE
--config-values config-partition surface (refined-verdicts Phase 1 slice 2)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -731,10 +731,15 @@ struct Btor2VerifyRecoverabilityArgs {
     predicate: Vec<String>,
     /// Also emit a structured `refinement` alongside the verdict: a `vacuous` witness when the target
     /// is never reachable (the `AG EF` is degenerate), and a best-effort "why ⊥ / what would decide it"
-    /// hint. Diagnostic-only — it never changes the canonical verdict. (The config-partition +
-    /// discovered-assumption refinements arrive in later phases.)
+    /// hint. Diagnostic-only — it never changes the canonical verdict.
     #[arg(long = "refine")]
     refine: bool,
+    /// Config-partition (refined-verdicts capability A): name config INPUTS to split the verdict over,
+    /// each `NAME=v1,v2,...` (repeatable). The refinement then reports a `config_partition` — "holds
+    /// for configs {A}, violated for {B}" — decided exactly per config (sound per cell). Implies the
+    /// refined output. Best for a NARROW / few-value config (the cross-product is capped).
+    #[arg(long = "config-values", value_name = "NAME=v1,v2,...")]
+    config_values: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -1814,9 +1819,14 @@ struct SvVerifyRecoverabilityArgs {
     predicate: Vec<String>,
     /// Also emit a structured `refinement` alongside the verdict: a `vacuous` witness when the target
     /// is never reachable, and a best-effort "why ⊥ / what would decide it" hint. Diagnostic-only —
-    /// never changes the canonical verdict. (Config-partition + assumption discovery arrive later.)
+    /// never changes the canonical verdict.
     #[arg(long = "refine")]
     refine: bool,
+    /// Config-partition (refined-verdicts capability A): name config INPUTS to split the verdict over,
+    /// each `NAME=v1,v2,...` (repeatable) → the refinement reports a `config_partition`, decided exactly
+    /// per config. Implies the refined output. Best for a narrow / few-value config (cross-product capped).
+    #[arg(long = "config-values", value_name = "NAME=v1,v2,...")]
+    config_values: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2688,8 +2698,8 @@ fn btor2_check_fsm(args: Btor2CheckFsmArgs) -> Result<(), String> {
 /// `POST /api/v1/btor2/verify-recoverability`.
 fn btor2_verify_recoverability(args: Btor2VerifyRecoverabilityArgs) -> Result<(), String> {
     use mununu_core::adapter::recoverability::{
-        parse_extra_predicate, recoverability_property_str, verify_recoverability_refined,
-        verify_recoverability_with_predicates,
+        parse_config_value_specs, parse_extra_predicate, recoverability_property_str,
+        verify_recoverability_refined, verify_recoverability_with_predicates,
     };
 
     let content = std::fs::read_to_string(&args.file)
@@ -2699,15 +2709,18 @@ fn btor2_verify_recoverability(args: Btor2VerifyRecoverabilityArgs) -> Result<()
         .iter()
         .map(|s| parse_extra_predicate(s))
         .collect::<Result<Vec<_>, _>>()?;
+    let config_specs = parse_config_value_specs(&args.config_values)?;
 
     let mut summary = serde_json::json!({
         "file": args.file.display().to_string(),
         "property": recoverability_property_str(&args.target),
     });
-    // `--refine` (refined-verdicts Phase 0): the canonical verdict PLUS a structured, diagnostic-only
-    // refinement carried alongside it (never changes the verdict). Without it, the plain verdict path.
-    let verdict = if args.refine {
-        let (verdict, refinement) = verify_recoverability_refined(&content, &args.target, &extra);
+    // `--refine` / `--config-values` (refined-verdicts): the canonical verdict PLUS a structured,
+    // diagnostic-only refinement (Vacuous / bot-diagnosis / config-partition) — never changes the
+    // verdict. Without either, the plain verdict path.
+    let verdict = if args.refine || !config_specs.is_empty() {
+        let (verdict, refinement) =
+            verify_recoverability_refined(&content, &args.target, &extra, &config_specs);
         summary["refinement"] =
             serde_json::to_value(&refinement).map_err(|e| format!("serialize refinement: {e}"))?;
         verdict
@@ -5311,7 +5324,7 @@ fn sv_verify_liveness_all(args: SvVerifyLivenessAllArgs) -> Result<(), String> {
 /// `mununu sv verify-recoverability` — lift SV and decide `AG EF good`.
 fn sv_verify_recoverability(args: SvVerifyRecoverabilityArgs) -> Result<(), String> {
     use mununu_core::adapter::recoverability::{
-        parse_extra_predicate, recoverability_property_str,
+        parse_config_value_specs, parse_extra_predicate, recoverability_property_str,
     };
     use mununu_core::adapter::sv_verify::{
         sv_verify_recoverability_refined, sv_verify_recoverability_with_predicates,
@@ -5323,14 +5336,16 @@ fn sv_verify_recoverability(args: SvVerifyRecoverabilityArgs) -> Result<(), Stri
         .iter()
         .map(|s| parse_extra_predicate(s))
         .collect::<Result<Vec<_>, _>>()?;
+    let config_specs = parse_config_value_specs(&args.config_values)?;
     let lift = read_sv_lift(&args.lift)?;
 
     let mut summary = serde_json::json!({
         "file": file,
         "property": recoverability_property_str(&args.target),
     });
-    let verdict = if args.refine {
-        let (verdict, refinement) = sv_verify_recoverability_refined(&lift, &args.target, &extra)?;
+    let verdict = if args.refine || !config_specs.is_empty() {
+        let (verdict, refinement) =
+            sv_verify_recoverability_refined(&lift, &args.target, &extra, &config_specs)?;
         summary["refinement"] =
             serde_json::to_value(&refinement).map_err(|e| format!("serialize refinement: {e}"))?;
         verdict

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1082,10 +1082,21 @@ pub fn verify_recoverability_refined(
     btor2_content: &str,
     good: &str,
     extra_predicates: &[PredicateSpec],
+    config_specs: &[(String, Vec<u64>)],
 ) -> (PropertyVerdict, VerdictRefinement) {
     let verdict = verify_recoverability_with_predicates(btor2_content, good, extra_predicates)
         .unwrap_or(PropertyVerdict::Unknown);
     let mut refinement = VerdictRefinement::default();
+
+    // Config-partition (capability A) — when the caller names config inputs, partition the verdict
+    // over their values (`--config-values`). A concrete decide per config, so it composes with any
+    // canonical verdict (it can even reveal a config that breaks a HOLDS). `None` ⇒ config-independent
+    // or over the enumeration cap.
+    if !config_specs.is_empty()
+        && let Some(part) = config_partition(btor2_content, good, config_specs)
+    {
+        refinement.config_partition = Some(part);
+    }
 
     // Vacuity probe — only for a non-`Holds` verdict (a `Holds` target is trivially reachable). A
     // sound `Unreachable` from the reachability portfolio (never emitted on free-init state) means
@@ -1104,6 +1115,35 @@ pub fn verify_recoverability_refined(
         }
     }
     (verdict, refinement)
+}
+
+/// Parse `--config-values`-style entries `"NAME=v1,v2,…"` into config-partition specs
+/// `(input_name, [values])`. Reuses the decimal-value convention; a malformed entry is an error.
+pub fn parse_config_value_specs(entries: &[String]) -> Result<Vec<(String, Vec<u64>)>, String> {
+    entries
+        .iter()
+        .map(|e| {
+            let (name, vals) = e
+                .split_once('=')
+                .ok_or_else(|| format!("--config-values `{e}`: expected `NAME=v1,v2,...`"))?;
+            let name = name.trim();
+            if name.is_empty() {
+                return Err(format!("--config-values `{e}`: empty signal name"));
+            }
+            let values = vals
+                .split(',')
+                .map(|v| {
+                    v.trim()
+                        .parse::<u64>()
+                        .map_err(|_| format!("--config-values `{e}`: `{v}` is not a decimal value"))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if values.is_empty() {
+                return Err(format!("--config-values `{e}`: no values listed"));
+            }
+            Ok((name.to_string(), values))
+        })
+        .collect()
 }
 
 /// SOUND vacuity probe: is `good` (a `REG == VALUE` atom) reachable from the initial state? Emits a
@@ -3556,7 +3596,7 @@ mod tests {
     fn refined_verdict_holds_design_has_empty_refinement() {
         const TOGGLE: &str =
             "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 not 1 2\n6 next 1 2 5\n";
-        let (verdict, refinement) = verify_recoverability_refined(TOGGLE, "flag == 0", &[]);
+        let (verdict, refinement) = verify_recoverability_refined(TOGGLE, "flag == 0", &[], &[]);
         assert_eq!(verdict, PropertyVerdict::Holds);
         assert!(
             refinement.is_empty(),
@@ -3571,7 +3611,7 @@ mod tests {
     fn refined_verdict_vacuous_target_is_flagged() {
         const STUCK: &str =
             "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 next 1 2 3\n";
-        let (verdict, refinement) = verify_recoverability_refined(STUCK, "flag == 1", &[]);
+        let (verdict, refinement) = verify_recoverability_refined(STUCK, "flag == 1", &[], &[]);
         assert_ne!(
             verdict,
             PropertyVerdict::Holds,

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -142,6 +142,7 @@ pub fn sv_verify_recoverability_refined(
     lift: &SvLift,
     target: &str,
     extra_predicates: &[PredicateSpec],
+    config_specs: &[(String, Vec<u64>)],
 ) -> Result<(PropertyVerdict, crate::verdict::VerdictRefinement), String> {
     parse_predicate_expr(target).map_err(|e| {
         format!("recoverability target `{target}` is not a register-comparison atom: {e:?}")
@@ -152,6 +153,7 @@ pub fn sv_verify_recoverability_refined(
             &btor2,
             target,
             extra_predicates,
+            config_specs,
         ),
     )
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -789,8 +789,8 @@ pub async fn btor2_verify_recoverability_handler(
     Json(request): Json<Btor2VerifyRecoverabilityRequest>,
 ) -> ApiResult<Json<Btor2VerifyRecoverabilityResponse>> {
     use crate::adapter::recoverability::{
-        parse_extra_predicate, recoverability_property_str, verify_recoverability_refined,
-        verify_recoverability_with_predicates,
+        parse_config_value_specs, parse_extra_predicate, recoverability_property_str,
+        verify_recoverability_refined, verify_recoverability_with_predicates,
     };
 
     let extra = request
@@ -802,9 +802,16 @@ pub async fn btor2_verify_recoverability_handler(
             message,
             details: None,
         })?;
-    // `refine` (refined-verdicts Phase 0): canonical verdict PLUS a diagnostic-only refinement.
-    let (verdict, refinement) = if request.refine {
-        let (v, r) = verify_recoverability_refined(&request.content, &request.target, &extra);
+    let config_specs = parse_config_value_specs(&request.config_values).map_err(|message| {
+        ApiError::BadRequest {
+            message,
+            details: None,
+        }
+    })?;
+    // `refine`/`config_values` (refined-verdicts): canonical verdict PLUS a diagnostic-only refinement.
+    let (verdict, refinement) = if request.refine || !config_specs.is_empty() {
+        let (v, r) =
+            verify_recoverability_refined(&request.content, &request.target, &extra, &config_specs);
         (v, Some(r))
     } else {
         let v = verify_recoverability_with_predicates(&request.content, &request.target, &extra)
@@ -1008,7 +1015,9 @@ pub async fn sv_verify_liveness_all_handler(
 pub async fn sv_verify_recoverability_handler(
     Json(request): Json<SvVerifyRecoverabilityRequest>,
 ) -> ApiResult<Json<Btor2VerifyRecoverabilityResponse>> {
-    use crate::adapter::recoverability::{parse_extra_predicate, recoverability_property_str};
+    use crate::adapter::recoverability::{
+        parse_config_value_specs, parse_extra_predicate, recoverability_property_str,
+    };
     use crate::adapter::sv_verify::{
         SvLift, sv_verify_recoverability_refined, sv_verify_recoverability_with_predicates,
     };
@@ -1023,6 +1032,12 @@ pub async fn sv_verify_recoverability_handler(
             message,
             details: None,
         })?;
+    let config_specs = parse_config_value_specs(&request.config_values).map_err(|message| {
+        ApiError::BadRequest {
+            message,
+            details: None,
+        }
+    })?;
     let lift = SvLift {
         source: request.source,
         additional_sources: request
@@ -1042,13 +1057,13 @@ pub async fn sv_verify_recoverability_handler(
             crate::adapter::yosys::SvFrontend::Auto
         },
     };
-    let (verdict, refinement) = if request.refine {
-        let (v, r) = sv_verify_recoverability_refined(&lift, &request.target, &extra).map_err(
-            |message| ApiError::BadRequest {
-                message,
-                details: None,
-            },
-        )?;
+    let (verdict, refinement) = if request.refine || !config_specs.is_empty() {
+        let (v, r) =
+            sv_verify_recoverability_refined(&lift, &request.target, &extra, &config_specs)
+                .map_err(|message| ApiError::BadRequest {
+                    message,
+                    details: None,
+                })?;
         (v, Some(r))
     } else {
         let v = sv_verify_recoverability_with_predicates(&lift, &request.target, &extra).map_err(
@@ -4446,6 +4461,7 @@ members = ["x"]
             target: "st == 0".to_string(),
             predicates: Vec::new(),
             refine: false,
+            config_values: Vec::new(),
         };
         let Json(out) = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4466,6 +4482,7 @@ members = ["x"]
             target: "flag == 1".to_string(),
             predicates: Vec::new(),
             refine: true,
+            config_values: Vec::new(),
         };
         let Json(out) = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4476,6 +4493,31 @@ members = ["x"]
         assert!(vac.good_unreachable);
     }
 
+    /// `config_values` carries a config-partition (refined-verdicts capability A): `busy` recovers
+    /// unless `mode == 3`, so the partition holds for mode ∈ {0,1,2} and violates for mode == 3.
+    #[tokio::test]
+    async fn btor2_verify_recoverability_config_values_partitions_the_verdict() {
+        const MODE_DEP: &str = "1 sort bitvec 1\n2 sort bitvec 2\n3 input 1 start\n4 input 2 mode\n\
+5 state 1 busy\n6 zero 1\n7 init 1 5 6\n8 const 2 11\n9 eq 1 4 8\n10 not 1 5\n11 and 1 3 10\n\
+12 and 1 5 9\n13 or 1 11 12\n14 next 1 5 13\n";
+        let request = Btor2VerifyRecoverabilityRequest {
+            content: MODE_DEP.to_string(),
+            target: "busy == 0".to_string(),
+            predicates: Vec::new(),
+            refine: false,
+            config_values: vec!["mode=0,1,2,3".to_string()],
+        };
+        let Json(out) = btor2_verify_recoverability_handler(Json(request))
+            .await
+            .expect("verify-recoverability --config-values runs");
+        let part = out
+            .refinement
+            .and_then(|r| r.config_partition)
+            .expect("config_values yields a config_partition");
+        assert_eq!(part.holds.len(), 3, "mode ∈ {{0,1,2}} HOLD");
+        assert_eq!(part.violated, vec![vec![("mode".to_string(), 3)]]);
+    }
+
     #[tokio::test]
     async fn btor2_verify_recoverability_handler_rejects_malformed_target() {
         let request = Btor2VerifyRecoverabilityRequest {
@@ -4483,6 +4525,7 @@ members = ["x"]
             target: "definitely not an atom".to_string(),
             predicates: Vec::new(),
             refine: false,
+            config_values: Vec::new(),
         };
         let err = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4577,6 +4620,7 @@ members = ["x"]
             target: "not an atom !!".to_string(),
             predicates: Vec::new(),
             refine: false,
+            config_values: Vec::new(),
         };
         let err = sv_verify_recoverability_handler(Json(request))
             .await

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1013,6 +1013,11 @@ pub struct Btor2VerifyRecoverabilityRequest {
     /// it never changes the canonical verdict. (Mirrors the CLI `--refine`.)
     #[serde(default)]
     pub refine: bool,
+    /// Config-partition (capability A): config inputs to split the verdict over, each
+    /// `"NAME=v1,v2,..."`. The refinement then carries a `config_partition` decided exactly per config.
+    /// Implies the refined output. Mirrors the CLI `--config-values`.
+    #[serde(default)]
+    pub config_values: Vec<String>,
 }
 
 /// Response for `POST /api/v1/btor2/verify-recoverability`.
@@ -1176,6 +1181,9 @@ pub struct SvVerifyRecoverabilityRequest {
     /// Diagnostic-only — never changes the canonical verdict.
     #[serde(default)]
     pub refine: bool,
+    /// Config-partition config inputs, each `"NAME=v1,v2,..."` (mirrors the CLI `--config-values`).
+    #[serde(default)]
+    pub config_values: Vec<String>,
 }
 
 /// Request for `POST /api/v1/sv/check-fsm` — the SV lift fields plus the FSM width


### PR DESCRIPTION
Exposes the config-partition mechanism (#416) to users across **CLI + API + UI**: name config INPUTS to split the recoverability verdict over, and the `refinement` carries a `config_partition` decided exactly per config — a flat verdict becomes *"holds for configs {A}, violated for {B}"*.

## Surfaces (parity, one pass)
- **CLI:** `--config-values NAME=v1,v2,...` (repeatable) on `btor2`/`sv verify-recoverability`; implies the refined output, composes with `--refine`.
- **API:** `config_values: Vec<String>` on both requests; handlers parse + route through the refined path.
- **UI:** `config_values?: string[]` on the recoverability client (mununu-ui PR #57).

## Core
`verify_recoverability_refined` gains a `config_specs` param → attaches `config_partition` when non-empty; new `parse_config_value_specs` (`"NAME=v1,v2,..."`). Sidecar-free (pins the named inputs on the same lifted BTOR2); **sound per cell** (each config is a concrete pinned model decided by `exact-symbolic`); never changes the canonical verdict.

## Validation
CLI smoke on a `mode`-dependent design:
```
{ "verdict": "holds",
  "refinement": { "config_partition": { "holds": [mode=0, mode=1, mode=2],
                                        "violated": [mode=3], "exhaustive": true } } }
```
— a flat HOLDS enriched to reveal the config that breaks it. Plus an API handler test asserting the same partition, and the core mechanism tests.

This is the **user-driven** path; the **auto** config-atom identification (from `wide_influences` inputs) is the follow-up slice.

Engine (§16): `exact-symbolic` full-state ROBDD per pinned config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)