### PR TITLE
feat(game): conjunctive fairness discovery — multi-pair GR(1)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -421,6 +421,18 @@ pub fn emit_latched_predicate_state(
     atom: &OracleAtom,
     reset_pinned: bool,
 ) -> Result<String, AdapterError> {
+    emit_latched_predicate_state_named(content, atom, ASSUME_PREV_SYMBOL, reset_pinned)
+}
+
+/// As [`emit_latched_predicate_state`] but with an explicit latch `symbol` — for a CONJUNCTION of
+/// fairness assumptions `GF a_1 ∧ … ∧ GF a_m`, where each `a_i` needs its OWN latch state
+/// (`mununu_assume_prev_0`, `_1`, …) so the multi-pair GR(1) fixpoint can reference them independently.
+pub fn emit_latched_predicate_state_named(
+    content: &str,
+    atom: &OracleAtom,
+    symbol: &str,
+    reset_pinned: bool,
+) -> Result<String, AdapterError> {
     let file = parser::parse(content).map_err(|mut e| {
         e.message = format!("adapter/btor2/bad_monitor: {}", e.message);
         e
@@ -452,14 +464,14 @@ pub fn emit_latched_predicate_state(
         btor2_cmp_keyword(atom.op)
     ));
 
-    // mununu_assume_prev latch: init 0, next = a_cmp. (`init` needs the state NID > the value NID, so
+    // `symbol` latch: init 0, next = a_cmp. (`init` needs the state NID > the value NID, so
     // `zero` is emitted before the state — the same ordering emit_ag_implies_next_monitor relies on.)
     let zero_bool = next_nid;
     next_nid += 1;
     appended.push(format!("{zero_bool} zero {bool_sort}"));
     let latch = next_nid;
     next_nid += 1;
-    appended.push(format!("{latch} state {bool_sort} {ASSUME_PREV_SYMBOL}"));
+    appended.push(format!("{latch} state {bool_sort} {symbol}"));
     let latch_init = next_nid;
     next_nid += 1;
     appended.push(format!("{latch_init} init {bool_sort} {latch} {zero_bool}"));

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -3015,6 +3015,58 @@ pub fn exact_two_player_gr1_realizable(
     Ok(exact_two_player_verdict(&latched, &formula, controllable)? == ExactVerdict::Holds)
 }
 
+/// P2.5-F — is `GF good` REALIZABLE under a CONJUNCTION of fairness assumptions
+/// `GF a_1 ∧ … ∧ GF a_m` (the multi-pair GR(1) objective `(⋀_i GF a_i) → GF good`)? Used when NO single
+/// justice assumption rescues an unrealizable recurrence game but a SET of them does (the fairness analog
+/// of [`crate::adapter::recoverability`]'s reach conjunctive slice).
+///
+/// **Soundness.** Each input assumption `a_i` is LATCHED into its own monitor state
+/// `mununu_assume_prev_i` (same pure-monitor argument as [`exact_two_player_gr1_realizable`], one latch
+/// per assumption), so `GF(mununu_assume_prev_i == 1) ⟺ GF a_i`. The controller then wins the
+/// STATE-fairness MULTI-pair GR(1) game (Piterman–Pnueli–Sa'ar), decided EXACTLY by
+/// [`exact_two_player_verdict`]:
+///
+/// ```text
+/// νZ. μY. ⋁_i νX_i. ( (good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y ∨ (mununu_assume_prev_i == 0 ∧ ⟨ctrl⟩X_i) )
+/// ```
+///
+/// The `⋁_i` over per-assumption `νX_i` "stall" branches encodes "the system wins if `good` recurs OR
+/// SOME assumption `a_i` is satisfied only finitely often" (`(⋀ GF a_i) → GF good` ≡ `GF good ∨ ⋁_i
+/// FG ¬a_i`). For `m = 1` it reduces exactly to [`exact_two_player_gr1_realizable`]; for `m = 0` (no
+/// assumption) to [`exact_two_player_buchi_realizable`]. `Ok(true)` = the controller wins under the
+/// conjunction. engine: `exact-symbolic` ROBDD (OxiDD) over the `m`-latch model.
+pub fn exact_two_player_gr1_conjunction_realizable(
+    btor2_content: &str,
+    good: &str,
+    assumes: &[crate::adapter::btor2::concrete_oracle::OracleAtom],
+    controllable: &[&str],
+) -> Result<bool, String> {
+    use crate::adapter::btor2::bad_monitor::{
+        ASSUME_PREV_SYMBOL, emit_latched_predicate_state_named,
+    };
+    if assumes.is_empty() {
+        return exact_two_player_buchi_realizable(btor2_content, good, controllable);
+    }
+    let ctrl = "<(ctrl = controllable)>";
+    let mut content = btor2_content.to_string();
+    let mut disjuncts: Vec<String> = Vec::with_capacity(assumes.len());
+    for (i, a) in assumes.iter().enumerate() {
+        let sym = format!("{ASSUME_PREV_SYMBOL}_{i}");
+        content = emit_latched_predicate_state_named(&content, a, &sym, false).map_err(|e| {
+            format!("exact two-player GR(1) conjunction: latching assumption {i}: {e}")
+        })?;
+        // One νX_i stall branch per assumption; X_i is a fresh fixpoint variable.
+        disjuncts.push(format!(
+            "(nu X{i}. ((({good}) && {ctrl} Z) || {ctrl} Y || (({sym} == 0) && {ctrl} X{i})))"
+        ));
+    }
+    let formula_str = format!("nu Z. (mu Y. ({}))", disjuncts.join(" || "));
+    let formula = crate::mu_calculus::parser::parse(&formula_str).map_err(|e| {
+        format!("exact two-player GR(1) conjunction: parsing `{formula_str}`: {e:?}")
+    })?;
+    Ok(exact_two_player_verdict(&content, &formula, controllable)? == ExactVerdict::Holds)
+}
+
 /// P2.5-F — decide a Control-tagged μ-calculus `formula` on the TWO-PLAYER KMTS (3-valued predicate
 /// cube) game: the scale backend of the unified verifier (past the exact BDD cap). `predicates` is the
 /// abstraction (name → atom); `controllable` names the controller's inputs. Returns the 3-valued verdict

--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1631,7 +1631,154 @@ pub fn discover_game_fairness_assumption(
             }
         }
     }
