### PR TITLE
fix(release): panic="unwind" so the exact-symbolic OOM backstop works in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,13 @@ required-features = ["cli"]
 [profile.release]
 lto = true
 codegen-units = 1
-panic = "abort"
+# MUST be "unwind" (NOT "abort"): the exact-symbolic BDD engine catches OxiDD
+# OutOfMemory on a too-wide cone via std::panic::catch_unwind and abstains to the
+# rest of the portfolio (see crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs).
+# `panic = "abort"` calls abort() before catch_unwind can intercept, turning that
+# sound abstain into a process SIGABRT (exit 134) in release only. A compile_error!
+# guard in mununu-core's crate root enforces this.
+panic = "unwind"
 
 [profile.dev]
 debug = true

--- a/crates/mununu-core/src/lib.rs
+++ b/crates/mununu-core/src/lib.rs
@@ -3,6 +3,20 @@
 //! Mununu core library — formal verification for reactive systems
 //! modeled as Compositional Labeled Transition Systems (CLTS).
 
+// The exact-symbolic BDD engine catches OxiDD OutOfMemory via std::panic::catch_unwind
+// (see adapter/btor2/symbolic_bitblast.rs) and abstains to the rest of the portfolio when a
+// cone is too wide to bit-blast. A `panic = "abort"` build silently defeats that backstop:
+// abort() fires before catch_unwind can intercept, turning a sound abstain into a process
+// SIGABRT on wide cones (release-only, since dev/test default to unwind). Enforce unwind at
+// compile time so the release profile can never regress this. (`cfg(panic = ...)` is stable
+// since Rust 1.60; inert under the unwind default.)
+#[cfg(panic = "abort")]
+compile_error!(
+    "mununu-core requires panic = \"unwind\" (see [profile.release] in the workspace Cargo.toml): \
+     the exact-symbolic engine relies on catch_unwind to abstain on BDD OutOfMemory; \
+     panic = \"abort\" turns that abstain into a SIGABRT."
+);
+
 pub mod abstraction;
 pub mod adapter;
 pub mod clts;


### PR DESCRIPTION
## Fix a release-only SIGABRT in the exact-symbolic BDD engine

### Symptom
`mununu btor2 verify <file>` aborted the whole process (exit 134, SIGABRT) in
**release** builds when a design's bit-blasted cone is too wide for the BDD engine
(e.g. a bit-blasted ~128-bit memory). In **debug** the identical command recovered
and returned a verdict from the rest of the portfolio.

### Root cause
The exact-symbolic engine bit-blasts the state vector into an OxiDD BDD. A cone
that doesn't compress exhausts the arena mid-build; OxiDD returns
`Err(OutOfMemory)`, the bit-blaster `.unwrap()`s it, and the resulting panic is
**by design** caught by `std::panic::catch_unwind` in
`exact_symbolic_verdict_with_witness` — converting it into a graceful *abstain* so
the other engines (native BMC / SPACER / interp) decide.

`[profile.release]` set `panic = "abort"`. With `abort`, a panic calls `abort()`
immediately and `catch_unwind` cannot intercept — so the backstop was dead in
release while it worked in debug/test (which default to `unwind`). This defeated
*every* `catch_unwind` robustness guard in the crate, not just this one.

### Fix
1. `[profile.release]`: `panic = "abort"` → `panic = "unwind"`, with a comment
   explaining the dependency.
2. A compile-time guard in `mununu-core`'s crate root:
   `#[cfg(panic = "abort")] compile_error!(...)` — so a future `panic = "abort"`
   fails the build with a clear message instead of silently re-breaking the
   backstop. (Inert under the unwind default; verified it fires under
   `-C panic=abort`.)

No verdict changes: abstaining to the portfolio is the sound behavior for the
exact engine; this only converts the abort into that abstain. The engine's
admission caps, node budget, and `catch_unwind` logic are untouched.

### Validation
- Release repro (the wide-memory fixture): **before** exit 134 (SIGABRT);
  **after** it returns `verdict: "violated"` with `reachable_by = [native, spacer,
  interp]` — `exact` **abstained** (not listed) — and exits cleanly (exit 2 = the
  verb's normal "violated" gate, no longer a process abort).
- No regression: a small counter BTOR2 still decides with `exact` in
  `reachable_by` — unchanged.
- Full workspace `make ci` (fmt + clippy -D warnings + tests) green.

### Optional follow-up (not implemented here)
The bit-count cap admits a ~128-bit *memory* cone (128 < the 192 auto-cap) even
though a memory-dominated cone reliably OOMs the BDD. A future hardening could
route memory/array-dominated cones away from exact so the common case doesn't rely
on the unwind path at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
