### PR TITLE
feat(recoverability): full positional env-strategy synthesis — the Mealy policy (P2.5-E)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2901,6 +2901,62 @@ pub fn exact_env_strategy_witness(btor2_content: &str, good: &str) -> Option<Sta
     bb.reach_good_play(&file, &good_bdd)
 }
 
+/// P2.5-E — a full POSITIONAL environment strategy for `AG EF good`: a memoryless policy over the
+/// design's reachable states. Where [`exact_env_strategy_witness`] returns ONE play (witnessing `EF good`
+/// from the initial state), this returns the `AG` part — the driving discipline for *every* reachable
+/// state, as a state-indexed map. It is the reusable object: an environment model, a directed-test seed,
+/// or the environment half of an assume-guarantee contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PositionalPolicy {
+    /// The state register the policy is indexed by (the register named in the `good` atom).
+    pub state_register: String,
+    /// One row per reachable value of `state_register`, ordered by rank then value.
+    pub entries: Vec<PolicyEntry>,
+}
+
+/// One control-state row of a [`PositionalPolicy`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyEntry {
+    /// The value of the policy's state register in this row.
+    pub state_value: u128,
+    /// Attractor distance to `good` (`0` = the state already satisfies `good`).
+    pub rank: u32,
+    /// The inputs the strategy FORCES in this state (name → value). An input that some rank-decreasing
+    /// move leaves free is omitted, so a nonempty map is the minimal driving discipline. The SAME input
+    /// appearing with DIFFERENT forced values across rows is the positional obligation, made explicit as
+    /// a map rather than read off a single trace.
+    pub forced_inputs: BTreeMap<String, u128>,
+}
+
+/// P2.5-E — synthesize the full positional environment strategy for `AG EF good` (see
+/// [`PositionalPolicy`]). `None` when `good` is not a resolvable `REG op VALUE` state atom over a state
+/// register, the model can't be built (over-cap / array / input-atom), or `good` is unreachable from the
+/// initial state (no strategy exists).
+///
+/// **Engine (§16):** `exact-symbolic` ROBDD — the `EF(good)` attractor supplies each state's rank;
+/// concrete forward reachability from the initial state enumerates the real reachable states (so the free
+/// reset does not make every encoding "winning"); each row's forced inputs are projected from the
+/// rank-decreasing moves.
+pub fn exact_env_strategy_policy(btor2_content: &str, good: &str) -> Option<PositionalPolicy> {
+    use crate::adapter::btor2::parser;
+    let (bb, file, good_bdd) = build_atom_model(btor2_content, good)?;
+    let resolve = |name: &str| -> String {
+        parser::resolve_to_canonical_name(
+            &file,
+            name,
+            parser::ResolveStrictness::Strict {
+                allow_reset_mux: true,
+            },
+        )
+        .unwrap_or_else(|| name.to_string())
+    };
+    let expr = resolve_predicate_expr_registers(&parse_predicate_atom_bool(good).ok()?, &resolve);
+    let mut regs: std::collections::HashSet<String> = std::collections::HashSet::new();
+    collect_predicate_registers(&expr, &mut regs);
+    let reg = regs.into_iter().next()?;
+    bb.env_strategy_policy(&file, &good_bdd, &reg)
+}
+
 /// D1.8b/b-2 — detect a liveness shape and return the node id of its target `p`.
 /// Recognised (both disjunct/conjunct orders; modalities must be bare `[]`):
 /// - bare `AF p` = `μX. (p ∨ [] X)`,
@@ -3378,6 +3434,179 @@ impl BddBitBlaster {
             s = ns;
         }
         None