+    // When NO single fairness assumption wins (multiple independent liveness blockers), fall back to the
+    // CONJUNCTIVE slice: a minimal SET of `GF(e_i == v_i)` under which the controller wins.
+    if found.is_empty()
+        && let Some(conj) = discover_game_fairness_conjunction(btor2_content, good, controllable)
+    {
+        found.push(conj);
+    }
     found
+}
+
+/// Capability B, Phase 2c (FAIRNESS, CONJUNCTIVE) — when NO single `GF(e_i == v_i)` rescues the
+/// unrealizable recurrence game (multiple INDEPENDENT liveness blockers), find a MINIMAL CONJUNCTION of
+/// fairness assumptions `GF(e_1 == v_1) ∧ … ∧ GF(e_k == v_k)` under which the controller wins
+/// `(⋀_i GF a_i) → GF good` (the multi-pair GR(1) objective). The fairness analog of
+/// [`discover_game_env_conjunction`] (which pins env inputs to CONSTANTS for a reach/safety `A ⇒ G`);
+/// here each `e_i` stays free EXCEPT that it must be `v_i` INFINITELY OFTEN.
+///
+/// Returns ONE minimal conjunction (≥2 assumptions), or `None` (already realizable, `good` not
+/// `REG == VALUE`, no winning value-combination within the caps, or it minimizes to a single assumption
+/// — that is the [`discover_game_fairness_assumption`] single-`GF` slice's job).
+///
+/// **Engine (§16):** `exact-symbolic` ROBDD multi-pair GR(1)
+/// ([`crate::adapter::btor2::symbolic_bitblast::exact_two_player_gr1_conjunction_realizable`]) over the
+/// `k`-latch model + the reach-portfolio non-vacuity gate. Bounded: candidate env inputs are restricted
+/// to `good`'s cone (`cone_leaf_nids`); the winning-combination search caps at `MAX_CONJ_BITS` total env
+/// bits (the νμ over `k` latches is pricier than a reach pin, so the cap is tighter than the reach
+/// slice's) and a wall-clock budget.
+fn discover_game_fairness_conjunction(
+    btor2_content: &str,
+    good: &str,
+    controllable: &[&str],
+) -> Option<DiscoveredAssumption> {
+    use crate::adapter::btor2::ast::Node;
+    use crate::adapter::btor2::concrete_oracle::OracleAtom;
+    use crate::adapter::btor2::dep_graph::cone_leaf_nids;
+    use crate::adapter::btor2::symbolic_bitblast::{
+        exact_two_player_buchi_realizable, exact_two_player_gr1_conjunction_realizable,
+    };
+    const MAX_INPUT_BITS: u32 = 3;
+    const MAX_CONJ_BITS: u32 = 6; // ≤ 64 value-combinations; the νμ over k latches is pricier than a pin
+    let budget_ms: u128 = std::env::var("MUNUNU_ASSUMPTION_BUDGET_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(90_000);
+    let start = std::time::Instant::now();
+
+    let (register, value) = match parse_predicate_expr(good).ok() {
+        Some(PredicateExpr::Cmp {
+            register,
+            op: CmpOp::Eq,
+            value,
+        }) => (register, value),
+        _ => return None,
+    };
+    // Only when the RECURRENCE game is genuinely unrealizable.
+    if exact_two_player_buchi_realizable(btor2_content, good, controllable) != Ok(false) {
+        return None;
+    }
+    // Non-vacuity is a property of the DESIGN (good reachable AND avoidable), independent of the
+    // assumption — check it once. A dead/stuck target yields no meaningful conjunction.
+    if !good_nonvacuous_under(btor2_content, &register, value) {
+        return None;
+    }
+    let ctrl_set: std::collections::HashSet<&str> = controllable.iter().copied().collect();
+    let Ok(file) = crate::adapter::btor2::parser::parse(btor2_content) else {
+        return None;
+    };
+    let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
+    let cone = cone_leaf_nids(&file, std::slice::from_ref(&register));
+    let mut axes: Vec<(String, u32)> = Vec::new();
+    for line in &file.lines {
+        if let Node::Input { sort, .. } = &line.node
+            && cone.contains(&line.nid)
+            && let Some(name) = symbols.get(&line.nid)
+            && !ctrl_set.contains(name.as_str())
+            && let Some(w) = crate::adapter::btor2::parser::bv_width(&file, *sort)
+            && w <= MAX_INPUT_BITS
+        {
+            axes.push((name.clone(), w));
+        }
+    }
+    axes.sort();
+    axes.dedup();
+    let total_bits: u32 = axes.iter().map(|(_, w)| *w).sum();
+    if axes.len() < 2 || total_bits > MAX_CONJ_BITS {
+        return None; // < 2 axes = not a conjunction; too wide = abstain
+    }
+
+    // `wins`: the SUBSET `kept` of axes, each assumed `GF(e_j == vals[j])`, makes the multi-pair GR(1)
+    // game realizable. (Non-vacuity already checked above — it does not depend on the assumption.)
+    let wins = |kept: &[usize], vals: &[u64]| -> bool {
+        let assumes: Vec<OracleAtom> = kept
+            .iter()
+            .map(|&j| OracleAtom::new(axes[j].0.clone(), CmpOp::Eq, vals[j] as u128))
+            .collect();
+        exact_two_player_gr1_conjunction_realizable(btor2_content, good, &assumes, controllable)
+            == Ok(true)
+    };
+
+    // Search the product of the axes' value ranges for a WINNING full assumption set (all axes assumed).
+    let ranges: Vec<u64> = axes.iter().map(|(_, w)| 1u64 << w).collect();
+    let total_combos: u64 = ranges.iter().product();
+    let all: Vec<usize> = (0..axes.len()).collect();
+    let mut vals: Option<Vec<u64>> = None;
+    for idx in 0..total_combos {
+        if start.elapsed().as_millis() > budget_ms {
+            break;
+        }
+        let mut rem = idx;
+        let candidate: Vec<u64> = ranges
+            .iter()
+            .map(|r| {
+                let v = rem % r;
+                rem /= r;
+                v
+            })
+            .collect();
+        if wins(&all, &candidate) {
+            vals = Some(candidate);
+            break;
+        }
+    }
+    let vals = vals?;
+
+    // MINIMIZE: greedily drop any assumption the controller wins WITHOUT (that env input can stay fully
+    // adversarial).
+    let mut needed: Vec<usize> = (0..axes.len()).collect();
+    for i in 0..axes.len() {
+        let trial: Vec<usize> = needed.iter().copied().filter(|&j| j != i).collect();
+        if wins(&trial, &vals) {
+            needed = trial;
+        }
+    }
+    if needed.len() < 2 {
+        return None; // reduced to a single fairness assumption — the single-`GF` slice's job
+    }
+    let phi = needed
+        .iter()
+        .map(|&j| format!("GF({} == {})", axes[j].0, vals[j]))
+        .collect::<Vec<_>>()
+        .join(" && ");
+    Some(DiscoveredAssumption {
+        phi,
+        kind: AssumptionKind::InputFairnessConjunction,
+        non_vacuous: true,
+        engine: "two-player multi-pair GR(1) game realizable under env-input fairness conjunction"
+            .to_string(),
+    })
 }
 
 /// Capability B, Phase 2c (CONJUNCTIVE) — when NO single environment-input hold makes the game realizable

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -4722,6 +4722,9 @@ members = ["x"]
     // Saturating 1-bit buffer `count' = (c∧¬e) ∨ (count∧¬(e∧¬c))`: recurrence `GF(count==1)` (ctrl=c) is
     // unrealizable (env pops forever), but realizable under the fairness assumption `GF(e==0)`.
     const GAME_BUFFER: &str = "1 sort bitvec 1\n2 input 1 c\n3 input 1 e\n4 state 1 count\n5 zero 1\n6 init 1 4 5\n7 not 1 3\n8 and 1 2 7\n9 not 1 2\n10 and 1 3 9\n11 not 1 10\n12 and 1 4 11\n13 or 1 8 12\n14 next 1 4 13\n";
+    // TWOGATE: two independent env gates (e1,e2) to `st==2`; recurrence needs BOTH `GF(e1==0)` and
+    // `GF(e2==0)` — no single fairness suffices ⇒ the conjunctive fallback.
+    const GAME_TWOGATE: &str = "1 sort bitvec 1\n2 sort bitvec 2\n3 input 1 c\n4 input 1 e1\n5 input 1 e2\n6 state 2 st\n7 zero 2\n8 init 2 6 7\n9 one 2\n10 constd 2 2\n11 not 1 4\n12 and 1 3 11\n13 not 1 5\n14 and 1 3 13\n15 eq 1 6 7\n16 eq 1 6 9\n17 ite 2 12 9 7\n18 ite 2 14 10 9\n19 ite 2 16 18 7\n20 ite 2 15 17 19\n21 next 2 6 20\n";
 
     /// `assume_clock_reset` over HTTP: the reset-adversarial game is unrealizable raw, but realizable when
     /// the reset is modeled as a posture (the modeling-artifact fix).
@@ -4864,6 +4867,30 @@ members = ["x"]
                 && a.kind == crate::verdict::AssumptionKind::InputFairness
                 && a.non_vacuous),
             "holds_under carries the fairness assumption GF(e==0): {:?}",
