### PR TITLE
feat(refined-verdicts): assumption discovery (capability B, Phase 2a) — HoldsUnder(input-hold)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -735,6 +735,13 @@ struct Btor2VerifyRecoverabilityArgs {
     /// "why ⊥ / what would decide it" hint. Diagnostic-only — it never changes the canonical verdict.
     #[arg(long = "refine")]
     refine: bool,
+    /// Assumption discovery (refined-verdicts capability B): when the property does NOT hold, search
+    /// for an environment assumption φ (a single narrow input held at a value) under which it becomes a
+    /// NON-VACUOUS HOLDS → the refinement reports `holds_under`. CONDITIONAL-only: it never changes the
+    /// canonical verdict (assumptions are not monotone for `AG EF`). Implies the refined output; opt-in
+    /// (it costs extra decide runs).
+    #[arg(long = "discover-assumptions")]
+    discover_assumptions: bool,
     /// Config-partition (refined-verdicts capability A): name config INPUTS to split the verdict over,
     /// each `NAME=v1,v2,...` (repeatable). The refinement then reports a `config_partition` — "holds
     /// for configs {A}, violated for {B}" — decided exactly per config (sound per cell). Implies the
@@ -1824,6 +1831,12 @@ struct SvVerifyRecoverabilityArgs {
     /// never changes the canonical verdict.
     #[arg(long = "refine")]
     refine: bool,
+    /// Assumption discovery (refined-verdicts capability B): when the property does NOT hold, search for
+    /// an environment assumption φ (a single narrow input held at a value) under which it becomes a
+    /// NON-VACUOUS HOLDS → the refinement reports `holds_under`. CONDITIONAL-only (never changes the
+    /// canonical verdict). Implies the refined output; opt-in (it costs extra decide runs).
+    #[arg(long = "discover-assumptions")]
+    discover_assumptions: bool,
     /// Config-partition (refined-verdicts capability A): name config INPUTS to split the verdict over,
     /// each `NAME=v1,v2,...` (repeatable) → the refinement reports a `config_partition`, decided exactly
     /// per config. Implies the refined output. Best for a narrow / few-value config (cross-product capped).
@@ -2717,12 +2730,17 @@ fn btor2_verify_recoverability(args: Btor2VerifyRecoverabilityArgs) -> Result<()
         "file": args.file.display().to_string(),
         "property": recoverability_property_str(&args.target),
     });
-    // `--refine` / `--config-values` (refined-verdicts): the canonical verdict PLUS a structured,
-    // diagnostic-only refinement (Vacuous / bot-diagnosis / config-partition) — never changes the
-    // verdict. Without either, the plain verdict path.
-    let verdict = if args.refine || !config_specs.is_empty() {
-        let (verdict, refinement) =
-            verify_recoverability_refined(&content, &args.target, &extra, &config_specs);
+    // `--refine` / `--config-values` / `--discover-assumptions` (refined-verdicts): the canonical
+    // verdict PLUS a structured, diagnostic-only refinement (Vacuous / bot-diagnosis / config-partition
+    // / holds_under) — never changes the verdict. Without any, the plain verdict path.
+    let verdict = if args.refine || !config_specs.is_empty() || args.discover_assumptions {
+        let (verdict, refinement) = verify_recoverability_refined(
+            &content,
+            &args.target,
+            &extra,
+            &config_specs,
+            args.discover_assumptions,
+        );
         summary["refinement"] =
             serde_json::to_value(&refinement).map_err(|e| format!("serialize refinement: {e}"))?;
         verdict
@@ -5345,9 +5363,14 @@ fn sv_verify_recoverability(args: SvVerifyRecoverabilityArgs) -> Result<(), Stri
         "file": file,
         "property": recoverability_property_str(&args.target),
     });
