### PR TITLE
feat(game): sound-posture two-player model — clock/reset not adversarial (--assume-clock-reset)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -810,6 +810,13 @@ struct Btor2GameArgs {
     /// environment counterstrategy's forced inputs are the blockers, searched first.
     #[arg(long = "discover-assumptions")]
     discover_assumptions: bool,
+    /// Model the CLOCK and RESET as a sound posture instead of adversarial inputs (the raw lifted BTOR2
+    /// carries `clk`/`rst` as free inputs, so a two-player game otherwise lets the environment FREEZE THE
+    /// CLOCK or HOLD RESET — spuriously unrealizable for a modeling, not functional, reason). Pins the
+    /// detected reset inactive (+ post-reset init) and the clock to a constant, so the game is the genuine
+    /// functional one. Recommended for real RTL.
+    #[arg(long = "assume-clock-reset")]
+    assume_clock_reset: bool,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2754,10 +2761,18 @@ fn btor2_check_fsm(args: Btor2CheckFsmArgs) -> Result<(), String> {
 /// peer of the API `POST /api/v1/btor2/game`. Exits non-zero (via `--fail-on`) on `unrealizable` (mapped
 /// to the `violated` verdict class); `realizable` maps to `holds`.
 fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
-    use mununu_core::adapter::btor2::symbolic_bitblast::exact_two_player_strategy;
+    use mununu_core::adapter::btor2::symbolic_bitblast::{
+        exact_two_player_strategy, game_sound_posture_model,
+    };
 
-    let content = std::fs::read_to_string(&args.file)
+    let raw = std::fs::read_to_string(&args.file)
         .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
+    // --assume-clock-reset: model clk/rst as a sound posture (not adversarial) before solving the game.
+    let content = if args.assume_clock_reset {
+        game_sound_posture_model(&raw)
+    } else {
+        raw
+    };
     let controllable: Vec<&str> = args.controllable.iter().map(String::as_str).collect();
     let strategy = exact_two_player_strategy(&content, &args.good, &controllable)?;
 
@@ -2765,6 +2780,7 @@ fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
         "file": args.file.display().to_string(),
         "good": args.good,
         "controllable": args.controllable,
+        "assume_clock_reset": args.assume_clock_reset,
         "realizable": strategy.realizable(),
     });
     summary["strategy"] =

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2859,6 +2859,55 @@ pub fn exact_symbolic_verdict_with_witness(
     verdict_with_witness_catching(btor2_content, formula, &std::collections::HashSet::new())
 }
 