+            out.holds_under
+        );
+    }
+
+    /// `objective: "recurrence"` + `discover_assumptions` over HTTP on TWOGATE: no single fairness
+    /// suffices, so the discovery falls through to a CONJUNCTION `GF(e1==0) && GF(e2==0)`
+    /// (`InputFairnessConjunction`).
+    #[tokio::test]
+    async fn btor2_game_handler_discovers_fairness_conjunction() {
+        let request = Btor2GameRequest {
+            content: GAME_TWOGATE.to_string(),
+            good: "st == 2".to_string(),
+            controllable: vec!["c".to_string()],
+            discover_assumptions: true,
+            objective: crate::api::models::GameObjective::Recurrence,
+            assume_clock_reset: false,
+        };
+        let Json(out) = btor2_game_handler(Json(request)).await.expect("game runs");
+        assert!(!out.realizable, "no single fairness rescues TWOGATE");
+        assert!(
+            out.holds_under.iter().any(|a| a.phi.contains("GF(e1 == 0)")
+                && a.phi.contains("GF(e2 == 0)")
+                && a.kind == crate::verdict::AssumptionKind::InputFairnessConjunction),
+            "holds_under carries the fairness conjunction: {:?}",
             out.holds_under
         );
     }

--- a/crates/mununu-core/src/verdict.rs
+++ b/crates/mununu-core/src/verdict.rs
@@ -129,6 +129,11 @@ pub enum AssumptionKind {
     /// (`GF a → GF good`, the GR(1) 1-pair objective). Distinct from `InputHold` (a SAFETY hold `G(a)`):
     /// fairness is strictly weaker (the environment may violate `a` finitely often).
     InputFairness,
+    /// A CONJUNCTION of fairness assumptions `GF(e_1 == v_1) ∧ … ∧ GF(e_k == v_k)` — the minimal set of
+    /// environment liveness assumptions under which an unrealizable RECURRENCE game becomes realizable
+    /// (`(⋀_i GF a_i) → GF good`, the MULTI-pair GR(1) objective), when no SINGLE fairness assumption
+    /// suffices (multiple independent liveness blockers). The fairness analog of `InputConjunction`.
+    InputFairnessConjunction,
 }
 
 /// See [`VerdictRefinement::holds_under`]. A CONDITIONAL result: the property holds under `phi`.

