### PR TITLE
fix(game): conjunction fairness discovery — axis fallback for output targets

### DIFF
--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -1699,21 +1699,34 @@ fn discover_game_fairness_conjunction(
         return None;
     };
     let symbols = crate::adapter::btor2::parser::collect_symbols(&file);
-    let cone = cone_leaf_nids(&file, std::slice::from_ref(&register));
-    let mut axes: Vec<(String, u32)> = Vec::new();
-    for line in &file.lines {
-        if let Node::Input { sort, .. } = &line.node
-            && cone.contains(&line.nid)
-            && let Some(name) = symbols.get(&line.nid)
-            && !ctrl_set.contains(name.as_str())
-            && let Some(w) = crate::adapter::btor2::parser::bv_width(&file, *sort)
-            && w <= MAX_INPUT_BITS
-        {
-            axes.push((name.clone(), w));
+    // Candidate axes = narrow NON-controllable primary inputs. Prefer `good`'s cone (bounds the product on
+    // wide-env designs); but `cone_leaf_nids` is a COMBINATIONAL cone, so for an OUTPUT / relational target
+    // it EXCLUDES an env input that only drives the target's state-register's NEXT logic (e.g. an ack that
+    // returns an FSM to its home state — `b2r_ack` for `sdrc_req_gen`'s `req_ack`). When the cone yields
+    // < 2 axes, fall back to ALL narrow non-controllable inputs (the single-`GF` candidate set, which is
+    // cone-free); the width cap still bounds the search.
+    let build_axes = |restrict_to_cone: bool| -> Vec<(String, u32)> {
+        let cone = restrict_to_cone.then(|| cone_leaf_nids(&file, std::slice::from_ref(&register)));
+        let mut axes: Vec<(String, u32)> = Vec::new();
+        for line in &file.lines {
+            if let Node::Input { sort, .. } = &line.node
+                && cone.as_ref().is_none_or(|c| c.contains(&line.nid))
+                && let Some(name) = symbols.get(&line.nid)
+                && !ctrl_set.contains(name.as_str())
+                && let Some(w) = crate::adapter::btor2::parser::bv_width(&file, *sort)
+                && w <= MAX_INPUT_BITS
+            {
+                axes.push((name.clone(), w));
+            }
         }
+        axes.sort();
+        axes.dedup();
+        axes
+    };
+    let mut axes = build_axes(true);
+    if axes.len() < 2 {
+        axes = build_axes(false);
     }
-    axes.sort();
-    axes.dedup();
     let total_bits: u32 = axes.iter().map(|(_, w)| *w).sum();
     if axes.len() < 2 || total_bits > MAX_CONJ_BITS {
         return None; // < 2 axes = not a conjunction; too wide = abstain

--- a/crates/mununu-core/tests/exact_two_player_fairness.rs
+++ b/crates/mununu-core/tests/exact_two_player_fairness.rs
@@ -159,6 +159,53 @@ fn discovery_is_empty_when_recurrence_already_holds() {
     );
 }
 
+// TWOGATE with a STATE-FUNCTION OUTPUT `done_o = (st == 2)` (depends on STATE only, not on the current
+// inputs — unlike an input-gated pulse). The output's combinational cone is just `st`, so the cone-
+// restricted axis search sees NEITHER `e1` nor `e2` (they only drive `st`'s NEXT) → the conjunction
+// discovery must FALL BACK to all narrow env inputs. Exercises `discover_game_fairness_conjunction`'s
+// output-target axis fallback end-to-end.
+const TWOGATE_OUT: &str = "\
+1 sort bitvec 1
+2 sort bitvec 2
+3 input 1 c
+4 input 1 e1
+5 input 1 e2
+6 state 2 st
+7 zero 2
+8 init 2 6 7
+9 one 2
+10 constd 2 2
+11 not 1 4
+12 and 1 3 11
+13 not 1 5
+14 and 1 3 13
+15 eq 1 6 7
+16 eq 1 6 9
+17 ite 2 12 9 7
+18 ite 2 14 10 9
+19 ite 2 16 18 7
+20 ite 2 15 17 19
+21 next 2 6 20
+22 eq 1 6 10 done_o
+23 output 22 done_o
+";
+
+/// AXIS-FALLBACK regression (a fix for the conjunction discovery on OUTPUT / relational targets): the
+/// combinational cone of `done_o = (st==2)` is just `st`, so the cone-restricted axis search finds
+/// NEITHER gate input (both only drive `st`'s next). The discovery must fall back to all narrow env
+/// inputs and still report `GF(e1==0) && GF(e2==0)`. (`done_o` is a STATE-function output — the game
+/// handles it; contrast a `req & ack`-style INPUT-dependent output, which is not a state predicate.)
+#[test]
+fn discovery_finds_conjunction_on_output_target_via_axis_fallback() {
+    let found = discover_game_fairness_assumption(TWOGATE_OUT, "done_o == 1", &["c"]);
+    assert!(
+        found.iter().any(|a| a.phi.contains("GF(e1 == 0)")
+            && a.phi.contains("GF(e2 == 0)")
+            && a.kind == mununu_core::verdict::AssumptionKind::InputFairnessConjunction),
+        "expected the conjunction via the output-target axis fallback: {found:?}"
+    );
+}
+
 /// SOUNDNESS GATE for the CONJUNCTIVE lever — the multi-pair GR(1) `νZ.μY. ⋁_i νX_i(…)`. On TWOGATE,
 /// two independent env gates each need their own pause, so:
 ///   - the bare recurrence is unrealizable,


### PR DESCRIPTION
## Conjunction fairness discovery: axis fallback for output/relational targets

Follow-up to the conjunctive fairness lever (#449). Fixes a real gap found during a
lift-engineering pass on the wide-hunt backlog.

### The bug

`discover_game_fairness_conjunction` restricted its candidate axes to
`cone_leaf_nids(good)` — a **combinational** cone. For an **output / relational**
target, that cone stops at the target's state register and therefore **drops an
env input that only drives that register's *next* logic** (e.g. an ack that
returns an FSM to its home state). With the second gate invisible, the conjunction
search never tried it and returned ∅ even when a two-gate conjunction genuinely
rescues the recurrence.

### The fix

When the cone-restricted axis set yields fewer than 2 axes, fall back to **all
narrow non-controllable inputs** — the same candidate set the single-`GF`
discovery already uses. Safe by construction: it only fires where the cone path
would have returned `None`; the multi-pair GR(1) realizability check and the
non-vacuity gate still guard every reported conjunction, so it cannot produce a
false positive.

### Validation

New synthetic `TWOGATE_OUT`: a two-independent-gate game whose target is a
**state-function output** `done_o = (st == 2)`. Its combinational cone is just
`st`, so the cone-restricted search sees *neither* gate input (both only drive
`st`'s next) — exercising the fallback end-to-end. Discovery now reports
`GF(e1 == 0) && GF(e2 == 0)`. Fairness suite: **10/10**.

This makes the conjunction lever handle state-function output targets (e.g. a
FIFO `full_o` that needs two gates), which it silently could not before.

*Note (no code, for the record):* the pass root-caused why `sdrc_req_gen` (a
genuine 2-independent-ack SDRAM FSM) returns ∅ — its natural target
`req_ack = req & b2r_arb_ok` is an **input-dependent** output, not a state
predicate, so `GF(req_ack)` is ill-posed in the state-based game. That is a
target-shape limitation, not a lift one; the lever-fit catalog now records the
state-predicate criterion for the fairness levers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