+/// P2.5-F — the SOUND-POSTURE two-player game model: exclude the CLOCK and RESET from the adversary.
+/// The raw lifted BTOR2 carries `clk`/`rst` as free primary inputs, so a two-player game treats them as
+/// ADVERSARIAL — the environment can FREEZE THE CLOCK (hold `clk` constant → the design never advances)
+/// or HOLD RESET (→ the FSM sticks in reset), making the reachability game spuriously unrealizable for a
+/// MODELING reason, not a functional one. In real synchronous verification the clock ticks and reset is a
+/// controlled posture. This transform models that: inject the post-reset `init`
+/// ([`crate::adapter::btor2::reset_init::inject_reset_init`]), then PIN the detected reset(s) to their
+/// inactive level and the clock(s) to a constant — so the game is over the FUNCTIONAL inputs only. Returns
+/// the content unchanged when there is no detected reset/clock (a pure-functional design is already sound).
+///
+/// **Soundness:** reset-released + reset-init IS the design's normal operational start (the same
+/// operational model the recoverability path uses); the clock is near-dangling in an `async2sync`-lifted
+/// design, so pinning it is a no-op on the transition. The resulting verdict/strategy is the genuine
+/// FUNCTIONAL game, free of the clock-freeze / reset-hold artifacts. Opt-in (the raw model is preserved
+/// for callers that want the literal all-inputs-adversarial reading).
+pub fn game_sound_posture_model(btor2_content: &str) -> String {
+    use crate::adapter::btor2::ast::Node;
+    let Ok(file) = crate::adapter::btor2::parser::parse(btor2_content) else {
+        return btor2_content.to_string();
+    };
+    let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
+    // Detected reset(s): (input name, inactive level). Post-reset `init` first, so pinning the reset
+    // inactive does not leave a HAVOC initial state (the reset would otherwise set the start state).
+    let resets = crate::adapter::fsm_scan::detect_resets(&file, &symbols);
+    let m = crate::adapter::btor2::reset_init::inject_reset_init(btor2_content, &resets)
+        .unwrap_or_else(|_| btor2_content.to_string());
+    let mut pins: Vec<(String, u64)> = resets;
+    // Clock(s): pin to 0 — near-dangling in async2sync, so this excludes any residual clock-gating from
+    // the adversary without changing functional behaviour.
+    let is_clock = |s: &str| -> bool {
+        matches!(
+            s.to_ascii_lowercase().as_str(),
+            "clk" | "clock" | "ck" | "i_clk" | "clk_i" | "iclk" | "clki"
+        )
+    };
+    for line in &file.lines {
+        if let Node::Input { .. } = &line.node
+            && let Some(name) = symbols.get(&line.nid)
+            && is_clock(name)
+        {
+            pins.push((name.clone(), 0));
+        }
+    }
+    if pins.is_empty() {
+        return m;
+    }
+    crate::adapter::btor2::pin::pin_inputs_to_constants(&m, &pins).0
+}
+
 /// P2.5-F — decide a Control-tagged μ-calculus `formula` on the TWO-PLAYER exact game, with
 /// `controllable` naming the controller's input signals (the rest are the environment's). The
 /// formula's `<(ctrl=controllable)>` / `[(ctrl=controllable)]` modalities are evaluated by the

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -884,19 +884,29 @@ pub async fn btor2_check_fsm_handler(
 pub async fn btor2_game_handler(
     Json(request): Json<Btor2GameRequest>,
 ) -> ApiResult<Json<Btor2GameResponse>> {
-    use crate::adapter::btor2::symbolic_bitblast::exact_two_player_strategy;
+    use crate::adapter::btor2::symbolic_bitblast::{
+        exact_two_player_strategy, game_sound_posture_model,
+    };
 
+    // assume_clock_reset: model clk/rst as a sound posture (not adversarial) before solving.
+    let content = if request.assume_clock_reset {
+        game_sound_posture_model(&request.content)
+    } else {
+        request.content.clone()
+    };
     let controllable: Vec<&str> = request.controllable.iter().map(String::as_str).collect();
-    let strategy = exact_two_player_strategy(&request.content, &request.good, &controllable)
-        .map_err(|message| ApiError::BadRequest {
-            message,
-            details: None,
+    let strategy =
+        exact_two_player_strategy(&content, &request.good, &controllable).map_err(|message| {
+            ApiError::BadRequest {
+                message,
+                details: None,
+            }
         })?;
     // discover_assumptions: when unrealizable, search for an environment assumption under which the
     // controller wins (CONDITIONAL — never flips `realizable`). No-op when already realizable.
     let holds_under = if request.discover_assumptions {
         crate::adapter::recoverability::discover_game_env_assumption(
-            &request.content,
+            &content,
             &request.good,
             &controllable,
         )
@@ -4681,6 +4691,39 @@ members = ["x"]
     // same known-answer 1-bit games as tests/exact_two_player_strategy.rs, over the HTTP handler.
     const GAME_CTRL: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 next 1 4 2\n";
     const GAME_ENVBLK: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 not 1 3\n8 and 1 2 7\n9 next 1 4 8\n";
+    // Reset-artifact game `st' = rst ? 0 : c`: with `rst` adversarial the env holds reset → unrealizable;
+    // `assume_clock_reset` pins the reset inactive → the functional game `st'=c` is realizable.
+    const GAME_RESET: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 rst\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 ite 1 3 5 2\n8 next 1 4 7\n";
+
+    /// `assume_clock_reset` over HTTP: the reset-adversarial game is unrealizable raw, but realizable when
+    /// the reset is modeled as a posture (the modeling-artifact fix).
+    #[tokio::test]
+    async fn btor2_game_handler_assume_clock_reset_removes_reset_artifact() {
+        let raw = Btor2GameRequest {
+            content: GAME_RESET.to_string(),
+            good: "st == 1".to_string(),
+            controllable: vec!["c".to_string()],
+            discover_assumptions: false,
+            assume_clock_reset: false,
+        };
+        let Json(out) = btor2_game_handler(Json(raw)).await.expect("game runs");
+        assert!(
+            !out.realizable,
+            "reset-adversarial ⇒ spuriously unrealizable"
+        );
+        let posture = Btor2GameRequest {
+            content: GAME_RESET.to_string(),
+            good: "st == 1".to_string(),
+            controllable: vec!["c".to_string()],
+            discover_assumptions: false,
+            assume_clock_reset: true,
+        };
+        let Json(out) = btor2_game_handler(Json(posture)).await.expect("game runs");
+        assert!(
+            out.realizable,
+            "reset as posture ⇒ the controller wins st'=c"
+        );
+    }
 
     #[tokio::test]
     async fn btor2_game_handler_realizable_returns_controller_strategy() {
@@ -4690,6 +4733,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
             discover_assumptions: false,
+            assume_clock_reset: false,
         };
         let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
         assert!(out.realizable, "st'=c: the controller wins");
@@ -4707,6 +4751,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
             discover_assumptions: false,
+            assume_clock_reset: false,
         };
         let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
         assert!(!out.realizable, "st'=c&¬e: the environment wins");
@@ -4725,6 +4770,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
             discover_assumptions: true,
+            assume_clock_reset: false,
         };
         let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
         assert!(
@@ -4747,6 +4793,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["nope".to_string()], // not a primary input
             discover_assumptions: false,
+            assume_clock_reset: false,
         };
         let err = btor2_game_handler(Json(request))
             .await

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1104,6 +1104,12 @@ pub struct Btor2GameRequest {
     /// when the game is already realizable. Mirrors the CLI `--discover-assumptions`.
     #[serde(default)]
     pub discover_assumptions: bool,
+    /// Model the clock and reset as a sound POSTURE instead of adversarial inputs — pin the detected reset
+    /// inactive (+ post-reset init) and the clock to a constant, so the environment cannot spuriously
+    /// FREEZE THE CLOCK or HOLD RESET (a modeling artifact of the raw lift). Recommended for real RTL.
+    /// Mirrors the CLI `--assume-clock-reset`.
+    #[serde(default)]
+    pub assume_clock_reset: bool,
 }
 
 /// Response for `POST /api/v1/btor2/game`.

--- a/crates/mununu-core/tests/exact_two_player_strategy.rs
+++ b/crates/mununu-core/tests/exact_two_player_strategy.rs
@@ -20,7 +20,14 @@
 
 use mununu_core::adapter::btor2::symbolic_bitblast::{
     TwoPlayerStrategy, exact_env_positional_strategy, exact_two_player_strategy,
+    game_sound_posture_model,
 };
+
+// A reset-artifact game: `st' = rst ? 0 : c` (active-high async reset). controllable = {c}. With `rst`
+// ADVERSARIAL the environment holds `rst=1` forever → `st` stuck at 0 → `st==1` unreachable ⇒ spuriously
+// UNREALIZABLE (a modeling artifact — reset is not a real adversarial input). `game_sound_posture_model`
+// pins the reset inactive (+ reset-init), so the sound game `st'=c` is realizable.
+const RESET_GAME: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 rst\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 ite 1 3 5 2\n8 next 1 4 7\n";
 
 // st' = c : the controller sets the next state directly (environment powerless).
 const CTRL_INIT0: &str = "\
@@ -200,4 +207,24 @@ fn edn_mode_controllable_counterstrategy_is_environment_only() {
             );
         }
     }
