### PR TITLE
feat(game): discover the environment assumption that makes an unrealizable game realizable (refined-verdicts Phase 2c)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -804,6 +804,12 @@ struct Btor2GameArgs {
     /// (adversarial) environment. A name that is not a real primary input is rejected.
     #[arg(long = "controllable", value_name = "INPUT")]
     controllable: Vec<String>,
+    /// When the game is UNREALIZABLE, search for an ENVIRONMENT ASSUMPTION under which the controller
+    /// wins (the assume-guarantee wedge) — a narrow environment-input hold `e == v` making `A ⇒ G`
+    /// realizable, reported in `holds_under` (CONDITIONAL — never flips the canonical `realizable`). The
+    /// environment counterstrategy's forced inputs are the blockers, searched first.
+    #[arg(long = "discover-assumptions")]
+    discover_assumptions: bool,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2763,6 +2769,19 @@ fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
     });
     summary["strategy"] =
         serde_json::to_value(&strategy).map_err(|e| format!("serialize strategy: {e}"))?;
+    // --discover-assumptions: when the game is unrealizable, search for an environment assumption under
+    // which the controller wins (CONDITIONAL — never flips `realizable`). No-op when already realizable.
+    if args.discover_assumptions {
+        let holds_under = mununu_core::adapter::recoverability::discover_game_env_assumption(
+            &content,
+            &args.good,
+            &controllable,
+        );
+        if !holds_under.is_empty() {
+            summary["holds_under"] = serde_json::to_value(&holds_under)
+                .map_err(|e| format!("serialize holds_under: {e}"))?;
+        }
+    }
     print_json_summary(&summary)?;
 
     // realizable == the controller wins (`holds`); unrealizable == no controller works (`violated`).

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1405,6 +1405,117 @@ fn synthesize_env_strategy_assumption(
     })
 }
 
