### PR TITLE
fix(exact): controller strategy is Mealy, not Moore — the responder can't be positional

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -3467,28 +3467,98 @@ pub fn exact_env_positional_strategy(
     bb.env_positional_strategy(&file, &good_bdd, &reg)
 }
 
-/// P2.5-F — a synthesized TWO-PLAYER strategy: the CONTROLLER's positional strategy when the reachability
-/// game `μX. (good ∨ ⟨ctrl⟩X)` is realizable, or the ENVIRONMENT's COUNTERSTRATEGY when it is not. Both
-/// are state-indexed forced-input maps ([`PositionalStrategy`]): the controller's forces CONTROLLABLE
-/// inputs (robust to every environment move) toward `good`; the environment's forces ENVIRONMENT inputs
-/// (robust to every controllable move) to keep the system out of the controller's winning region.
+/// One `(environment-input guard → forced controllable inputs)` move of a Mealy controller
+/// ([`MealyStrategy`]). The game is Mealy — the environment moves and the controller RESPONDS
+/// ([`ExactModel::cpre_controllable`], `∀env ∃ctrl`) — so the controller's move may depend on the
+/// current environment input. `env_inputs` is empty for an env-independent (Moore) move.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TwoPlayerStrategy {
-    /// `true` = the controller wins from the initial state (spec realizable) and `strategy` is its
-    /// strategy; `false` = the environment wins (unrealizable) and `strategy` is its counterstrategy.
-    pub realizable: bool,
-    /// The winner's positional strategy.
-    pub strategy: PositionalStrategy,
+pub struct MealyMove {
+    /// The environment-input valuation this move responds to; empty = env-independent (holds for every
+    /// environment move).
+    pub env_inputs: BTreeMap<String, u128>,
+    /// The controllable inputs the controller forces in response.
+    pub forced_ctrl: BTreeMap<String, u128>,
+}
+
+/// One control-state row of a [`MealyStrategy`]: the controller's response(s) at that control value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MealyEntry {
+    /// The value of the strategy's state register.
+    pub state_value: u128,
+    /// The attractor rank (distance to `good`); 0 = already `good` (no move needed).
+    pub rank: u32,
+    /// The controller's move(s). A single `env_inputs`-empty move = a Moore (env-independent) response;
+    /// several moves = a genuinely reactive response, one per environment input valuation.
+    pub moves: Vec<MealyMove>,
+    /// `false` = the reactive-move enumeration hit its bound and `moves` is a partial cover (only for
+    /// wide-environment reactive states; never for the Moore fast-path). No silent truncation.
+    pub complete: bool,
+}
+
+/// P2.5-F — a Mealy CONTROLLER strategy for a realizable reachability game: at each control state the
+/// controller forces the controllable inputs (possibly reacting to the environment input — the game is
+/// `∀env ∃ctrl`) to a rank-decreasing move. Contrast [`PositionalStrategy`], which the ENVIRONMENT
+/// counterstrategy uses (the environment is the first-mover, so its winning strategy is positional).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MealyStrategy {
+    /// The state register the strategy is indexed by.
+    pub state_register: String,
+    /// One row per reachable control-state value, sorted by rank then value.
+    pub entries: Vec<MealyEntry>,
+}
+
+impl MealyStrategy {
+    /// The positional (Moore) projection, when every entry's response is env-independent (a single
+    /// `env_inputs`-empty move) — i.e. the controller needs no reaction to the environment. `None` when
+    /// any state requires a genuinely reactive (env-dependent) move, since no state-only strategy exists
+    /// there. With all inputs controllable (no environment) this always succeeds and equals the 1-player
+    /// [`exact_env_positional_strategy`].
+    pub fn as_positional(&self) -> Option<PositionalStrategy> {
+        let mut entries = Vec::with_capacity(self.entries.len());
+        for e in &self.entries {
+            let forced = match e.moves.as_slice() {
+                [] => BTreeMap::new(),
+                [m] if m.env_inputs.is_empty() => m.forced_ctrl.clone(),
+                _ => return None, // reactive: no env-independent positional move
+            };
+            entries.push(StrategyEntry {
+                state_value: e.state_value,
+                rank: e.rank,
+                forced_inputs: forced,
+            });
+        }
+        Some(PositionalStrategy {
+            state_register: self.state_register.clone(),
+            entries,
+        })
+    }
+}
+
+/// P2.5-F — a synthesized TWO-PLAYER strategy for the controllable-reachability game `μX. (good ∨
+/// ⟨ctrl⟩X)`: the CONTROLLER's Mealy strategy when it is realizable, or the ENVIRONMENT's positional
+/// COUNTERSTRATEGY when it is not (by determinacy, exactly one holds). The asymmetry is intrinsic to the
+/// Mealy game (`∀env ∃ctrl`): the environment is the first-mover, so its winning strategy is positional
+/// (state-indexed); the controller responds, so its strategy may depend on the environment input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TwoPlayerStrategy {
+    /// The controller wins from the initial state (spec realizable) — its Mealy strategy.
+    ControllerStrategy(MealyStrategy),
+    /// The environment wins (unrealizable) — its positional counterstrategy, forcing environment inputs
+    /// (robust to every controllable move) to keep the play out of the controller's winning region.
+    EnvironmentCounterstrategy(PositionalStrategy),
 }
 
 /// P2.5-F — synthesize the two-player strategy for the controllable-reachability game to `good` with