--- a/crates/mununu-core/tests/exact_two_player_fairness.rs
+++ b/crates/mununu-core/tests/exact_two_player_fairness.rs
@@ -17,7 +17,8 @@
 use mununu_core::adapter::btor2::concrete_oracle::OracleAtom;
 use mununu_core::adapter::btor2::predicate_expr::CmpOp;
 use mununu_core::adapter::btor2::symbolic_bitblast::{
-    exact_two_player_buchi_realizable, exact_two_player_gr1_realizable,
+    exact_two_player_buchi_realizable, exact_two_player_gr1_conjunction_realizable,
+    exact_two_player_gr1_realizable,
 };
 use mununu_core::adapter::recoverability::discover_game_fairness_assumption;
 
@@ -48,6 +49,34 @@ const CTRL_INIT1: &str = "\
 5 one 1
 6 init 1 4 5
 7 next 1 4 2
+";
+
+// TWO independent env gates on the path to `good = (st == 2)`, each needing its own fairness pause:
+//   st 0 --(c ∧ ¬e1)--> st 1 --(c ∧ ¬e2)--> st 2 --> st 0 (auto, non-idleable)
+// Controller drives `c`; the environment owns e1, e2. Reaching st==2 recurrently needs BOTH `e1` and
+// `e2` to pause infinitely often — neither single `GF(e_i==0)` suffices (the other gate stays shut).
+const TWOGATE: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 input 1 c
+4 input 1 e1
+5 input 1 e2
+6 state 2 st
+7 zero 2
+8 init 2 6 7
+9 one 2
+10 constd 2 2
+11 not 1 4
+12 and 1 3 11
+13 not 1 5
+14 and 1 3 13
+15 eq 1 6 7
+16 eq 1 6 9
+17 ite 2 12 9 7
+18 ite 2 14 10 9
+19 ite 2 16 18 7
+20 ite 2 15 17 19
+21 next 2 6 20
 ";
 
 /// The RECURRENCE game `GF(count==1)` (controller = push) is UNREALIZABLE: the environment pops forever