+    }
+
+    /// P2.5-E — the full positional policy (see [`PositionalPolicy`]). The `EF(good)` attractor gives each
+    /// state its rank; concrete forward reachability from the initial state enumerates the real reachable
+    /// states; the forced inputs per control state are projected from the rank-decreasing moves.
+    fn env_strategy_policy(
+        &self,
+        file: &Btor2File,
+        good: &BDDFunction,
+        reg_name: &str,
+    ) -> Option<PositionalPolicy> {
+        let exact = self.exact_model();
+        // EF(good) attractor layers: L_0 = good, L_k = L_{k-1} ∨ ◇L_{k-1}. rank(s) = min k: s ∈ L_k.
+        let mut layers = vec![good.clone()];
+        loop {
+            let prev = layers.last().unwrap();
+            let next = prev.or(&exact.diamond_pre(prev)).unwrap();
+            if &next == prev {
+                break;
+            }
+            layers.push(next);
+        }
+        let winning = layers.last().unwrap().clone();
+        let init = self.initial_state_bdd(file);
+        if init.and(&winning).unwrap() == self.ff {
+            return None; // good unreachable from init — no strategy
+        }
+        // The policy is indexed by this state register.
+        if !self
+            .cells
+            .iter()
+            .any(|c| c.is_state && c.symbol == reg_name)
+        {
+            return None;
+        }
+        // rank(s): the least attractor layer containing the concrete state s.
+        let rank_of = |s: &BTreeMap<String, u128>| -> u32 {
+            let mt = self.state_minterm(s);
+            (0..layers.len())
+                .find(|&k| mt.and(&layers[k]).unwrap() != self.ff)
+                .unwrap_or(0) as u32
+        };
+        // Concrete forward reachability from init (under all inputs) — stays on the design's real states,
+        // so the free reset does not make every encoding "winning" (a symbolic winning-region walk would).
+        let mut frontier: Vec<BTreeMap<String, u128>> = Vec::new();
+        {
+            let mut r = init.clone();
+            for _ in 0..1024 {
+                if r == self.ff {
+                    break;
+                }
+                let s = self.pick_state_assignment(&r);
+                r = r.and(&self.state_minterm(&s).not().unwrap()).unwrap();
+                frontier.push(s);
+            }
+        }
+        let mut visited: std::collections::HashSet<BTreeMap<String, u128>> =
+            std::collections::HashSet::new();
+        let mut reached: Vec<(BTreeMap<String, u128>, u32)> = Vec::new();
+        let mut guard = 0usize;
+        while let Some(s) = frontier.pop() {
+            guard += 1;
+            if guard > 200_000 {
+                break; // reachable-set guard (should never fire for a control FSM)
+            }
+            if !visited.insert(s.clone()) {
+                continue;
+            }
+            let k = rank_of(&s);
+            for ns in self.concrete_successors(&exact, &s) {
+                if !visited.contains(&ns) {
+                    frontier.push(ns);
+                }
+            }
+            reached.push((s, k));
+        }
+        // The min rank per state-register value (its shortest distance to `good`).
+        let mut min_rank: BTreeMap<u128, u32> = BTreeMap::new();
+        for (s, k) in &reached {
+            let v = *s.get(reg_name).unwrap_or(&0);
+            min_rank
+                .entry(v)
+                .and_modify(|r| *r = (*r).min(*k))
+                .or_insert(*k);
+        }
+        // The forced-input discipline is projected from the rank-decreasing moves of the MIN-RANK
+        // states of each control value (its fastest-progress behaviour). Aggregating over higher-rank
+        // states of the same control value — which may branch differently on OTHER registers (e.g. a
+        // wipe-round flag) — would cancel the forcing; the min-rank moves are the clean discipline.
+        let mut moves_by_val: BTreeMap<u128, BDDFunction> = BTreeMap::new();
+        for (s, k) in &reached {
+            let v = *s.get(reg_name).unwrap_or(&0);
+            if *k == 0 || *k != min_rank[&v] {
+                continue;
+            }
+            let m = self
+                .state_minterm(s)
+                .and(&exact.move_into(&layers[(*k - 1) as usize]))
+                .unwrap();
+            moves_by_val
+                .entry(v)
+                .and_modify(|acc| *acc = acc.or(&m).unwrap())
+                .or_insert(m);
+        }
+        let mut entries: Vec<PolicyEntry> = min_rank
+            .iter()
+            .map(|(&v, &rank)| {
+                let mut forced = BTreeMap::new();
+                if let Some(mv) = moves_by_val.get(&v)
+                    && *mv != self.ff
+                {
+                    for cell in self.cells.iter().filter(|c| !c.is_state) {
+                        if let Some(val) = self.forced_cell_value(mv, cell) {
+                            forced.insert(cell.symbol.clone(), val);
+                        }
+                    }
+                }
+                PolicyEntry {
+                    state_value: v,
+                    rank,
+                    forced_inputs: forced,
+                }
+            })
+            .collect();
+        entries.sort_by(|a, b| a.rank.cmp(&b.rank).then(a.state_value.cmp(&b.state_value)));
+        Some(PositionalPolicy {
+            state_register: reg_name.to_string(),
+            entries,
+        })
+    }
+
+    /// The distinct concrete next-states reachable from `s` under some constraint-respecting input.
+    /// Enumerates by picking a full `(state = s, input)` assignment, stepping it, then subtracting every
+    /// input that leads to that successor — so the loop count is the number of DISTINCT successors (few).
+    fn concrete_successors(
+        &self,
+        exact: &ExactModel,
+        s: &BTreeMap<String, u128>,
+    ) -> Vec<BTreeMap<String, u128>> {
+        let mut rem = self.state_minterm(s).and(&self.constraint_bdd).unwrap();
+        let mut outs = Vec::new();
+        for _ in 0..4096 {
+            if rem == self.ff {
+                break;
+            }
+            let full = self.pick_full_assignment(&rem);
+            let mut ns = s.clone();
+            for (reg, val) in self.eval_step(&full) {
+                ns.insert(reg, val);
+            }
+            rem = rem
+                .and(&exact.to_next(&self.state_minterm(&ns)).not().unwrap())
+                .unwrap();
+            outs.push(ns);
+        }
+        outs
+    }
+
+    /// The value `cell` is forced to across the (state,input) set `set` (assumed non-empty), or `None`
+    /// if any of `cell`'s bits can take either value there — i.e. the cell is not (fully) constrained.
+    fn forced_cell_value(&self, set: &BDDFunction, cell: &Cell) -> Option<u128> {
+        let mut val = 0u128;
+        for (b, var) in cell.vars.iter().enumerate() {
+            let with1 = set.and(var).unwrap();
+            let with0 = set.and(&var.not().unwrap()).unwrap();
+            if with1 != self.ff && with0 != self.ff {
+                return None;
+            }
+            if with1 != self.ff {
+                val |= 1u128 << b;
+            }
+        }
+        Some(val)
     }
 
     /// `¬EF p = ¬(μX. (p ∨ ◇X))` over the exact model — the "trap" region: states from which