-/// `controllable` naming the controller's inputs. `realizable` iff the controller wins from the initial
-/// state (== [`exact_two_player_verdict`] on `μX. good ∨ ⟨ctrl⟩X`). `None` when `good` is not a resolvable
-/// state atom or the model can't be built.
+/// `controllable` naming the controller's inputs. Returns the CONTROLLER's Mealy strategy when the
+/// controller wins from the initial state (== [`exact_two_player_verdict`] holds on `μX. good ∨ ⟨ctrl⟩X`),
+/// or the ENVIRONMENT's positional counterstrategy when it does not. `None` when `good` is not a
+/// resolvable state atom or the model can't be built.
 ///
 /// **Engine (§16):** `exact-symbolic` ROBDD — the controllable attractor (`cpre_controllable`) supplies
-/// ranks; concrete forward reachability enumerates the real states; each row's forced inputs come from
-/// the winner's forcing moves ([`ExactModel::ctrl_forcing_moves`] / [`ExactModel::env_forcing_moves`]).
+/// ranks; concrete forward reachability enumerates the real states. The controller's moves come from
+/// [`ExactModel::ctrl_forcing_moves`] (env-independent, Moore fast-path) or, where the controller must
+/// react, the per-environment move relation ([`ExactModel::move_into`]); the environment counterstrategy
+/// from [`ExactModel::env_forcing_moves`].
 pub fn exact_two_player_strategy(
     btor2_content: &str,
     good: &str,
@@ -4125,15 +4195,19 @@ impl BddBitBlaster {
 
     /// P2.5-F — synthesize the two-player strategy for the controllable-reachability game to `good`, with
     /// `controllable` the controller's input names. Solves the attractor `μX. good ∨ CPre_ctrl(X)`; the
-    /// controller wins iff `init ⊆ attractor`. Returns the WINNER's positional strategy:
-    /// - **realizable** (controller wins): each reachable winning state's row forces the CONTROLLABLE
-    ///   inputs to a rank-decreasing move ([`ExactModel::ctrl_forcing_moves`] into the next-lower attractor
-    ///   layer) — robust to every environment move. With all inputs controllable this reduces to the
-    ///   1-player [`Self::env_positional_strategy`].
-    /// - **unrealizable** (environment wins): each reachable state OUTSIDE the attractor forces the
-    ///   ENVIRONMENT inputs to a move that keeps the play out of it ([`ExactModel::env_forcing_moves`]) —
-    ///   the counterstrategy witnessing why no controller can reach `good`. A safety/maintain strategy, so
-    ///   every row has rank 0 (no distance-to-target metric).
+    /// controller wins iff `init ⊆ attractor`. Returns the WINNER's strategy, and the Mealy/positional
+    /// asymmetry is intrinsic to the game (`CPre_ctrl = ∀env ∃ctrl` — the environment moves, the
+    /// controller responds):
+    /// - **realizable** (controller wins): a [`MealyStrategy`]. At each reachable winning state force a
+    ///   rank-decreasing controllable move: env-independent when one exists ([`ExactModel::ctrl_forcing_moves`]
+    ///   — the Moore fast-path), else ONE response per environment input ([`ExactModel::move_into`] — a
+    ///   genuinely reactive controller, since the controller is the responder). With all inputs
+    ///   controllable this is Moore everywhere and `MealyStrategy::as_positional` equals the 1-player
+    ///   [`Self::env_positional_strategy`].
+    /// - **unrealizable** (environment wins): a positional [`PositionalStrategy`] — the environment is the
+    ///   first-mover, so its winning strategy is state-indexed. Each reachable state OUTSIDE the attractor
+    ///   forces ENVIRONMENT inputs that keep the play out of it ([`ExactModel::env_forcing_moves`],
+    ///   ∀ctrl-robust). A safety/maintain strategy, so every row has rank 0.
     ///
     /// `None` when `reg_name` is not a state register.
     fn two_player_strategy(
@@ -4228,65 +4302,154 @@ impl BddBitBlaster {
                 .and_modify(|r| *r = (*r).min(*k))
                 .or_insert(*k);
         }
-        // Forced moves of the MIN-RANK states of each control value. Controller: the rank-decreasing
-        // controllable move (`ctrl_forcing_moves` into the next-lower layer, robust to every env move).
-        // Environment: the region-maintaining environment move (`env_forcing_moves` staying in ¬attractor).
-        let mut moves_by_val: BTreeMap<u128, BDDFunction> = BTreeMap::new();
-        for (s, k) in &reached {
-            let v = *s.get(reg_name).unwrap_or(&0);
-            if *k != min_rank[&v] {
-                continue;
-            }
-            let m = if realizable {
-                if *k == 0 {
-                    continue; // already at `good` — no forcing move needed
+        let is_ctrl = |c: &&Cell| -> bool { !c.is_state && controllable.contains(&c.symbol) };
+        let is_env = |c: &&Cell| -> bool { !c.is_state && !controllable.contains(&c.symbol) };
+        if realizable {
+            // CONTROLLER (Mealy: the environment moves, the controller responds — `cpre_controllable` is
+            // `∀env ∃ctrl`). At each min-rank control value force a rank-decreasing move into the next-lower
+            // layer: env-independent when one exists (the Moore fast-path), else one response per
+            // environment input (a genuinely reactive controller — the responder cannot be positional).
+            const MAX_REACTIVE_MOVES: usize = 256;
+            // Per value: the union of its min-rank state minterms + that value's (uniform) rank.
+            let mut states_by_val: BTreeMap<u128, (BDDFunction, u32)> = BTreeMap::new();
+            for (s, k) in &reached {
+                let v = *s.get(reg_name).unwrap_or(&0);
+                if *k != min_rank[&v] {
+                    continue;
                 }
-                self.state_minterm(s)
-                    .and(&exact.ctrl_forcing_moves(&layers[(*k - 1) as usize]))
-                    .unwrap()
-            } else {
-                self.state_minterm(s)
-                    .and(&exact.env_forcing_moves(&region))
-                    .unwrap()
-            };
-            moves_by_val
-                .entry(v)
-                .and_modify(|acc| *acc = acc.or(&m).unwrap())
-                .or_insert(m);
-        }
-        // Project onto the WINNER's own inputs: controllable inputs for the controller, environment inputs
-        // for the counterstrategy. (The other player's inputs are ∀-quantified out by the forcing move.)
-        let owns = |cell: &Cell| -> bool {
-            !cell.is_state && (realizable == controllable.contains(&cell.symbol))
-        };
-        let mut entries: Vec<StrategyEntry> = min_rank
-            .iter()
-            .map(|(&v, &rank)| {
-                let mut forced = BTreeMap::new();
-                if let Some(mv) = moves_by_val.get(&v)
-                    && *mv != self.ff
-                {
-                    for cell in self.cells.iter().filter(|c| owns(c)) {
-                        if let Some(val) = self.forced_cell_value(mv, cell) {
-                            forced.insert(cell.symbol.clone(), val);
+                let mt = self.state_minterm(s);
+                states_by_val
+                    .entry(v)
+                    .and_modify(|(acc, _)| *acc = acc.or(&mt).unwrap())
+                    .or_insert((mt, *k));
+            }
+            let mut entries: Vec<MealyEntry> = Vec::new();
+            for (&v, (mt, rank)) in &states_by_val {
+                if *rank == 0 {
+                    // already at `good` — no move needed.
+                    entries.push(MealyEntry {
+                        state_value: v,
+                        rank: 0,
+                        moves: Vec::new(),
+                        complete: true,
+                    });
+                    continue;
+                }
+                let lower = &layers[(*rank - 1) as usize];
+                // Moore fast-path: a single controllable move robust to every environment input.
+                let moore = mt.and(&exact.ctrl_forcing_moves(lower)).unwrap();
+                if moore != self.ff {
+                    let mut forced_ctrl = BTreeMap::new();
+                    for cell in self.cells.iter().filter(is_ctrl) {
+                        if let Some(val) = self.forced_cell_value(&moore, cell) {
+                            forced_ctrl.insert(cell.symbol.clone(), val);
                         }
                     }
+                    entries.push(MealyEntry {
+                        state_value: v,
+                        rank: *rank,
+                        moves: vec![MealyMove {
+                            env_inputs: BTreeMap::new(),
+                            forced_ctrl,
+                        }],
+                        complete: true,
+                    });
+                    continue;
                 }
-                StrategyEntry {
+                // Reactive: enumerate one controllable response per environment-input valuation. The state
+                // is in the attractor, so `∀env ∃ctrl` — every environment column has a response.
+                let mut rem = mt.and(&exact.move_into(lower)).unwrap();
+                let mut moves: Vec<MealyMove> = Vec::new();
+                for _ in 0..MAX_REACTIVE_MOVES {
+                    if rem == self.ff {
+                        break;
+                    }
+                    let full = self.pick_full_assignment(&rem);
+                    let mut env_inputs = BTreeMap::new();
+                    let mut env_mt = self.tt.clone();
+                    for cell in self.cells.iter().filter(is_env) {
+                        let val = *full.get(&cell.symbol).unwrap_or(&0);
+                        env_inputs.insert(cell.symbol.clone(), val);
+                        for (b, var) in cell.vars.iter().enumerate() {
+                            let lit = if (val >> b) & 1 == 1 {
+                                var.clone()
+                            } else {
+                                var.not().unwrap()
+                            };
+                            env_mt = env_mt.and(&lit).unwrap();
+                        }
+                    }
+                    let mut forced_ctrl = BTreeMap::new();
+                    for cell in self.cells.iter().filter(is_ctrl) {
+                        forced_ctrl
+                            .insert(cell.symbol.clone(), *full.get(&cell.symbol).unwrap_or(&0));
+                    }
+                    moves.push(MealyMove {
+                        env_inputs,
+                        forced_ctrl,
+                    });
+                    rem = rem.and(&env_mt.not().unwrap()).unwrap();
+                }
+                entries.push(MealyEntry {
                     state_value: v,
-                    rank,
-                    forced_inputs: forced,
-                }
-            })
-            .collect();
-        entries.sort_by(|a, b| a.rank.cmp(&b.rank).then(a.state_value.cmp(&b.state_value)));
-        Some(TwoPlayerStrategy {
-            realizable,
-            strategy: PositionalStrategy {
+                    rank: *rank,
+                    moves,
+                    complete: rem == self.ff, // false = the reactive fan-out hit the bound (no silent cap)
+                });
+            }
+            entries.sort_by(|a, b| a.rank.cmp(&b.rank).then(a.state_value.cmp(&b.state_value)));
+            Some(TwoPlayerStrategy::ControllerStrategy(MealyStrategy {
                 state_register: reg_name.to_string(),
                 entries,
-            },
-        })
+            }))
+        } else {
+            // ENVIRONMENT counterstrategy — positional (the environment is the first-mover). At each
+            // reachable state outside the attractor force env inputs keeping the play out of it
+            // (`env_forcing_moves`, robust to every controllable move). The `∀ctrl` is the correct dual of
+            // `cpre_controllable`'s `∀env ∃ctrl`, so this exists iff the controller has no strategy.
+            let mut moves_by_val: BTreeMap<u128, BDDFunction> = BTreeMap::new();
+            for (s, k) in &reached {
+                let v = *s.get(reg_name).unwrap_or(&0);
+                if *k != min_rank[&v] {
+                    continue;
+                }
+                let m = self
+                    .state_minterm(s)
+                    .and(&exact.env_forcing_moves(&region))
+                    .unwrap();
+                moves_by_val
+                    .entry(v)
+                    .and_modify(|acc| *acc = acc.or(&m).unwrap())
+                    .or_insert(m);
+            }
+            let mut entries: Vec<StrategyEntry> = min_rank
+                .iter()
+                .map(|(&v, &rank)| {
+                    let mut forced = BTreeMap::new();
+                    if let Some(mv) = moves_by_val.get(&v)
+                        && *mv != self.ff
+                    {
+                        for cell in self.cells.iter().filter(is_env) {
+                            if let Some(val) = self.forced_cell_value(mv, cell) {
+                                forced.insert(cell.symbol.clone(), val);
+                            }
+                        }
+                    }
+                    StrategyEntry {
+                        state_value: v,
+                        rank,
+                        forced_inputs: forced,
+                    }
+                })
+                .collect();
+            entries.sort_by(|a, b| a.rank.cmp(&b.rank).then(a.state_value.cmp(&b.state_value)));
+            Some(TwoPlayerStrategy::EnvironmentCounterstrategy(
+                PositionalStrategy {
+                    state_register: reg_name.to_string(),
+                    entries,
+                },
+            ))
+        }
     }
 
     /// The distinct concrete next-states reachable from `s` under some constraint-respecting input.

--- a/crates/mununu-core/tests/exact_two_player_strategy.rs
+++ b/crates/mununu-core/tests/exact_two_player_strategy.rs
@@ -1,26 +1,28 @@
 //! P2.5-F — the exact-symbolic engine EXTRACTING the two-player game strategy via
 //! `exact_two_player_strategy`. Where `exact_two_player_verdict` answers realizable? (yes/no), this
-//! recovers the WINNER's positional strategy: the CONTROLLER's forced controllable inputs when the
-//! reachability game is realizable, or the ENVIRONMENT's counterstrategy (forced environment inputs
-//! witnessing why no controller wins) when it is not.
+//! recovers the WINNER's strategy: the CONTROLLER's Mealy strategy when the reachability game is
+//! realizable, or the ENVIRONMENT's positional counterstrategy (the witness for why no controller wins)
+//! when it is not.
 //!
-//! Validation is by KNOWN ANSWER on the same minimal 1-bit games as `exact_two_player_game.rs`
-//! (`st' = c`, `st' = c & ¬e`), plus a REDUCTION check + an unrealizable finding on the real OpenTitan
-//! `edn_main_sm` fixture:
+//! The Mealy/positional asymmetry is intrinsic to the game (`CPre_ctrl = ∀env ∃ctrl` — the environment
+//! moves, the controller responds): the environment is the first-mover, so its winning strategy is
+//! positional; the controller responds, so its strategy may depend on the environment input. Validation
+//! is by KNOWN ANSWER on three minimal 1-bit games plus a reduction + an unrealizable finding on the
+//! real OpenTitan `edn_main_sm`:
 //!
-//! - `CTRL`  (`st' = c`)       : realizable — controller forces `c = 1` to reach `st = 1`.
-//! - `ENVBLK`(`st' = c & ¬e`)  : unrealizable — the environment counterstrategy forces `e = 1` to keep
-//!   `st = 0` against every controllable move.
-//! - `edn` all-controllable    : the two-player strategy must EQUAL the 1-player positional strategy
-//!   (`∀∅ ∃all` reduces `cpre_controllable`→`diamond_pre`, `ctrl_forcing_moves`→`move_into`).
-//! - `edn` mode-controllable   : unrealizable — the counterstrategy forces only ENVIRONMENT inputs
-//!   (the acks/escalation), never the controllable mode signals.
+//! - `CTRL`  (`st' = c`)       : realizable, env-INDEPENDENT — controller forces `c = 1` (Moore move).
+//! - `XORG`  (`st' = c ⊕ e`)   : realizable, but REACTIVE — no single `c` works for all `e`, so the
+//!   controller must respond `c = ¬e`. This is the case a Moore (state-only) extractor gets WRONG.
+//! - `ENVBLK`(`st' = c & ¬e`)  : unrealizable — the environment counterstrategy forces `e = 1`.
+//! - `edn` all-controllable    : Moore everywhere, so `MealyStrategy::as_positional` EQUALS the 1-player
+//!   positional strategy.
+//! - `edn` mode-controllable   : unrealizable — the counterstrategy forces only ENVIRONMENT inputs.
 
 use mununu_core::adapter::btor2::symbolic_bitblast::{
-    PositionalStrategy, exact_env_positional_strategy, exact_two_player_strategy,
+    TwoPlayerStrategy, exact_env_positional_strategy, exact_two_player_strategy,
 };
 
-// st' = c : the controller sets the next state.
+// st' = c : the controller sets the next state directly (environment powerless).
 const CTRL_INIT0: &str = "\
 1 sort bitvec 1
 2 input 1 c
@@ -29,6 +31,18 @@ const CTRL_INIT0: &str = "\
 5 zero 1
 6 init 1 4 5
 7 next 1 4 2
+";
+
+// st' = c ⊕ e : reaching st=1 needs c = ¬e — a REACTIVE controller (no env-independent winning move).
+const XORG_INIT0: &str = "\
+1 sort bitvec 1
+2 input 1 c
+3 input 1 e
+4 state 1 st
+5 zero 1
+6 init 1 4 5
+7 xor 1 2 3
+8 next 1 4 7
 ";
 
 // st' = c & ¬e : the environment can force st' = 0 by asserting e.
@@ -59,99 +73,126 @@ const EDN_ALL: &[&str] = &[
     "sw_cmd_req_load_i",
 ];
 
-/// The value the strategy forces `input` to at control-state `state_value`, or `None` if free/absent.
-fn forced(s: &PositionalStrategy, state_value: u128, input: &str) -> Option<u128> {
-    s.entries
-        .iter()
-        .find(|e| e.state_value == state_value)?
-        .forced_inputs
-        .get(input)
-        .copied()
-}
-
-/// CTRL (st'=c), `good = st==1`, `c` controllable: the game is realizable (the controller forces it in
-/// one step). The controller strategy forces `c = 1` at the rank-1 state `st=0`, and forces nothing at
-/// the already-good `st=1` (rank 0). It must NOT force the environment input `e`.
+/// CTRL (st'=c), `good = st==1`, `c` controllable: realizable and env-INDEPENDENT. The controller
+/// strategy is a single Moore move forcing `c = 1` at the rank-1 state `st=0`, nothing at the already-good
+/// `st=1`, and it never forces the environment input `e`.
 #[test]
-fn controller_strategy_forces_the_winning_move() {
+fn controller_strategy_moore_move() {
     let strat = exact_two_player_strategy(CTRL_INIT0, "st == 1", &["c"]).unwrap();
-    assert!(strat.realizable, "st'=c: the controller wins");
-    let s = &strat.strategy;
-    assert_eq!(s.state_register, "st");
-    // st=0 is rank 1 (one controllable step to good) and forces c=1.
-    assert_eq!(
-        forced(s, 0, "c"),
-        Some(1),
-        "at st=0 the controller sets c=1"
+    let TwoPlayerStrategy::ControllerStrategy(m) = strat else {
+        panic!("st'=c is realizable ⇒ a controller strategy");
+    };
+    assert_eq!(m.state_register, "st");
+    let at0 = m.entries.iter().find(|e| e.state_value == 0).unwrap();
+    assert_eq!(at0.rank, 1);
+    // A single env-independent move forcing c=1, robust to every e.
+    assert_eq!(at0.moves.len(), 1);
+    assert!(
+        at0.moves[0].env_inputs.is_empty(),
+        "the move is env-independent"
     );
-    // The controller never forces the environment's input.
-    assert_eq!(
-        forced(s, 0, "e"),
-        None,
-        "e is the environment's, not forced"
+    assert_eq!(at0.moves[0].forced_ctrl.get("c"), Some(&1));
+    assert!(
+        !at0.moves[0].forced_ctrl.contains_key("e"),
+        "e is not the controller's"
     );
-    // The already-good state has rank 0 and needs no forcing move.
-    let good_entry = s.entries.iter().find(|e| e.state_value == 1).unwrap();
-    assert_eq!(good_entry.rank, 0);
-    assert!(good_entry.forced_inputs.is_empty());
+    // The already-good state needs no move.
+    let at1 = m.entries.iter().find(|e| e.state_value == 1).unwrap();
+    assert_eq!(at1.rank, 0);
+    assert!(at1.moves.is_empty());
+    // Moore everywhere ⇒ it projects to a positional strategy.
+    assert!(m.as_positional().is_some());
 }
 
-/// ENVBLK (st'=c&¬e), `good = st==1`, `c` controllable: UNREALIZABLE — for `e=1` no `c` reaches good, so
-/// `∀e` fails and the controller cannot win. The extractor returns the ENVIRONMENT's counterstrategy:
-/// at `st=0` it forces `e = 1` (the unique move keeping the play out of `{st==1}` against every `c`), and
-/// forces nothing on the controllable input `c`.
+/// XORG (st'=c⊕e), `good = st==1`, `c` controllable: realizable but REACTIVE. There is NO single `c` that
+/// reaches good for every `e` (`∃c ∀e. c⊕e==1` is false), yet `∀e ∃c` holds (`c=¬e`). The Mealy strategy
+/// must give two env-conditioned responses: `e=0 → c=1`, `e=1 → c=0`. A state-only (Moore) extractor would
+/// emit no forced input here — the bug this fix closes — so `as_positional` must be `None`.
 #[test]
-fn environment_counterstrategy_forces_the_blocking_move() {
+fn controller_strategy_reactive_mealy_move() {
+    let strat = exact_two_player_strategy(XORG_INIT0, "st == 1", &["c"]).unwrap();
+    let TwoPlayerStrategy::ControllerStrategy(m) = strat else {
+        panic!("st'=c⊕e is realizable (Mealy c=¬e) ⇒ a controller strategy");
+    };
+    let at0 = m.entries.iter().find(|e| e.state_value == 0).unwrap();
+    assert_eq!(at0.rank, 1);
+    assert!(
+        at0.complete,
+        "the reactive fan-out (2 moves) is fully enumerated"
+    );
+    // Two env-conditioned responses, each c = ¬e.
+    assert_eq!(at0.moves.len(), 2, "one response per environment input");
+    for mv in &at0.moves {
+        let e = *mv
+            .env_inputs
+            .get("e")
+            .expect("the response is conditioned on e");
+        let c = *mv.forced_ctrl.get("c").expect("the controller forces c");
+        assert_eq!(c, 1 - e, "the controller plays c = ¬e");
+    }
+    // No env-independent positional move exists here.
+    assert!(
+        m.as_positional().is_none(),
+        "a reactive controller has no state-only positional strategy"
+    );
+}
+
+/// ENVBLK (st'=c&¬e), `good = st==1`, `c` controllable: UNREALIZABLE — for `e=1` no `c` reaches good.
+/// The extractor returns the ENVIRONMENT's positional counterstrategy: at `st=0` it forces `e = 1` (the
+/// move keeping the play out of `{st==1}` against every `c`), and never forces the controllable input `c`.
+#[test]
+fn environment_counterstrategy_positional_move() {
     let strat = exact_two_player_strategy(ENVBLK_INIT0, "st == 1", &["c"]).unwrap();
-    assert!(!strat.realizable, "st'=c&¬e: the environment wins");
-    let s = &strat.strategy;
-    // The environment holds e=1 at st=0 to keep the controller out of st=1.
+    let TwoPlayerStrategy::EnvironmentCounterstrategy(p) = strat else {
+        panic!("st'=c&¬e is unrealizable ⇒ an environment counterstrategy");
+    };
+    let at0 = p.entries.iter().find(|e| e.state_value == 0).unwrap();
     assert_eq!(
-        forced(s, 0, "e"),
-        Some(1),
+        at0.forced_inputs.get("e"),
+        Some(&1),
         "the environment blocks with e=1"
     );
-    // It does not (cannot) force the controller's input.
-    assert_eq!(forced(s, 0, "c"), None, "c is the controller's, not forced");
+    assert!(
+        !at0.forced_inputs.contains_key("c"),
+        "c is the controller's, not forced"
+    );
 }
 
-/// Reduction on real RTL: with EVERY input controllable, the controllable predecessor collapses to the
-/// single-agent diamond and the forcing move to `move_into`, so the two-player strategy must be EXACTLY
-/// the 1-player positional strategy (`exact_env_positional_strategy`). Cross-checks the game extractor
-/// against the already-validated 1-player extractor on the OpenTitan boot FSM.
+/// Reduction on real RTL: with EVERY input controllable, the game is Moore everywhere (no environment to
+/// react to), so the controller Mealy strategy projects to a positional one that EQUALS the 1-player
+/// `exact_env_positional_strategy`. Cross-checks the game extractor against the 1-player extractor on the
+/// OpenTitan boot FSM.
 #[test]
-fn edn_all_controllable_strategy_equals_one_player() {
+fn edn_all_controllable_projects_to_one_player() {
     let good = "state_q == 44";
     let one = exact_env_positional_strategy(EDN, good).expect("1-player strategy");
-    let two = exact_two_player_strategy(EDN, good, EDN_ALL).expect("2-player strategy");
-    assert!(
-        two.realizable,
-        "all-controllable: the handshake is reachable"
-    );
+    let strat = exact_two_player_strategy(EDN, good, EDN_ALL).expect("2-player strategy");
+    let TwoPlayerStrategy::ControllerStrategy(m) = strat else {
+        panic!("all-controllable: the handshake is reachable ⇒ a controller strategy");
+    };
     assert_eq!(
-        two.strategy, one,
-        "all-controllable two-player strategy == one-player positional strategy"
+        m.as_positional(),
+        Some(one),
+        "all-controllable Mealy strategy projects to the 1-player positional strategy"
     );
 }
 
 /// The genuine two-player finding on real RTL: with only the mode signals controllable, the boot
-/// handshake is UNREALIZABLE (the environment withholds the ack / escalates). The extractor returns the
-/// environment's counterstrategy — and it forces ONLY environment inputs, never the controllable mode
-/// signals. This is the witness behind the assume-guarantee reading (the handshake needs an environment
-/// assumption).
+/// handshake is UNREALIZABLE (the environment withholds the ack / escalates). The counterstrategy is
+/// positional and forces ONLY environment inputs, never the controllable mode signals — the witness
+/// behind the assume-guarantee reading (the handshake needs an environment ack assumption).
 #[test]
 fn edn_mode_controllable_counterstrategy_is_environment_only() {
     let mode: &[&str] = &["boot_req_mode_i", "edn_enable_i"];
     let strat = exact_two_player_strategy(EDN, "state_q == 44", mode).expect("2-player strategy");
+    let TwoPlayerStrategy::EnvironmentCounterstrategy(p) = strat else {
+        panic!("mode-controllable, acks environment: unrealizable ⇒ a counterstrategy");
+    };
     assert!(
-        !strat.realizable,
-        "mode-controllable, acks environment: unrealizable ⇒ a counterstrategy"
-    );
-    assert!(
-        !strat.strategy.entries.is_empty(),
+        !p.entries.is_empty(),
         "the initial state is in the environment's winning region ⇒ at least one row"
     );
-    for e in &strat.strategy.entries {
+    for e in &p.entries {
         for k in e.forced_inputs.keys() {
             assert!(
                 k != "boot_req_mode_i" && k != "edn_enable_i",


### PR DESCRIPTION
## Summary

Follow-up to #439, from a review question: *shouldn't the environment forcing move be existential on the controllable input?* Working it through, the environment side is already correct — but the review surfaced a genuine **decision asymmetry** that lands on the **controller**.

The game is **Mealy** (`CPre_ctrl = ∀env ∃ctrl`, as the verdict declares — "environment moves, controller responds"). In a game, only the **first-mover** has a positional (state-indexed) winning strategy; the **responder**'s strategy is a function of the current opponent move. The environment is the first-mover here, so its counterstrategy is correctly positional — but the **controller responds**, so its strategy is `c = f(state, env-input)`, *not* a state-only row.

#439 extracted a state-only (Moore) controller move (`ctrl_forcing_moves`, `∀env` — one `c` robust to every `e`). Sound *when* such a move exists, but **incomplete / misleading** when the controller must react:

> `st' = c ⊕ e` reaching `st==1` is realizable (Mealy `c=¬e`, so `∀e ∃c` holds), yet no single `c` works for all `e` (`∃c ∀e` is false) — so the old extractor emitted an **empty forced-input row** for a genuinely winning state. A consumer reading "input free here" loses.

## Fix

- `TwoPlayerStrategy` is now an **enum**: `ControllerStrategy(MealyStrategy)` (realizable) | `EnvironmentCounterstrategy(PositionalStrategy)` (unrealizable) — by determinacy exactly one holds.
- `MealyStrategy` rows carry `Vec<MealyMove { env_inputs, forced_ctrl }>`:
  - **Moore fast-path**: a single `env_inputs`-empty move (`ctrl_forcing_moves`) when an env-independent winning move exists (the common case — all current FSM fixtures);
  - **reactive**: one response per environment-input valuation, from `move_into`, bounded by `MAX_REACTIVE_MOVES` with a `complete` flag (no silent truncation).
- `MealyStrategy::as_positional()` = `Some` iff every row is Moore; with all inputs controllable it always succeeds and equals the 1-player `exact_env_positional_strategy`.
- **The environment counterstrategy is unchanged.** `env_forcing_moves` (`∀ctrl`) is the exact De Morgan dual of `∀env ∃ctrl`, so it is positional and "counterstrategy exists ⟺ no controller strategy" holds: `¬μX.(good ∨ ∀e∃c.δ∈X) = νX.(¬good ∧ ∃e∀c.δ∈X)`.

## Validation (`tests/exact_two_player_strategy.rs`, gate `make ci`)

- **CTRL** (`st'=c`): realizable, env-independent — single Moore move forcing `c=1`; `as_positional` `Some`.
- **XORG** (`st'=c⊕e`): realizable but **reactive** — two env-conditioned moves, each `c=¬e`; `complete`; `as_positional` `None`. **The case #439 got wrong.**
- **ENVBLK** (`st'=c&¬e`): unrealizable — positional environment counterstrategy forces `e=1`.
- **Industrial edn** all-controllable: Moore everywhere ⇒ `as_positional` equals the 1-player positional strategy (reduction cross-check).
- **Industrial edn** mode-controllable: unrealizable ⇒ positional counterstrategy forcing only environment inputs (the assume-guarantee witness).

## Scope

`exact-symbolic` only. The register-keyed aggregation caveat is shared with the 1-player extractor. `gr1.rs` / `parity_game.rs` untouched (differential oracles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)