### PR TITLE
feat(refined-verdicts): env-strategy EXISTENCE generalized over μ-calculus (P2.5-E T1)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2828,6 +2828,37 @@ pub fn exact_env_strategy(btor2_content: &str, good: &str) -> Result<EnvStrategy
     }
 }
 
+/// P2.5-E T1 — env-strategy EXISTENCE for ANY μ-calculus property, over the bit-blasted BDD.
+///
+/// An environment strategy can enforce `formula` from the initial state iff `init ⊆ W`, where
+/// `W = evaluate(env_enforce(formula))` is the winning region of the 1-player control game (the
+/// environment owns every transition; the `□→◇` [`env_enforce`] rewrite makes each modality the
+/// environment's move). Since `exact_symbolic_verdict` already returns `Holds` exactly when `init ⊆
+/// evaluate(φ)`, existence is simply `exact_symbolic_verdict(env_enforce(formula)) == Holds`.
+///
+/// Returns `Ok(Some(true))` (a strategy exists), `Ok(Some(false))` (the adversary can force `¬formula` —
+/// solve `invert(formula)`'s game for the counter-strategy region), or `Ok(None)` when the exact engine
+/// cannot decide (over the cone/bit cap, in-cone array, input-atom — the caller abstains). GENERALIZES
+/// [`exact_env_strategy`] (recoverability shape), which stays as the differential oracle + the witness/
+/// non-vacuity path; strategy-WITNESS extraction for arbitrary `formula` is T2. CONDITIONAL-ONLY: this
+/// never changes a canonical verdict.
+///
+/// **Engine (§16):** `exact-symbolic` full-state ROBDD (OxiDD) — `evaluate(env_enforce(φ))` reuses the
+/// existing `diamond_pre` (∃input = the env's move) + Kleene fixpoint; no `Control`-honoring needed in the
+/// 1-player case (⟨ctrl⟩ ≡ ◇ when the env owns all inputs). Tool-free, host-runnable.
+pub fn exact_env_strategy_exists(
+    btor2_content: &str,
+    formula: &Formula,
+) -> Result<Option<bool>, String> {
+    let enforced = crate::mu_calculus::env_enforce::env_enforce(formula);
+    match exact_symbolic_verdict(btor2_content, &enforced) {
+        Ok(ExactVerdict::Holds) => Ok(Some(true)),
+        Ok(ExactVerdict::Violated) => Ok(Some(false)),
+        // The exact engine abstained (over-cap / in-cone array / input-atom) — undecided, not a strategy.
+        Err(_) => Ok(None),
+    }
+}
+
 /// D1.8b/b-2 — detect a liveness shape and return the node id of its target `p`.
 /// Recognised (both disjunct/conjunct orders; modalities must be bare `[]`):
 /// - bare `AF p` = `μX. (p ∨ [] X)`,
@@ -6295,6 +6326,44 @@ mod tests {
                 EnvStrategyOutcome::Inapplicable(_)
             ),
             "a stay-in-good strategy is vacuous ⇒ must not be reported as Maintainable"