--- a/crates/mununu-core/tests/wall_class_matrix.rs
+++ b/crates/mununu-core/tests/wall_class_matrix.rs
@@ -1301,3 +1301,112 @@ fn rom_ctrl_witness_play_exhibits_positional_ack_strategy() {
         "the play reaches Done (518)"
     );
 }
+
+/// P2.5-E — the FULL positional strategy (Mealy policy over reachable states), the generalization of the
+/// single witness play. `exact_env_strategy_policy` returns a state-indexed map; for edn the map prescribes
+/// `boot_req_mode_i` at OPPOSITE values in two control states — the positional obligation as a policy
+/// rather than one trace: `=1` at Idle (193, request the boot) and `=0` at BootDone (240, release to
+/// progress). The map also covers the whole reachable region (every control state gets a discipline).
+#[test]
+fn edn_full_positional_policy_maps_boot_req_per_state() {
+    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_strategy_policy;
+    let policy = exact_env_strategy_policy(EDN_BOOT, "state_q == 44").expect("a strategy exists");
+    let forced = |v: u128, sig: &str| -> Option<u128> {
+        policy
+            .entries
+            .iter()
+            .find(|e| e.state_value == v)
+            .and_then(|e| e.forced_inputs.get(sig).copied())
+    };
+    // The SAME input forced to OPPOSITE values in two states — the positional obligation, as a map.
+    assert_eq!(
+        forced(193, "boot_req_mode_i"),
+        Some(1),
+        "Idle: request the boot"
+    );
+    assert_eq!(
+        forced(240, "boot_req_mode_i"),
+        Some(0),
+        "BootDone: release boot_req to progress"
+    );
+    // The target is already good (rank 0), and the policy covers the reachable control states.
+    assert!(
+        policy
+            .entries
+            .iter()
+            .any(|e| e.state_value == 44 && e.rank == 0)
+    );
+    assert!(
+        policy.entries.len() >= 5,
+        "policy covers the reachable region, not one path: {} entries",
+        policy.entries.len()
+    );
+}
+
+/// P2.5-E — the full positional policy on OTBN. The map captures the "acknowledge only when expected"
+/// discipline across ALL states: `urnd_reseed_ack_i = 0` at Halt (1) — a stray ACK would trap — and `= 1`
+/// at UrndRefresh (242) to progress to Running (119). The per-control-state forced inputs come from the
+/// MIN-RANK (fastest-progress) moves, so the UrndRefresh row is not muddied by the wipe-round register.
+#[test]
+fn otbn_full_positional_policy_maps_ack_per_state() {
+    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_strategy_policy;
+    let policy =
+        exact_env_strategy_policy(OTBN_START_STOP, "state_q == 119").expect("a strategy exists");
+    let forced = |v: u128, sig: &str| -> Option<u128> {
+        policy
+            .entries
+            .iter()
+            .find(|e| e.state_value == v)
+            .and_then(|e| e.forced_inputs.get(sig).copied())
+    };
+    assert_eq!(
+        forced(1, "urnd_reseed_ack_i"),
+        Some(0),
+        "Halt: keep ACK silent (a stray ACK traps to Locked)"
+    );
+    assert_eq!(
+        forced(242, "urnd_reseed_ack_i"),
+        Some(1),
+        "UrndRefresh: assert ACK to progress to Running"
+    );
+    assert!(
+        policy
+            .entries
+            .iter()
+            .any(|e| e.state_value == 119 && e.rank == 0)
+    );
+}
+
+/// P2.5-E — the full positional policy on the ROM controller. The map prescribes `kmac_done_i = 0` at
+/// ReadingLow (201) — a stray ACK trips the consistency check → Invalid — and `= 1` at ReadingHigh (185)
+/// to hand off the digest toward Checking → Done (518). The same ack-when-expected discipline as OTBN,
+/// on a second security FSM.
+#[test]
+fn rom_ctrl_full_positional_policy_maps_ack_per_state() {
+    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_strategy_policy;
+    let policy =
+        exact_env_strategy_policy(ROM_CTRL_FSM, "state_q == 518").expect("a strategy exists");
+    let forced = |v: u128, sig: &str| -> Option<u128> {
+        policy
+            .entries
+            .iter()
+            .find(|e| e.state_value == v)
+            .and_then(|e| e.forced_inputs.get(sig).copied())
+    };
+    assert_eq!(
+        forced(201, "kmac_done_i"),
+        Some(0),
+        "ReadingLow: keep the KMAC ACK silent (a stray ACK trips the consistency check)"
+    );
+    assert_eq!(
+        forced(185, "kmac_done_i"),
+        Some(1),
+        "ReadingHigh: assert the KMAC ACK to progress toward Done"
+    );
+    assert!(
+        policy
+            .entries
+            .iter()
+            .any(|e| e.state_value == 518 && e.rank == 0)
+    );
+}


