### PR TITLE
feat(exact): validate the two-player input partition (Stage 2)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2794,6 +2794,31 @@ fn exact_symbolic_verdict_with_witness_inner(
         ));
     }
 
+    // P2.5-F — validate the two-player partition. Every declared controllable input must be a real
+    // primary input of the design. A name matching nothing would otherwise fall back SILENTLY to the
+    // environment (a sound but pessimistic all-environment reading, and not the partition the caller
+    // asked for) — error instead. On a flattened design the BTOR2 inputs ARE the top module's primary
+    // inputs (Yosys `flatten` resolves declared module-to-module wires to internal signals), so a name
+    // that is not here is either a typo or an internal signal driven by another module — not a top input.
+    if !controllable.is_empty() {
+        let mut unknown: Vec<&str> = controllable
+            .iter()
+            .filter(|c| !input_leaf_names.contains(c.as_str()))
+            .map(String::as_str)
+            .collect();
+        if !unknown.is_empty() {
+            unknown.sort_unstable();
+            let mut inputs: Vec<&str> = input_leaf_names.iter().map(String::as_str).collect();
+            inputs.sort_unstable();
+            return Err(format!(
+                "exact two-player MC: declared controllable input(s) {unknown:?} are not primary \
+                 inputs of the design (primary inputs: {inputs:?}). Declare a real top-level input; \
+                 for a multi-module design ensure it is a top input, not one driven by another \
+                 module's output (which flatten resolves to an internal signal, not a free input)."
+            ));
+        }
+    }
+
     let bb = BddBitBlaster::build_with_keep(&file, keep_set.as_ref())?;
     let exact = if controllable.is_empty() {
         bb.exact_model()

--- a/crates/mununu-core/tests/exact_two_player_game.rs
+++ b/crates/mununu-core/tests/exact_two_player_game.rs
@@ -135,3 +135,19 @@ fn empty_partition_degenerates_to_box() {
         ExactVerdict::Violated,
     );
 }
+
+/// Stage-2 partition validation: a declared controllable input that is NOT a primary input is an error,
+/// not a silent fall-back to the environment. `"nope"` matches no input ⇒ `Err` (the message lists the
+/// real primary inputs). This closes the silent all-environment gap: a typo or an internally-driven
+/// signal is rejected rather than quietly reinterpreted as environment.
+#[test]
+fn unknown_controllable_input_is_rejected() {
+    let f = parser::parse("mu X. ((st == 1) || <(ctrl = controllable)> X)").unwrap();
+    let err = exact_two_player_verdict(CTRL_INIT0, &f, &["nope"]).unwrap_err();
+    assert!(
+        err.contains("not primary inputs") && err.contains("nope"),
+        "expected a partition-validation error naming the unknown input, got: {err}"
+    );
+    // The real input names still work.
+    assert!(exact_two_player_verdict(CTRL_INIT0, &f, &["c"]).is_ok());
+}


### PR DESCRIPTION
## What

`exact_two_player_verdict` now **errors when a declared controllable input is not a real primary input** of the design, instead of silently leaving it in the environment. A mismatched name (a typo, or an internal signal driven by another module) previously fell back to the sound-but-pessimistic all-environment reading — not the partition the caller asked for, and silent. The error lists the design's actual primary inputs.

First slice of Stage 2 (input-partition source) of the unified two-player μ-calculus game verifier (`.claude/plans/unified-two-player-mu-calculus-verifier.md`).

## It also settles the multi-module environment question

- **On the standard flattened lift** (what the exact path consumes), the environment is *already* exactly the top module's primary inputs: Yosys `flatten` (`run_sv_flatten_btor2`) resolves every declared module-to-module wire into an internal signal, so the BTOR2's `input` lines are the top primary inputs. Assigning the non-controllable primary inputs to the environment realizes "only inputs coming into the top module" by construction. A black-boxed submodule's output becomes a free input → correctly environment (a chaotic over-approximation).
- **The modular (non-flattened) derivation** — env = all module inputs minus those bound to a *declared* module's output, via `multi_module.rs::parse_instance_connections` — is recorded as tasks M1–M3 in the plan; it matters only if the exact/KMTS path ever consumes a non-flattened composition.

## Test

`unknown_controllable_input_is_rejected` (host, gate `make ci`): an undeclared controllable name is an `Err` naming the real inputs; the real names still work. fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)