### PR TITLE
feat(exact): two-player strategy + counterstrategy extraction from the game attractor

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2322,6 +2322,34 @@ impl ExactModel {
         forced.exists(&self.env_cube).unwrap()
     }
 
+    /// P2.5-F (strategy extraction) — the `(state, ctrl-input)` pairs from which, WHATEVER the
+    /// environment does, the controller's move lands the successor in `keep`: `∀env. constraint ∧ next ∈
+    /// keep`. `cpre_controllable(keep) = ctrl_forcing_moves(keep).∃ctrl`. A single state's slice,
+    /// projected onto the controllable inputs, is the controller's forced move there (env-oblivious /
+    /// positional; with no environment inputs it is the whole move).
+    pub fn ctrl_forcing_moves(&self, keep: &BDDFunction) -> BDDFunction {
+        use oxidd::BooleanFunctionQuant;
+        self.to_next(keep)
+            .and(&self.constraint)
+            .unwrap()
+            .forall(&self.env_cube)
+            .unwrap()
+    }
+
+    /// Dual — the `(state, env-input)` pairs from which, WHATEVER the controller does, the successor is
+    /// in `keep`: `∀ctrl. constraint ⟹ next ∈ keep`. The environment's forcing moves, for the
+    /// counterstrategy when the controller loses.
+    pub fn env_forcing_moves(&self, keep: &BDDFunction) -> BDDFunction {
+        use oxidd::BooleanFunctionQuant;
+        self.constraint
+            .not()
+            .unwrap()
+            .or(&self.to_next(keep))
+            .unwrap()
+            .forall(&self.ctrl_cube)
+            .unwrap()
+    }
+
     // ---- Phase 2b: symbolic environment-strategy synthesis ----------------------------------------
     // `AG EF good` under an environment strategy. The environment OWNS the inputs, so `◇` = ∃input
     // (`diamond_pre`) is exactly Eve's controllable move; there is no adversary among the inputs (the
@@ -3439,6 +3467,54 @@ pub fn exact_env_positional_strategy(
     bb.env_positional_strategy(&file, &good_bdd, &reg)
 }
 
+/// P2.5-F — a synthesized TWO-PLAYER strategy: the CONTROLLER's positional strategy when the reachability
+/// game `μX. (good ∨ ⟨ctrl⟩X)` is realizable, or the ENVIRONMENT's COUNTERSTRATEGY when it is not. Both
+/// are state-indexed forced-input maps ([`PositionalStrategy`]): the controller's forces CONTROLLABLE
+/// inputs (robust to every environment move) toward `good`; the environment's forces ENVIRONMENT inputs
+/// (robust to every controllable move) to keep the system out of the controller's winning region.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TwoPlayerStrategy {
+    /// `true` = the controller wins from the initial state (spec realizable) and `strategy` is its
+    /// strategy; `false` = the environment wins (unrealizable) and `strategy` is its counterstrategy.
+    pub realizable: bool,
+    /// The winner's positional strategy.
+    pub strategy: PositionalStrategy,
+}
+
+/// P2.5-F — synthesize the two-player strategy for the controllable-reachability game to `good` with
+/// `controllable` naming the controller's inputs. `realizable` iff the controller wins from the initial
+/// state (== [`exact_two_player_verdict`] on `μX. good ∨ ⟨ctrl⟩X`). `None` when `good` is not a resolvable
+/// state atom or the model can't be built.
+///
+/// **Engine (§16):** `exact-symbolic` ROBDD — the controllable attractor (`cpre_controllable`) supplies
+/// ranks; concrete forward reachability enumerates the real states; each row's forced inputs come from
+/// the winner's forcing moves ([`ExactModel::ctrl_forcing_moves`] / [`ExactModel::env_forcing_moves`]).
+pub fn exact_two_player_strategy(
+    btor2_content: &str,
+    good: &str,
+    controllable: &[&str],
+) -> Option<TwoPlayerStrategy> {
+    use crate::adapter::btor2::parser;
+    let (bb, file, good_bdd) = build_atom_model(btor2_content, good)?;
+    let resolve = |name: &str| -> String {
+        parser::resolve_to_canonical_name(
+            &file,
+            name,
+            parser::ResolveStrictness::Strict {
+                allow_reset_mux: true,
+            },
+        )
+        .unwrap_or_else(|| name.to_string())
+    };
+    let expr = resolve_predicate_expr_registers(&parse_predicate_atom_bool(good).ok()?, &resolve);
+    let mut regs: std::collections::HashSet<String> = std::collections::HashSet::new();
+    collect_predicate_registers(&expr, &mut regs);
+    let reg = regs.into_iter().next()?;
+    let ctrl: std::collections::HashSet<String> =
+        controllable.iter().map(|s| s.to_string()).collect();
+    bb.two_player_strategy(&file, &good_bdd, &reg, &ctrl)
+}
+
 /// D1.8b/b-2 — detect a liveness shape and return the node id of its target `p`.
 /// Recognised (both disjunct/conjunct orders; modalities must be bare `[]`):
 /// - bare `AF p` = `μX. (p ∨ [] X)`,
