### PR TITLE
feat(game): surface-wire the two-player game + strategy synthesis (CLI + API)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -297,6 +297,17 @@ enum Btor2Command {
     /// the word-level reachability portfolio (scales past the exact engine). Prints one
     /// line per register; exits non-zero on any reachable illegal encoding.
     CheckFsm(Btor2CheckFsmArgs),
+    /// Solve a two-player controllable-reachability GAME and synthesize the winner's strategy.
+    ///
+    /// Partitions the primary inputs into controller-owned (`--controllable`, repeatable) vs
+    /// environment-owned (the rest, adversarial), then decides whether the CONTROLLER can force the
+    /// design to the `--good` state atom against every environment move (the Mealy game
+    /// `μX. good ∨ ⟨ctrl⟩X`). Prints `realizable` + the controller's Mealy strategy when it wins, or
+    /// `unrealizable` + the environment's positional COUNTERSTRATEGY (the witness for why no controller
+    /// works — e.g. an ack the environment withholds, motivating an assume-guarantee assumption) when it
+    /// does not. Decided by the exact-symbolic ROBDD engine (definite within its cap). Surface peer of
+    /// `POST /api/v1/btor2/game`. Exits non-zero (`--fail-on`) on `unrealizable`.
+    Game(Btor2GameArgs),
 }
 
 /// R.5 Item 3 sub-item 3.5 (2026-06-04) — predicate-source
@@ -776,6 +787,23 @@ struct Btor2CheckFsmArgs {
     /// Max state-register width to treat as an FSM (wider = datapath/counter, skipped).
     #[arg(long, value_name = "BITS", default_value_t = mununu_core::adapter::fsm_scan::DEFAULT_FSM_MAX_WIDTH)]
     max_width: u32,
+    #[command(flatten)]
+    ci: CiArgs,
+}
+
+#[derive(Args, Debug)]
+struct Btor2GameArgs {
+    /// Path to the BTOR2 input file.
+    #[arg(value_name = "BTOR2_FILE")]
+    file: PathBuf,
+    /// The reachability target `good` state atom the controller tries to force — a single
+    /// register-comparison atom (`"state_q == 44"`).
+    #[arg(long, value_name = "REG op VALUE")]
+    good: String,
+    /// A controller-owned primary input (repeatable). Every other primary input belongs to the
+    /// (adversarial) environment. A name that is not a real primary input is rejected.
+    #[arg(long = "controllable", value_name = "INPUT")]
+    controllable: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2675,6 +2703,7 @@ fn handle_btor2(command: Btor2Command) -> Result<(), String> {
         Btor2Command::VerifyRecoverability(args) => btor2_verify_recoverability(args),
         Btor2Command::VerifySafety(args) => btor2_verify_safety(args),
         Btor2Command::CheckFsm(args) => btor2_check_fsm(args),
+        Btor2Command::Game(args) => btor2_game(args),
     }
 }
 
@@ -2711,6 +2740,38 @@ fn btor2_check_fsm(args: Btor2CheckFsmArgs) -> Result<(), String> {
     // Exit code: the worst verdict across the checked registers.
     let worst = worst_verdict(findings.iter().map(|f| PropertyVerdict::as_str(f.verdict)));
     ci_gate_exit(worst, args.ci.fail_on);
+    Ok(())
+}
+
+/// `mununu btor2 game` — solve the two-player controllable-reachability game and synthesize the winner's
+/// strategy (the controller's Mealy strategy, or the environment's positional counterstrategy). Surface
+/// peer of the API `POST /api/v1/btor2/game`. Exits non-zero (via `--fail-on`) on `unrealizable` (mapped
+/// to the `violated` verdict class); `realizable` maps to `holds`.
+fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
+    use mununu_core::adapter::btor2::symbolic_bitblast::exact_two_player_strategy;
+
+    let content = std::fs::read_to_string(&args.file)
+        .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
+    let controllable: Vec<&str> = args.controllable.iter().map(String::as_str).collect();
+    let strategy = exact_two_player_strategy(&content, &args.good, &controllable)?;
+
+    let mut summary = serde_json::json!({
+        "file": args.file.display().to_string(),
+        "good": args.good,
+        "controllable": args.controllable,
+        "realizable": strategy.realizable(),
+    });
+    summary["strategy"] =
+        serde_json::to_value(&strategy).map_err(|e| format!("serialize strategy: {e}"))?;
+    print_json_summary(&summary)?;
+
+    // realizable == the controller wins (`holds`); unrealizable == no controller works (`violated`).
+    let verdict = if strategy.realizable() {
+        "holds"
+    } else {
+        "violated"
+    };
+    ci_gate_exit(verdict, args.ci.fail_on);
     Ok(())
 }
 

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -3413,7 +3413,7 @@ pub fn exact_env_strategy_witness(btor2_content: &str, good: &str) -> Option<Sta
 /// from the initial state), this returns the `AG` part — the driving discipline for *every* reachable
 /// state, as a state-indexed map. It is the reusable object: an environment model, a directed-test seed,
 /// or the environment half of an assume-guarantee contract.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct PositionalStrategy {
     /// The state register the strategy is indexed by (the register named in the `good` atom).
     pub state_register: String,
