### PR TITLE
feat(game): fairness (liveness) env-assumption discovery — GR(1) 1-pair

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -2798,10 +2798,9 @@ fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
     } else {
         exact_two_player_reach_realizable(&content, &args.good, &controllable)?
     };
-    // STRATEGY extraction + assumption discovery are REACH-only today: the state-indexed strategy is a
-    // reachability attractor (wrong shape for Büchi), and the assumption search is a reach `A ⇒ G` — a
-    // fairness (GF a → GF good) assumption for recurrence is the follow-up. Also best-effort: the strategy
-    // needs a STATE-register target, so it is omitted for a combinational-output / relational `good`.
+    // STRATEGY extraction is REACH-only: the state-indexed strategy is a reachability attractor (the wrong
+    // shape for Büchi). Also best-effort: it needs a STATE-register target, so it is omitted for a
+    // combinational-output / relational `good`.
     let strategy = if recurrence {
         None
     } else {
@@ -2820,15 +2819,24 @@ fn btor2_game(args: Btor2GameArgs) -> Result<(), String> {
         summary["strategy"] =
             serde_json::to_value(s).map_err(|e| format!("serialize strategy: {e}"))?;
     }
-    // --discover-assumptions: when the (reach) game is unrealizable, search for an environment assumption
-    // under which the controller wins (CONDITIONAL — never flips `realizable`). No-op when already
-    // realizable or under `--objective recurrence` (fairness discovery is the follow-up).
-    if args.discover_assumptions && !recurrence {
-        let holds_under = mununu_core::adapter::recoverability::discover_game_env_assumption(
-            &content,
-            &args.good,
-            &controllable,
-        );
+    // --discover-assumptions: when the game is unrealizable, search for an environment assumption under
+    // which the controller wins (CONDITIONAL — never flips `realizable`). For `reach` this is a SAFETY
+    // hold / conjunction (`A ⇒ G`); for `recurrence` it is a FAIRNESS assumption `GF a → GF good` (the
+    // GR(1) 1-pair objective). No-op when the game is already realizable.
+    if args.discover_assumptions {
+        let holds_under = if recurrence {
+            mununu_core::adapter::recoverability::discover_game_fairness_assumption(
+                &content,
+                &args.good,
+                &controllable,
+            )
+        } else {
+            mununu_core::adapter::recoverability::discover_game_env_assumption(
+                &content,
+                &args.good,
+                &controllable,
+            )
+        };
         if !holds_under.is_empty() {
             summary["holds_under"] = serde_json::to_value(&holds_under)
                 .map_err(|e| format!("serialize holds_under: {e}"))?;

--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -57,6 +57,11 @@ pub const BAD_COND_SYMBOL: &str = "mununu_bad";
 /// antecedent truth).
 pub const ANTE_PREV_SYMBOL: &str = "mununu_ante_prev";
 
+/// The 1-bit latch synthesised for a FAIRNESS environment assumption (holds the
+/// previous cycle's truth of the assumption predicate `a`). See
+/// [`emit_latched_predicate_state`].
+pub const ASSUME_PREV_SYMBOL: &str = "mununu_assume_prev";
+
 fn err(message: String) -> AdapterError {
     AdapterError {
         kind: AdapterErrorKind::UnsupportedConstruct,
@@ -396,6 +401,70 @@ pub fn emit_ag_implies_next_monitor(
     ));
     let bad_line = next_nid;
     appended.push(format!("{bad_line} bad {bad_cond}"));
+
+    Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
+}
+
+/// Append a 1-bit latch state (init 0, `next = (atom.signal atom.op atom.value)`) named
+/// [`ASSUME_PREV_SYMBOL`], recording whether the assumption predicate `atom` held on each transition.
+/// The atom's signal may be a STATE cell, a PRIMARY INPUT, or a combinational OUTPUT port.
+///
+/// This is the SOUND encoding of an INPUT/transition-level fairness assumption `GF a` as a
+/// STATE-predicate fairness `GF(mununu_assume_prev == 1)`: an input is not part of the state, so it
+/// cannot appear directly in a state-fairness fixpoint (a naive νμν with an input-predicate conjunct
+/// would be unsound). Latching `a` into a fresh 1-bit state samples the assumption on each transition;
+/// `GF(mununu_assume_prev == 1) ⟺ GF a` on the play (a one-cycle offset is immaterial to an
+/// infinitely-often objective). The latch is a PURE MONITOR — no new choice, no feedback into the
+/// original transition — so every strategy/play is preserved and a game verdict transfers unchanged.
+pub fn emit_latched_predicate_state(
+    content: &str,
+    atom: &OracleAtom,
+    reset_pinned: bool,
+) -> Result<String, AdapterError> {
+    let file = parser::parse(content).map_err(|mut e| {
+        e.message = format!("adapter/btor2/bad_monitor: {}", e.message);
+        e
+    })?;
+    // The assumption signal: a state cell, a primary input, or a combinational output port.
+    let (sig_nid, sig_sort) = state_nid_and_sort(&file, &atom.signal, reset_pinned)
+        .or_else(|| input_nid_and_sort(&file, &atom.signal))
+        .or_else(|| output_nid_and_sort(&file, &atom.signal))
+        .ok_or_else(|| {
+            err(format!(
+                "adapter/btor2/bad_monitor: fairness assumption signal `{}` does not resolve to a \
+                 state cell, primary input, or output port",
+                atom.signal
+            ))
+        })?;
+
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut appended: Vec<String> = Vec::new();
+    let bool_sort = find_or_make_bool_sort(&file, &mut next_nid, &mut appended);
+
+    // a = (signal op value)
+    let a_const = next_nid;
+    next_nid += 1;
+    appended.push(format!("{a_const} constd {sig_sort} {}", atom.value));
+    let a_cmp = next_nid;
+    next_nid += 1;
+    appended.push(format!(
+        "{a_cmp} {} {bool_sort} {sig_nid} {a_const}",
+        btor2_cmp_keyword(atom.op)
+    ));
+
+    // mununu_assume_prev latch: init 0, next = a_cmp. (`init` needs the state NID > the value NID, so
+    // `zero` is emitted before the state — the same ordering emit_ag_implies_next_monitor relies on.)
+    let zero_bool = next_nid;
+    next_nid += 1;
+    appended.push(format!("{zero_bool} zero {bool_sort}"));
+    let latch = next_nid;
+    next_nid += 1;
+    appended.push(format!("{latch} state {bool_sort} {ASSUME_PREV_SYMBOL}"));
+    let latch_init = next_nid;
+    next_nid += 1;
+    appended.push(format!("{latch_init} init {bool_sort} {latch} {zero_bool}"));
+    let latch_next = next_nid;
+    appended.push(format!("{latch_next} next {bool_sort} {latch} {a_cmp}"));
 
     Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
 }

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2970,6 +2970,51 @@ pub fn exact_two_player_buchi_realizable(
     Ok(exact_two_player_verdict(btor2_content, &formula, controllable)? == ExactVerdict::Holds)
 }
 
+/// P2.5-F — is the RECURRENCE game `GF good` REALIZABLE UNDER the FAIRNESS environment assumption
+/// `GF assume` (the GR(1) 1-pair objective `GF assume → GF good`)?
+///
+/// **Soundness — why the assumption is LATCHED, not written into the formula.** `assume` is typically a
+/// PRIMARY-INPUT predicate (`incr_rptr_i == 0`); an input is not part of the state, so it cannot appear
+/// directly in a state-fairness fixpoint (a naive νμν with an input-predicate conjunct would be
+/// unsound — the input is ∀/∃-quantified by the surrounding CPre and the fixpoint types are muddled).
+/// We latch the assumption event into a fresh 1-bit state `mununu_assume_prev`
+/// ([`crate::adapter::btor2::bad_monitor::emit_latched_predicate_state`]) — a pure monitor for which
+/// `GF(mununu_assume_prev == 1) ⟺ GF assume` — and decide the STATE-fairness GR(1) 1-pair game
+///
+/// ```text
+/// νZ. μY. νX. ( (good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y ∨ (mununu_assume_prev == 0 ∧ ⟨ctrl⟩X) )
+/// ```
+///
+/// EXACTLY via [`exact_two_player_verdict`] (Piterman–Pnueli–Sa'ar). The νX "stall" branch captures the
+/// system winning for free when the assumption is only finitely satisfied; when the environment plays
+/// `assume` infinitely often the stall is disabled infinitely often, forcing μ-progress to `good`. A
+/// definite verdict is exact and transfers to the concrete game. With a trivially-true assumption the
+/// νX branch vanishes and this reduces to [`exact_two_player_buchi_realizable`].
+///
+/// engine: `exact-symbolic` ROBDD (OxiDD), triple-nested νμν two-player fixpoint over the
+/// assumption-latched model. `Ok(true)` = the controller wins `GF assume → GF good`.
+pub fn exact_two_player_gr1_realizable(
+    btor2_content: &str,
+    good: &str,
+    assume: &crate::adapter::btor2::concrete_oracle::OracleAtom,
+    controllable: &[&str],
+) -> Result<bool, String> {
+    let latched = crate::adapter::btor2::bad_monitor::emit_latched_predicate_state(
+        btor2_content,
+        assume,
+        false,
+    )
+    .map_err(|e| format!("exact two-player GR(1): latching the assumption: {e}"))?;
+    let latch = crate::adapter::btor2::bad_monitor::ASSUME_PREV_SYMBOL;
+    let formula_str = format!(
+        "nu Z. (mu Y. (nu X. ((({good}) && <(ctrl = controllable)> Z) || <(ctrl = controllable)> Y \
+         || (({latch} == 0) && <(ctrl = controllable)> X))))"
+    );
+    let formula = crate::mu_calculus::parser::parse(&formula_str)
+        .map_err(|e| format!("exact two-player GR(1): parsing `{formula_str}`: {e:?}"))?;
+    Ok(exact_two_player_verdict(&latched, &formula, controllable)? == ExactVerdict::Holds)
+}
+
 /// P2.5-F — decide a Control-tagged μ-calculus `formula` on the TWO-PLAYER KMTS (3-valued predicate
 /// cube) game: the scale backend of the unified verifier (past the exact BDD cap). `predicates` is the
 /// abstraction (name → atom); `controllable` names the controller's inputs. Returns the 3-valued verdict

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1532,6 +1532,108 @@ pub fn discover_game_env_assumption(
     found
 }
 
+/// Capability B, Phase 2c (FAIRNESS / liveness) — when the RECURRENCE (Büchi) game `GF good` is
+/// UNREALIZABLE, find a LIVENESS environment assumption `GF(in == v)` (the environment input holds `v`
+/// INFINITELY OFTEN) under which the controller wins `GF good` — the GR(1) 1-pair objective
+/// `GF a → GF good`. Distinct from [`discover_game_env_assumption`]'s `InputHold` (a SAFETY hold
+/// `G(a)`): fairness is strictly WEAKER — the environment may violate `a` finitely often.
+///
+/// **Scope (measure-first, honest).** Fairness rescues RESPONSE / handshake shapes ("if the environment
+/// eventually acks, the controller eventually completes"), NOT RATE / accumulation targets: a bounded
+/// buffer's `GF(full)` is NOT fairness-rescuable, because `GF(¬drain)` (drain paused infinitely often)
+/// still lets the environment net-drain (drain 99, pause 1) — the accumulation never completes. So this
+/// correctly returns ∅ on a rate machine (the FIFO) and finds the rescue on a response FSM.
+///
+/// **Engine (§16):** `exact-symbolic` ROBDD — [`exact_two_player_gr1_realizable`] decides the
+/// state-fairness GR(1) νμν on the assumption-LATCHED model (a sound encoding of the input-level
+/// `GF a`); the reach-portfolio non-vacuity gate rejects a vacuous rescue (`good` unreachable or
+/// stuck-true). Bounded: narrow env inputs (≤ 3 bits) × values, a pin count cap, and a wall-clock
+/// budget. The report is CONDITIONAL — the caller never lifts it to an unconditional realizable.
+pub fn discover_game_fairness_assumption(
+    btor2_content: &str,
+    good: &str,
+    controllable: &[&str],
+) -> Vec<DiscoveredAssumption> {
+    use crate::adapter::btor2::ast::Node;
+    use crate::adapter::btor2::concrete_oracle::OracleAtom;
+    use crate::adapter::btor2::symbolic_bitblast::{
+        exact_two_player_buchi_realizable, exact_two_player_gr1_realizable,
+    };
+    const MAX_INPUT_BITS: u32 = 3; // ≤ 8 values — a narrow ack/enable, not a datapath
+    const MAX_CANDIDATE_PINS: usize = 48;
+    let budget_ms: u128 = std::env::var("MUNUNU_ASSUMPTION_BUDGET_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(90_000);
+    let start = std::time::Instant::now();
+
+    // `good` must be `REG == VALUE` (a state register OR a named combinational output) — the non-vacuity
+    // gate needs the register/output + value.
+    let (register, value) = match parse_predicate_expr(good).ok() {
+        Some(PredicateExpr::Cmp {
+            register,
+            op: CmpOp::Eq,
+            value,
+        }) => (register, value),
+        _ => return Vec::new(),
+    };
+
+    // Only search when the RECURRENCE game is genuinely UNREALIZABLE (a realizable Büchi game needs no
+    // assumption — the false-positive control). This is also what makes a discovered φ a GENUINE rescue:
+    // any realizable GR(1) under `GF a` (given Büchi is ⊥) truly uses the assumption.
+    match exact_two_player_buchi_realizable(btor2_content, good, controllable) {
+        Ok(false) => {}         // unrealizable → search for an enabling fairness assumption
+        _ => return Vec::new(), // realizable, or `good` not resolvable / over-cap
+    }
+
+    let ctrl_set: std::collections::HashSet<&str> = controllable.iter().copied().collect();
+    let Ok(file) = crate::adapter::btor2::parser::parse(btor2_content) else {
+        return Vec::new();
+    };
+    let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
+    // Candidate assumption axes = the design's NARROW ENVIRONMENT primary inputs.
+    let mut candidates: Vec<(String, u32)> = Vec::new();
+    for line in &file.lines {
+        if let Node::Input { sort, .. } = &line.node
+            && let Some(name) = symbols.get(&line.nid)
+            && !ctrl_set.contains(name.as_str())
+            && let Some(w) = crate::adapter::btor2::parser::bv_width(&file, *sort)
+            && w <= MAX_INPUT_BITS
+        {
+            candidates.push((name.clone(), w));
+        }
+    }
+    candidates.sort();
+    candidates.dedup();
+
+    let mut found: Vec<DiscoveredAssumption> = Vec::new();
+    let mut tried = 0usize;
+    'outer: for (name, w) in candidates {
+        for c in 0..(1u64 << w) {
+            if tried >= MAX_CANDIDATE_PINS || start.elapsed().as_millis() > budget_ms {
+                break 'outer;
+            }
+            tried += 1;
+            let atom = OracleAtom::new(name.clone(), CmpOp::Eq, c as u128);
+            // SOUNDNESS: GR(1) 1-pair on the assumption-latched model (exact/2-valued sound); the
+            // non-vacuity gate rejects a realizable-but-vacuous rescue (good unreachable or stuck-true).
+            // CONDITIONAL — the caller never lifts it to an unconditional realizable.
+            let realizable =
+                exact_two_player_gr1_realizable(btor2_content, good, &atom, controllable)
+                    == Ok(true);
+            if realizable && good_nonvacuous_under(btor2_content, &register, value) {
+                found.push(DiscoveredAssumption {
+                    phi: format!("GF({name} == {c})"),
+                    kind: AssumptionKind::InputFairness,
+                    non_vacuous: true,
+                    engine: "two-player GR(1) game realizable under env-input fairness".to_string(),
+                });
+            }
+        }
+    }
+    found
+}
+
 /// Capability B, Phase 2c (CONJUNCTIVE) — when NO single environment-input hold makes the game realizable
 /// (the design has MULTIPLE independent adversarial blockers, e.g. the OpenTitan edn/otbn boot handshakes:
 /// the environment can block by withholding the ack OR escalating OR requesting a wipe), find a MINIMAL

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -910,21 +910,30 @@ pub async fn btor2_game_handler(
         message,
         details: None,
     })?;
-    // STRATEGY + assumption discovery are REACH-only today (the strategy is a reachability attractor, the
-    // assumption search a reach `A ⇒ G`; a fairness GF a → GF good assumption for recurrence is the
-    // follow-up). Strategy is also best-effort: it needs a STATE-register target, so it is `null` for a
+    // STRATEGY extraction is REACH-only (the strategy is a reachability attractor, the wrong shape for
+    // Büchi); it is also best-effort — it needs a STATE-register target, so it is `null` for a
     // combinational-output / relational `good` (a FIFO's `full_o`).
     let strategy = if recurrence {
         None
     } else {
         exact_two_player_strategy(&content, &request.good, &controllable).ok()
     };
-    let holds_under = if request.discover_assumptions && !recurrence {
-        crate::adapter::recoverability::discover_game_env_assumption(
-            &content,
-            &request.good,
-            &controllable,
-        )
+    // Assumption discovery: for `reach` a SAFETY hold / conjunction (`A ⇒ G`); for `recurrence` a
+    // FAIRNESS assumption `GF a → GF good` (the GR(1) 1-pair objective).
+    let holds_under = if request.discover_assumptions {
+        if recurrence {
+            crate::adapter::recoverability::discover_game_fairness_assumption(
+                &content,
+                &request.good,
+                &controllable,
+            )
+        } else {
+            crate::adapter::recoverability::discover_game_env_assumption(
+                &content,
+                &request.good,
+                &controllable,
+            )
+        }
     } else {
         Vec::new()
     };
@@ -4710,6 +4719,9 @@ members = ["x"]
     // Reset-artifact game `st' = rst ? 0 : c`: with `rst` adversarial the env holds reset → unrealizable;
     // `assume_clock_reset` pins the reset inactive → the functional game `st'=c` is realizable.
     const GAME_RESET: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 rst\n4 state 1 st\n5 zero 1\n6 init 1 4 5\n7 ite 1 3 5 2\n8 next 1 4 7\n";
+    // Saturating 1-bit buffer `count' = (c∧¬e) ∨ (count∧¬(e∧¬c))`: recurrence `GF(count==1)` (ctrl=c) is
+    // unrealizable (env pops forever), but realizable under the fairness assumption `GF(e==0)`.
+    const GAME_BUFFER: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 count\n5 zero 1\n6 init 1 4 5\n7 not 1 3\n8 and 1 2 7\n9 not 1 2\n10 and 1 3 9\n11 not 1 10\n12 and 1 4 11\n13 or 1 8 12\n14 next 1 4 13\n";
 
     /// `assume_clock_reset` over HTTP: the reset-adversarial game is unrealizable raw, but realizable when
     /// the reset is modeled as a posture (the modeling-artifact fix).
@@ -4826,6 +4838,33 @@ members = ["x"]
         assert!(
             out.strategy.is_none(),
             "recurrence is verdict-only today (no reachability strategy)"
+        );
+    }
+
+    /// `objective: "recurrence"` + `discover_assumptions` over HTTP: the unrealizable buffer recurrence
+    /// game returns a `holds_under` carrying the FAIRNESS assumption `GF(e == 0)` (CONDITIONAL —
+    /// `realizable` stays false).
+    #[tokio::test]
+    async fn btor2_game_handler_discovers_fairness_assumption() {
+        let request = Btor2GameRequest {
+            content: GAME_BUFFER.to_string(),
+            good: "count == 1".to_string(),
+            controllable: vec!["c".to_string()],
+            discover_assumptions: true,
+            objective: crate::api::models::GameObjective::Recurrence,
+            assume_clock_reset: false,
+        };
+        let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
+        assert!(
+            !out.realizable,
+            "recurrence is unrealizable without a fairness assumption"
+        );
+        assert!(
+            out.holds_under.iter().any(|a| a.phi == "GF(e == 0)"
+                && a.kind == crate::verdict::AssumptionKind::InputFairness
+                && a.non_vacuous),
+            "holds_under carries the fairness assumption GF(e==0): {:?}",
+            out.holds_under
         );
     }
 

--- a/crates/mununu-core/src/verdict.rs
+++ b/crates/mununu-core/src/verdict.rs
@@ -124,6 +124,11 @@ pub enum AssumptionKind {
     ResetEventually,
     /// A synthesized positional environment strategy (1-player: the environment owns all inputs).
     EnvStrategy,
+    /// A LIVENESS / fairness environment assumption `GF(in == v)` — the environment input holds `v`
+    /// INFINITELY OFTEN — under which an unrealizable RECURRENCE (Büchi) game `GF good` becomes realizable
+    /// (`GF a → GF good`, the GR(1) 1-pair objective). Distinct from `InputHold` (a SAFETY hold `G(a)`):
+    /// fairness is strictly weaker (the environment may violate `a` finitely often).
+    InputFairness,
 }
 
 /// See [`VerdictRefinement::holds_under`]. A CONDITIONAL result: the property holds under `phi`.

--- a/crates/mununu-core/tests/exact_two_player_fairness.rs
+++ b/crates/mununu-core/tests/exact_two_player_fairness.rs
@@ -1,0 +1,131 @@
+//! P2.5-F — FAIRNESS environment-assumption discovery for the two-player RECURRENCE (Büchi) game:
+//! the GR(1) 1-pair objective `GF a → GF good`, decided EXACTLY by `exact_two_player_gr1_realizable`
+//! over the assumption-latched model, and searched by `discover_game_fairness_assumption`.
+//!
+//! Validation is by KNOWN ANSWER on a minimal 1-bit "buffer" game whose winning region is computed by
+//! hand. State `count ∈ {0,1}`, `good = (count == 1)`. Inputs `c` (controllable = "push") and `e`
+//! (environment = "pop"). The transition is a saturating ±1 counter:
+//!
+//!   count' = (c ∧ ¬e) ∨ (count ∧ ¬(e ∧ ¬c))
+//!     c=1,e=0 → 1 (push)      ¬c,e   → 0 (pop)      otherwise → count (hold)
+//!
+//! Key dynamics: a pop-WITH-push HOLDS (c=1,e=1 → count'=count), so once `count=1` the controller
+//! keeps it at 1 by playing c=1 — this is what makes the fairness assumption `GF(e==0)` SUFFICIENT
+//! (reach 1 on any e=0 step, then hold). Without the assumption the environment pops forever (e=1) and
+//! starves `count`.
+
+use mununu_core::adapter::btor2::concrete_oracle::OracleAtom;
+use mununu_core::adapter::btor2::predicate_expr::CmpOp;
+use mununu_core::adapter::btor2::symbolic_bitblast::{
+    exact_two_player_buchi_realizable, exact_two_player_gr1_realizable,
+};
+use mununu_core::adapter::recoverability::discover_game_fairness_assumption;
+
+// count' = (c ∧ ¬e) ∨ (count ∧ ¬(e ∧ ¬c)); init count=0.
+const BUFFER: &str = "\
+1 sort bitvec 1
+2 input 1 c
+3 input 1 e
+4 state 1 count
+5 zero 1
+6 init 1 4 5
+7 not 1 3
+8 and 1 2 7
+9 not 1 2
+10 and 1 3 9
+11 not 1 10
+12 and 1 4 11
+13 or 1 8 12
+14 next 1 4 13
+";
+
+// st' = c, init st=1 — the controller trivially maintains st=1 (Büchi realizable WITHOUT any assumption).
+const CTRL_INIT1: &str = "\
+1 sort bitvec 1
+2 input 1 c
+3 input 1 e
+4 state 1 st
+5 one 1
+6 init 1 4 5
+7 next 1 4 2
+";
+
+/// The RECURRENCE game `GF(count==1)` (controller = push) is UNREALIZABLE: the environment pops forever
+/// (e=1) and `count` is starved. This is the ⊥ a fairness assumption must rescue.
+#[test]
+fn buffer_recurrence_is_unrealizable_without_an_assumption() {
+    assert_eq!(
+        exact_two_player_buchi_realizable(BUFFER, "count == 1", &["c"]),
+        Ok(false),
+        "the environment pops every cycle ⇒ count never recurrently reaches 1"
+    );
+}
+
+/// The fairness assumption `GF(e==0)` (the environment pauses popping infinitely often) RESCUES it:
+/// `GF(e==0) → GF(count==1)` is REALIZABLE — whenever e=0 the controller pushes to 1, and a pop-with-push
+/// holds it there. This is the fairness lever's positive case.
+#[test]
+fn buffer_recurrence_is_realizable_under_pop_pause_fairness() {
+    let assume = OracleAtom::new("e", CmpOp::Eq, 0);
+    assert_eq!(
+        exact_two_player_gr1_realizable(BUFFER, "count == 1", &assume, &["c"]),
+        Ok(true),
+        "GF(e==0) → GF(count==1): reach 1 on an e=0 step, hold with c=1"
+    );
+}
+
+/// SOUNDNESS CONTROL — a USELESS assumption does NOT rescue. `GF(e==1)` (the environment pops infinitely
+/// often) is satisfied by popping EVERY cycle, which starves `count` ⇒ `GF(e==1) → GF(count==1)` stays
+/// UNREALIZABLE. A fairness lever that "rescued" this would be unsound (fabricating a win).
+#[test]
+fn buffer_recurrence_is_not_rescued_by_a_useless_assumption() {
+    let assume = OracleAtom::new("e", CmpOp::Eq, 1);
+    assert_eq!(
+        exact_two_player_gr1_realizable(BUFFER, "count == 1", &assume, &["c"]),
+        Ok(false),
+        "GF(e==1) is met by popping every cycle ⇒ no rescue"
+    );
+}
+
+/// REDUCTION / no-over-firing control — when the plain Büchi game is ALREADY realizable (st'=c, init
+/// st=1), the GR(1) game with any assumption is ALSO realizable (an assumption can only help). The
+/// fairness path must not spuriously turn a win into a loss.
+#[test]
+fn gr1_reduces_to_realizable_when_buchi_already_wins() {
+    assert_eq!(
+        exact_two_player_buchi_realizable(CTRL_INIT1, "st == 1", &["c"]),
+        Ok(true),
+    );
+    let assume = OracleAtom::new("e", CmpOp::Eq, 0);
+    assert_eq!(
+        exact_two_player_gr1_realizable(CTRL_INIT1, "st == 1", &assume, &["c"]),
+        Ok(true),
+        "an assumption never breaks an already-realizable recurrence game"
+    );
+}
+
+/// DISCOVERY end-to-end: on the unrealizable buffer game, `discover_game_fairness_assumption` finds the
+/// enabling fairness assumption `GF(e == 0)` (non-vacuous) — and ONLY that one (not the useless
+/// `GF(e == 1)`).
+#[test]
+fn discovery_finds_the_pop_pause_fairness_assumption() {
+    let found = discover_game_fairness_assumption(BUFFER, "count == 1", &["c"]);
+    assert!(
+        found.iter().any(|a| a.phi == "GF(e == 0)" && a.non_vacuous),
+        "expected to discover GF(e == 0): {found:?}"
+    );
+    assert!(
+        !found.iter().any(|a| a.phi == "GF(e == 1)"),
+        "must NOT discover the useless GF(e == 1): {found:?}"
+    );
+}
+
+/// DISCOVERY false-positive control — on an already-realizable recurrence game, discovery returns ∅
+/// (no assumption is needed; fabricating one would be a false positive).
+#[test]
+fn discovery_is_empty_when_recurrence_already_holds() {
+    assert!(
+        discover_game_fairness_assumption(CTRL_INIT1, "st == 1", &["c"]).is_empty(),
+        "a realizable recurrence game needs no fairness assumption"
+    );
+}


### PR DESCRIPTION
## Fairness (liveness) environment-assumption discovery — GR(1) 1-pair

When a two-player **recurrence** game `GF good` is unrealizable,
`btor2 game --objective recurrence --discover-assumptions` now searches for a
**liveness** environment assumption `GF(in == v)` (the env input holds `v`
*infinitely often*) under which the controller wins `GF a → GF good` — the GR(1)
1-pair objective. This is strictly weaker than the reach case's safety hold
`G(a)`: the environment may violate `a` finitely often.

### Soundness — the load-bearing decision

`assume` is typically a **primary input** (`incr_rptr_i == 0`). An input is not
part of the state, so a naive νμν with an input-predicate conjunct would be
**unsound**. The fix latches the assumption event into a fresh 1-bit state
`mununu_assume_prev` (`emit_latched_predicate_state`) — a **pure monitor** (no
choice, no feedback into the original transition, so every strategy/play is
preserved) for which `GF(mununu_assume_prev == 1) ⟺ GF assume`. The controller
then wins the **state-fairness** GR(1) νμν, decided exactly by
`exact_two_player_verdict`:

```
νZ. μY. νX. ( (good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y ∨ (mununu_assume_prev == 0 ∧ ⟨ctrl⟩X) )
```

*engine: exact-symbolic ROBDD (OxiDD), triple-nested νμν over the latched model.*
With a trivially-true assumption the νX branch vanishes and this reduces to the
Büchi game.

### Validation — known answer, with the mandatory controls

`tests/exact_two_player_fairness.rs` (6/6), on a 1-bit saturating buffer:

- recurrence unrealizable without an assumption;
- **rescued** by `GF(e == 0)` (the fairness positive case);
- **not** rescued by the useless `GF(e == 1)` (env pops every cycle — the soundness control);
- no over-firing (already-realizable stays realizable);
- discovery finds **only** `GF(e == 0)`, and ∅ when recurrence already holds.

### Measure-first finding: fairness ≠ rate

On the real OpenTitan FIFO (`prim_fifo_sync_cnt`), `GF(full_o == 1)` fairness
discovery returns **∅** — `GF` is too weak for a **rate/accumulation** target:
`GF(incr_rptr_i == 0)` (consumer pauses infinitely often) still lets the env
net-drain (read 99, pause 1), so a depth-4 buffer never recurrently fills.
Fairness rescues **response/handshake** shapes, not rate machines. The synthetic
buffer (not rate-limited) *is* rescued end-to-end via the CLI (`holds_under =
[GF(e == 0)]`), validating the wiring. The RTL response-FSM corpus target is the
documented follow-up.

### Surface parity

- CLI `btor2 game --objective recurrence --discover-assumptions`
- API `POST /api/v1/btor2/game` (recurrence + `discover_assumptions` → fairness)
- UI `AssumptionKind` gains `"InputFairness"` — sibling mununu-ui PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
