### PR TITLE
feat(game): recurrence (Büchi) objective — force good infinitely often

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -791,15 +791,29 @@ struct Btor2CheckFsmArgs {
     ci: CiArgs,
 }
 
+/// The two-player game winning objective (`btor2 game --objective`).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+enum GameObjective {
+    /// Force `good` at least ONCE — the reachability game `μX. good ∨ ⟨ctrl⟩X`.
+    Reach,
+    /// Force `good` INFINITELY OFTEN — the Büchi game `νZ.μY. (good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y`.
+    Recurrence,
+}
+
 #[derive(Args, Debug)]
 struct Btor2GameArgs {
     /// Path to the BTOR2 input file.
     #[arg(value_name = "BTOR2_FILE")]
     file: PathBuf,
-    /// The reachability target `good` state atom the controller tries to force — a single
-    /// register-comparison atom (`"state_q == 44"`).
+    /// The target `good` atom the controller tries to force — a single register-comparison /
+    /// combinational-output atom (`"state_q == 44"`, `"full_o == 1"`).
     #[arg(long, value_name = "REG op VALUE")]
     good: String,
+    /// The winning objective: `reach` (default) = force `good` ONCE (`μX. good ∨ ⟨ctrl⟩X`); `recurrence`
+    /// = force `good` INFINITELY OFTEN — the Büchi game `νZ.μY. (good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y`. Strategy
+    /// extraction and assumption discovery apply to `reach` only today.
+    #[arg(long = "objective", value_enum, default_value_t = GameObjective::Reach)]
+    objective: GameObjective,
     /// A controller-owned primary input (repeatable). Every other primary input belongs to the
     /// (adversarial) environment. A name that is not a real primary input is rejected.
     #[arg(long = "controllable", value_name = "INPUT")]
@@ -2762,7 +2776,8 @@ fn btor2_check_fsm(args: Btor2CheckFsmArgs) -> Result<(), String> {
 /// to the `violated` verdict class); `realizable` maps to `holds`.
 fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
     use mununu_core::adapter::btor2::symbolic_bitblast::{
-        exact_two_player_reach_realizable, exact_two_player_strategy, game_sound_posture_model,
+        exact_two_player_buchi_realizable, exact_two_player_reach_realizable,
+        exact_two_player_strategy, game_sound_posture_model,
     };
 
     let raw = std::fs::read_to_string(&args.file)
@@ -2774,15 +2789,29 @@ fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
         raw
     };
     let controllable: Vec<&str> = args.controllable.iter().map(String::as_str).collect();
-    // The VERDICT works on any resolvable target (state cell, combinational output, relation); it also
-    // validates the controllable partition. The STRATEGY is best-effort — it needs a STATE-register
-    // target, so it is omitted for a combinational-output / relational `good` (a FIFO's `full_o`).
-    let realizable = exact_two_player_reach_realizable(&content, &args.good, &controllable)?;
-    let strategy = exact_two_player_strategy(&content, &args.good, &controllable).ok();
+    let recurrence = args.objective == GameObjective::Recurrence;
+    // The VERDICT works on any resolvable target (state cell, combinational output, relation) for both
+    // objectives; it also validates the controllable partition. `reach` = force `good` once; `recurrence`
+    // = force `good` infinitely often (Büchi).
+    let realizable = if recurrence {
+        exact_two_player_buchi_realizable(&content, &args.good, &controllable)?
+    } else {
+        exact_two_player_reach_realizable(&content, &args.good, &controllable)?
+    };
+    // STRATEGY extraction + assumption discovery are REACH-only today: the state-indexed strategy is a
+    // reachability attractor (wrong shape for Büchi), and the assumption search is a reach `A ⇒ G` — a
+    // fairness (GF a → GF good) assumption for recurrence is the follow-up. Also best-effort: the strategy
+    // needs a STATE-register target, so it is omitted for a combinational-output / relational `good`.
+    let strategy = if recurrence {
+        None
+    } else {
+        exact_two_player_strategy(&content, &args.good, &controllable).ok()
+    };
 
     let mut summary = serde_json::json!({
         "file": args.file.display().to_string(),
         "good": args.good,
+        "objective": if recurrence { "recurrence" } else { "reach" },
         "controllable": args.controllable,
         "assume_clock_reset": args.assume_clock_reset,
         "realizable": realizable,
@@ -2791,9 +2820,10 @@ fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
         summary["strategy"] =
             serde_json::to_value(s).map_err(|e| format!("serialize strategy: {e}"))?;
     }
-    // --discover-assumptions: when the game is unrealizable, search for an environment assumption under
-    // which the controller wins (CONDITIONAL — never flips `realizable`). No-op when already realizable.
-    if args.discover_assumptions {
+    // --discover-assumptions: when the (reach) game is unrealizable, search for an environment assumption
+    // under which the controller wins (CONDITIONAL — never flips `realizable`). No-op when already
+    // realizable or under `--objective recurrence` (fairness discovery is the follow-up).
+    if args.discover_assumptions && !recurrence {
         let holds_under = mununu_core::adapter::recoverability::discover_game_env_assumption(
             &content,
             &args.good,

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2944,6 +2944,32 @@ pub fn exact_two_player_reach_realizable(
     Ok(exact_two_player_verdict(btor2_content, &formula, controllable)? == ExactVerdict::Holds)
 }
 
+/// P2.5-F — is the controllable-RECURRENCE (Büchi) game "visit `good` INFINITELY OFTEN" REALIZABLE?
+/// Builds the recurrence formula `νZ. μY. ((good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y)` and decides it via
+/// [`exact_two_player_verdict`] — the nested `νμ` is the genuine Büchi winning region (the exact engine
+/// evaluates the two-player nested fixpoint soundly; validated by known answer in
+/// `tests/exact_two_player_game.rs::controllable_recurrence_holds_iff_environment_cannot_starve`). Like
+/// [`exact_two_player_reach_realizable`], `good` may be any atom `predicate_bdd` resolves (state cell,
+/// combinational output, or a relation — a FIFO's `full_o == 1`). `Ok(true)` = the controller can force
+/// `good` recurrently against every environment strategy from the initial state.
+///
+/// This is the OBJECTIVE primitive; a fairness ENVIRONMENT assumption `GF a → GF good` (rescuing an
+/// unrealizable recurrence game) is a SEPARATE follow-up that requires the transition-relativized CPre
+/// (Klein–Pnueli / Bloem GR(1) input-fairness) — a naive νμν with an input-predicate conjunct is UNSOUND
+/// because an input is not part of the state.
+pub fn exact_two_player_buchi_realizable(
+    btor2_content: &str,
+    good: &str,
+    controllable: &[&str],
+) -> Result<bool, String> {
+    let formula_str = format!(
+        "nu Z. (mu Y. ((({good}) && <(ctrl = controllable)> Z) || <(ctrl = controllable)> Y))"
+    );
+    let formula = crate::mu_calculus::parser::parse(&formula_str)
+        .map_err(|e| format!("exact two-player recurrence: parsing `{formula_str}`: {e:?}"))?;
+    Ok(exact_two_player_verdict(btor2_content, &formula, controllable)? == ExactVerdict::Holds)
+}
+
 /// P2.5-F — decide a Control-tagged μ-calculus `formula` on the TWO-PLAYER KMTS (3-valued predicate
 /// cube) game: the scale backend of the unified verifier (past the exact BDD cap). `predicates` is the
 /// abstraction (name → atom); `controllable` names the controller's inputs. Returns the 3-valued verdict

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -885,8 +885,10 @@ pub async fn btor2_game_handler(
     Json(request): Json<Btor2GameRequest>,
 ) -> ApiResult<Json<Btor2GameResponse>> {
     use crate::adapter::btor2::symbolic_bitblast::{
-        exact_two_player_reach_realizable, exact_two_player_strategy, game_sound_posture_model,
+        exact_two_player_buchi_realizable, exact_two_player_reach_realizable,
+        exact_two_player_strategy, game_sound_posture_model,
     };
+    use crate::api::models::GameObjective;
 
     // assume_clock_reset: model clk/rst as a sound posture (not adversarial) before solving.
     let content = if request.assume_clock_reset {
@@ -895,18 +897,29 @@ pub async fn btor2_game_handler(
         request.content.clone()
     };
     let controllable: Vec<&str> = request.controllable.iter().map(String::as_str).collect();
-    // The VERDICT works on any resolvable target (state cell, combinational output, relation) and
-    // validates the partition; the STRATEGY needs a STATE-register target, so it is best-effort —
-    // omitted (`null`) for a combinational-output / relational `good` (a FIFO's `full_o`).
-    let realizable = exact_two_player_reach_realizable(&content, &request.good, &controllable)
-        .map_err(|message| ApiError::BadRequest {
-            message,
-            details: None,
-        })?;
-    let strategy = exact_two_player_strategy(&content, &request.good, &controllable).ok();
-    // discover_assumptions: when unrealizable, search for an environment assumption under which the
-    // controller wins (CONDITIONAL — never flips `realizable`). No-op when already realizable.
-    let holds_under = if request.discover_assumptions {
+    let recurrence = request.objective == GameObjective::Recurrence;
+    // The VERDICT works on any resolvable target (state cell, combinational output, relation) for both
+    // objectives and validates the partition. `reach` = force `good` once; `recurrence` = force `good`
+    // infinitely often (Büchi).
+    let realizable = if recurrence {
+        exact_two_player_buchi_realizable(&content, &request.good, &controllable)
+    } else {
+        exact_two_player_reach_realizable(&content, &request.good, &controllable)
+    }
+    .map_err(|message| ApiError::BadRequest {
+        message,
+        details: None,
+    })?;
+    // STRATEGY + assumption discovery are REACH-only today (the strategy is a reachability attractor, the
+    // assumption search a reach `A ⇒ G`; a fairness GF a → GF good assumption for recurrence is the
+    // follow-up). Strategy is also best-effort: it needs a STATE-register target, so it is `null` for a
+    // combinational-output / relational `good` (a FIFO's `full_o`).
+    let strategy = if recurrence {
+        None
+    } else {
+        exact_two_player_strategy(&content, &request.good, &controllable).ok()
+    };
+    let holds_under = if request.discover_assumptions && !recurrence {
         crate::adapter::recoverability::discover_game_env_assumption(
             &content,
             &request.good,
@@ -919,6 +932,7 @@ pub async fn btor2_game_handler(
     Ok(Json(Btor2GameResponse {
         realizable,
         good: request.good,
+        objective: request.objective,
         controllable: request.controllable,
         holds_under,
         strategy,
@@ -4706,6 +4720,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
             discover_assumptions: false,
+            objective: crate::api::models::GameObjective::Reach,
             assume_clock_reset: false,
         };
         let Json(out) = btor2_game_handler(Json(raw)).await.expect("game runs");
@@ -4718,6 +4733,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
             discover_assumptions: false,
+            objective: crate::api::models::GameObjective::Reach,
             assume_clock_reset: true,
         };
         let Json(out) = btor2_game_handler(Json(posture)).await.expect("game runs");
@@ -4735,6 +4751,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
             discover_assumptions: false,
+            objective: crate::api::models::GameObjective::Reach,
             assume_clock_reset: false,
         };
         let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
@@ -4753,6 +4770,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
             discover_assumptions: false,
+            objective: crate::api::models::GameObjective::Reach,
             assume_clock_reset: false,
         };
         let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
@@ -4772,6 +4790,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["c".to_string()],
             discover_assumptions: true,
+            objective: crate::api::models::GameObjective::Reach,
             assume_clock_reset: false,
         };
         let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
@@ -4788,6 +4807,28 @@ members = ["x"]
         );
     }
 
+    /// `objective: "recurrence"` over HTTP: the Büchi game on `st'=c` is realizable (the controller keeps
+    /// `st==1` forever), the objective is echoed, and the strategy is omitted (recurrence is verdict-only
+    /// today — the reachability strategy would be the wrong shape).
+    #[tokio::test]
+    async fn btor2_game_handler_recurrence_objective_is_verdict_only() {
+        let request = Btor2GameRequest {
+            content: GAME_CTRL.to_string(),
+            good: "st == 1".to_string(),
+            controllable: vec!["c".to_string()],
+            discover_assumptions: false,
+            objective: crate::api::models::GameObjective::Recurrence,
+            assume_clock_reset: false,
+        };
+        let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
+        assert!(out.realizable, "st'=c: the controller forces st=1 i.o.");
+        assert_eq!(out.objective, crate::api::models::GameObjective::Recurrence);
+        assert!(
+            out.strategy.is_none(),
+            "recurrence is verdict-only today (no reachability strategy)"
+        );
+    }
+
     #[tokio::test]
     async fn btor2_game_handler_rejects_unknown_controllable_input() {
         let request = Btor2GameRequest {
@@ -4795,6 +4836,7 @@ members = ["x"]
             good: "st == 1".to_string(),
             controllable: vec!["nope".to_string()], // not a primary input
             discover_assumptions: false,
+            objective: crate::api::models::GameObjective::Reach,
             assume_clock_reset: false,
         };
         let err = btor2_game_handler(Json(request))

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1086,9 +1086,20 @@ pub struct Btor2CheckFsmResponse {
     pub registers: Vec<FsmRegisterFinding>,
 }
 
-/// Request for the two-player controllable-reachability game (`POST /api/v1/btor2/game`). Mirrors the CLI
-/// `mununu btor2 game`: decide whether the CONTROLLER can force the design to `good` against every
-/// environment move, and synthesize the winner's strategy.
+/// The two-player game winning objective (`objective` field). Mirrors the CLI `--objective`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GameObjective {
+    /// Force `good` at least ONCE — the reachability game `μX. good ∨ ⟨ctrl⟩X`.
+    #[default]
+    Reach,
+    /// Force `good` INFINITELY OFTEN — the Büchi game `νZ.μY. (good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y`.
+    Recurrence,
+}
+
+/// Request for the two-player controllable game (`POST /api/v1/btor2/game`). Mirrors the CLI
+/// `mununu btor2 game`: decide whether the CONTROLLER can force the design to `good` (once for `reach`,
+/// infinitely often for `recurrence`) against every environment move, and synthesize the winner's strategy.
 #[derive(Debug, Deserialize)]
 pub struct Btor2GameRequest {
     /// BTOR2 source content.
@@ -1099,9 +1110,15 @@ pub struct Btor2GameRequest {
     /// A name that is not a real primary input is a `BadRequest`.
     #[serde(default)]
     pub controllable: Vec<String>,
+    /// The winning objective: `"reach"` (default) = force `good` ONCE; `"recurrence"` = force `good`
+    /// INFINITELY OFTEN (the Büchi game). Strategy + assumption discovery apply to `reach` only today.
+    /// Mirrors the CLI `--objective`.
+    #[serde(default)]
+    pub objective: GameObjective,
     /// When the game is UNREALIZABLE, also search for an ENVIRONMENT ASSUMPTION under which the controller
     /// wins (the assume-guarantee wedge) → `holds_under`. CONDITIONAL — never flips `realizable`. No-op
-    /// when the game is already realizable. Mirrors the CLI `--discover-assumptions`.
+    /// when the game is already realizable or under `objective = "recurrence"`. Mirrors the CLI
+    /// `--discover-assumptions`.
     #[serde(default)]
     pub discover_assumptions: bool,
     /// Model the clock and reset as a sound POSTURE instead of adversarial inputs — pin the detected reset
@@ -1116,10 +1133,13 @@ pub struct Btor2GameRequest {
 #[derive(Debug, Serialize)]
 pub struct Btor2GameResponse {
     /// `true` = the controller can force `good` against every environment move (the spec is realizable);
-    /// `false` = the environment can prevent it (unrealizable).
+    /// `false` = the environment can prevent it (unrealizable). For `objective = "recurrence"` this is
+    /// "force `good` infinitely often" (the Büchi game).
     pub realizable: bool,
     /// The `good` atom, echoed for provenance.
     pub good: String,
+    /// The winning objective decided, echoed for provenance (`reach` or `recurrence`).
+    pub objective: GameObjective,
     /// The controller-owned inputs, echoed for provenance.
     pub controllable: Vec<String>,
     /// Discovered environment assumption(s) under which the (unrealizable) game becomes realizable —

--- a/crates/mununu-core/tests/exact_two_player_game.rs
+++ b/crates/mununu-core/tests/exact_two_player_game.rs
@@ -16,8 +16,8 @@
 //! the oracle.)
 
 use mununu_core::adapter::btor2::symbolic_bitblast::{
-    ExactVerdict, exact_two_player_reach_realizable, exact_two_player_strategy,
-    exact_two_player_verdict,
+    ExactVerdict, exact_two_player_buchi_realizable, exact_two_player_reach_realizable,
+    exact_two_player_strategy, exact_two_player_verdict,
 };
 use mununu_core::mu_calculus::parser;
 
@@ -135,6 +135,36 @@ fn controllable_safety_holds_iff_environment_cannot_knock_out() {
     );
 }
 
+/// Controllable RECURRENCE / Büchi (`νμ`): can the CONTROLLER visit `good = (st == 1)` INFINITELY OFTEN?
+/// The recurrence formula is `νZ. μY. ((good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y)`. This is the DECISIVE soundness gate
+/// for the nested-fixpoint two-player evaluation (the reach/safety tests exercise only a SINGLE fixpoint):
+/// `CTRL` (st'=c) — the controller sets c=1 every step ⇒ st=1 always ⇒ good i.o. ⇒ HOLDS. `ENVBLK`
+/// (st'=c&¬e) — the environment plays e=1 forever ⇒ st=0 after step 1 ⇒ good only finitely often ⇒ VIOLATED.
+#[test]
+fn controllable_recurrence_holds_iff_environment_cannot_starve() {
+    let gf_good =
+        "nu Z. (mu Y. (((st == 1) && <(ctrl = controllable)> Z) || <(ctrl = controllable)> Y))";
+    assert_eq!(
+        verdict(CTRL_INIT1, gf_good),
+        ExactVerdict::Holds,
+        "st'=c: the controller keeps st=1 ⇒ visits good infinitely often"
+    );
+    assert_eq!(
+        verdict(ENVBLK_INIT1, gf_good),
+        ExactVerdict::Violated,
+        "st'=c&¬e: the environment starves good with e=1 forever"
+    );
+    // DUAL sanity: the controller CAN force GF(st==0) on ENVBLK (set c=0 ⇒ st'=0) — confirms the νμ
+    // nesting is not accidentally collapsing to the reach/safety single-fixpoint answer.
+    let gf_zero =
+        "nu Z. (mu Y. (((st == 0) && <(ctrl = controllable)> Z) || <(ctrl = controllable)> Y))";
+    assert_eq!(
+        verdict(ENVBLK_INIT1, gf_zero),
+        ExactVerdict::Holds,
+        "st'=c&¬e: the controller forces st=0 (c=0) ⇒ visits st=0 infinitely often"
+    );
+}
+
 /// The DUAL — environment predecessor (`cpre_environment`). Can the ENVIRONMENT force reaching
 /// `st == 0` (init st=1)? `ENVBLK`: `∃e ∀c: (c&¬e)==0` holds for e=1 ⇒ HOLDS. `CTRL`: the environment
 /// is powerless (`∀c: c==0` fails, c=1 keeps st=1) ⇒ VIOLATED. The mirror image of the controllable
@@ -204,6 +234,30 @@ fn reach_realizable_decides_a_combinational_output_target() {
     assert_eq!(
         exact_two_player_reach_realizable(CTRL_OUT, "st == 1", &["c"]),
         exact_two_player_reach_realizable(CTRL_OUT, "busy_o == 0", &["c"]),
+    );
+}
+
+/// The `exact_two_player_buchi_realizable` HELPER (the recurrence primitive behind `--objective
+/// recurrence`) agrees with the hand-written recurrence formula: realizable on `CTRL` (the controller
+/// keeps `st==1` forever) and unrealizable on `ENVBLK` (the environment starves it), and it accepts a
+/// combinational-output target (`busy_o == 0`) just like the reach helper.
+#[test]
+fn buchi_helper_matches_the_recurrence_known_answer() {
+    assert_eq!(
+        exact_two_player_buchi_realizable(CTRL_INIT1, "st == 1", &["c"]),
+        Ok(true),
+        "st'=c: the controller forces st=1 infinitely often"
+    );
+    assert_eq!(
+        exact_two_player_buchi_realizable(ENVBLK_INIT1, "st == 1", &["c"]),
+        Ok(false),
+        "st'=c&¬e: the environment starves st=1"
+    );
+    // Combinational-output recurrence: force `busy_o == 0` (⇔ st==1) infinitely often on CTRL_OUT (st'=c).
+    assert_eq!(
+        exact_two_player_buchi_realizable(CTRL_OUT, "busy_o == 0", &["c"]),
+        Ok(true),
+        "st'=c: the controller forces busy_o=0 (st=1) infinitely often — a combinational-output target"
     );
 }
 


### PR DESCRIPTION
## Two-player game verb: recurrence (Büchi) objective

The game verb decided only **reachability** (`μX. good ∨ ⟨ctrl⟩X` — force `good`
once). This adds the **recurrence** objective (`--objective recurrence`): force
`good` *infinitely often* — the Büchi game
`νZ. μY. ((good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y)`, decided by a new
`exact_two_player_buchi_realizable` via `exact_two_player_verdict`.

**Engine:** exact-symbolic ROBDD (OxiDD), nested-νμ two-player fixpoint. The
soundness of the nested-fixpoint two-player evaluation is the decisive gate — it
is validated by known answer (`controllable_recurrence_holds_iff_environment_cannot_starve`),
including a dual-sanity case that rules out an accidental single-fixpoint
collapse.

### Surface parity

- CLI `btor2 game --objective reach|recurrence` (default `reach`)
- API `Btor2GameRequest.objective` / `Btor2GameResponse.objective` (`GameObjective`)
- UI `GameObjective` + `runBtor2Game` — sibling mununu-ui PR

Recurrence is **verdict-only** today: the state-indexed strategy is a
reachability attractor (wrong shape for Büchi), and assumption discovery is a
reach `A ⇒ G`. A fairness env assumption (`GF a → GF good`) rescuing an
unrealizable recurrence game is the follow-up — and it requires the
transition-relativized CPre (Klein–Pnueli / Bloem input-fairness); a naive νμν
with an input-predicate conjunct would be **unsound** (an input is not part of
the state).

### Measured on real OpenTitan RTL

`prim_fifo_sync_cnt` (Depth=4, Apache-2.0), `--objective recurrence --assume-clock-reset`:

| target | controllable | verdict |
|---|---|---|
| `GF(full_o == 1)` | `incr_wptr_i` (producer only) | **realizable: false** — the consumer drains as fast as the producer fills |
| `GF(full_o == 1)` | `incr_wptr_i` + `incr_rptr_i` + `clr_i` (whole datapath) | **realizable: true** — owns the datapath, holds it full |

The gap between the two is exactly what a fairness assumption
`GF(incr_rptr_i == 0)` (the consumer eventually pauses) would close for the
producer-only case — the fairness lever's clean validation target, now
established.

### Tests

- `controllable_recurrence_holds_iff_environment_cannot_starve` (formula-level, with dual sanity).
- `buchi_helper_matches_the_recurrence_known_answer` (helper + combinational-output recurrence).
- `btor2_game_handler_recurrence_objective_is_verdict_only` (HTTP).
- UI `game.test.ts` recurrence case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