@@ -3422,7 +3422,7 @@ pub struct PositionalStrategy {
 }
 
 /// One control-state row of a [`PositionalStrategy`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct StrategyEntry {
     /// The value of the strategy's state register in this row.
     pub state_value: u128,
@@ -3471,7 +3471,7 @@ pub fn exact_env_positional_strategy(
 /// ([`MealyStrategy`]). The game is Mealy — the environment moves and the controller RESPONDS
 /// ([`ExactModel::cpre_controllable`], `∀env ∃ctrl`) — so the controller's move may depend on the
 /// current environment input. `env_inputs` is empty for an env-independent (Moore) move.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct MealyMove {
     /// The environment-input valuation this move responds to; empty = env-independent (holds for every
     /// environment move).
@@ -3481,7 +3481,7 @@ pub struct MealyMove {
 }
 
 /// One control-state row of a [`MealyStrategy`]: the controller's response(s) at that control value.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct MealyEntry {
     /// The value of the strategy's state register.
     pub state_value: u128,
@@ -3499,7 +3499,7 @@ pub struct MealyEntry {
 /// controller forces the controllable inputs (possibly reacting to the environment input — the game is
 /// `∀env ∃ctrl`) to a rank-decreasing move. Contrast [`PositionalStrategy`], which the ENVIRONMENT
 /// counterstrategy uses (the environment is the first-mover, so its winning strategy is positional).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct MealyStrategy {
     /// The state register the strategy is indexed by.
     pub state_register: String,
@@ -3539,20 +3539,36 @@ impl MealyStrategy {
 /// COUNTERSTRATEGY when it is not (by determinacy, exactly one holds). The asymmetry is intrinsic to the
 /// Mealy game (`∀env ∃ctrl`): the environment is the first-mover, so its winning strategy is positional
 /// (state-indexed); the controller responds, so its strategy may depend on the environment input.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TwoPlayerStrategy {
-    /// The controller wins from the initial state (spec realizable) — its Mealy strategy.
+    /// The controller wins from the initial state (spec realizable) — its Mealy strategy. Serializes as
+    /// `{"kind": "controller_strategy", "state_register": …, "entries": […]}`.
     ControllerStrategy(MealyStrategy),
     /// The environment wins (unrealizable) — its positional counterstrategy, forcing environment inputs
     /// (robust to every controllable move) to keep the play out of the controller's winning region.
+    /// Serializes as `{"kind": "environment_counterstrategy", "state_register": …, "entries": […]}`.
     EnvironmentCounterstrategy(PositionalStrategy),
+}
+
+impl TwoPlayerStrategy {
+    /// `true` when the controller wins from the initial state (the spec is realizable) and this carries
+    /// its strategy; `false` when the environment wins (unrealizable) and this carries the counterstrategy.
+    pub fn realizable(&self) -> bool {
+        matches!(self, TwoPlayerStrategy::ControllerStrategy(_))
+    }
 }
 
 /// P2.5-F — synthesize the two-player strategy for the controllable-reachability game to `good` with
 /// `controllable` naming the controller's inputs. Returns the CONTROLLER's Mealy strategy when the
 /// controller wins from the initial state (== [`exact_two_player_verdict`] holds on `μX. good ∨ ⟨ctrl⟩X`),
-/// or the ENVIRONMENT's positional counterstrategy when it does not. `None` when `good` is not a
-/// resolvable state atom or the model can't be built.
+/// or the ENVIRONMENT's positional counterstrategy when it does not (`TwoPlayerStrategy::realizable`
+/// distinguishes them). The surface entry point behind `mununu btor2 game` / `POST /api/v1/btor2/game`.
+///
+/// `Err` when `good` is not a resolvable `REG op VALUE` state atom, the model can't be built (over the
+/// exact cap / array / input-atom), the atom references no state register, or a declared `controllable`
+/// name is not a real primary input — the same partition validation as [`exact_two_player_verdict`], so a
+/// typo or an internally-driven signal is rejected rather than silently reinterpreted as environment.
 ///
 /// **Engine (§16):** `exact-symbolic` ROBDD — the controllable attractor (`cpre_controllable`) supplies
 /// ranks; concrete forward reachability enumerates the real states. The controller's moves come from
@@ -3563,9 +3579,39 @@ pub fn exact_two_player_strategy(
     btor2_content: &str,
     good: &str,
     controllable: &[&str],
-) -> Option<TwoPlayerStrategy> {
+) -> Result<TwoPlayerStrategy, String> {
     use crate::adapter::btor2::parser;
-    let (bb, file, good_bdd) = build_atom_model(btor2_content, good)?;
+    let (bb, file, good_bdd) = build_atom_model(btor2_content, good).ok_or_else(|| {
+        format!(
+            "exact two-player strategy: `{good}` is not a resolvable `REG op VALUE` state atom, or the \
+             model can't be built (over the exact cap / array / input-atom)"
+        )
+    })?;
+    // Validate the partition: every declared controllable input must be a real primary input, else it
+    // would fall back SILENTLY to the environment (the same rule + rationale as `exact_two_player_verdict`).
+    if !controllable.is_empty() {
+        let inputs: std::collections::HashSet<String> = crate::adapter::sts_ir::BtorSts::new(&file)
+            .leaf_cells()
+            .map_err(|e| format!("exact two-player strategy: {e}"))?
+            .into_iter()
+            .filter(|c| !c.is_state)
+            .map(|c| c.name)
+            .collect();
+        let mut unknown: Vec<&str> = controllable
+            .iter()
+            .copied()
+            .filter(|c| !inputs.contains(*c))
+            .collect();
+        if !unknown.is_empty() {
+            unknown.sort_unstable();
+            let mut names: Vec<&str> = inputs.iter().map(String::as_str).collect();
+            names.sort_unstable();
+            return Err(format!(
+                "exact two-player strategy: declared controllable input(s) {unknown:?} are not primary \
+                 inputs of the design (primary inputs: {names:?})"
+            ));
+        }
+    }
     let resolve = |name: &str| -> String {
         parser::resolve_to_canonical_name(
             &file,
@@ -3576,13 +3622,21 @@ pub fn exact_two_player_strategy(
         )
         .unwrap_or_else(|| name.to_string())
     };
-    let expr = resolve_predicate_expr_registers(&parse_predicate_atom_bool(good).ok()?, &resolve);
+    let expr = resolve_predicate_expr_registers(
+        &parse_predicate_atom_bool(good).map_err(|e| format!("exact two-player strategy: {e}"))?,
+        &resolve,
+    );
     let mut regs: std::collections::HashSet<String> = std::collections::HashSet::new();
     collect_predicate_registers(&expr, &mut regs);
-    let reg = regs.into_iter().next()?;
+    let reg = regs.into_iter().next().ok_or_else(|| {
+        format!("exact two-player strategy: `{good}` references no state register")
+    })?;
     let ctrl: std::collections::HashSet<String> =
         controllable.iter().map(|s| s.to_string()).collect();
     bb.two_player_strategy(&file, &good_bdd, &reg, &ctrl)
+        .ok_or_else(|| {
+            format!("exact two-player strategy: `{reg}` is not a state register in the design")
+        })
 }
 
 /// D1.8b/b-2 — detect a liveness shape and return the node id of its target `p`.

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -873,6 +873,34 @@ pub async fn btor2_check_fsm_handler(
     }))
 }
 
