### PR TITLE
fix(refined-verdicts): resolve OUTPUT-port targets in the vacuity / non-vacuity monitor

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -188,12 +188,21 @@ pub fn emit_ag_state_atom_monitor(
         e
     })?;
 
-    let (sig_nid, sig_sort) = state_nid_and_sort(&file, signal, reset_pinned).ok_or_else(|| {
-        err(format!(
-            "adapter/btor2/bad_monitor: `{signal}` does not resolve to a state cell \
-             (the AG(state-atom) monitor requires a state register or a value-alias of one)"
-        ))
-    })?;
+    // Resolve the atom's signal to its per-cycle value net: a STATE register (value-alias / reset-mux
+    // aware) first, else a combinational OUTPUT port (its driver net). Many real recoverability targets
+    // (`busy` / `done` / `valid` / `ready`) are outputs driven from the FSM (e.g. `state != IDLE`), not
+    // state cells — comparing the driver's value is the same sound per-cycle observation. Without the
+    // output fallback the `EF(atom)` reachability monitor (used by `probe_vacuous` and the assumption
+    // non-vacuity gate) fails on every output target.
+    let (sig_nid, sig_sort) = state_nid_and_sort(&file, signal, reset_pinned)
+        .or_else(|| output_nid_and_sort(&file, signal))
+        .ok_or_else(|| {
+            err(format!(
+                "adapter/btor2/bad_monitor: `{signal}` does not resolve to a state cell or output port \
+                 (the AG(state-atom) monitor requires a state register, a value-alias of one, or an \
+                 output net)"
+            ))
+        })?;
 
     let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
     let mut appended: Vec<String> = Vec::new();

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -4071,6 +4071,44 @@ mod tests {
         );
     }
 
+    // Like the real lift: the recovery target `busy` is a combinational OUTPUT (`busy = st != IDLE`),
+    // NOT a state cell. IDLE(0)--go-->WORK(1); WORK--en=0-->FAULT(2,absorbing)/--en=1-->IDLE. `busy==0`
+    // ⇔ `st==0`. Exercises the output-port resolution in the non-vacuity gate (`emit_ag_state_atom_monitor`
+    // output fallback) — without it the gate errors on every `busy`/`done`/`valid`/`ready` output target.
+    const EN_TRAP_OUTPUT: &str = "\
+1 sort bitvec 2
+2 sort bitvec 1
+3 input 2 en
+4 input 2 go
+5 state 1 st
+6 zero 1
+7 init 1 5 6
+8 one 1
+9 constd 1 2
+10 eq 2 5 6
+11 eq 2 5 8
+13 ite 1 4 8 6
+14 ite 1 3 6 9
+15 ite 1 11 14 9
+16 ite 1 10 13 15
+17 next 1 5 16
+18 neq 2 5 6
+19 output 18 busy
+";
+
+    /// Capability B slice 1 — the recovery target is a combinational OUTPUT (`busy`), the common real-RTL
+    /// shape. Assumption discovery must find the non-vacuous `en == 1` hold, which requires the
+    /// non-vacuity gate to resolve `busy` via the OUTPUT-port fallback (not just state cells). This is the
+    /// exact gap that blocked the composition on the `compute_engine_faulty` lift (`busy` is an output).
+    #[test]
+    fn discover_assumptions_resolves_output_target() {
+        let found = discover_assumptions(EN_TRAP_OUTPUT, "busy == 0", &[]);
+        assert!(
+            found.iter().any(|a| a.phi == "en == 1" && a.non_vacuous),
+            "output-target non-vacuity gate must resolve `busy` and find HoldsUnder(en==1): {found:?}"
+        );
+    }
+
     /// Capability B slice 1 SOUNDNESS CONTROL — a structurally-dead target (`st` stuck at 1, `st==0`
     /// unreachable regardless of the input `x`) must yield NO discovered assumption: no input hold can
     /// make an unreachable `good` non-vacuously hold, so assumption discovery must NOT fabricate a φ.


### PR DESCRIPTION
## The bug

`emit_ag_state_atom_monitor` — the `EF(atom)` reachability monitor behind both the **assumption non-vacuity gate** and **Phase-0 `probe_vacuous`** — required the target to resolve to a **state cell**. But many real recoverability targets are combinational **OUTPUTS** (`busy` / `done` / `valid` / `ready`) driven from the FSM (e.g. `busy = state != IDLE`), not state registers. So the monitor errored on every output target, and the non-vacuity gate silently rejected the discovered assumption — even though `verify_recoverability` decides the output atom fine (so the *verdict* was correct; only the non-vacuity *certificate* couldn't be built).

This is exactly what blocked the A→B composition on the `compute_engine_faulty` lift (root-caused via a forced-rebuild debug trace: `busy does not resolve to a state cell`).

## The fix

An **OUTPUT-port fallback** (`output_nid_and_sort`, already used by the response monitor) after the state-cell resolution. Comparing the output driver's per-cycle value is the same sound observation.

**Soundness:** a strict ADD — reached only when state resolution fails; state-cell behavior is identical; the output driver is the signal's exact per-cycle value, so the `EF(atom)` reachability stays sound.

## Impact — the composition now fires on real RTL

`compute_engine_faulty` (where `busy` is an output) now yields:
```
verdict: holds
config_partition{ holds:[rst_n=0], violated:[rst_n=1] }   ← A: operationally traps
holds_under:[ rst_n == 1 && err == 0 ]                     ← B: …unless the fault strobe is held low
```
The operational lockup-avoidance surfaced automatically on clean-room RTL. Bonus: Phase-0 `probe_vacuous` now works on output targets too.

## Test
`discover_assumptions_resolves_output_target` (`EN_TRAP_OUTPUT` — `busy` as a combinational output; the non-vacuity gate resolves it via the fallback and finds `HoldsUnder(en==1)`). Host, gates `make ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)