+/// Capability B, Phase 2c (TWO-PLAYER) — discover an ENVIRONMENT ASSUMPTION under which the
+/// controllable-reachability GAME to `good` becomes REALIZABLE. When the controller cannot force `good`
+/// against a free adversary (`exact_two_player_strategy` returns an `EnvironmentCounterstrategy`), search
+/// for a constraint on the ENVIRONMENT (non-controllable) inputs under which the controller WINS — the
+/// assume-guarantee wedge: `G` is unrealizable, but `A ⇒ G` is realizable ("the boot handshake completes
+/// IF the acknowledging module eventually acks"). Each returned [`DiscoveredAssumption`] is CONDITIONAL
+/// (the caller's canonical verdict is unchanged). Empty when the game is ALREADY realizable (no
+/// assumption needed — the soundness/false-positive control), when `good` is not `REG == VALUE`, or when
+/// no single narrow env-input hold wins.
+///
+/// The environment COUNTERSTRATEGY is the witness: the env inputs it FORCES are the blockers, so those
+/// axes are searched FIRST — a hold that constrains the environment away from its blocking discipline is
+/// the natural assumption. Unlike the 1-player [`synthesize_env_strategy_assumption`] (which asks whether
+/// the environment, owning ALL inputs, can MAINTAIN recovery), this splits inputs into controller vs
+/// environment and asks whether CONSTRAINING the adversary lets the CONTROLLER win — the generalization
+/// the refined-verdicts plan flagged, unblocked by the two-player CPre (`exact_model_partitioned`).
+///
+/// **Engine (§16):** `exact-symbolic` ROBDD two-player game ([`exact_two_player_strategy`], `∀env ∃ctrl`
+/// CPre) on each [`pin_inputs_to_constants`] env-pinned concrete model (2-valued sound per pin) + the
+/// reach portfolio for the non-vacuity gate. A candidate cap + a wall-clock budget bound the search.
+pub fn discover_game_env_assumption(
+    btor2_content: &str,
+    good: &str,
+    controllable: &[&str],
+) -> Vec<DiscoveredAssumption> {
+    use crate::adapter::btor2::ast::Node;
+    use crate::adapter::btor2::pin::pin_inputs_to_constants;
+    use crate::adapter::btor2::symbolic_bitblast::{TwoPlayerStrategy, exact_two_player_strategy};
+    const MAX_INPUT_BITS: u32 = 3; // ≤ 8 values — a narrow control/ack/enable, not a datapath
+    const MAX_CANDIDATE_PINS: usize = 48;
+    let budget_ms: u128 = std::env::var("MUNUNU_ASSUMPTION_BUDGET_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(90_000);
+    let start = std::time::Instant::now();
+
+    // `good` must be `REG == VALUE` — the non-vacuity gate needs the register + value.
+    let (register, value) = match parse_predicate_expr(good).ok() {
+        Some(PredicateExpr::Cmp {
+            register,
+            op: CmpOp::Eq,
+            value,
+        }) => (register, value),
+        _ => return Vec::new(),
+    };
+
+    // Only search when the game is genuinely UNREALIZABLE — a realizable game needs no assumption (the
+    // false-positive control: discovery must not fabricate an enabling φ for a controller that already
+    // wins). The returned counterstrategy names the blocking env inputs.
+    let counter = match exact_two_player_strategy(btor2_content, good, controllable) {
+        Ok(TwoPlayerStrategy::EnvironmentCounterstrategy(p)) => p,
+        _ => return Vec::new(), // realizable, or `good` not a resolvable atom / over-cap
+    };
+    let priority: std::collections::HashSet<String> = counter
+        .entries
+        .iter()
+        .flat_map(|e| e.forced_inputs.keys().cloned())
+        .collect();
+
+    let ctrl_set: std::collections::HashSet<&str> = controllable.iter().copied().collect();
+    let Ok(file) = crate::adapter::btor2::parser::parse(btor2_content) else {
+        return Vec::new();
+    };
+    let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
+    // Candidate assumption axes = the design's NARROW ENVIRONMENT primary inputs (narrow, non-controllable).
+    let mut candidates: Vec<(String, u32)> = Vec::new();
+    for line in &file.lines {
+        if let Node::Input { sort, .. } = &line.node
+            && let Some(name) = symbols.get(&line.nid)
+            && !ctrl_set.contains(name.as_str())
+            && let Some(w) = crate::adapter::btor2::parser::bv_width(&file, *sort)
+            && w <= MAX_INPUT_BITS
+        {
+            candidates.push((name.clone(), w));
+        }
+    }
+    candidates.sort();
+    candidates.dedup();
+    // Search the counterstrategy-forced (blocking) env inputs FIRST — the witness guides the search.
+    candidates.sort_by_key(|(n, _)| (!priority.contains(n), n.clone()));
+
+    let mut found: Vec<DiscoveredAssumption> = Vec::new();
+    let mut pins_tried = 0usize;
+    'outer: for (name, w) in candidates {
+        for c in 0..(1u64 << w) {
+            if pins_tried >= MAX_CANDIDATE_PINS || start.elapsed().as_millis() > budget_ms {
+                break 'outer;
+            }
+            pins_tried += 1;
+            let (pinned, _) = pin_inputs_to_constants(btor2_content, &[(name.clone(), c)]);
+            // SOUNDNESS: the env input is pinned to a CONSTANT ⇒ the two-player game on the pinned model
+            // is exact/2-valued sound; the non-vacuity gate rejects a realizable-but-vacuous hold (good
+            // unreachable or stuck-true under the assumption). The report stays CONDITIONAL — the caller
+            // never lifts it to an unconditional realizable.
+            let realizable = matches!(
+                exact_two_player_strategy(&pinned, good, controllable),
+                Ok(s) if s.realizable()
+            );
+            if realizable && good_nonvacuous_under(&pinned, &register, value) {
+                found.push(DiscoveredAssumption {
+                    phi: format!("{name} == {c}"),
+                    kind: AssumptionKind::InputHold,
+                    non_vacuous: true,
+                    engine: "two-player game realizable under env-input hold".to_string(),
+                });
+            }
+        }
+    }
+    found
+}
+
 /// Capability A (refined-verdicts Phase 1) — partition the `AG EF good` verdict over the CONFIG the
 /// recovery rides on. For each config valuation (the cross-product of each `(input, candidate values)`
 /// spec) PIN those inputs to constants and decide the CONCRETE pinned model with the exact engine —