+        );
+    }
+
+    /// P2.5-E T1 — env-strategy EXISTENCE, GENERALIZED. `exact_env_strategy_exists` decides env-enforce
+    /// for ANY μ-calculus formula. On the recoverability formula it AGREES with the bespoke
+    /// `exact_env_strategy` (subsumption: Maintainable ⟺ Some(true)); it also decides a SAFETY property
+    /// (env-can-stay-out-of-the-trap) — a shape the recoverability-specific synth cannot express.
+    #[test]
+    fn env_strategy_exists_generalizes_over_mu_calculus() {
+        use crate::mu_calculus::parser::parse;
+        // (a) Recoverability formula on POSITIONAL_TRAP — subsumes exact_env_strategy (Maintainable).
+        let recov = parse("nu Y. ((mu X. ((st == 0) || <> X)) && [] Y)").expect("parse");
+        assert_eq!(
+            exact_env_strategy_exists(POSITIONAL_TRAP, &recov).expect("runs"),
+            Some(true),
+            "env can enforce AG EF(st==0) via a positional strategy"
+        );
+        assert!(
+            matches!(
+                exact_env_strategy(POSITIONAL_TRAP, "st == 0").expect("runs"),
+                EnvStrategyOutcome::Maintainable { .. }
+            ),
+            "the general existence must AGREE with the bespoke recoverability synth"
+        );
+        // (b) SAFETY property (generality) — the env can keep `st` out of the TRAP(3) forever.
+        let safety = parse("nu X. ((! (st == 3)) && [] X)").expect("parse");
+        assert_eq!(
+            exact_env_strategy_exists(POSITIONAL_TRAP, &safety).expect("runs"),
+            Some(true),
+            "env can stay out of the trap (a safety objective, not recoverability)"
+        );
+        // (c) NO strategy — a forced trap: st=A(0) --any--> TRAP(1), so the env cannot avoid `st==1`.
+        const FORCED: &str = "1 sort bitvec 1\n2 input 1 x\n3 state 1 st\n4 zero 1\n5 init 1 3 4\n6 one 1\n7 next 1 3 6\n";
+        let avoid = parse("nu X. ((! (st == 1)) && [] X)").expect("parse");
+        assert_eq!(
+            exact_env_strategy_exists(FORCED, &avoid).expect("runs"),
+            Some(false),
+            "the env cannot avoid the forced trap ⇒ no strategy"
         );
     }
 