### PR DESCRIPTION
## What

Generalizes the T2 witness (`exact_env_strategy_witness` — one winning play from the initial state, an `EF good` witness) to the **full positional strategy**: a memoryless policy over the design's reachable states — the `AG` part of `AG EF good`. This is the reusable synthesis object the article's synthesis section pointed to: an environment model, a directed-test seed, or the environment half of an assume-guarantee contract.

## API (`symbolic_bitblast.rs`)

- `PositionalPolicy { state_register, entries }` + `PolicyEntry { state_value, rank, forced_inputs }`
- `exact_env_strategy_policy(btor2, good) -> Option<PositionalPolicy>`

## Engine (exact-symbolic ROBDD, OxiDD)

- the `EF(good)` attractor supplies each state's **rank** (distance to good);
- **concrete forward reachability** from the single initial state enumerates the design's *real* reachable states. The model is compose-based (pre-image oriented), and the free reset would otherwise make a symbolic winning-region = every encoding — so forward-from-init is the correct region;
- per control-state (projected onto the target's state register), the forced-input discipline is projected from the **min-rank** (fastest-progress) rank-decreasing moves. Aggregating over higher-rank states of the same control value cancels the forcing when they branch on *another* register (e.g. OTBN's wipe-round flag), so the min-rank restriction keeps the per-control-state discipline clean.

## The policy makes the positional obligation explicit (same input, opposite forced values)

| design | policy highlights |
|---|---|
| edn | `boot_req_mode_i` = 1 @ Idle(193), 0 @ BootDone(240) |
| otbn | `urnd_reseed_ack_i` = 0 @ Halt(1), 1 @ UrndRefresh(242) — the full policy captures the whole "ack only when expected" rule (ack=1 only at Initial+UrndRefresh, 0 elsewhere) |
| rom_ctrl | `kmac_done_i` = 0 @ ReadingLow(201), 1 @ ReadingHigh(185) |

The map also covers the reachable region (e.g. "assert reset from Locked/glitch") — the genuine `AG EF` witness, not one path.

## Tests

`wall_class_matrix.rs` (host, gate `make ci`): three full-policy tests (edn/otbn/rom_ctrl) asserting the positional signal is forced to opposite values across states and the target is rank 0. All pass; fmt + clippy clean.

## Scope

Lands the synthesis **engine + validation** (T2-style — surface-wiring onto `--discover-assumptions` is the follow-up). `gr1.rs` untouched (symbolic re-impl per the plan's refactor decision). No 2-player split (all 1-player env cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)