### PR TITLE
feat(game): two-player verb decides RELATIONAL / combinational-output targets

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2762,7 +2762,7 @@ fn btor2_check_fsm(args: Btor2CheckFsmArgs) -> Result<(), String> {
 /// to the `violated` verdict class); `realizable` maps to `holds`.
 fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
     use mununu_core::adapter::btor2::symbolic_bitblast::{
-        exact_two_player_strategy, game_sound_posture_model,
+        exact_two_player_reach_realizable, exact_two_player_strategy, game_sound_posture_model,
     };
 
     let raw = std::fs::read_to_string(&args.file)
@@ -2774,17 +2774,23 @@ fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
         raw
     };
     let controllable: Vec<&str> = args.controllable.iter().map(String::as_str).collect();
-    let strategy = exact_two_player_strategy(&content, &args.good, &controllable)?;
+    // The VERDICT works on any resolvable target (state cell, combinational output, relation); it also
+    // validates the controllable partition. The STRATEGY is best-effort — it needs a STATE-register
+    // target, so it is omitted for a combinational-output / relational `good` (a FIFO's `full_o`).
+    let realizable = exact_two_player_reach_realizable(&content, &args.good, &controllable)?;
+    let strategy = exact_two_player_strategy(&content, &args.good, &controllable).ok();
 
     let mut summary = serde_json::json!({
         "file": args.file.display().to_string(),
         "good": args.good,
         "controllable": args.controllable,
         "assume_clock_reset": args.assume_clock_reset,
-        "realizable": strategy.realizable(),
+        "realizable": realizable,
     });
-    summary["strategy"] =
-        serde_json::to_value(&strategy).map_err(|e| format!("serialize strategy: {e}"))?;
+    if let Some(s) = &strategy {
+        summary["strategy"] =
+            serde_json::to_value(s).map_err(|e| format!("serialize strategy: {e}"))?;
+    }
     // --discover-assumptions: when the game is unrealizable, search for an environment assumption under
     // which the controller wins (CONDITIONAL — never flips `realizable`). No-op when already realizable.
     if args.discover_assumptions {
@@ -2801,11 +2807,7 @@ fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
     print_json_summary(&summary)?;
 
     // realizable == the controller wins (`holds`); unrealizable == no controller works (`violated`).
-    let verdict = if strategy.realizable() {
-        "holds"
-    } else {
-        "violated"
-    };
+    let verdict = if realizable { "holds" } else { "violated" };
     ci_gate_exit(verdict, args.ci.fail_on);
     Ok(())
 }

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2926,6 +2926,24 @@ pub fn exact_two_player_verdict(
     verdict_with_witness_catching(btor2_content, formula, &set).map(|(v, _)| v)
 }
 