@@ -4112,6 +4223,50 @@ mod tests {
                 .iter()
                 .any(|a| a.phi == "en == 1" && a.non_vacuous),
             "the enabling assumption rides in holds_under: {refinement:?}"
+        );
+    }
+
+    // --- Capability B, Phase 2c (TWO-PLAYER assumption discovery) -----------------------------------
+    // The same 1-bit games as tests/exact_two_player_strategy.rs: `st' = c` (controller wins),
+    // `st' = c & ¬e` (environment blocks with e=1), `st' = 0` (target unreachable).
+    const GAME_CTRL: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 next 1 4 2\n";
+    const GAME_ENVBLK: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 not 1 3\n8 and 1 2 7\n9 next 1 4 8\n";
+    const GAME_STUCK: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 next 1 4 5\n";
+
+    /// The wedge: `ENVBLK` (`st'=c&¬e`) is UNREALIZABLE (the environment blocks `st==1` with `e=1`), but
+    /// under the environment assumption `e == 0` the controller wins (`st'=c`, set `c=1`). Discovery
+    /// finds the non-vacuous `HoldsUnder(e == 0)` — the assume-guarantee assumption on the adversary.
+    #[test]
+    fn discover_game_env_assumption_finds_the_enabling_assumption() {
+        let found = discover_game_env_assumption(GAME_ENVBLK, "st == 1", &["c"]);
+        assert!(
+            found
+                .iter()
+                .any(|a| a.phi == "e == 0" && a.kind == AssumptionKind::InputHold && a.non_vacuous),
+            "expected a non-vacuous HoldsUnder(e == 0) making the game realizable: {found:?}"
+        );
+    }
+
+    /// False-positive control: a game the controller ALREADY wins (`st'=c`, realizable) needs no
+    /// assumption — discovery must return ∅, never fabricate an enabling φ.
+    #[test]
+    fn discover_game_env_assumption_empty_when_already_realizable() {
+        let found = discover_game_env_assumption(GAME_CTRL, "st == 1", &["c"]);
+        assert!(
+            found.is_empty(),
+            "a realizable game needs no environment assumption: {found:?}"
+        );
+    }
+
+    /// Soundness control: an unrealizable game whose target is structurally UNREACHABLE (`st'=0`, so
+    /// `st==1` is never reached under any env constraint) must NOT yield a spurious assumption — the
+    /// realizability + non-vacuity gates both reject every env hold.
+    #[test]
+    fn discover_game_env_assumption_no_spurious_phi_on_dead_target() {
+        let found = discover_game_env_assumption(GAME_STUCK, "st == 1", &["c"]);
+        assert!(
+            found.is_empty(),
+            "a structurally-unreachable target must not fabricate an enabling φ: {found:?}"
         );
     }
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -892,11 +892,23 @@ pub async fn btor2_game_handler(
             message,
             details: None,
         })?;
+    // discover_assumptions: when unrealizable, search for an environment assumption under which the
+    // controller wins (CONDITIONAL — never flips `realizable`). No-op when already realizable.
+    let holds_under = if request.discover_assumptions {
+        crate::adapter::recoverability::discover_game_env_assumption(
+            &request.content,
+            &request.good,
+            &controllable,
+        )
+    } else {
+        Vec::new()
+    };
 
     Ok(Json(Btor2GameResponse {
         realizable: strategy.realizable(),
         good: request.good,
         controllable: request.controllable,
+        holds_under,
         strategy,
     }))
 }
@@ -4677,6 +4689,7 @@ members = ["x"]
             content: GAME_CTRL.to_string(),
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
+            discover_assumptions: false,
         };
         let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
         assert!(out.realizable, "st'=c: the controller wins");
@@ -4693,6 +4706,7 @@ members = ["x"]
             content: GAME_ENVBLK.to_string(),
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
+            discover_assumptions: false,
         };
         let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
         assert!(!out.realizable, "st'=c&¬e: the environment wins");
@@ -4702,12 +4716,37 @@ members = ["x"]
         ));
     }
 