@@ -127,5 +156,83 @@ fn discovery_is_empty_when_recurrence_already_holds() {
     assert!(
         discover_game_fairness_assumption(CTRL_INIT1, "st == 1", &["c"]).is_empty(),
         "a realizable recurrence game needs no fairness assumption"
+    );
+}
+
+/// SOUNDNESS GATE for the CONJUNCTIVE lever — the multi-pair GR(1) `νZ.μY. ⋁_i νX_i(…)`. On TWOGATE,
+/// two independent env gates each need their own pause, so:
+///   - the bare recurrence is unrealizable,
+///   - NEITHER single `GF(e_i==0)` rescues (the other gate stays shut — the crucial non-over-firing
+///     control: a lever that "rescued" with one assumption would be unsound), and
+///   - the CONJUNCTION `GF(e1==0) ∧ GF(e2==0)` DOES rescue.
+#[test]
+fn conjunctive_fairness_rescues_when_no_single_assumption_does() {
+    let e1_low = OracleAtom::new("e1", CmpOp::Eq, 0);
+    let e2_low = OracleAtom::new("e2", CmpOp::Eq, 0);
+
+    assert_eq!(
+        exact_two_player_buchi_realizable(TWOGATE, "st == 2", &["c"]),
+        Ok(false),
+        "bare recurrence: the environment shuts either gate forever"
+    );
+    // Neither single justice assumption suffices.
+    assert_eq!(
+        exact_two_player_gr1_realizable(TWOGATE, "st == 2", &e1_low, &["c"]),
+        Ok(false),
+        "GF(e1==0) alone: gate 1 (e2) still shut ⇒ st==2 unreachable"
+    );
+    assert_eq!(
+        exact_two_player_gr1_realizable(TWOGATE, "st == 2", &e2_low, &["c"]),
+        Ok(false),
+        "GF(e2==0) alone: gate 0 (e1) still shut ⇒ st==1 unreachable"
+    );
+    // The conjunction rescues.
+    assert_eq!(
+        exact_two_player_gr1_conjunction_realizable(
+            TWOGATE,
+            "st == 2",
+            &[e1_low.clone(), e2_low.clone()],
+            &["c"]
+        ),
+        Ok(true),
+        "GF(e1==0) ∧ GF(e2==0): both gates pause i.o. ⇒ st==2 recurs"
+    );
+}
+
+/// DISCOVERY end-to-end for the CONJUNCTIVE fallback: on TWOGATE (no single fairness rescues),
+/// `discover_game_fairness_assumption` falls through to the conjunction and reports
+/// `GF(e1 == 0) && GF(e2 == 0)` with kind `InputFairnessConjunction`.
+#[test]
+fn discovery_finds_the_fairness_conjunction_when_no_single_works() {
+    let found = discover_game_fairness_assumption(TWOGATE, "st == 2", &["c"]);
+    assert!(
+        found.iter().any(|a| a.phi.contains("GF(e1 == 0)")
+            && a.phi.contains("GF(e2 == 0)")
+            && a.kind == mununu_core::verdict::AssumptionKind::InputFairnessConjunction
+            && a.non_vacuous),
+        "expected the conjunction GF(e1==0) && GF(e2==0): {found:?}"
+    );
+}
+
+/// REDUCTION sanity for the conjunctive helper: a 1-element conjunction equals the single-pair GR(1),
+/// and a 0-element conjunction equals the bare Büchi game. Confirms the multi-pair νZ.μY.⋁νX formula
+/// does not drift from the shipped single-pair / recurrence primitives.
+#[test]
+fn conjunction_reduces_to_single_and_buchi() {
+    let e_low = OracleAtom::new("e", CmpOp::Eq, 0);
+    // m = 1 ≡ single-pair GR(1) (on the BUFFER game where GF(e==0) rescues).
+    assert_eq!(
+        exact_two_player_gr1_conjunction_realizable(
+            BUFFER,
+            "count == 1",
+            std::slice::from_ref(&e_low),
+            &["c"]
+        ),
+        exact_two_player_gr1_realizable(BUFFER, "count == 1", &e_low, &["c"]),
+    );
+    // m = 0 ≡ bare Büchi recurrence.
+    assert_eq!(
+        exact_two_player_gr1_conjunction_realizable(BUFFER, "count == 1", &[], &["c"]),
+        exact_two_player_buchi_realizable(BUFFER, "count == 1", &["c"]),
     );
 }