+/// P2.5-F — is the controllable-reachability game to `good` REALIZABLE? Builds the reachability formula
+/// `μX. (good ∨ ⟨ctrl⟩X)` and decides it via [`exact_two_player_verdict`]. Unlike
+/// [`exact_two_player_strategy`] (which extracts a state-INDEXED strategy and so requires `good` to name a
+/// STATE register), this needs only the VERDICT — so `good` may be a combinational OUTPUT or a RELATIONAL
+/// atom (`full_o == 1`, `wptr == rptr`), exactly the datapath targets a FIFO-class design uses. `good` is
+/// any atom the exact engine's `predicate_bdd` resolves (state cell, named combinational output, or a
+/// `REG op REG`/`REG op VALUE` comparison). `Ok(true)` = the controller wins from the initial state.
+pub fn exact_two_player_reach_realizable(
+    btor2_content: &str,
+    good: &str,
+    controllable: &[&str],
+) -> Result<bool, String> {
+    let formula_str = format!("mu X. (({good}) || <(ctrl = controllable)> X)");
+    let formula = crate::mu_calculus::parser::parse(&formula_str)
+        .map_err(|e| format!("exact two-player reach: parsing `{formula_str}`: {e:?}"))?;
+    Ok(exact_two_player_verdict(btor2_content, &formula, controllable)? == ExactVerdict::Holds)
+}
+
 /// P2.5-F — decide a Control-tagged μ-calculus `formula` on the TWO-PLAYER KMTS (3-valued predicate
 /// cube) game: the scale backend of the unified verifier (past the exact BDD cap). `predicates` is the
 /// abstraction (name → atom); `controllable` names the controller's inputs. Returns the 3-valued verdict

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1432,7 +1432,9 @@ pub fn discover_game_env_assumption(
 ) -> Vec<DiscoveredAssumption> {
     use crate::adapter::btor2::ast::Node;
     use crate::adapter::btor2::pin::pin_inputs_to_constants;
-    use crate::adapter::btor2::symbolic_bitblast::{TwoPlayerStrategy, exact_two_player_strategy};
+    use crate::adapter::btor2::symbolic_bitblast::{
+        TwoPlayerStrategy, exact_two_player_reach_realizable, exact_two_player_strategy,
+    };
     const MAX_INPUT_BITS: u32 = 3; // ≤ 8 values — a narrow control/ack/enable, not a datapath
     const MAX_CANDIDATE_PINS: usize = 48;
     let budget_ms: u128 = std::env::var("MUNUNU_ASSUMPTION_BUDGET_MS")
@@ -1441,7 +1443,8 @@ pub fn discover_game_env_assumption(
         .unwrap_or(90_000);
     let start = std::time::Instant::now();
 
-    // `good` must be `REG == VALUE` — the non-vacuity gate needs the register + value.
+    // `good` must be `REG == VALUE` (a state register OR a named combinational output like `full_o == 1`)
+    // — the non-vacuity gate needs the register/output + value.
     let (register, value) = match parse_predicate_expr(good).ok() {
         Some(PredicateExpr::Cmp {
             register,
@@ -1453,16 +1456,24 @@ pub fn discover_game_env_assumption(
 
     // Only search when the game is genuinely UNREALIZABLE — a realizable game needs no assumption (the
     // false-positive control: discovery must not fabricate an enabling φ for a controller that already
-    // wins). The returned counterstrategy names the blocking env inputs.
-    let counter = match exact_two_player_strategy(btor2_content, good, controllable) {
-        Ok(TwoPlayerStrategy::EnvironmentCounterstrategy(p)) => p,
-        _ => return Vec::new(), // realizable, or `good` not a resolvable atom / over-cap
-    };
-    let priority: std::collections::HashSet<String> = counter
-        .entries
-        .iter()
-        .flat_map(|e| e.forced_inputs.keys().cloned())
-        .collect();
+    // wins). Uses the FORMULA verdict (`exact_two_player_reach_realizable`), so `good` may be a
+    // combinational OUTPUT / relational target (a FIFO's `full_o`), not only a state register.
+    match exact_two_player_reach_realizable(btor2_content, good, controllable) {
+        Ok(false) => {}         // unrealizable → search for an enabling assumption
+        _ => return Vec::new(), // realizable, or `good` not resolvable / over-cap
+    }
+    // The env COUNTERSTRATEGY (when extractable — a state-register target) names the blocking env inputs,
+    // searched FIRST. Best-effort: a combinational-output/relational target has no state-indexed strategy,
+    // so `priority` is empty there and every candidate is searched.
+    let priority: std::collections::HashSet<String> =
+        match exact_two_player_strategy(btor2_content, good, controllable) {
+            Ok(TwoPlayerStrategy::EnvironmentCounterstrategy(p)) => p
+                .entries
+                .iter()
+                .flat_map(|e| e.forced_inputs.keys().cloned())
+                .collect(),
+            _ => std::collections::HashSet::new(),
+        };
 
     let ctrl_set: std::collections::HashSet<&str> = controllable.iter().copied().collect();
     let Ok(file) = crate::adapter::btor2::parser::parse(btor2_content) else {
@@ -1499,10 +1510,8 @@ pub fn discover_game_env_assumption(
             // is exact/2-valued sound; the non-vacuity gate rejects a realizable-but-vacuous hold (good
             // unreachable or stuck-true under the assumption). The report stays CONDITIONAL — the caller
             // never lifts it to an unconditional realizable.
-            let realizable = matches!(
-                exact_two_player_strategy(&pinned, good, controllable),
-                Ok(s) if s.realizable()
-            );
+            let realizable =
+                exact_two_player_reach_realizable(&pinned, good, controllable) == Ok(true);
             if realizable && good_nonvacuous_under(&pinned, &register, value) {
                 found.push(DiscoveredAssumption {
                     phi: format!("{name} == {c}"),
@@ -1548,7 +1557,7 @@ fn discover_game_env_conjunction(
     use crate::adapter::btor2::ast::Node;
     use crate::adapter::btor2::dep_graph::cone_leaf_nids;
     use crate::adapter::btor2::pin::pin_inputs_to_constants;
-    use crate::adapter::btor2::symbolic_bitblast::{TwoPlayerStrategy, exact_two_player_strategy};
+    use crate::adapter::btor2::symbolic_bitblast::exact_two_player_reach_realizable;
     const MAX_INPUT_BITS: u32 = 3;
     const MAX_CONJ_BITS: u32 = 12; // ≤ 4096 combinations searched
     let budget_ms: u128 = std::env::var("MUNUNU_ASSUMPTION_BUDGET_MS")
@@ -1565,10 +1574,10 @@ fn discover_game_env_conjunction(
         }) => (register, value),
         _ => return None,
     };
-    // Only when the game is unrealizable (a realizable game needs no assumption).
-    match exact_two_player_strategy(btor2_content, good, controllable) {
-        Ok(TwoPlayerStrategy::EnvironmentCounterstrategy(_)) => {}
-        _ => return None,
+    // Only when the game is unrealizable (a realizable game needs no assumption). Formula verdict, so
+    // `good` may be a combinational-output / relational target (a FIFO's `full_o`).
+    if exact_two_player_reach_realizable(btor2_content, good, controllable) != Ok(false) {
+        return None;
     }
     let ctrl_set: std::collections::HashSet<&str> = controllable.iter().copied().collect();
     let Ok(file) = crate::adapter::btor2::parser::parse(btor2_content) else {
@@ -1600,7 +1609,7 @@ fn discover_game_env_conjunction(
     // The reused realizable + non-vacuous check on a pin set.
     let wins = |pins: &[(String, u64)]| -> bool {
         let (pinned, _) = pin_inputs_to_constants(btor2_content, pins);
-        matches!(exact_two_player_strategy(&pinned, good, controllable), Ok(s) if s.realizable())
+        exact_two_player_reach_realizable(&pinned, good, controllable) == Ok(true)
             && good_nonvacuous_under(&pinned, &register, value)
     };
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -885,7 +885,7 @@ pub async fn btor2_game_handler(
     Json(request): Json<Btor2GameRequest>,
 ) -> ApiResult<Json<Btor2GameResponse>> {
     use crate::adapter::btor2::symbolic_bitblast::{
-        exact_two_player_strategy, game_sound_posture_model,
+        exact_two_player_reach_realizable, exact_two_player_strategy, game_sound_posture_model,
     };
 
     // assume_clock_reset: model clk/rst as a sound posture (not adversarial) before solving.
@@ -895,13 +895,15 @@ pub async fn btor2_game_handler(
         request.content.clone()
     };
     let controllable: Vec<&str> = request.controllable.iter().map(String::as_str).collect();
-    let strategy =
-        exact_two_player_strategy(&content, &request.good, &controllable).map_err(|message| {
-            ApiError::BadRequest {
-                message,
-                details: None,
-            }
+    // The VERDICT works on any resolvable target (state cell, combinational output, relation) and
+    // validates the partition; the STRATEGY needs a STATE-register target, so it is best-effort —
+    // omitted (`null`) for a combinational-output / relational `good` (a FIFO's `full_o`).
+    let realizable = exact_two_player_reach_realizable(&content, &request.good, &controllable)
+        .map_err(|message| ApiError::BadRequest {
+            message,
+            details: None,
         })?;
+    let strategy = exact_two_player_strategy(&content, &request.good, &controllable).ok();
     // discover_assumptions: when unrealizable, search for an environment assumption under which the
     // controller wins (CONDITIONAL — never flips `realizable`). No-op when already realizable.
     let holds_under = if request.discover_assumptions {
@@ -915,7 +917,7 @@ pub async fn btor2_game_handler(
     };
 
     Ok(Json(Btor2GameResponse {
-        realizable: strategy.realizable(),
+        realizable,
         good: request.good,
         controllable: request.controllable,
         holds_under,
@@ -4739,7 +4741,7 @@ members = ["x"]
         assert!(out.realizable, "st'=c: the controller wins");
         assert!(matches!(
             out.strategy,
-            TwoPlayerStrategy::ControllerStrategy(_)
+            Some(TwoPlayerStrategy::ControllerStrategy(_))
         ));
     }
 
@@ -4757,7 +4759,7 @@ members = ["x"]
         assert!(!out.realizable, "st'=c&¬e: the environment wins");
         assert!(matches!(
             out.strategy,
-            TwoPlayerStrategy::EnvironmentCounterstrategy(_)
+            Some(TwoPlayerStrategy::EnvironmentCounterstrategy(_))
         ));
     }
 

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1129,9 +1129,11 @@ pub struct Btor2GameResponse {
     pub holds_under: Vec<crate::verdict::DiscoveredAssumption>,
     /// The winner's strategy: a `controller_strategy` (Mealy, when realizable) or an
     /// `environment_counterstrategy` (positional, when not) — the [`crate::adapter::btor2::symbolic_bitblast::TwoPlayerStrategy`]
-    /// serialized with a `"kind"` tag. The counterstrategy is the witness for the assume-guarantee reading
-    /// (why no controller works).
-    pub strategy: crate::adapter::btor2::symbolic_bitblast::TwoPlayerStrategy,
+    /// serialized with a `"kind"` tag. **Present only for a STATE-register `good`**: the strategy is
+    /// state-indexed, so it is omitted (`null`) for a combinational-output / relational target (a FIFO's
+    /// `full_o`), where `realizable` + `holds_under` still apply.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<crate::adapter::btor2::symbolic_bitblast::TwoPlayerStrategy>,
 }
 
 /// The SV → BTOR2 lift inputs shared by the SV-direct verb endpoints

--- a/crates/mununu-core/tests/exact_two_player_game.rs
+++ b/crates/mununu-core/tests/exact_two_player_game.rs
@@ -15,8 +15,40 @@
 //! `parity_game.rs` solver on a shared CLTS is a follow-up; here the hand-computed winning regions are
 //! the oracle.)
 
-use mununu_core::adapter::btor2::symbolic_bitblast::{ExactVerdict, exact_two_player_verdict};
+use mununu_core::adapter::btor2::symbolic_bitblast::{
+    ExactVerdict, exact_two_player_reach_realizable, exact_two_player_strategy,
+    exact_two_player_verdict,
+};
 use mununu_core::mu_calculus::parser;
+
+// st' = c, with a NAMED COMBINATIONAL OUTPUT `busy_o = ¬st` (not a state register). The realizability
+// VERDICT resolves the output atom; the state-INDEXED STRATEGY cannot (no register in `good`). This is
+// the FIFO-class datapath shape: the target is a combinational output (`full_o`, `empty_o`), not a cell.
+const CTRL_OUT: &str = "\
+1 sort bitvec 1
+2 input 1 c
+3 input 1 e
+4 state 1 st
+5 zero 1
+6 init 1 4 5
+7 next 1 4 2
+8 not 1 4 busy_o
+9 output 8
+";
+// st' = c & ¬e with the same `busy_o = ¬st` output: the environment can block st=1, so busy_o stays 1.
+const ENVBLK_OUT: &str = "\
+1 sort bitvec 1
+2 input 1 c
+3 input 1 e
+4 state 1 st
+5 zero 1
+6 init 1 4 5
+7 not 1 3
+8 and 1 2 7
+9 next 1 4 8
+10 not 1 4 busy_o
+11 output 10
+";
 
 // st' = c : the controller sets the next state.
 const CTRL_INIT0: &str = "\
@@ -150,4 +182,44 @@ fn unknown_controllable_input_is_rejected() {
     );
     // The real input names still work.
     assert!(exact_two_player_verdict(CTRL_INIT0, &f, &["c"]).is_ok());
+}
+
+/// Relational / combinational-OUTPUT target: `exact_two_player_reach_realizable` decides a game whose
+/// `good` is a named combinational output (`busy_o = ¬st`), not a state register — the FIFO-class datapath
+/// shape (`full_o`, `empty_o`). The controller forcing `busy_o == 0` ⇔ forcing `st == 1`, so the answer
+/// matches the state-atom game: realizable on `CTRL_OUT`, unrealizable on `ENVBLK_OUT`.
+#[test]
+fn reach_realizable_decides_a_combinational_output_target() {
+    assert_eq!(
+        exact_two_player_reach_realizable(CTRL_OUT, "busy_o == 0", &["c"]),
+        Ok(true),
+        "st'=c: the controller forces busy_o=0 (st=1) in one step"
+    );
+    assert_eq!(
+        exact_two_player_reach_realizable(ENVBLK_OUT, "busy_o == 0", &["c"]),
+        Ok(false),
+        "st'=c&¬e: the environment blocks with e=1, so busy_o stays 1"
+    );
+    // Sanity: the output atom tracks its state equivalent (`st == 1`) exactly.
+    assert_eq!(
+        exact_two_player_reach_realizable(CTRL_OUT, "st == 1", &["c"]),
+        exact_two_player_reach_realizable(CTRL_OUT, "busy_o == 0", &["c"]),
+    );
+}
+
+/// The state-INDEXED strategy cannot be extracted for a combinational-output `good` (it references no
+/// state register) — the verb makes it best-effort and falls back to `realizable` + `holds_under`. This
+/// pins WHY the strategy is `Option`: the verdict decides the same target the strategy cannot index.
+#[test]
+fn strategy_extraction_declines_a_combinational_output_target() {
+    let err = exact_two_player_strategy(CTRL_OUT, "busy_o == 0", &["c"]).unwrap_err();
+    assert!(
+        err.contains("state register") || err.contains("resolvable"),
+        "expected a no-state-register error for a combinational output, got: {err}"
+    );
+    // ...but the VERDICT on the very same target decides.
+    assert_eq!(
+        exact_two_player_reach_realizable(CTRL_OUT, "busy_o == 0", &["c"]),
+        Ok(true),
+    );
 }


### PR DESCRIPTION
## Two-player game verb decides RELATIONAL / combinational-output targets

The two-player game verb previously required `good` to name a **state register**,
because it went straight to `exact_two_player_strategy` (state-indexed). That
rejects a FIFO-class datapath target like `full_o == 1` / `empty_o == 1` — a
combinational **output**, not a cell — which is exactly the shape a decomposable
assume-guarantee assumption lives on.

### What changed

Split the two concerns the old verb conflated:

- **Realizability** (the verdict) now routes through a new
  `exact_two_player_reach_realizable(btor2, good, controllable)` — it builds the
  reachability game `μX.(good ∨ ⟨ctrl⟩X)` and decides it via
  `exact_two_player_verdict`, so `good` may be any atom the exact engine's
  `predicate_bdd` resolves (state cell, named combinational output, or a
  `REG op REG` / `REG op VALUE` relation).
- The **strategy** (state-indexed) stays best-effort — omitted (`Option`/`null`)
  for a combinational-output / relational `good`, present for a state target.

`discover_game_env_assumption` + `discover_game_env_conjunction` now use the
formula-verdict for both the unrealizable gate and the per-pin `wins` check, so
env-assumption discovery works on relational targets too.

**Engine:** exact-symbolic ROBDD (OxiDD), full-state bit-blast μ-fixpoint, same
cone restriction + sound posture as `exact_symbolic_verdict`; the explicit
gr1/parity_game solver is the differential oracle.

### Surface parity

- CLI `btor2 game`
- API `POST /api/v1/btor2/game` (`Btor2GameResponse.strategy` now `Option`)
- UI `runBtor2Game` (`strategy?`) — sibling mununu-ui PR

### Validated on real OpenTitan RTL

`prim_fifo_sync_cnt` (Depth=4, Apache-2.0), sound-posture model:

```
btor2 game --good "full_o == 1" --controllable incr_wptr_i \
  --assume-clock-reset --discover-assumptions fifo4.btor2
```

→ `realizable: false` + `holds_under: clr_i == 0 && incr_rptr_i == 0`
(`non_vacuous`, `InputConjunction`) — the minimal **decomposable** environment
assumption (no clear + no read). It escalated to a conjunction because neither
conjunct alone suffices (clear wipes the FIFO, read drains it). This is the first
RTL-native decomposable-assumption `holds_under` row.

### Tests

- Two combinational-output regressions in `exact_two_player_game.rs` (the verdict
  decides `busy_o == 0`; strategy extraction declines the same target).
- UI `game.test.ts` relational case (`strategy` absent, `realizable` + `holds_under` present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