+    /// `--discover-assumptions` over HTTP: the unrealizable ENVBLK game returns a `holds_under` carrying
+    /// the enabling environment assumption `e == 0` (CONDITIONAL — `realizable` stays false).
+    #[tokio::test]
+    async fn btor2_game_handler_discovers_env_assumption() {
+        let request = Btor2GameRequest {
+            content: GAME_ENVBLK.to_string(),
+            good: "st == 1".to_string(),
+            controllable: vec!["c".to_string()],
+            discover_assumptions: true,
+        };
+        let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
+        assert!(
+            !out.realizable,
+            "canonical realizable stays false (conditional-only)"
+        );
+        assert!(
+            out.holds_under
+                .iter()
+                .any(|a| a.phi == "e == 0" && a.non_vacuous),
+            "holds_under carries the enabling assumption e==0: {:?}",
+            out.holds_under
+        );
+    }
+
     #[tokio::test]
     async fn btor2_game_handler_rejects_unknown_controllable_input() {
         let request = Btor2GameRequest {
             content: GAME_CTRL.to_string(),
             good: "st == 1".to_string(),
             controllable: vec!["nope".to_string()], // not a primary input
+            discover_assumptions: false,
         };
         let err = btor2_game_handler(Json(request))
             .await

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1099,6 +1099,11 @@ pub struct Btor2GameRequest {
     /// A name that is not a real primary input is a `BadRequest`.
     #[serde(default)]
     pub controllable: Vec<String>,
+    /// When the game is UNREALIZABLE, also search for an ENVIRONMENT ASSUMPTION under which the controller
+    /// wins (the assume-guarantee wedge) → `holds_under`. CONDITIONAL — never flips `realizable`. No-op
+    /// when the game is already realizable. Mirrors the CLI `--discover-assumptions`.
+    #[serde(default)]
+    pub discover_assumptions: bool,
 }
 
 /// Response for `POST /api/v1/btor2/game`.
@@ -1111,6 +1116,11 @@ pub struct Btor2GameResponse {
     pub good: String,
     /// The controller-owned inputs, echoed for provenance.
     pub controllable: Vec<String>,
+    /// Discovered environment assumption(s) under which the (unrealizable) game becomes realizable —
+    /// each a CONDITIONAL `HoldsUnder(φ)` (never flips `realizable`). Only when `discover_assumptions`
+    /// was requested and the game is unrealizable; empty otherwise.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub holds_under: Vec<crate::verdict::DiscoveredAssumption>,
     /// The winner's strategy: a `controller_strategy` (Mealy, when realizable) or an
     /// `environment_counterstrategy` (positional, when not) — the [`crate::adapter::btor2::symbolic_bitblast::TwoPlayerStrategy`]
     /// serialized with a `"kind"` tag. The counterstrategy is the witness for the assume-guarantee reading


### PR DESCRIPTION
## Summary

The **assume-guarantee wedge**, unblocked by the two-player game arc (#434–440): when the controllable-reachability **game** to `good` is **unrealizable** (the controller cannot force it against a free adversary), discover an **environment assumption A** under which the controller **wins** — `G` is unrealizable but `A ⇒ G` is realizable ("the boot handshake completes *if* the acking module eventually acks"). This is the two-player generalization the refined-verdicts plan flagged as *"NOT built"* (a controllability-aware CPre + `Control`-honoring `evaluate` + strategy extraction) — all now shipped, so **capability B gets its genuine two-player slice**.

## Core — `recoverability.rs::discover_game_env_assumption(btor2, good, controllable)`

- Searches **only when the game is unrealizable** (`exact_two_player_strategy` → `EnvironmentCounterstrategy`) — a realizable game needs no assumption (the false-positive control). The **environment counterstrategy is the witness**: the env inputs it *forces* are the blockers, searched **first**.
- Each narrow (≤3-bit) non-controllable input is pinned to a constant; the game is re-decided via `exact_two_player_strategy(pinned).realizable()`; a realizable + non-vacuous (reach-portfolio gate) hold becomes `DiscoveredAssumption { phi: "e == v", kind: InputHold, engine: "two-player game realizable under env-input hold" }`. **Conditional** — never flips the canonical `realizable`.
- Unlike the 1-player 2b (`synthesize_env_strategy_assumption`, ∃input "can the env *maintain* recovery"), this is the genuine two-player wedge (`∀env ∃ctrl`, "does *constraining the adversary* let the *controller* win"), sound per pin (a pinned input is a constant).

## Surface parity

- **CLI:** `btor2 game --discover-assumptions` (→ `holds_under` in the JSON).
- **API:** `POST /api/v1/btor2/game {discover_assumptions}` → `Btor2GameResponse.holds_under`.
- **UI:** `runBtor2Game` (`discover_assumptions?` / `holds_under?`) — **mununu-ui PR #59**.

## Tests (gate `make ci`)

Synthetic 1-bit games: **ENVBLK** (`st'=c&¬e`, unrealizable) discovers non-vacuous `HoldsUnder(e == 0)`; a **realizable** game → ∅ (false-positive control); a **dead target** (`st'=0`) → ∅ (soundness control, no spurious φ). API handler test: `discover_assumptions:true` returns `holds_under = [e==0]` with `realizable:false`. fmt + clippy clean.

## Scope

The **single-hold** slice — a block needing a *conjunctive* env assumption (edn: withhold-ack **and** no-escalate) may find ∅; conjunctive/schedule env assumptions are the follow-up. Real-RTL (edn/otbn) measurement + the ledger §D two-player-`HoldsUnder` row are pending the image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)