+/// Solve the two-player controllable-reachability game (`POST /api/v1/btor2/game`) and synthesize the
+/// winner's strategy. Surface peer of the CLI `mununu btor2 game`: partitions the primary inputs into
+/// controller-owned (`controllable`) vs environment-owned (the adversary), decides whether the controller
+/// can force the design to `good` against every environment move, and returns `realizable` plus the
+/// controller's Mealy strategy — or, when unrealizable, the environment's positional counterstrategy (the
+/// witness for why no controller works, motivating an assume-guarantee assumption). A malformed BTOR2
+/// source, an unresolvable `good` atom, or a `controllable` name that is not a primary input is a
+/// `BadRequest`.
+pub async fn btor2_game_handler(
+    Json(request): Json<Btor2GameRequest>,
+) -> ApiResult<Json<Btor2GameResponse>> {
+    use crate::adapter::btor2::symbolic_bitblast::exact_two_player_strategy;
+
+    let controllable: Vec<&str> = request.controllable.iter().map(String::as_str).collect();
+    let strategy = exact_two_player_strategy(&request.content, &request.good, &controllable)
+        .map_err(|message| ApiError::BadRequest {
+            message,
+            details: None,
+        })?;
+
+    Ok(Json(Btor2GameResponse {
+        realizable: strategy.realizable(),
+        good: request.good,
+        controllable: request.controllable,
+        strategy,
+    }))
+}
+
 // --- SV-direct verbs: lift SV (sv2v + Yosys) then decide, in one call. Surface peers
 // of the CLI `sv verify` / `verify-liveness` / `verify-recoverability`; they return
 // the same `Btor2Verify*Response` shapes as the BTOR2-direct verbs. The lift needs