@@ -4044,6 +4120,172 @@ impl BddBitBlaster {
         Some(PositionalStrategy {
             state_register: reg_name.to_string(),
             entries,
+        })
+    }
+
+    /// P2.5-F — synthesize the two-player strategy for the controllable-reachability game to `good`, with
+    /// `controllable` the controller's input names. Solves the attractor `μX. good ∨ CPre_ctrl(X)`; the
+    /// controller wins iff `init ⊆ attractor`. Returns the WINNER's positional strategy:
+    /// - **realizable** (controller wins): each reachable winning state's row forces the CONTROLLABLE
+    ///   inputs to a rank-decreasing move ([`ExactModel::ctrl_forcing_moves`] into the next-lower attractor
+    ///   layer) — robust to every environment move. With all inputs controllable this reduces to the
+    ///   1-player [`Self::env_positional_strategy`].
+    /// - **unrealizable** (environment wins): each reachable state OUTSIDE the attractor forces the
+    ///   ENVIRONMENT inputs to a move that keeps the play out of it ([`ExactModel::env_forcing_moves`]) —
+    ///   the counterstrategy witnessing why no controller can reach `good`. A safety/maintain strategy, so
+    ///   every row has rank 0 (no distance-to-target metric).
+    ///
+    /// `None` when `reg_name` is not a state register.
+    fn two_player_strategy(
+        &self,
+        file: &Btor2File,
+        good: &BDDFunction,
+        reg_name: &str,
+        controllable: &std::collections::HashSet<String>,
+    ) -> Option<TwoPlayerStrategy> {
+        let exact = self.exact_model_partitioned(controllable);
+        // Controllable-reachability attractor: L_0 = good, L_k = L_{k-1} ∨ CPre_ctrl(L_{k-1}).
+        // rank(s) = min k : s ∈ L_k. The controller wins from init iff init ⊆ the fixpoint.
+        let mut layers = vec![good.clone()];
+        loop {
+            let prev = layers.last().unwrap();
+            let next = prev.or(&exact.cpre_controllable(prev)).unwrap();
+            if &next == prev {
+                break;
+            }
+            layers.push(next);
+        }
+        let winning = layers.last().unwrap().clone();
+        if !self
+            .cells
+            .iter()
+            .any(|c| c.is_state && c.symbol == reg_name)
+        {
+            return None;
+        }
+        let init = self.initial_state_bdd(file);
+        let realizable = init.and(&winning).unwrap() != self.ff;
+        // The winner's region: the controller lives inside the attractor; the environment lives outside it
+        // (by determinacy of the reachability game, ¬attractor is the environment's winning region).
+        let region = if realizable {
+            winning.clone()
+        } else {
+            winning.not().unwrap()
+        };
+        // rank(s): the attractor layer for the controller; 0 everywhere for the environment (safety game).
+        let rank_of = |s: &BTreeMap<String, u128>| -> u32 {
+            if !realizable {
+                return 0;
+            }
+            let mt = self.state_minterm(s);
+            (0..layers.len())
+                .find(|&k| mt.and(&layers[k]).unwrap() != self.ff)
+                .unwrap_or(0) as u32
+        };
+        // Concrete forward reachability from init (under all inputs), kept to the winner's region — so the
+        // free reset does not make every encoding "winning", exactly as the 1-player extractor does.
+        let mut frontier: Vec<BTreeMap<String, u128>> = Vec::new();
+        {
+            let mut r = init.clone();
+            for _ in 0..1024 {
+                if r == self.ff {
+                    break;
+                }
+                let s = self.pick_state_assignment(&r);
+                r = r.and(&self.state_minterm(&s).not().unwrap()).unwrap();
+                frontier.push(s);
+            }
+        }
+        let mut visited: std::collections::HashSet<BTreeMap<String, u128>> =
+            std::collections::HashSet::new();
+        let mut reached: Vec<(BTreeMap<String, u128>, u32)> = Vec::new();
+        let mut guard = 0usize;
+        while let Some(s) = frontier.pop() {
+            guard += 1;
+            if guard > 200_000 {
+                break;
+            }
+            if !visited.insert(s.clone()) {
+                continue;
+            }
+            for ns in self.concrete_successors(&exact, &s) {
+                if !visited.contains(&ns) {
+                    frontier.push(ns);
+                }
+            }
+            // Only states in the winner's region carry a strategy row.
+            if self.state_minterm(&s).and(&region).unwrap() != self.ff {
+                let k = rank_of(&s);
+                reached.push((s, k));
+            }
+        }
+        // Min rank per state-register value (its fastest progress, as in the 1-player extractor).
+        let mut min_rank: BTreeMap<u128, u32> = BTreeMap::new();
+        for (s, k) in &reached {
+            let v = *s.get(reg_name).unwrap_or(&0);
+            min_rank
+                .entry(v)
+                .and_modify(|r| *r = (*r).min(*k))
+                .or_insert(*k);
+        }
+        // Forced moves of the MIN-RANK states of each control value. Controller: the rank-decreasing
+        // controllable move (`ctrl_forcing_moves` into the next-lower layer, robust to every env move).
+        // Environment: the region-maintaining environment move (`env_forcing_moves` staying in ¬attractor).
+        let mut moves_by_val: BTreeMap<u128, BDDFunction> = BTreeMap::new();
+        for (s, k) in &reached {
+            let v = *s.get(reg_name).unwrap_or(&0);
+            if *k != min_rank[&v] {
+                continue;
+            }
+            let m = if realizable {
+                if *k == 0 {
+                    continue; // already at `good` — no forcing move needed
+                }
+                self.state_minterm(s)
+                    .and(&exact.ctrl_forcing_moves(&layers[(*k - 1) as usize]))
+                    .unwrap()
+            } else {
+                self.state_minterm(s)
+                    .and(&exact.env_forcing_moves(&region))
+                    .unwrap()
+            };
+            moves_by_val
+                .entry(v)
+                .and_modify(|acc| *acc = acc.or(&m).unwrap())
+                .or_insert(m);
+        }
+        // Project onto the WINNER's own inputs: controllable inputs for the controller, environment inputs
+        // for the counterstrategy. (The other player's inputs are ∀-quantified out by the forcing move.)
+        let owns = |cell: &Cell| -> bool {
+            !cell.is_state && (realizable == controllable.contains(&cell.symbol))
+        };
+        let mut entries: Vec<StrategyEntry> = min_rank
+            .iter()
+            .map(|(&v, &rank)| {
+                let mut forced = BTreeMap::new();
+                if let Some(mv) = moves_by_val.get(&v)
+                    && *mv != self.ff
+                {
+                    for cell in self.cells.iter().filter(|c| owns(c)) {
+                        if let Some(val) = self.forced_cell_value(mv, cell) {
+                            forced.insert(cell.symbol.clone(), val);
+                        }
+                    }
+                }
+                StrategyEntry {
+                    state_value: v,
+                    rank,
+                    forced_inputs: forced,
+                }
+            })
+            .collect();
+        entries.sort_by(|a, b| a.rank.cmp(&b.rank).then(a.state_value.cmp(&b.state_value)));
+        Some(TwoPlayerStrategy {
+            realizable,
+            strategy: PositionalStrategy {
+                state_register: reg_name.to_string(),
+                entries,
+            },
         })
     }
 