### PR DESCRIPTION
## Conjunctive fairness discovery — multi-pair GR(1)

Extends the single-`GF` fairness lever (mununu #448) with a **single → conjunction
fallback**: when no single justice assumption `GF(e_i == v_i)` rescues an
unrealizable recurrence game, `discover_game_fairness_conjunction` searches for a
**minimal set** `GF(e_1==v_1) ∧ … ∧ GF(e_k==v_k)` under which the controller wins
`(⋀_i GF a_i) → GF good` — the multi-pair GR(1) objective. This is the fairness
analog of the shipped *reach* conjunctive slice (which found the FIFO decomposable
row).

### Engine

`exact_two_player_gr1_conjunction_realizable` decides the state-fairness
**multi-pair** GR(1) game (Piterman–Pnueli–Sa'ar), exactly, over one latch per
assumption (`emit_latched_predicate_state_named`, `mununu_assume_prev_i`):

```
νZ. μY. ⋁_i νX_i. ( (good ∧ ⟨ctrl⟩Z) ∨ ⟨ctrl⟩Y ∨ (mununu_assume_prev_i == 0 ∧ ⟨ctrl⟩X_i) )
```

The `⋁_i` over per-assumption `νX_i` stall branches encodes
`(⋀ GF a_i) → GF good ≡ GF good ∨ ⋁_i FG ¬a_i`. *engine: exact-symbolic ROBDD
(OxiDD).* For `m=1` it reduces to the single-pair GR(1); for `m=0` to the Büchi game.

### Validation (known answer, with controls) — `exact_two_player_fairness.rs`, 9/9

Synthetic **TWOGATE**: two independent env gates to `st==2`.
- bare recurrence unrealizable;
- **neither** single `GF(e_i==0)` rescues (the crucial non-over-firing soundness control);
- the **conjunction** `GF(e1==0) ∧ GF(e2==0)` rescues;
- reduction sanity: `m=1` ≡ single-pair GR(1), `m=0` ≡ Büchi;
- discovery reports the conjunction with kind `InputFairnessConjunction`.

### Measure-first outcome (honest)

- **Wall-class:** the conjunction decides TWOGATE, which single-`GF` leaves ⊥ —
  genuine marginal reach over the single-`GF` lever.
- **Corpus:** marginal reach is **∅** today. csrng `GF(CmdPrep)` stays ∅ because
  `enable_i` is a *persistence/rate* confound (the FSM needs `enable` held *during*
  the advance, not merely infinitely often — a justice conjunction cannot express
  that); edn/otbn are *positional*. The corpus's multi-gate FSMs are
  persistence/rate/positional-confounded, not clean 2-independent-justice-gate
  designs. This mirrors the single-`GF` trajectory (wall-class-validated first,
  then awaited spiCtrl for a clean RTL row); the conjunctive analog awaits a
  2-independent-justice-gate RTL target.

Integration is principled per the wall-class-matrix rule's explicit-justification
clause: a sound generalization of the shipped single-`GF`, decides the wall-class,
and is the exact analog of the shipped reach conjunctive slice.

### Surface parity

Rides the existing `btor2 game --objective recurrence --discover-assumptions`
(CLI + API auto-covered) + UI `AssumptionKind` gains `"InputFairnessConjunction"`.

Compassion (`G(req → F ack)`, Streett) is **deferred** — it needs its own
Streett/Rabin-game sound formulation + known-answer validation, and no validated
RTL target motivates it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
