### PR TITLE
refactor(recoverability): games terminology — positional strategy, not "Mealy policy"

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2901,23 +2901,23 @@ pub fn exact_env_strategy_witness(btor2_content: &str, good: &str) -> Option<Sta
     bb.reach_good_play(&file, &good_bdd)
 }
 
-/// P2.5-E — a full POSITIONAL environment strategy for `AG EF good`: a memoryless policy over the
+/// P2.5-E — a full POSITIONAL environment strategy for `AG EF good`: a memoryless strategy over the
 /// design's reachable states. Where [`exact_env_strategy_witness`] returns ONE play (witnessing `EF good`
 /// from the initial state), this returns the `AG` part — the driving discipline for *every* reachable
 /// state, as a state-indexed map. It is the reusable object: an environment model, a directed-test seed,
 /// or the environment half of an assume-guarantee contract.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PositionalPolicy {
-    /// The state register the policy is indexed by (the register named in the `good` atom).
+pub struct PositionalStrategy {
+    /// The state register the strategy is indexed by (the register named in the `good` atom).
     pub state_register: String,
     /// One row per reachable value of `state_register`, ordered by rank then value.
-    pub entries: Vec<PolicyEntry>,
+    pub entries: Vec<StrategyEntry>,
 }
 
-/// One control-state row of a [`PositionalPolicy`].
+/// One control-state row of a [`PositionalStrategy`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PolicyEntry {
-    /// The value of the policy's state register in this row.
+pub struct StrategyEntry {
+    /// The value of the strategy's state register in this row.
     pub state_value: u128,
     /// Attractor distance to `good` (`0` = the state already satisfies `good`).
     pub rank: u32,
@@ -2929,7 +2929,7 @@ pub struct PolicyEntry {
 }
 
 /// P2.5-E — synthesize the full positional environment strategy for `AG EF good` (see
-/// [`PositionalPolicy`]). `None` when `good` is not a resolvable `REG op VALUE` state atom over a state
+/// [`PositionalStrategy`]). `None` when `good` is not a resolvable `REG op VALUE` state atom over a state
 /// register, the model can't be built (over-cap / array / input-atom), or `good` is unreachable from the
 /// initial state (no strategy exists).
 ///
@@ -2937,7 +2937,10 @@ pub struct PolicyEntry {
 /// concrete forward reachability from the initial state enumerates the real reachable states (so the free
 /// reset does not make every encoding "winning"); each row's forced inputs are projected from the
 /// rank-decreasing moves.
-pub fn exact_env_strategy_policy(btor2_content: &str, good: &str) -> Option<PositionalPolicy> {
+pub fn exact_env_positional_strategy(
+    btor2_content: &str,
+    good: &str,
+) -> Option<PositionalStrategy> {
     use crate::adapter::btor2::parser;
     let (bb, file, good_bdd) = build_atom_model(btor2_content, good)?;
     let resolve = |name: &str| -> String {
@@ -2954,7 +2957,7 @@ pub fn exact_env_strategy_policy(btor2_content: &str, good: &str) -> Option<Posi
     let mut regs: std::collections::HashSet<String> = std::collections::HashSet::new();
     collect_predicate_registers(&expr, &mut regs);
     let reg = regs.into_iter().next()?;
-    bb.env_strategy_policy(&file, &good_bdd, &reg)
+    bb.env_positional_strategy(&file, &good_bdd, &reg)
 }
 
 /// D1.8b/b-2 — detect a liveness shape and return the node id of its target `p`.
@@ -3436,15 +3439,15 @@ impl BddBitBlaster {
         None
     }
 
-    /// P2.5-E — the full positional policy (see [`PositionalPolicy`]). The `EF(good)` attractor gives each
+    /// P2.5-E — the full positional strategy (see [`PositionalStrategy`]). The `EF(good)` attractor gives each
     /// state its rank; concrete forward reachability from the initial state enumerates the real reachable
     /// states; the forced inputs per control state are projected from the rank-decreasing moves.
-    fn env_strategy_policy(
+    fn env_positional_strategy(
         &self,
         file: &Btor2File,
         good: &BDDFunction,
         reg_name: &str,
-    ) -> Option<PositionalPolicy> {
+    ) -> Option<PositionalStrategy> {
         let exact = self.exact_model();
         // EF(good) attractor layers: L_0 = good, L_k = L_{k-1} ∨ ◇L_{k-1}. rank(s) = min k: s ∈ L_k.
         let mut layers = vec![good.clone()];
@@ -3461,7 +3464,7 @@ impl BddBitBlaster {
         if init.and(&winning).unwrap() == self.ff {
             return None; // good unreachable from init — no strategy
         }
-        // The policy is indexed by this state register.
+        // The strategy is indexed by this state register.
         if !self
             .cells
             .iter()
@@ -3538,7 +3541,7 @@ impl BddBitBlaster {
                 .and_modify(|acc| *acc = acc.or(&m).unwrap())
                 .or_insert(m);
         }
-        let mut entries: Vec<PolicyEntry> = min_rank
+        let mut entries: Vec<StrategyEntry> = min_rank
             .iter()
             .map(|(&v, &rank)| {
                 let mut forced = BTreeMap::new();
@@ -3551,7 +3554,7 @@ impl BddBitBlaster {
                         }
                     }
                 }
-                PolicyEntry {
+                StrategyEntry {
                     state_value: v,
                     rank,
                     forced_inputs: forced,
@@ -3559,7 +3562,7 @@ impl BddBitBlaster {
             })
             .collect();
         entries.sort_by(|a, b| a.rank.cmp(&b.rank).then(a.state_value.cmp(&b.state_value)));
-        Some(PositionalPolicy {
+        Some(PositionalStrategy {
             state_register: reg_name.to_string(),
             entries,
         })

--- a/crates/mununu-core/src/verdict.rs
+++ b/crates/mununu-core/src/verdict.rs
@@ -118,7 +118,7 @@ pub enum AssumptionKind {
     InputSchedule,
     /// "Reset is eventually asserted."
     ResetEventually,
-    /// A synthesized environment strategy (Mealy contract).
+    /// A synthesized positional environment strategy (1-player: the environment owns all inputs).
     EnvStrategy,
 }
 

--- a/crates/mununu-core/tests/wall_class_matrix.rs
+++ b/crates/mununu-core/tests/wall_class_matrix.rs
@@ -1302,17 +1302,18 @@ fn rom_ctrl_witness_play_exhibits_positional_ack_strategy() {
     );
 }
 
-/// P2.5-E — the FULL positional strategy (Mealy policy over reachable states), the generalization of the
-/// single witness play. `exact_env_strategy_policy` returns a state-indexed map; for edn the map prescribes
-/// `boot_req_mode_i` at OPPOSITE values in two control states — the positional obligation as a policy
+/// P2.5-E — the FULL positional strategy (positional strategy over reachable states), the generalization of the
+/// single witness play. `exact_env_positional_strategy` returns a state-indexed map; for edn the map prescribes
+/// `boot_req_mode_i` at OPPOSITE values in two control states — the positional obligation as a strategy
 /// rather than one trace: `=1` at Idle (193, request the boot) and `=0` at BootDone (240, release to
 /// progress). The map also covers the whole reachable region (every control state gets a discipline).
 #[test]
-fn edn_full_positional_policy_maps_boot_req_per_state() {
-    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_strategy_policy;
-    let policy = exact_env_strategy_policy(EDN_BOOT, "state_q == 44").expect("a strategy exists");
+fn edn_full_positional_strategy_maps_boot_req_per_state() {
+    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_positional_strategy;
+    let strategy =
+        exact_env_positional_strategy(EDN_BOOT, "state_q == 44").expect("a strategy exists");
     let forced = |v: u128, sig: &str| -> Option<u128> {
-        policy
+        strategy
             .entries
             .iter()
             .find(|e| e.state_value == v)
@@ -1329,31 +1330,31 @@ fn edn_full_positional_policy_maps_boot_req_per_state() {
         Some(0),
         "BootDone: release boot_req to progress"
     );
-    // The target is already good (rank 0), and the policy covers the reachable control states.
+    // The target is already good (rank 0), and the strategy covers the reachable control states.
     assert!(
-        policy
+        strategy
             .entries
             .iter()
             .any(|e| e.state_value == 44 && e.rank == 0)
     );
     assert!(
-        policy.entries.len() >= 5,
-        "policy covers the reachable region, not one path: {} entries",
-        policy.entries.len()
+        strategy.entries.len() >= 5,
+        "strategy covers the reachable region, not one path: {} entries",
+        strategy.entries.len()
     );
 }
 
-/// P2.5-E — the full positional policy on OTBN. The map captures the "acknowledge only when expected"
+/// P2.5-E — the full positional strategy on OTBN. The map captures the "acknowledge only when expected"
 /// discipline across ALL states: `urnd_reseed_ack_i = 0` at Halt (1) — a stray ACK would trap — and `= 1`
 /// at UrndRefresh (242) to progress to Running (119). The per-control-state forced inputs come from the
 /// MIN-RANK (fastest-progress) moves, so the UrndRefresh row is not muddied by the wipe-round register.
 #[test]
-fn otbn_full_positional_policy_maps_ack_per_state() {
-    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_strategy_policy;
-    let policy =
-        exact_env_strategy_policy(OTBN_START_STOP, "state_q == 119").expect("a strategy exists");
+fn otbn_full_positional_strategy_maps_ack_per_state() {
+    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_positional_strategy;
+    let strategy = exact_env_positional_strategy(OTBN_START_STOP, "state_q == 119")
+        .expect("a strategy exists");
     let forced = |v: u128, sig: &str| -> Option<u128> {
-        policy
+        strategy
             .entries
             .iter()
             .find(|e| e.state_value == v)
@@ -1370,24 +1371,24 @@ fn otbn_full_positional_policy_maps_ack_per_state() {
         "UrndRefresh: assert ACK to progress to Running"
     );
     assert!(
-        policy
+        strategy
             .entries
             .iter()
             .any(|e| e.state_value == 119 && e.rank == 0)
     );
 }
 
-/// P2.5-E — the full positional policy on the ROM controller. The map prescribes `kmac_done_i = 0` at
+/// P2.5-E — the full positional strategy on the ROM controller. The map prescribes `kmac_done_i = 0` at
 /// ReadingLow (201) — a stray ACK trips the consistency check → Invalid — and `= 1` at ReadingHigh (185)
 /// to hand off the digest toward Checking → Done (518). The same ack-when-expected discipline as OTBN,
 /// on a second security FSM.
 #[test]
-fn rom_ctrl_full_positional_policy_maps_ack_per_state() {
-    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_strategy_policy;
-    let policy =
-        exact_env_strategy_policy(ROM_CTRL_FSM, "state_q == 518").expect("a strategy exists");
+fn rom_ctrl_full_positional_strategy_maps_ack_per_state() {
+    use mununu_core::adapter::btor2::symbolic_bitblast::exact_env_positional_strategy;
+    let strategy =
+        exact_env_positional_strategy(ROM_CTRL_FSM, "state_q == 518").expect("a strategy exists");
     let forced = |v: u128, sig: &str| -> Option<u128> {
-        policy
+        strategy
             .entries
             .iter()
             .find(|e| e.state_value == v)
@@ -1404,7 +1405,7 @@ fn rom_ctrl_full_positional_policy_maps_ack_per_state() {
         "ReadingHigh: assert the KMAC ACK to progress toward Done"
     );
     assert!(
-        policy
+        strategy
             .entries
             .iter()
             .any(|e| e.state_value == 518 && e.rank == 0)


### PR DESCRIPTION
## What

Aligns the 1-player environment-strategy API (from PR #432) with the infinite-games / model-checking literature, and removes two imprecise names I introduced.

- **"Mealy policy" → positional strategy.** A Mealy machine reacts to inputs; the 1-player object is a map `state → input` with nothing to react to (the environment owns all inputs), so it is a **positional (memoryless) strategy**, not Mealy. The legitimate Mealy uses (`gr1.rs`, `parity_game.rs`, TLSF/GR(1) synthesis — genuine reactive controllers) are **untouched**.
- **"policy" → "strategy".** "Policy" is the MDP/RL word; in games the term is *strategy*.

## Renames (public API from PR #432 — fresh, no external users)

```
PositionalPolicy          -> PositionalStrategy
PolicyEntry               -> StrategyEntry
exact_env_strategy_policy -> exact_env_positional_strategy
env_strategy_policy (fn)  -> env_positional_strategy
tests *_positional_policy_* -> *_positional_strategy_*
```

Also `verdict.rs` `AssumptionKind::EnvStrategy` doc: "Mealy contract" → "positional environment strategy (1-player)".

## Why

Part of standardizing on established model-checking / infinite-games vocabulary (no invented names). See the two design docs (`.claude/plans/controllability-and-assumption-discovery.md` §3, `.claude/plans/unified-two-player-mu-calculus-verifier.md` §0) for the terminology standard this follows.

## Validation

No behaviour change. fmt + clippy clean; the three full positional-strategy tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)