--- a/crates/mununu-core/tests/exact_two_player_strategy.rs
+++ b/crates/mununu-core/tests/exact_two_player_strategy.rs
@@ -1,0 +1,162 @@
+//! P2.5-F — the exact-symbolic engine EXTRACTING the two-player game strategy via
+//! `exact_two_player_strategy`. Where `exact_two_player_verdict` answers realizable? (yes/no), this
+//! recovers the WINNER's positional strategy: the CONTROLLER's forced controllable inputs when the
+//! reachability game is realizable, or the ENVIRONMENT's counterstrategy (forced environment inputs
+//! witnessing why no controller wins) when it is not.
+//!
+//! Validation is by KNOWN ANSWER on the same minimal 1-bit games as `exact_two_player_game.rs`
+//! (`st' = c`, `st' = c & ¬e`), plus a REDUCTION check + an unrealizable finding on the real OpenTitan
+//! `edn_main_sm` fixture:
+//!
+//! - `CTRL`  (`st' = c`)       : realizable — controller forces `c = 1` to reach `st = 1`.
+//! - `ENVBLK`(`st' = c & ¬e`)  : unrealizable — the environment counterstrategy forces `e = 1` to keep
+//!   `st = 0` against every controllable move.
+//! - `edn` all-controllable    : the two-player strategy must EQUAL the 1-player positional strategy
+//!   (`∀∅ ∃all` reduces `cpre_controllable`→`diamond_pre`, `ctrl_forcing_moves`→`move_into`).
+//! - `edn` mode-controllable   : unrealizable — the counterstrategy forces only ENVIRONMENT inputs
+//!   (the acks/escalation), never the controllable mode signals.
+
+use mununu_core::adapter::btor2::symbolic_bitblast::{
+    PositionalStrategy, exact_env_positional_strategy, exact_two_player_strategy,
+};
+
+// st' = c : the controller sets the next state.
+const CTRL_INIT0: &str = "\
+1 sort bitvec 1
+2 input 1 c
+3 input 1 e
+4 state 1 st
+5 zero 1
+6 init 1 4 5
+7 next 1 4 2
+";
+
+// st' = c & ¬e : the environment can force st' = 0 by asserting e.
+const ENVBLK_INIT0: &str = "\
+1 sort bitvec 1
+2 input 1 c
+3 input 1 e
+4 state 1 st
+5 zero 1
+6 init 1 4 5
+7 not 1 3
+8 and 1 2 7
+9 next 1 4 8
+";
+
+const EDN: &str = include_str!("fixtures/wall_classes/edn_boot_sm.btor");
+const EDN_ALL: &[&str] = &[
+    "auto_req_mode_i",
+    "boot_req_mode_i",
+    "clk_i",
+    "cmd_sent_i",
+    "csrng_ack_err_i",
+    "csrng_cmd_ack_i",
+    "edn_enable_i",
+    "local_escalate_i",
+    "max_reqs_cnt_zero_i",
+    "rst_ni",
+    "sw_cmd_req_load_i",
+];
+
+/// The value the strategy forces `input` to at control-state `state_value`, or `None` if free/absent.
+fn forced(s: &PositionalStrategy, state_value: u128, input: &str) -> Option<u128> {
+    s.entries
+        .iter()
+        .find(|e| e.state_value == state_value)?
+        .forced_inputs
+        .get(input)
+        .copied()
+}
+
+/// CTRL (st'=c), `good = st==1`, `c` controllable: the game is realizable (the controller forces it in
+/// one step). The controller strategy forces `c = 1` at the rank-1 state `st=0`, and forces nothing at
+/// the already-good `st=1` (rank 0). It must NOT force the environment input `e`.
+#[test]
+fn controller_strategy_forces_the_winning_move() {
+    let strat = exact_two_player_strategy(CTRL_INIT0, "st == 1", &["c"]).unwrap();
+    assert!(strat.realizable, "st'=c: the controller wins");
+    let s = &strat.strategy;
+    assert_eq!(s.state_register, "st");
+    // st=0 is rank 1 (one controllable step to good) and forces c=1.
+    assert_eq!(
+        forced(s, 0, "c"),
+        Some(1),
+        "at st=0 the controller sets c=1"
+    );
+    // The controller never forces the environment's input.
+    assert_eq!(
+        forced(s, 0, "e"),
+        None,
+        "e is the environment's, not forced"
+    );
+    // The already-good state has rank 0 and needs no forcing move.
+    let good_entry = s.entries.iter().find(|e| e.state_value == 1).unwrap();
+    assert_eq!(good_entry.rank, 0);
+    assert!(good_entry.forced_inputs.is_empty());
+}
+
+/// ENVBLK (st'=c&¬e), `good = st==1`, `c` controllable: UNREALIZABLE — for `e=1` no `c` reaches good, so
+/// `∀e` fails and the controller cannot win. The extractor returns the ENVIRONMENT's counterstrategy:
+/// at `st=0` it forces `e = 1` (the unique move keeping the play out of `{st==1}` against every `c`), and
+/// forces nothing on the controllable input `c`.
+#[test]
+fn environment_counterstrategy_forces_the_blocking_move() {
+    let strat = exact_two_player_strategy(ENVBLK_INIT0, "st == 1", &["c"]).unwrap();
+    assert!(!strat.realizable, "st'=c&¬e: the environment wins");
+    let s = &strat.strategy;
+    // The environment holds e=1 at st=0 to keep the controller out of st=1.
+    assert_eq!(
+        forced(s, 0, "e"),
+        Some(1),
+        "the environment blocks with e=1"
+    );
+    // It does not (cannot) force the controller's input.
+    assert_eq!(forced(s, 0, "c"), None, "c is the controller's, not forced");
+}
+
+/// Reduction on real RTL: with EVERY input controllable, the controllable predecessor collapses to the
+/// single-agent diamond and the forcing move to `move_into`, so the two-player strategy must be EXACTLY
+/// the 1-player positional strategy (`exact_env_positional_strategy`). Cross-checks the game extractor
+/// against the already-validated 1-player extractor on the OpenTitan boot FSM.
+#[test]
+fn edn_all_controllable_strategy_equals_one_player() {
+    let good = "state_q == 44";
+    let one = exact_env_positional_strategy(EDN, good).expect("1-player strategy");
+    let two = exact_two_player_strategy(EDN, good, EDN_ALL).expect("2-player strategy");
+    assert!(
+        two.realizable,
+        "all-controllable: the handshake is reachable"
+    );
+    assert_eq!(
+        two.strategy, one,
+        "all-controllable two-player strategy == one-player positional strategy"
+    );
+}
+
+/// The genuine two-player finding on real RTL: with only the mode signals controllable, the boot
+/// handshake is UNREALIZABLE (the environment withholds the ack / escalates). The extractor returns the
+/// environment's counterstrategy — and it forces ONLY environment inputs, never the controllable mode
+/// signals. This is the witness behind the assume-guarantee reading (the handshake needs an environment
+/// assumption).
+#[test]
+fn edn_mode_controllable_counterstrategy_is_environment_only() {
+    let mode: &[&str] = &["boot_req_mode_i", "edn_enable_i"];
+    let strat = exact_two_player_strategy(EDN, "state_q == 44", mode).expect("2-player strategy");
+    assert!(
+        !strat.realizable,
+        "mode-controllable, acks environment: unrealizable ⇒ a counterstrategy"
+    );
+    assert!(
+        !strat.strategy.entries.is_empty(),
+        "the initial state is in the environment's winning region ⇒ at least one row"
+    );
+    for e in &strat.strategy.entries {
+        for k in e.forced_inputs.keys() {
+            assert!(
+                k != "boot_req_mode_i" && k != "edn_enable_i",
+                "the counterstrategy forces environment inputs only, got controllable {k}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The exact two-player game engine (`exact_two_player_verdict`, #434–#438) answered *realizable?* (yes/no). This recovers the **winner's positional strategy** — the controller's forced controllable inputs when the reachability game is realizable, or the environment's **counterstrategy** (the witness for *why no controller wins*) when it is not. It completes the "strategy / counterstrategy extraction from the fixpoint ranks" slice of the unified two-player mu-calculus verifier (`.claude/plans/unified-two-player-mu-calculus-verifier.md` §2 step 6).

## Engine — `exact-symbolic` ROBDD (OxiDD)

- Two `ExactModel` forcing-move helpers (per-move witnesses under each forcing quantifier):
  - `ctrl_forcing_moves(keep) = ∀env. constraint ∧ next∈keep` — `(state, ctrl)` pairs whose move lands in `keep` whatever the environment does (`cpre_controllable = ctrl_forcing_moves.∃ctrl`).
  - `env_forcing_moves(keep) = ∀ctrl. constraint ⟹ next∈keep` — the dual for the environment.
- `exact_two_player_strategy(btor2, good, controllable) -> Option<TwoPlayerStrategy>`: solve the controllable-reachability attractor `μX. good ∨ CPre_ctrl(X)`; the controller wins iff `init ⊆ attractor` (== `exact_two_player_verdict`). `TwoPlayerStrategy { realizable, strategy: PositionalStrategy }`:
  - **realizable** → controller strategy: each reachable winning state forces the **controllable** inputs to a rank-decreasing move (`ctrl_forcing_moves` into the next-lower attractor layer, ∀env-robust).
  - **unrealizable** → environment counterstrategy: each reachable state *outside* the attractor forces the **environment** inputs to keep the play out of it (`env_forcing_moves`, ∀ctrl-robust) — the assume-guarantee witness. Safety/maintain strategy ⇒ rank 0 everywhere.
- Concrete forward reachability from init, kept to the winner's region — so the free reset does not make every encoding "winning" (the same discipline as the 1-player extractor).

## Reduction cross-check (soundness)

With **every** input controllable, `cpre_controllable → diamond_pre` and `ctrl_forcing_moves → move_into`, so `exact_two_player_strategy(all)` is **exactly** the 1-player `exact_env_positional_strategy`. Asserted on real RTL below.

## Validation (`tests/exact_two_player_strategy.rs`, gate `make ci`)

- **CTRL** (`st'=c`): realizable — controller forces `c=1` at `st=0` (rank 1), nothing at the already-good `st=1` (rank 0), never forces the environment input `e`.
- **ENVBLK** (`st'=c&¬e`): unrealizable — the environment counterstrategy forces `e=1` at `st=0` (the unique blocking move), does not force the controller input `c`.
- **Industrial edn** (real OpenTitan boot FSM), all-controllable: realizable, and the two-player strategy **equals the 1-player positional strategy exactly** (the reduction).
- **Industrial edn**, mode-controllable: unrealizable — the counterstrategy forces **only environment inputs** (acks/escalation), never the controllable mode signals. The witness behind the assume-guarantee finding (the boot handshake needs an environment ack assumption).

## Scope

`exact-symbolic` only (KMTS / interpolation strategy extraction is a follow-up). Surface-wiring onto `--discover-assumptions` (CLI+API+UI) is the next slice. `gr1.rs` / `parity_game.rs` untouched (differential oracles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)