### PR TITLE
fix(cli): keep logs off stdout so `mununu ... | jq` never breaks

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2307,16 +2307,22 @@ fn init_tracing(quiet: bool) {
 
             tracing::info!(
                 log_file = %log_file.display(),
-                "Logging initialized. Logs are written to both stdout and file."
+                "Logging initialized. Logs are written to both stderr and file."
             );
         }
         Err(e) => {
             eprintln!(
-                "Warning: Failed to set up file logging ({:?}): {}. Logs will only go to stdout.",
+                "Warning: Failed to set up file logging ({:?}): {}. Logs will only go to stderr.",
                 log_file, e
             );
-            // Fall back to stdout-only logging
-            let builder = fmt().with_env_filter(filter).with_target(false).compact();
+            // Fall back to STDERR-only logging. `fmt()`'s default writer is STDOUT, which would
+            // pollute the JSON result stream (`mununu … | jq` breaks) whenever the `logs/` dir is
+            // unwritable (read-only CWD / sandbox / CI). stdout is reserved for the command's data.
+            let builder = fmt()
+                .with_env_filter(filter)
+                .with_writer(std::io::stderr)
+                .with_target(false)
+                .compact();
             let _ = builder.try_init();
         }
     }


### PR DESCRIPTION
## The bug

`init_tracing`'s file-logging **fallback** used `fmt()` — whose default writer is **stdout** — so whenever the `logs/` dir is unwritable (read-only CWD / sandbox / CI) every log line polluted the JSON result stream and broke `mununu … | jq`. stdout is reserved for the command's data. (The two log messages also wrongly said "stdout"; the primary path already writes stderr+file.)

## The fix

The fallback writes to **stderr** (`with_writer(std::io::stderr)`), matching the primary path's stderr+file layers. Corrected the messages ("stderr and file" / "only go to stderr").

Surfaced by the §D sweep (ledger §3.12d) — a reminder that stdout must stay clean for machine-readable output. Surface-neutral (no CLI/API/UI change), so `/parity-check` N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)