-    let verdict = if args.refine || !config_specs.is_empty() {
-        let (verdict, refinement) =
-            sv_verify_recoverability_refined(&lift, &args.target, &extra, &config_specs)?;
+    let verdict = if args.refine || !config_specs.is_empty() || args.discover_assumptions {
+        let (verdict, refinement) = sv_verify_recoverability_refined(
+            &lift,
+            &args.target,
+            &extra,
+            &config_specs,
+            args.discover_assumptions,
+        )?;
         summary["refinement"] =
             serde_json::to_value(&refinement).map_err(|e| format!("serialize refinement: {e}"))?;
         verdict

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -49,7 +49,10 @@ use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
 use crate::mu_calculus::Environment;
 use crate::mu_calculus::parser as mu_parser;
 use crate::mu_calculus::trit::Trit;
-use crate::verdict::{ConfigPartition, PropertyVerdict, VacuityWitness, VerdictRefinement};
+use crate::verdict::{
+    AssumptionKind, ConfigPartition, DiscoveredAssumption, PropertyVerdict, VacuityWitness,
+    VerdictRefinement,
+};
 
 /// Max CEGAR refinement iterations for the scalable recoverability path — a sensible
 /// default: a pure state-atom `AG EF` target either decides at the seed abstraction or
@@ -1083,6 +1086,7 @@ pub fn verify_recoverability_refined(
     good: &str,
     extra_predicates: &[PredicateSpec],
     config_specs: &[(String, Vec<u64>)],
+    discover_assumptions_flag: bool,
 ) -> (PropertyVerdict, VerdictRefinement) {
     let verdict = verify_recoverability_with_predicates(btor2_content, good, extra_predicates)
         .unwrap_or(PropertyVerdict::Unknown);
@@ -1116,6 +1120,17 @@ pub fn verify_recoverability_refined(
         let diag = diagnose_recoverability_bot(btor2_content, good);
         if !diag.is_empty() {
             refinement.bot_diagnosis = Some(diag);
+        }
+    }
+
+    // Assumption discovery (capability B) — only when the UNCONSTRAINED property does NOT hold (an
+    // enabling assumption is only interesting for a ⊥/VIOLATED design) and the caller opted in (it
+    // costs runs). CONDITIONAL-ONLY: the discovered `holds_under` NEVER changes the canonical verdict —
+    // assumptions are not monotone for `AG EF`, so a `HoldsUnder(φ)` does not transfer unconditionally.
+    if discover_assumptions_flag && verdict != PropertyVerdict::Holds {
+        let assumptions = discover_assumptions(btor2_content, good);
+        if !assumptions.is_empty() {
+            refinement.holds_under = assumptions;
         }
     }
     (verdict, refinement)
@@ -1180,6 +1195,112 @@ fn probe_vacuous(btor2_content: &str, good: &str) -> Option<VacuityWitness> {
         }),
         _ => None, // Reachable, or Unknown/Contradiction ⇒ not (soundly) vacuous
     }
+}
+
+/// The MANDATORY non-vacuity gate for a discovered `HoldsUnder` (the i2c I1 / P1.2 lesson): an
+/// `AG EF(REG == VALUE)` HOLDS is meaningful ONLY if `good` is genuinely REACHED *and* genuinely LEFT
+/// under the assumption. Otherwise it is trivially true — `good` unreachable (nothing to recover to),
+/// or `good` stuck-true (the system never leaves it) — and the φ is worthless. Both directions via the
+/// sound [`decide_reach_portfolio`]; a `Reachable` on each is required. Any non-`Reachable` (including
+/// `Unknown`) fails the gate — we NEVER report a `HoldsUnder` we cannot certify is non-vacuous.
+fn good_nonvacuous_under(content: &str, register: &str, value: u64) -> bool {
+    use crate::adapter::btor2::bad_monitor::emit_ag_state_atom_monitor;
+    use crate::adapter::reach_portfolio::{ReachVerdict, decide_reach_portfolio};
+    let reachable = |op: CmpOp| -> bool {
+        let Ok(m) = emit_ag_state_atom_monitor(content, register, op, value as u128, false) else {
+            return false;
+        };
+        let Ok(f) = crate::adapter::btor2::parser::parse(&m) else {
+            return false;
+        };
+        matches!(decide_reach_portfolio(&f).verdict, ReachVerdict::Reachable)
+    };
+    // good REACHED: `EF(REG == VALUE)` — the `AG(REG != VALUE)` monitor's `bad` is `(REG == VALUE)`.
+    // good LEFT (not stuck-true): `EF(REG != VALUE)` — the `AG(REG == VALUE)` monitor's `bad` is `(REG != VALUE)`.
+    reachable(CmpOp::Ne) && reachable(CmpOp::Eq)
+}
+
+/// Capability B (refined-verdicts Phase 2) — DISCOVER an environment assumption φ under which an
+/// otherwise ⊥/VIOLATED `AG EF good` becomes a NON-VACUOUS HOLDS. Slice 1 searches single-input HOLDS
+/// assumptions: for each NARROW named primary input, pin it to each value, re-decide with the exact
+/// engine, and keep the pins that yield a HOLDS whose `good` passes the non-vacuity gate
+/// ([`good_nonvacuous_under`]). Each returned [`DiscoveredAssumption`] is CONDITIONAL — the caller's
+/// canonical verdict is UNCHANGED (assumptions are not monotone for `AG EF`; a `HoldsUnder(φ)` does not
+/// transfer to the unconstrained system). Conjunctive / wide-input / temporal (`ResetEventually`) /
+/// env-strategy assumptions are deferred to later Phase-2 slices; an empty result is the honest
+/// "no single-input assumption found."
+///
+/// **Engine (§16):** `exact-symbolic` full-state ROBDD (OxiDD) on each [`pin_inputs_to_constants`]
+/// concrete model (2-valued sound per pin) + the `decide_reach_portfolio` reachability engine for the
+/// non-vacuity gate. Tool-free, sidecar-free. A candidate cap + a total wall-clock budget
+/// (`MUNUNU_ASSUMPTION_BUDGET_MS`, default 90 s) bound the enumeration on wide designs.
+fn discover_assumptions(btor2_content: &str, good: &str) -> Vec<DiscoveredAssumption> {
+    use crate::adapter::btor2::ast::Node;
+    use crate::adapter::btor2::pin::pin_inputs_to_constants;
+    const MAX_INPUT_BITS: u32 = 3; // ≤ 8 values per input — a narrow control/enable, not a datapath
+    const MAX_CANDIDATE_PINS: usize = 48;
+    let budget_ms: u128 = std::env::var("MUNUNU_ASSUMPTION_BUDGET_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(90_000);
+    let start = std::time::Instant::now();
+
+    // Only `REG == VALUE` targets — the non-vacuity gate needs the register + value.
+    let (register, value) = match parse_predicate_expr(good).ok() {
+        Some(PredicateExpr::Cmp {
+            register,
+            op: CmpOp::Eq,
+            value,
+        }) => (register, value),
+        _ => return Vec::new(),
+    };
+    let Ok(file) = crate::adapter::btor2::parser::parse(btor2_content) else {
+        return Vec::new();
+    };
+    let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
+
+    // Candidate hold-axes = the design's NARROW named primary inputs. A pin that does not affect the
+    // recovery cone simply won't flip the verdict (so it is never reported) — the re-verify IS the
+    // relevance filter — so no explicit cone restriction is needed here.
+    let mut candidates: Vec<(String, u32)> = Vec::new();
+    for line in &file.lines {
+        if let Node::Input { sort, .. } = &line.node
+            && let Some(name) = symbols.get(&line.nid)
+            && let Some(w) = crate::adapter::btor2::parser::bv_width(&file, *sort)
+            && w <= MAX_INPUT_BITS
+        {
+            candidates.push((name.clone(), w));
+        }
+    }
+    candidates.sort();
+    candidates.dedup();
+
+    let mut found: Vec<DiscoveredAssumption> = Vec::new();
+    let mut pins_tried = 0usize;
+    'outer: for (name, w) in candidates {
+        for c in 0..(1u64 << w) {
+            if pins_tried >= MAX_CANDIDATE_PINS || start.elapsed().as_millis() > budget_ms {
+                break 'outer;
+            }
+            pins_tried += 1;
+            let (pinned, _) = pin_inputs_to_constants(btor2_content, &[(name.clone(), c)]);
+            // SOUNDNESS: each pinned model is CONCRETE ⇒ exact-symbolic on it is 2-valued sound; the
+            // non-vacuity gate rejects a HOLDS whose `good` is unreachable or stuck-true. The REPORT
+            // stays conditional-only (the caller never lifts it to a bare Holds).
+            if verify_recoverability_with_predicates(&pinned, good, &[]).ok()
+                == Some(PropertyVerdict::Holds)
+                && good_nonvacuous_under(&pinned, &register, value)
+            {
+                found.push(DiscoveredAssumption {
+                    phi: format!("{name} == {c}"),
+                    kind: AssumptionKind::InputHold,
+                    non_vacuous: true,
+                    engine: "exact-symbolic under single-input hold".to_string(),
+                });
+            }
+        }
+    }
+    found
 }
 
 /// Capability A (refined-verdicts Phase 1) — partition the `AG EF good` verdict over the CONFIG the