--- a/crates/mununu-core/src/mu_calculus/env_enforce.rs
+++ b/crates/mununu-core/src/mu_calculus/env_enforce.rs
@@ -1,0 +1,146 @@
+//! Environment-enforce rewrite (P2.5-E T1 — env-strategy generalization over μ-calculus).
+//!
+//! Rewrites a μ-calculus property `φ` into `env_enforce(φ)` — the 1-player CONTROL reading where the
+//! ENVIRONMENT owns every transition (it PICKS the successor). Structurally: every `□` (Box, "for ALL
+//! successors") becomes `◇` (Diamond, "the env picks A successor"); everything else (`μ`/`ν`, `∧`/`∨`/`¬`,
+//! predicates, `◇`) is unchanged. Evaluating `env_enforce(φ)` over the model yields the WINNING REGION —
+//! the states from which an environment strategy can make `φ` hold along the chosen trajectory — so
+//! `init ⊆ W` ⟺ such a strategy EXISTS.
+//!
+//! This GENERALIZES the recoverability special case: `env_enforce(AG EF good) = νY.(μX.(good ∨ ◇X)) ∧ ◇Y`
+//! — exactly the `env_maintain_region(EF good)` the bespoke `exact_env_strategy` hand-codes (which stays as
+//! the differential oracle). Combined with the existing `exact_symbolic_verdict`, existence for ANY
+//! μ-calculus property is `exact_symbolic_verdict(env_enforce(φ)) == Holds`.
+//!
+//! SOUND for the 1-player case (env = sole player): with all inputs one player `⟨ctrl⟩ = ◇ = ∃input`, so
+//! the control LABEL is inert and only the `□→◇` structure matters — hence no `Control`-honoring in the
+//! evaluator is needed for T1. The 2-player split (`∃ctrl ∀env`, distinguishing controllable from
+//! adversarial inputs) is T3 (needs the ctrl/env input-cube partition + `Control`-aware evaluation).
+//! `invert.rs` is the DUAL (opposite game / counter-strategy region); this is the same-polarity
+//! successor-swap.
+
+use super::{Formula, FormulaBuilder, FormulaVarId, ModalKind, Node, NodeId};
+use std::collections::HashMap;
+
+/// Rewrite `formula` into its environment-enforce form: every `□` becomes `◇` (the environment picks the
+/// successor); `μ`/`ν`/`∧`/`∨`/`¬`/predicates/`◇` and every modal guard are structurally unchanged.
+pub fn env_enforce(formula: &Formula) -> Formula {
+    let mut builder = FormulaBuilder::default();
+    let mut var_map: HashMap<FormulaVarId, FormulaVarId> = HashMap::new();
+    let root = rewrite_node(formula, formula.root(), &mut builder, &mut var_map);
+    builder.into_formula(root)
+}
+
+fn rewrite_node(
+    formula: &Formula,
+    node_id: NodeId,
+    builder: &mut FormulaBuilder,
+    var_map: &mut HashMap<FormulaVarId, FormulaVarId>,
+) -> NodeId {
+    match formula.node(node_id).clone() {
+        Node::True => builder.push_node(Node::True),
+        Node::False => builder.push_node(Node::False),
+        Node::Predicate(p) => builder.push_node(Node::Predicate(p)),
+        Node::Not(inner) => {
+            let n = rewrite_node(formula, inner, builder, var_map);
+            builder.push_node(Node::Not(n))
+        }
+        Node::And(a, b) => {
+            let na = rewrite_node(formula, a, builder, var_map);
+            let nb = rewrite_node(formula, b, builder, var_map);
+            builder.push_node(Node::And(na, nb))
+        }
+        Node::Or(a, b) => {
+            let na = rewrite_node(formula, a, builder, var_map);
+            let nb = rewrite_node(formula, b, builder, var_map);
+            builder.push_node(Node::Or(na, nb))
+        }
+        // The successor-swap: `□ → ◇` (the env picks a successor); `◇` stays `◇`. Guard preserved (in the
+        // 1-player reading the control label is inert; a later 2-player pass would set it).
+        Node::Modal {
+            kind: _,
+            guard,
+            target,
+        } => {
+            let t = rewrite_node(formula, target, builder, var_map);
+            builder.push_node(Node::Modal {
+                kind: ModalKind::Diamond,
+                guard,
+                target: t,
+            })
+        }
+        Node::Mu { var, body } => {
+            let new_var = builder.push_var(formula.vars()[var.0].name.clone());
+            var_map.insert(var, new_var);
+            let new_body = rewrite_node(formula, body, builder, var_map);
+            builder.push_node(Node::Mu {
+                var: new_var,
+                body: new_body,
+            })
+        }
+        Node::Nu { var, body } => {
+            let new_var = builder.push_var(formula.vars()[var.0].name.clone());
+            var_map.insert(var, new_var);
+            let new_body = rewrite_node(formula, body, builder, var_map);
+            builder.push_node(Node::Nu {
+                var: new_var,
+                body: new_body,
+            })
+        }
+        Node::Variable(var) => {
+            let mapped = var_map.get(&var).copied().unwrap_or(var);
+            builder.push_node(Node::Variable(mapped))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mu_calculus::parser;
+
+    use super::super::{ModalKind, Node};
+
+    fn count_modals(f: &Formula) -> (usize, usize) {
+        let mut boxes = 0;
+        let mut diamonds = 0;
+        for n in f.nodes() {
+            if let Node::Modal { kind, .. } = n {
+                match kind {
+                    ModalKind::Box => boxes += 1,
+                    ModalKind::Diamond => diamonds += 1,
+                }
+            }
+        }
+        (boxes, diamonds)
+    }
+
+    #[test]
+    fn env_enforce_flips_box_to_diamond_only() {
+        // AG EF good = nu Y. ((mu X. (good || <> X)) && [] Y): 1 box (outer AG) + 1 diamond (inner EF).
+        // env_enforce → the box becomes a diamond ⇒ 0 boxes, 2 diamonds; the mu/nu structure is intact.
+        let f = parser::parse("nu Y. ((mu X. (good || <> X)) && [] Y)").unwrap();
+        assert_eq!(count_modals(&f), (1, 1), "original: 1 box, 1 diamond");
+        let e = env_enforce(&f);
+        assert_eq!(count_modals(&e), (0, 2), "env_enforce: every box → diamond");
+    }
+
+    #[test]
+    fn env_enforce_safety_invariant() {
+        // AG !bad = nu X. ((! bad) && [] X). env_enforce → nu X. ((! bad) && <> X) = "env can stay safe".
+        let f = parser::parse("nu X. ((! bad) && [] X)").unwrap();
+        assert_eq!(
+            count_modals(&env_enforce(&f)),
+            (0, 1),
+            "safety box → diamond"
+        );
+    }
+
+    #[test]
+    fn env_enforce_idempotent_on_diamond_only() {
+        // A formula with no box: env_enforce is structurally a no-op (twice == once, same modal counts).
+        let f = parser::parse("mu X. (good || <> X)").unwrap();
+        assert_eq!(count_modals(&env_enforce(&f)), (0, 1));
+        assert_eq!(count_modals(&env_enforce(&env_enforce(&f))), (0, 1));
+    }
+}

--- a/crates/mununu-core/src/mu_calculus/mod.rs
+++ b/crates/mununu-core/src/mu_calculus/mod.rs
@@ -6,6 +6,7 @@
 
 use crate::clts::{Clts, IdStorage, StateId, Transition};
 
+pub mod env_enforce;
 pub mod evaluator;
 pub mod gr1;
 pub mod gr1_build;


### PR DESCRIPTION
## Generalize env-strategy from recoverability to any μ-calculus property

Env-strategy synthesis (#424) was recoverability-shape-specific. T1 generalizes its **existence** check to **any μ-calculus property** via the control-rewrite the §0 precedent audit identified.

An environment strategy can enforce `φ` from the initial state iff `init ⊆ W`, where `W = evaluate(env_enforce(φ))` is the winning region of the 1-player control game (the environment owns every transition). Since `exact_symbolic_verdict` already returns `Holds` exactly when `init ⊆ evaluate(φ)`, existence is just:
```
exact_env_strategy_exists(φ)  ==  exact_symbolic_verdict(env_enforce(φ)) == Holds
```

### The rewrite
`mu_calculus/env_enforce.rs::env_enforce(φ)` — the **successor-swap**: every `□` (all-successors, adversarial) becomes `◇` (the environment picks a successor); `μ`/`ν`/`∧`/`∨`/`¬`/predicates/`◇` unchanged. It generalizes the bespoke reduction exactly:
```
env_enforce(AG EF good) = νY.(μX.(good ∨ ◇X)) ∧ ◇Y   =   the hand-coded env_maintain_region(EF good)
```

### The key simplification (from §0)
The 1-player case needs **no `Control`-honoring in the evaluator** — with the env owning all inputs, `⟨ctrl⟩ ≡ ◇ = ∃input`, so the control *label* is inert and only the `□→◇` *structure* matters. So T1 is a small AST rewrite + the **existing** `exact_symbolic_verdict` — no new evaluate plumbing. The 2-player split (`∃ctrl ∀env`) and the strategy *witness* extraction are T3/T2. `exact_env_strategy` (#424) stays as the recoverability differential oracle.

### Soundness
Conditional-only (never changes a canonical verdict); each fixpoint is over the concrete bit-blasted relation (exact = 2-valued sound). `invert(φ)` remains the dual (opposite game / counter region) — this is the same-polarity successor-swap. Bounded by the exact cone/bit cap (over-cap ⇒ `None`, the caller abstains).

### Tests (host, gate `make ci`)
`env_enforce` flips box→diamond only (recoverability + safety + idempotence); `exact_env_strategy_exists` **agrees with `exact_env_strategy` on the recoverability shape** (subsumption), **decides a safety objective** (generality beyond recoverability), and returns `Some(false)` on a forced trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)