@@ -4634,6 +4662,56 @@ members = ["x"]
         let err = btor2_check_fsm_handler(Json(request))
             .await
             .expect_err("malformed BTOR2 must be rejected");
+        assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    // Two-player game verb: `st' = c` (controller wins) and `st' = c & ¬e` (environment blocks) — the
+    // same known-answer 1-bit games as tests/exact_two_player_strategy.rs, over the HTTP handler.
+    const GAME_CTRL: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 next 1 4 2\n";
+    const GAME_ENVBLK: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 not 1 3\n8 and 1 2 7\n9 next 1 4 8\n";
+
+    #[tokio::test]
+    async fn btor2_game_handler_realizable_returns_controller_strategy() {
+        use crate::adapter::btor2::symbolic_bitblast::TwoPlayerStrategy;
+        let request = Btor2GameRequest {
+            content: GAME_CTRL.to_string(),
+            good: "st == 1".to_string(),
+            controllable: vec!["c".to_string()],
+        };
+        let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
+        assert!(out.realizable, "st'=c: the controller wins");
+        assert!(matches!(
+            out.strategy,
+            TwoPlayerStrategy::ControllerStrategy(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn btor2_game_handler_unrealizable_returns_counterstrategy() {
+        use crate::adapter::btor2::symbolic_bitblast::TwoPlayerStrategy;
+        let request = Btor2GameRequest {
+            content: GAME_ENVBLK.to_string(),
+            good: "st == 1".to_string(),
+            controllable: vec!["c".to_string()],
+        };
+        let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
+        assert!(!out.realizable, "st'=c&¬e: the environment wins");
+        assert!(matches!(
+            out.strategy,
+            TwoPlayerStrategy::EnvironmentCounterstrategy(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn btor2_game_handler_rejects_unknown_controllable_input() {
+        let request = Btor2GameRequest {
+            content: GAME_CTRL.to_string(),
+            good: "st == 1".to_string(),
+            controllable: vec!["nope".to_string()], // not a primary input
+        };
+        let err = btor2_game_handler(Json(request))
+            .await
+            .expect_err("an unknown controllable input must be rejected");
         assert!(matches!(err, ApiError::BadRequest { .. }));
     }
 

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1086,6 +1086,38 @@ pub struct Btor2CheckFsmResponse {
     pub registers: Vec<FsmRegisterFinding>,
 }
 
+/// Request for the two-player controllable-reachability game (`POST /api/v1/btor2/game`). Mirrors the CLI
+/// `mununu btor2 game`: decide whether the CONTROLLER can force the design to `good` against every
+/// environment move, and synthesize the winner's strategy.
+#[derive(Debug, Deserialize)]
+pub struct Btor2GameRequest {
+    /// BTOR2 source content.
+    pub content: String,
+    /// The reachability target `good` state atom (`"REG op VALUE"`, e.g. `"state_q == 44"`).
+    pub good: String,
+    /// The controller-owned primary inputs; every other primary input is the (adversarial) environment's.
+    /// A name that is not a real primary input is a `BadRequest`.
+    #[serde(default)]
+    pub controllable: Vec<String>,
+}
+
+/// Response for `POST /api/v1/btor2/game`.
+#[derive(Debug, Serialize)]
+pub struct Btor2GameResponse {
+    /// `true` = the controller can force `good` against every environment move (the spec is realizable);
+    /// `false` = the environment can prevent it (unrealizable).
+    pub realizable: bool,
+    /// The `good` atom, echoed for provenance.
+    pub good: String,
+    /// The controller-owned inputs, echoed for provenance.
+    pub controllable: Vec<String>,
+    /// The winner's strategy: a `controller_strategy` (Mealy, when realizable) or an
+    /// `environment_counterstrategy` (positional, when not) — the [`crate::adapter::btor2::symbolic_bitblast::TwoPlayerStrategy`]
+    /// serialized with a `"kind"` tag. The counterstrategy is the witness for the assume-guarantee reading
+    /// (why no controller works).
+    pub strategy: crate::adapter::btor2::symbolic_bitblast::TwoPlayerStrategy,
+}
+
 /// The SV → BTOR2 lift inputs shared by the SV-direct verb endpoints
 /// (`/api/v1/sv/verify`, `/sv/verify-liveness`, `/sv/verify-recoverability`). These
 /// lift the module (sv2v + Yosys) and then decide the corresponding BTOR2 property,

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -139,6 +139,10 @@ fn create_router() -> Router {
             "/api/v1/btor2/check-fsm",
             post(handlers::btor2_check_fsm_handler),
         )
+        // P2.5-F two-player game — decide controllable-reachability of `good` under an input partition
+        // (controller vs environment) and synthesize the winner's strategy (controller Mealy strategy or
+        // environment counterstrategy). Surface peer of the CLI `mununu btor2 game`.
+        .route("/api/v1/btor2/game", post(handlers::btor2_game_handler))
         // cegar-extraction Stage 2 — SV-direct CEGAR one-call (sv2v +
         // Yosys → flattened BTOR2 → cegar_refine_loop). Surface peer of
         // the CLI `mununu sv cegar`; lets the extraction-tab SV workflow


### PR DESCRIPTION
## Summary

Exposes the two-player controllable-reachability game (`exact_two_player_strategy`, #439/#440) on all three surfaces (Surface Parity). Given a BTOR2 model, a `good` state atom, and a controller/environment input partition, decide whether the **controller** can force `good` against every environment move, and synthesize the winner's strategy — the controller's **Mealy strategy** (realizable) or the environment's positional **counterstrategy** (unrealizable; the witness for why no controller works, motivating an assume-guarantee assumption).

**Engine:** `exact-symbolic` ROBDD, unchanged from #439/#440 — this is wiring + serialization + partition validation.

## Core (`adapter/btor2/symbolic_bitblast.rs`)

- The strategy types (`TwoPlayerStrategy` / `MealyStrategy` / `MealyEntry` / `MealyMove` / `PositionalStrategy` / `StrategyEntry`) derive `serde::Serialize`. The enum is internally tagged — `{"kind": "controller_strategy" | "environment_counterstrategy", "state_register": …, "entries": […]}`. Values serialize as JSON numbers (control-FSM narrow, within the exact cap).
- `TwoPlayerStrategy::realizable()` helper.
- **`exact_two_player_strategy` now returns `Result<TwoPlayerStrategy, String>`** (was `Option`) and **validates the partition**: every declared controllable input must be a real primary input — the same rule + rationale as `exact_two_player_verdict` (a typo or internally-driven signal would otherwise fall back silently to the environment). Existing engine tests are unaffected (`.unwrap()`/`.expect()` work on `Result`).

## CLI — `mununu btor2 game`

`--good "REG op VALUE"` + repeatable `--controllable INPUT`; prints `{file, good, controllable, realizable, strategy}` as JSON; `--fail-on` maps realizable→holds, unrealizable→violated.

## API — `POST /api/v1/btor2/game`

`Btor2GameRequest {content, good, controllable}` → `Btor2GameResponse {realizable, good, controllable, strategy}`. A malformed source / unresolvable atom / non-primary controllable input is a `BadRequest`.

## Validation (gate `make ci`)

- API handler tests: realizable CTRL → `controller_strategy`; unrealizable ENVBLK → `environment_counterstrategy`; unknown controllable input → `BadRequest`.
- Engine tests (`tests/exact_two_player_strategy.rs`) green under the `Result` signature.
- fmt + clippy clean; `/parity-check`: **0 drift**.

## UI peer

`runBtor2Game` + typed request/response + `TwoPlayerStrategy` discriminated union + `game.test.ts` ship in **mununu-ui PR #58** (same feature, separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)