@@ -3632,7 +3753,8 @@ mod tests {
     fn refined_verdict_holds_design_has_empty_refinement() {
         const TOGGLE: &str =
             "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 not 1 2\n6 next 1 2 5\n";
-        let (verdict, refinement) = verify_recoverability_refined(TOGGLE, "flag == 0", &[], &[]);
+        let (verdict, refinement) =
+            verify_recoverability_refined(TOGGLE, "flag == 0", &[], &[], false);
         assert_eq!(verdict, PropertyVerdict::Holds);
         assert!(
             refinement.is_empty(),
@@ -3647,7 +3769,8 @@ mod tests {
     fn refined_verdict_vacuous_target_is_flagged() {
         const STUCK: &str =
             "1 sort bitvec 1\n2 state 1 flag\n3 zero 1\n4 init 1 2 3\n5 next 1 2 3\n";
-        let (verdict, refinement) = verify_recoverability_refined(STUCK, "flag == 1", &[], &[]);
+        let (verdict, refinement) =
+            verify_recoverability_refined(STUCK, "flag == 1", &[], &[], false);
         assert_ne!(
             verdict,
             PropertyVerdict::Holds,
@@ -3812,7 +3935,8 @@ mod tests {
     /// while the refinement reveals the operational trap.
     #[test]
     fn verify_recoverability_refined_auto_populates_config_partition_from_reset() {
-        let (verdict, refinement) = verify_recoverability_refined(RESET_DEP, "busy == 0", &[], &[]);
+        let (verdict, refinement) =
+            verify_recoverability_refined(RESET_DEP, "busy == 0", &[], &[], false);
         assert_eq!(
             verdict,
             PropertyVerdict::Holds,
@@ -3823,6 +3947,102 @@ mod tests {
             .expect("bare --refine auto-identifies the reset config axis");
         assert_eq!(part.holds, vec![vec![("rst_n".to_string(), 0)]]);
         assert_eq!(part.violated, vec![vec![("rst_n".to_string(), 1)]]);
+    }
+
+    // A trap FSM: IDLE(0) --go--> WORK(1); WORK --en=0--> FAULT(2, absorbing) / --en=1--> IDLE.
+    // Free-input: FAULT is reachable (IDLE→WORK→en=0) and absorbing ⇒ `AG EF(st==0)` VIOLATED. Held
+    // `en==1`: WORK always returns to IDLE and FAULT becomes UNREACHABLE ⇒ AG (over reachable states)
+    // HOLDS — the non-monotone flip that assumption discovery surfaces as `HoldsUnder(en==1)`. Holding
+    // `go==0` also makes it "HOLD" but VACUOUSLY (st never leaves 0) ⇒ the non-vacuity gate must reject it.
+    const EN_TRAP: &str = "\
+1 sort bitvec 2
+2 sort bitvec 1
+3 input 2 en
+4 input 2 go
+5 state 1 st
+6 zero 1
+7 init 1 5 6
+8 one 1
+9 constd 1 2
+10 eq 2 5 6
+11 eq 2 5 8
+13 ite 1 4 8 6
+14 ite 1 3 6 9
+15 ite 1 11 14 9
+16 ite 1 10 13 15
+17 next 1 5 16
+";
+
+    /// Capability B slice 1 — assumption discovery finds the single-input hold `en == 1` under which the
+    /// free-input-VIOLATED `AG EF(st==0)` becomes a NON-VACUOUS HOLDS (holding `en` high keeps the FAULT
+    /// trap unreachable). The vacuous `go == 0` hold (st never leaves IDLE) must be REJECTED by the gate.
+    #[test]
+    fn discover_assumptions_finds_nonvacuous_input_hold() {
+        let found = discover_assumptions(EN_TRAP, "st == 0");
+        assert!(
+            found.iter().any(|a| a.phi == "en == 1"
+                && a.kind == AssumptionKind::InputHold
+                && a.non_vacuous),
+            "expected a non-vacuous HoldsUnder(en == 1): {found:?}"
+        );
+        assert!(
+            !found.iter().any(|a| a.phi == "go == 0"),
+            "the vacuous `go==0` hold (st stuck at IDLE) must fail the non-vacuity gate: {found:?}"
+        );
+    }
+
+    /// Capability B slice 1 — end-to-end via `verify_recoverability_refined` (opt-in flag): the
+    /// discovered assumption rides in `holds_under`, and the CANONICAL verdict stays VIOLATED (the
+    /// conditional-only guard — assumptions are not monotone for `AG EF`, so a HoldsUnder never lifts
+    /// the verdict to a bare Holds).
+    #[test]
+    fn refined_verdict_carries_discovered_assumption_without_changing_verdict() {
+        let (verdict, refinement) =
+            verify_recoverability_refined(EN_TRAP, "st == 0", &[], &[], true);
+        assert_eq!(
+            verdict,
+            PropertyVerdict::Violated,
+            "free-input the FAULT trap is reachable ⇒ canonical verdict stays VIOLATED"
+        );
+        assert!(
+            refinement
+                .holds_under
+                .iter()
+                .any(|a| a.phi == "en == 1" && a.non_vacuous),
+            "the enabling assumption rides in holds_under: {refinement:?}"
+        );
+    }
+
+    /// Capability B slice 1 SOUNDNESS CONTROL — a structurally-dead target (`st` stuck at 1, `st==0`
+    /// unreachable regardless of the input `x`) must yield NO discovered assumption: no input hold can
+    /// make an unreachable `good` non-vacuously hold, so assumption discovery must NOT fabricate a φ.
+    #[test]
+    fn discover_assumptions_none_for_structurally_dead_target() {
+        const DEAD: &str = "\
+1 sort bitvec 1
+2 input 1 x
+3 state 1 st
+4 one 1
+5 init 1 3 4
+6 next 1 3 4
+";
+        assert!(
+            discover_assumptions(DEAD, "st == 0").is_empty(),
+            "no input hold makes an unreachable target non-vacuously hold ⇒ no spurious assumption"
+        );
+    }
+
+    /// Capability B slice 1 CONTROL — a design that already HOLDS free-input needs no assumption: with
+    /// the flag set, discovery does not run (verdict == Holds) ⇒ `holds_under` stays empty (no noise).
+    #[test]
+    fn refined_verdict_no_assumption_when_already_holds() {
+        let (verdict, refinement) =
+            verify_recoverability_refined(RESET_DEP, "busy == 0", &[], &[], true);
+        assert_eq!(verdict, PropertyVerdict::Holds);
+        assert!(
+            refinement.holds_under.is_empty(),
+            "a free-HOLDS design needs no enabling assumption: {refinement:?}"
+        );
     }
 
     /// Actionable-⊥ diagnosis — a recovery target riding only NARROW control state localizes NO

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -135,14 +135,16 @@ pub fn sv_verify_recoverability_with_predicates(
 }
 
 /// `sv verify-recoverability --refine` — lift SV and decide `AG EF target`, returning the canonical
-/// verdict PLUS a structured [`VerdictRefinement`] (the `Vacuous`/`bot_diagnosis` today; the config
-/// partition and discovered assumptions in later phases). The refinement is diagnostic-only — it never
-/// changes the canonical verdict. Sidecar-free (operates on the same lift as the plain verb).
+/// verdict PLUS a structured [`VerdictRefinement`]: a `Vacuous` witness, an auto `config_partition`
+/// over the detected reset, a `bot_diagnosis` hint, and — when `discover_assumptions` is set and the
+/// property does not hold — discovered `holds_under` assumptions. The refinement is diagnostic-only — it
+/// never changes the canonical verdict. Sidecar-free (operates on the same lift as the plain verb).
 pub fn sv_verify_recoverability_refined(
     lift: &SvLift,
     target: &str,
     extra_predicates: &[PredicateSpec],
     config_specs: &[(String, Vec<u64>)],
+    discover_assumptions: bool,
 ) -> Result<(PropertyVerdict, crate::verdict::VerdictRefinement), String> {
     parse_predicate_expr(target).map_err(|e| {
         format!("recoverability target `{target}` is not a register-comparison atom: {e:?}")
@@ -154,6 +156,7 @@ pub fn sv_verify_recoverability_refined(
             target,
             extra_predicates,
             config_specs,
+            discover_assumptions,
         ),
     )
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -808,19 +808,27 @@ pub async fn btor2_verify_recoverability_handler(
             details: None,
         }
     })?;
-    // `refine`/`config_values` (refined-verdicts): canonical verdict PLUS a diagnostic-only refinement.
-    let (verdict, refinement) = if request.refine || !config_specs.is_empty() {
-        let (v, r) =
-            verify_recoverability_refined(&request.content, &request.target, &extra, &config_specs);
-        (v, Some(r))
-    } else {
-        let v = verify_recoverability_with_predicates(&request.content, &request.target, &extra)
-            .map_err(|message| ApiError::BadRequest {
-                message,
-                details: None,
-            })?;
-        (v, None)
-    };
+    // `refine`/`config_values`/`discover_assumptions` (refined-verdicts): canonical verdict PLUS a
+    // diagnostic-only refinement.
+    let (verdict, refinement) =
+        if request.refine || !config_specs.is_empty() || request.discover_assumptions {
+            let (v, r) = verify_recoverability_refined(
+                &request.content,
+                &request.target,
+                &extra,
+                &config_specs,
+                request.discover_assumptions,
+            );
+            (v, Some(r))
+        } else {
+            let v =
+                verify_recoverability_with_predicates(&request.content, &request.target, &extra)
+                    .map_err(|message| ApiError::BadRequest {
+                        message,
+                        details: None,
+                    })?;
+            (v, None)
+        };
 
     Ok(Json(Btor2VerifyRecoverabilityResponse {
         verdict: verdict.as_str().to_string(),
@@ -1057,23 +1065,28 @@ pub async fn sv_verify_recoverability_handler(
             crate::adapter::yosys::SvFrontend::Auto
         },
     };
-    let (verdict, refinement) = if request.refine || !config_specs.is_empty() {
-        let (v, r) =
-            sv_verify_recoverability_refined(&lift, &request.target, &extra, &config_specs)
+    let (verdict, refinement) =
+        if request.refine || !config_specs.is_empty() || request.discover_assumptions {
+            let (v, r) = sv_verify_recoverability_refined(
+                &lift,
+                &request.target,
+                &extra,
+                &config_specs,
+                request.discover_assumptions,
+            )
+            .map_err(|message| ApiError::BadRequest {
+                message,
+                details: None,
+            })?;
+            (v, Some(r))
+        } else {
+            let v = sv_verify_recoverability_with_predicates(&lift, &request.target, &extra)
                 .map_err(|message| ApiError::BadRequest {
                     message,
                     details: None,
                 })?;
-        (v, Some(r))
-    } else {
-        let v = sv_verify_recoverability_with_predicates(&lift, &request.target, &extra).map_err(
-            |message| ApiError::BadRequest {
-                message,
-                details: None,
-            },
-        )?;
-        (v, None)
-    };
+            (v, None)
+        };
     Ok(Json(Btor2VerifyRecoverabilityResponse {
         verdict: verdict.as_str().to_string(),
         property,
@@ -4462,6 +4475,7 @@ members = ["x"]
             predicates: Vec::new(),
             refine: false,
             config_values: Vec::new(),
+            discover_assumptions: false,
         };
         let Json(out) = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4483,6 +4497,7 @@ members = ["x"]
             predicates: Vec::new(),
             refine: true,
             config_values: Vec::new(),
+            discover_assumptions: false,
         };
         let Json(out) = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4506,6 +4521,7 @@ members = ["x"]
             predicates: Vec::new(),
             refine: false,
             config_values: vec!["mode=0,1,2,3".to_string()],
+            discover_assumptions: false,
         };
         let Json(out) = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4519,6 +4535,37 @@ members = ["x"]
     }
 
     #[tokio::test]
+    async fn btor2_verify_recoverability_discover_assumptions_finds_enabling_hold() {
+        // IDLE(0) --go--> WORK(1); WORK --en=0--> FAULT(2, absorbing) / --en=1--> IDLE. Free-input the
+        // FAULT trap is reachable ⇒ VIOLATED; held `en==1` keeps it unreachable ⇒ a non-vacuous HOLDS.
+        const EN_TRAP: &str = "1 sort bitvec 2\n2 sort bitvec 1\n3 input 2 en\n4 input 2 go\n\
+5 state 1 st\n6 zero 1\n7 init 1 5 6\n8 one 1\n9 constd 1 2\n10 eq 2 5 6\n11 eq 2 5 8\n\
+13 ite 1 4 8 6\n14 ite 1 3 6 9\n15 ite 1 11 14 9\n16 ite 1 10 13 15\n17 next 1 5 16\n";
+        let request = Btor2VerifyRecoverabilityRequest {
+            content: EN_TRAP.to_string(),
+            target: "st == 0".to_string(),
+            predicates: Vec::new(),
+            refine: false,
+            config_values: Vec::new(),
+            discover_assumptions: true,
+        };
+        let Json(out) = btor2_verify_recoverability_handler(Json(request))
+            .await
+            .expect("verify-recoverability --discover-assumptions runs");
+        assert_eq!(
+            out.verdict, "violated",
+            "canonical verdict is unchanged (conditional-only)"
+        );
+        let holds_under = out.refinement.map(|r| r.holds_under).unwrap_or_default();
+        assert!(
+            holds_under
+                .iter()
+                .any(|a| a.phi == "en == 1" && a.non_vacuous),
+            "discovers the enabling assumption en == 1: {holds_under:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn btor2_verify_recoverability_handler_rejects_malformed_target() {
         let request = Btor2VerifyRecoverabilityRequest {
             content: LIVENESS_STALLER.to_string(),
@@ -4526,6 +4573,7 @@ members = ["x"]
             predicates: Vec::new(),
             refine: false,
             config_values: Vec::new(),
+            discover_assumptions: false,
         };
         let err = btor2_verify_recoverability_handler(Json(request))
             .await
@@ -4621,6 +4669,7 @@ members = ["x"]
             predicates: Vec::new(),
             refine: false,
             config_values: Vec::new(),
+            discover_assumptions: false,
         };
         let err = sv_verify_recoverability_handler(Json(request))
             .await

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1019,6 +1019,12 @@ pub struct Btor2VerifyRecoverabilityRequest {
     /// Implies the refined output. Mirrors the CLI `--config-values`.
     #[serde(default)]
     pub config_values: Vec<String>,
+    /// Assumption discovery (capability B): when the property does NOT hold, search for an environment
+    /// assumption φ under which it becomes a non-vacuous HOLDS → the refinement carries `holds_under`.
+    /// CONDITIONAL-only (never changes the canonical verdict). Implies the refined output. Mirrors the
+    /// CLI `--discover-assumptions`.
+    #[serde(default)]
+    pub discover_assumptions: bool,
 }
 
 /// Response for `POST /api/v1/btor2/verify-recoverability`.
@@ -1185,6 +1191,10 @@ pub struct SvVerifyRecoverabilityRequest {
     /// Config-partition config inputs, each `"NAME=v1,v2,..."` (mirrors the CLI `--config-values`).
     #[serde(default)]
     pub config_values: Vec<String>,
+    /// Assumption discovery (capability B): search for an enabling φ when the property does not hold →
+    /// `holds_under` (conditional-only). Mirrors the CLI `--discover-assumptions`.
+    #[serde(default)]
+    pub discover_assumptions: bool,
 }
 
 /// Request for `POST /api/v1/sv/check-fsm` — the SV lift fields plus the FSM width

--- a/crates/mununu-core/tests/wall_class_matrix.rs
+++ b/crates/mununu-core/tests/wall_class_matrix.rs
@@ -780,7 +780,8 @@ fn config_partition_over_reset_partitions_opentitan_fsms() {
 fn auto_config_partition_identifies_reset_on_opentitan_fsms() {
     use mununu_core::adapter::recoverability::verify_recoverability_refined;
 
-    let (_v, aes) = verify_recoverability_refined(AES_CIPHER, "aes_cipher_ctrl_cs == 9", &[], &[]);
+    let (_v, aes) =
+        verify_recoverability_refined(AES_CIPHER, "aes_cipher_ctrl_cs == 9", &[], &[], false);
     let part = aes
         .config_partition
         .expect("bare --refine auto-identifies rst_ni on aes_cipher");
@@ -790,7 +791,7 @@ fn auto_config_partition_identifies_reset_on_opentitan_fsms() {
         "auto reset-partition reproduces the aes_cipher branching pair: {part:?}"
     );
 
-    let (_v, csrng) = verify_recoverability_refined(CSRNG, "state_q == 55", &[], &[]);
+    let (_v, csrng) = verify_recoverability_refined(CSRNG, "state_q == 55", &[], &[], false);
     let part = csrng
         .config_partition
         .expect("bare --refine auto-identifies rst_ni on csrng");


### PR DESCRIPTION
## Phase 2a — assumption discovery (refined-verdicts capability B)

When an `AG EF(good)` recoverability does **not** hold, `--discover-assumptions` searches for an environment assumption φ under which it becomes a **non-vacuous HOLDS**, reported as `refinement.holds_under`. Slice 1 covers **single-input holds**: for each narrow named primary input, pin it to each value, re-decide with the exact engine, and keep the pins that yield a HOLDS whose `good` is genuinely **reached** *and* **left** (the mandatory non-vacuity gate).

### The non-monotone flip is the point
Holding an input can make a **trap unreachable**, so the property holds over the reachable states even though the free-input design is VIOLATED — e.g. *"hold `en` high and the FAULT lockup is never entered."* This is exactly what capability B surfaces: the enabling environment contract.

### Soundness (load-bearing)
Assumptions are **NOT monotone for `AG EF`**, so a discovered `HoldsUnder(φ)` does **not** transfer to the unconstrained system. It is **conditional-only**: the canonical `PropertyVerdict` is **unchanged** (stays Unknown/Violated) — a refinement never surfaces as a bare Holds. The non-vacuity gate rejects a φ that makes `good` trivially true (unreachable or stuck-true), reusing the `EF(good)` / `EF(¬good)` dual discipline (the i2c I1 / P1.2 lesson).

### Engine (§16)
`exact-symbolic` full-state ROBDD (OxiDD) on each `pin_inputs_to_constants` concrete model (2-valued sound per pin) + `decide_reach_portfolio` for the non-vacuity gate. Tool-free, sidecar-free. A candidate cap (48 pins) + a wall-clock budget (`MUNUNU_ASSUMPTION_BUDGET_MS`, default 90 s) bound the enumeration on wide designs.

### Surface (parity, same PR)
- **CLI**: `--discover-assumptions` on `btor2`/`sv verify-recoverability`
- **API**: `discover_assumptions` on both requests + handlers
- **UI** (separate PR, mununu-ui `cb18467`): `discover_assumptions?` on both requests; also backfilled `refine?`/`config_values?` on the SV request (a Phase-1 parity gap). `holds_under` was already in the Phase-0 `VerdictRefinement`.

### Tests
- 4 core: non-vacuous input-hold found; vacuous hold rejected by the gate; **no spurious φ on a structurally-dead target** (soundness control); conditional-only guard (verdict stays Violated); no-assumption-when-already-Holds control.
- 1 API handler test (EN_TRAP → `holds_under:[en == 1]`, verdict `violated`).
- CLI smoke verified end-to-end. All host, gate `make ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)