### PR TITLE
fix(sv): design-dir --top note no longer reads as "your --top was ignored"

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -5284,11 +5284,23 @@ fn read_sv_lift(args: &SvLiftArgs) -> Result<mununu_core::adapter::sv_verify::Sv
         let files = source_manifest::discover_sv_files(dir)?;
         let design_name = dir.file_name().and_then(|s| s.to_str());
         let a = source_manifest::assemble_sv_design(&files, design_name);
-        for note in &a.notes {
-            eprintln!("design-dir: {note}");
-        }
         // explicit --top overrides the detected top; --include-dir adds to detected dirs.
         let top = args.top.clone().or(a.top);
+        for note in &a.notes {
+            // When an explicit `--top` is given it WINS (`args.top.or(a.top)` above), so the
+            // auto-detection's "N top candidates → ambiguous"/"no un-instantiated module" notes are
+            // moot and actively misleading (they read as "your --top was ignored" when it was not).
+            // Suppress just those; keep every other assembly note.
+            if args.top.is_some()
+                && (note.contains("top candidate") || note.contains("un-instantiated module"))
+            {
+                continue;
+            }
+            eprintln!("design-dir: {note}");
+        }
+        if let Some(t) = &args.top {
+            eprintln!("design-dir: explicit --top '{t}' used (overrides any auto-detection)");
+        }
         let include_dirs = args
             .include_dirs
             .iter()


### PR DESCRIPTION
## Summary

A cosmetic-but-misleading console note in the shared `sv` `--design-dir` resolver. When `sv <verb> --design-dir DIR --top X` is used, the explicit `--top X` **wins** ([main.rs](crates/mununu-cli/src/main.rs) design-dir branch: `top = args.top.clone().or(a.top)`). But the resolver printed *all* of `assemble_sv_design`'s notes verbatim first — including the auto-detection's `"N top candidates → ambiguous — Yosys auto-detect"` / `"no un-instantiated module found"` lines — which, with an explicit `--top`, are moot and read as *"your --top was ignored"* when it was not.

This exact misread produced a wrong benchmark-ledger entry during a CPU-recoverability probe (t6507lp's ⊥ was briefly attributed to a top-selection bug, when the ⊥ is a genuine datapath-coupled over-cap and the `--top` override worked correctly).

## Fix

In the shared SV-lift resolver (all `sv --design-dir` verbs): suppress just the top-detection notes when `args.top` is `Some`, and print an explicit `design-dir: explicit --top 'X' used (overrides any auto-detection)` line. Every other assembly note (include-fragment, `.sv`/`.v` twin dedup, header-only) is unchanged.

Cosmetic / clarity only — **no change to which top is actually lifted** (that logic was already correct). fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)