+}
+
+/// The sound-posture transform removes the reset-hold ARTIFACT: the raw reset-adversarial game is
+/// (spuriously) unrealizable — the environment holds `rst=1` forever — but on `game_sound_posture_model`
+/// (reset pinned inactive + reset-init) the genuine functional game `st'=c` is realizable.
+#[test]
+fn sound_posture_removes_the_reset_hold_artifact() {
+    // Raw model: reset is adversarial → the environment blocks by holding reset → unrealizable.
+    let raw = exact_two_player_strategy(RESET_GAME, "st == 1", &["c"]).unwrap();
+    assert!(
+        matches!(raw, TwoPlayerStrategy::EnvironmentCounterstrategy(_)),
+        "raw (reset-adversarial): the env holds reset ⇒ spuriously unrealizable"
+    );
+    // Sound posture: reset is a released posture (not adversarial) → the controller wins `st'=c`.
+    let sound_model = game_sound_posture_model(RESET_GAME);
+    let sound = exact_two_player_strategy(&sound_model, "st == 1", &["c"]).unwrap();
+    assert!(
+        matches!(sound, TwoPlayerStrategy::ControllerStrategy(_)),
+        "sound posture (reset released): the controller forces st=1 ⇒ realizable"
+    );
 }


### PR DESCRIPTION
## Summary

The raw lifted BTOR2 carries `clk`/`rst` as free primary inputs, so a two-player game treats them as **adversarial** — the environment can **freeze the clock** (hold `clk` constant → the design never advances) or **hold reset** (→ the FSM sticks in reset), making a reachability game *spuriously* unrealizable for a **modeling** reason, not a functional one. In real synchronous verification the clock ticks and reset is a controlled posture.

`game_sound_posture_model(btor2)` models that: inject the post-reset `init` (reuse `inject_reset_init`), pin the detected reset(s) (`detect_resets`) to their inactive level, and pin the clock(s) to a constant — so the game is over the **functional** inputs only. It's a preprocessing transform applied when the caller opts in (no core game signature change).

**Surface parity:** CLI `btor2 game --assume-clock-reset`, API `Btor2GameRequest.assume_clock_reset`, UI `runBtor2Game` (**mununu-ui PR #61**).

## Why (measured motivation)

Probed via the `--controllable` frontier: edn/otbn are realizable *only* all-controllable, and removing `rst_ni` flips them to ⊥ (`clk_i` is near-dangling). So their mode/start-controllable ⊥ was **multi-causal** — reset-hold artifact + a genuine functional block — not the clean ack-withholding story §3.12i implied.

## Tests (gate `make ci`)

- Synthetic reset-artifact game `st'=rst?0:c`: raw = spuriously unrealizable (env holds reset); `game_sound_posture_model` = realizable (`st'=c`).
- API handler: `assume_clock_reset` flips the same game raw-⊥ → posture-realizable.

## Measured (mununu-sva-pono, rebuilt binary)

edn mode-only RAW ⊥ → **POSTURE still ⊥** (`holds_under=[]`). So the reset-hold was *not* edn's blocker — under the sound model the ⊥ is **purely functional** (the full CSRNG partner is genuinely needed), confirming the earlier finding that edn/otbn have **no decomposable env assumption** (ledger §3.12i). So `--assume-clock-reset` is a **soundness/interpretability** fix (every verdict/strategy/counterstrategy is now free of clk-freeze/reset-hold pollution), not a §D mover on edn/otbn — correctly, their ⊥ is real + functional. fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)