### PR TITLE
SVA $past depth + bounded sequences (##k / [*n]) + KMTS must⊆may soundness fixes

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -3391,7 +3391,13 @@ fn render_extract_sva_text(report: &mununu_core::adapter::slang::translate::Tran
         let shadows: Vec<String> = report
             .required_shadows
             .iter()
-            .map(|s| format!("{}({})", s.base, s.width))
+            .map(|s| {
+                if s.depth > 1 {
+                    format!("{}({}) x{} deep", s.base, s.width, s.depth)
+                } else {
+                    format!("{}({})", s.base, s.width)
+                }
+            })
             .collect();
         println!("  required __past shadow registers: {}", shadows.join(", "));
     }
@@ -3424,7 +3430,7 @@ fn render_extract_sva_json(report: &mununu_core::adapter::slang::translate::Tran
     let required_shadows: Vec<serde_json::Value> = report
         .required_shadows
         .iter()
-        .map(|s| serde_json::json!({ "base": s.base, "width": s.width }))
+        .map(|s| serde_json::json!({ "base": s.base, "width": s.width, "depth": s.depth }))
         .collect();
     let out = serde_json::json!({
         "translated": translated,

--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -1068,6 +1068,7 @@ fn apply_sampled_must_inference(
     // passes route through the STS-IR seam (AR-S2).
     use crate::adapter::btor2::smt_must_edge::{
         SmtMustVerdict, build_register_nid_map, smt_per_target_must_check,
+        smt_source_cube_proven_feasible,
     };
     let mut warnings: Vec<crate::adapter::AdapterWarning> = Vec::new();
     // R.6.6 gate — skip all post-passes under controllability-aware mode.
@@ -1079,6 +1080,48 @@ fn apply_sampled_must_inference(
         };
     }
     let approx = crate::adapter::WarningKind::ApproximateTranslation;
+
+    // SOUNDNESS (must ⊆ may fix, Tier 0) — a source cube whose predicate
+    // conjunction is UNSATISFIABLE has no concrete state, yet every must-check
+    // below fabricates a vacuous `Must` out of it (an empty `src` makes
+    // `src ∧ trans ∧ ¬tgt` trivially UNSAT). That `Sharp` edge breaks the KMTS
+    // invariant `R_must ⊆ R_may` and is the root of the false-`Violated` /
+    // `TritBdd` panic on `$past` models (past-shadow-soundness.md §6) — a cube
+    // like `din == V ∧ din__past == V'` with contradictory dimensions on one
+    // register is empty yet promotes a must-edge. Prove each candidate source
+    // cube feasible ONCE (one shared encode + z3 scope) and drop must-promotion
+    // for the proven-empty ones. `Off` promotes nothing, so it needs no check.
+    let infeasible_sources: std::collections::HashSet<usize> =
+        if matches!(must_edge_inference, MustEdgeInference::Off) {
+            std::collections::HashSet::new()
+        } else {
+            let cfg = z3::Config::new();
+            z3::with_z3_config(&cfg, || -> std::collections::HashSet<usize> {
+                let Ok(view) = encode_design_for_lift(file) else {
+                    // Encoder failure — cannot prove any cube empty. The must-checks
+                    // below re-encode and likewise promote nothing on failure, so an
+                    // empty exclusion set is consistent (nothing to gate).
+                    return std::collections::HashSet::new();
+                };
+                let nid_map = build_register_nid_map(&view);
+                sampled_targets_per_source
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, targets)| !targets.is_empty())
+                    .filter(|(src, _)| {
+                        !smt_source_cube_proven_feasible(
+                            &view,
+                            *src as u64,
+                            predicates,
+                            &nid_map,
+                            5_000,
+                        )
+                    })
+                    .map(|(src, _)| src)
+                    .collect()
+            })
+        };
+
     match must_edge_inference {
         MustEdgeInference::Off => MustInferenceOutcome {
             sharp_promoted: 0,
@@ -1097,6 +1140,10 @@ fn apply_sampled_must_inference(
                 let mut promoted = 0usize;
                 for (src_idx, targets) in sampled_targets_per_source.iter().enumerate() {
                     if targets.is_empty() {
+                        continue;
+                    }
+                    // Fix B — no vacuous must-edge out of a proven-empty cube.
+                    if infeasible_sources.contains(&src_idx) {
                         continue;
                     }
                     let src_id = state_ids[src_idx];
@@ -1153,6 +1200,8 @@ fn apply_sampled_must_inference(
             let candidates: Vec<(usize, usize)> = sampled_targets_per_source
                 .iter()
                 .enumerate()
+                // Fix B — exclude proven-empty source cubes (vacuous ∀∃ must).
+                .filter(|(src, _)| !infeasible_sources.contains(src))
                 .flat_map(|(src, targets)| targets.iter().map(move |&t| (src, t)))
                 .collect();
             let must = BtorSts::new(file).must_edges_over(predicates, &candidates, 5_000);
@@ -1199,6 +1248,8 @@ fn apply_sampled_must_inference(
             let singleton_candidates: Vec<(usize, usize)> = sampled_targets_per_source
                 .iter()
                 .enumerate()
+                // Fix B — exclude proven-empty source cubes (vacuous ∀∃ must).
+                .filter(|(src, _)| !infeasible_sources.contains(src))
                 .flat_map(|(src, targets)| targets.iter().map(move |&t| (src, t)))
                 .collect();
             let singleton_musts = sts.must_edges_over(predicates, &singleton_candidates, 5_000);
@@ -1220,7 +1271,12 @@ fn apply_sampled_must_inference(
             let hyper_may: Vec<(usize, usize)> = sampled_targets_per_source
                 .iter()
                 .enumerate()
-                .filter(|(src, targets)| !promoted_srcs.contains(src) && targets.len() > 1)
+                .filter(|(src, targets)| {
+                    !promoted_srcs.contains(src)
+                        && targets.len() > 1
+                        // Fix B — exclude proven-empty source cubes (vacuous hyper-must).
+                        && !infeasible_sources.contains(src)
+                })
                 .flat_map(|(src, targets)| targets.iter().map(move |&t| (src, t)))
                 .collect();
             let hyper_edges = sts.hyper_must_edges(predicates, &hyper_may, 5_000);
@@ -1252,6 +1308,57 @@ fn apply_sampled_must_inference(
             }
         }
     }
+}
+
+/// SOUNDNESS (must ⊆ may fix, Tier 0) — validate the KMTS invariant
+/// `R_must ⊆ R_may` on a freshly-lifted CLTS, ALWAYS (release included), not only
+/// under the debug-`assert!` in [`crate::mu_calculus::symbolic::TritBdd::from_parts`].
+///
+/// The 3-valued modal operators are sound only when every must-edge is also a
+/// may-edge (Bruns–Godefroid; see `symbolic.rs` §5 and past-shadow-soundness.md
+/// §5). Both evaluators build `R_may` from EVERY outgoing edge and `R_must` from
+/// `Sharp` ∪ `MustHyperOnly` edges (`symbolic.rs:357-377`, `evaluator.rs:20-56`),
+/// so a `Sharp` edge is trivially a may-edge and cannot break containment on its
+/// own. The one relation-level obligation that can fail is a
+/// `MustHyperOnly(src → T)` whose target set `T` is not covered by `src`'s
+/// may-successors — a hyper-must built over a candidate set that is not a subset
+/// of the emitted may-relation. Left unchecked it panics `TritBdd::from_parts` in
+/// debug and silently computes a wrong verdict in release. This runs once per lift
+/// (O(edges), SMT-free) and turns that into an honest `IrConsistencyError`.
+fn assert_must_subset_may(
+    clts: &Clts<DefaultStateIdx, DefaultLabelIdx>,
+) -> Result<(), AdapterError> {
+    use crate::clts::TransitionModality;
+    for sid in clts.states() {
+        // R_may successors of `sid` = the targets of ALL its outgoing edges
+        // (every edge contributes to R_may in both evaluators).
+        let may_succ: std::collections::HashSet<usize> = clts
+            .outgoing(sid)
+            .iter()
+            .map(|t| t.target().index())
+            .collect();
+        for t in clts.outgoing(sid) {
+            if let TransitionModality::MustHyperOnly(targets) = t.modality() {
+                for tgt in targets.iter() {
+                    if !may_succ.contains(&tgt.index()) {
+                        return Err(AdapterError {
+                            kind: crate::adapter::AdapterErrorKind::IrConsistencyError,
+                            location: None,
+                            message: format!(
+                                "adapter/btor2/kmts_lift: KMTS invariant R_must ⊆ R_may violated — \
+                                 the MustHyperOnly edge from state {} names hyper-target {} which is \
+                                 not a may-successor of it. A hyper-must target set must be a subset \
+                                 of the emitted may-relation (docs/design/past-shadow-soundness.md §6).",
+                                sid.index(),
+                                tgt.index()
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn materialize_clts_from_lazy(
@@ -1358,6 +1465,9 @@ pub fn materialize_clts_from_lazy(
         location: None,
         message: format!("adapter/btor2/materialize_clts_from_lazy: builder.build failed: {e}"),
     })?;
+
+    // Fix C — enforce R_must ⊆ R_may before the KMTS reaches any evaluator.
+    assert_must_subset_may(&clts)?;
 
     Ok(PredicateCubeLiftResult {
         clts,
@@ -2251,7 +2361,21 @@ pub fn predicate_cube_lift(
                 }
                 _ => {
                     // P1 #3 — canonical ∀∃ standard per-target must → Sharp.
-                    let must_edges = sts.must_edges(&cube_preds, 5_000);
+                    //
+                    // SOUNDNESS (must ⊆ may fix, Tier 0) — restrict the must-image to
+                    // the `may_edges` already emitted above (`must_edges_over`) instead
+                    // of the full `2^|P|×2^|P|` grid (`must_edges`). The ∀∃ must is
+                    // vacuously true out of an UNSATISFIABLE source cube (∀ over ∅), so
+                    // the all-pairs form fabricates a `Sharp` edge to a target that has
+                    // NO may-edge (the ∃-witness may-check correctly excludes an empty
+                    // src) — breaking the KMTS invariant `R_must ⊆ R_may`, which trips
+                    // `TritBdd::from_parts` (symbolic engine) and yields a spurious
+                    // `Violated` in the explicit engine (past-shadow-soundness.md §6).
+                    // `may_edges` is the emitted may-relation, so every promoted edge is
+                    // a may-edge BY CONSTRUCTION (candidates ⊆ may), and an empty src —
+                    // absent from `may_edges` — is never a candidate. Genuine ∀∃ musts
+                    // out of a satisfiable src are unaffected (∀∃ ⟹ ∃ ⟹ may).
+                    let must_edges = sts.must_edges_over(&cube_preds, &may_edges, 5_000);
                     let promoted = must_edges.len();
                     for (i, j) in must_edges {
                         builder.transition_ids_with_modality(
@@ -2266,7 +2390,7 @@ pub fn predicate_cube_lift(
                         warnings.push(crate::adapter::AdapterWarning {
                             kind: crate::adapter::WarningKind::ApproximateTranslation,
                             message: format!(
-                                "[P1 #3 may+must] predicate_cube_lift: SmtAllPairs may + SMT must composition promoted {promoted} edge(s) MayOnly → Sharp via the canonical ∀∃ must-relation (Z3-proved; sound under-approximation). The resulting KMTS carries both may (over-approx) and must (under-approx) edges, enabling sound DEFINITE 3-valued verdicts."
+                                "[P1 #3 may+must] predicate_cube_lift: SmtAllPairs may + SMT must composition promoted {promoted} edge(s) MayOnly → Sharp via the canonical ∀∃ must-relation restricted to the emitted may-edges (Z3-proved; sound under-approximation, R_must ⊆ R_may by construction). The resulting KMTS carries both may (over-approx) and must (under-approx) edges, enabling sound DEFINITE 3-valued verdicts."
                             ),
                             location: None,
                         });
@@ -2492,6 +2616,9 @@ pub fn predicate_cube_lift(
         location: None,
         message: format!("adapter/btor2/predicate_cube_lift: builder.build failed: {e}"),
     })?;
+
+    // Fix C — enforce R_must ⊆ R_may before the KMTS reaches any evaluator.
+    assert_must_subset_may(&clts)?;
 
     let elapsed = start.elapsed();
 
@@ -5757,5 +5884,192 @@ mod tests {
                 "a memory-free design must have no array cells"
             );
         });
+    }
+
+    // ---- must ⊆ may soundness fix (Tier 0) ------------------------------------
+
+    // A 2-bit counter `s` (s' = s + 1) with two predicates on the SAME register:
+    // p0 = (s == 0), p1 = (s == 1). Cube 3 (0b11) asserts `s == 0 ∧ s == 1`, which
+    // is UNSATISFIABLE — no concrete state inhabits it. Every must-check fabricates
+    // a vacuous `Must` out of such an empty cube (`src ∧ trans ∧ ¬tgt` is trivially
+    // UNSAT when `src` is UNSAT), which broke `R_must ⊆ R_may` and produced the
+    // false-`Violated` / `TritBdd` panic on `$past` models
+    // (docs/design/past-shadow-soundness.md §6). The fix drops must-promotion out of
+    // proven-empty cubes while keeping it for the feasible ones.
+    const UNSAT_CUBE_COUNTER: &str = "\
+1 sort bitvec 2
+2 state 1 s
+3 one 1
+4 add 1 2 3
+5 zero 1
+6 init 1 2 5
+7 next 1 2 4
+";
+
+    fn unsat_cube_preds() -> Vec<PredicateSpec> {
+        vec![
+            PredicateSpec {
+                name: "p0".into(),
+                register: "s".into(),
+                value: 0,
+            },
+            PredicateSpec {
+                name: "p1".into(),
+                register: "s".into(),
+                value: 1,
+            },
+        ]
+    }
+
+    fn must_edge_sources(r: &PredicateCubeLiftResult) -> std::collections::BTreeSet<usize> {
+        use crate::clts::{StateId, TransitionModality};
+        let mut set = std::collections::BTreeSet::new();
+        for i in 0..r.cube_count {
+            let sid = StateId::<DefaultStateIdx>::from_index(i).expect("state id");
+            for t in r.clts.outgoing(sid) {
+                if matches!(
+                    t.modality(),
+                    TransitionModality::Sharp | TransitionModality::MustHyperOnly(_)
+                ) {
+                    set.insert(i);
+                }
+            }
+        }
+        set
+    }
+
+    fn has_sharp_edge(r: &PredicateCubeLiftResult, from: usize, to: usize) -> bool {
+        use crate::clts::{StateId, TransitionModality};
+        let sid = StateId::<DefaultStateIdx>::from_index(from).expect("state id");
+        r.clts
+            .outgoing(sid)
+            .iter()
+            .any(|t| matches!(t.modality(), TransitionModality::Sharp) && t.target().index() == to)
+    }
+
+    #[test]
+    fn must_subset_may_no_vacuous_must_from_unsat_cube_all_pairs() {
+        // Fix A — SmtAllPairs may + the ∀∃ must restricted to the emitted may-edges.
+        let opts = PredicateCubeLiftOptions {
+            may_edge_inference: MayEdgeInference::SmtAllPairs,
+            must_edge_inference: MustEdgeInference::SmtPerTargetStandard,
+            ..Default::default()
+        };
+        let r = predicate_cube_lift(
+            unsat_cube_preds(),
+            UNSAT_CUBE_COUNTER,
+            &AdapterOptions::default(),
+            &opts,
+        )
+        .expect("lift Ok (assert_must_subset_may passed)");
+        assert_eq!(r.cube_count, 4);
+        // The unsat cube 3 sources NO must-edge (it has no may-edge to restrict to).
+        assert!(
+            !must_edge_sources(&r).contains(&3),
+            "unsat cube 3 must not source a must-edge"
+        );
+        // A feasible, deterministic cube keeps its must-edge (no over-restriction):
+        // cube 1 (s==0) → cube 2 (s==1) is the single successor.
+        assert!(
+            has_sharp_edge(&r, 1, 2),
+            "feasible cube 1 (s==0) must keep its Sharp edge to cube 2 (s==1)"
+        );
+    }
+
+    #[test]
+    fn must_subset_may_no_vacuous_must_from_unsat_cube_sampling() {
+        // Fix B — the sampling may path (default) under each SMT must mode. The
+        // canonical-representative sampler emits spurious may-edges out of the unsat
+        // cube, so the must post-pass gates on a PROVEN-feasible source rather than
+        // on the mere presence of a sampled edge.
+        for must in [
+            MustEdgeInference::SmtPerTarget,
+            MustEdgeInference::SmtPerTargetStandard,
+            MustEdgeInference::SmtHyperMust,
+        ] {
+            let opts = PredicateCubeLiftOptions {
+                may_edge_inference: MayEdgeInference::Off, // sampling
+                must_edge_inference: must,
+                ..Default::default()
+            };
+            let r = predicate_cube_lift(
+                unsat_cube_preds(),
+                UNSAT_CUBE_COUNTER,
+                &AdapterOptions::default(),
+                &opts,
+            )
+            .unwrap_or_else(|e| panic!("lift Ok for {must:?}: {}", e.message));
+            assert_eq!(r.cube_count, 4);
+            assert!(
+                !must_edge_sources(&r).contains(&3),
+                "{must:?}: unsat cube 3 must not source a must-edge"
+            );
+            assert!(
+                has_sharp_edge(&r, 1, 2),
+                "{must:?}: feasible cube 1 (s==0) must keep its Sharp edge to cube 2 (s==1)"
+            );
+        }
+    }
+
+    #[test]
+    fn assert_must_subset_may_rejects_hyper_target_outside_may() {
+        use crate::clts::TransitionModality;
+        // s0 --MustHyperOnly({s1, s2})--> primary s1 is s0's ONLY edge, so
+        // may_succ(s0) = {s1}. s2 is reachable only via s1 (s1 --MayOnly--> s2), so
+        // it is NOT a may-successor of s0 → the hyper-must breaks R_must ⊆ R_may.
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        for i in 0..3 {
+            b.state(format!("s{i}"));
+        }
+        b.initial("s0");
+        let step = b.labels().intern(["step"]).unwrap();
+        let ids: Vec<_> = (0..3)
+            .map(|i| b.state_id_or_insert(format!("s{i}")).unwrap())
+            .collect();
+        b.transition_ids_with_modality(ids[1], &[step], ids[2], TransitionModality::MayOnly);
+        let hyper: smallvec::SmallVec<[_; 4]> = smallvec::smallvec![ids[1], ids[2]];
+        b.transition_ids_with_modality(
+            ids[0],
+            &[step],
+            ids[1],
+            TransitionModality::must_hyper(hyper),
+        );
+        let clts = b.build().expect("builds");
+        let err =
+            assert_must_subset_may(&clts).expect_err("must reject the uncovered hyper target");
+        assert_eq!(
+            err.kind,
+            crate::adapter::AdapterErrorKind::IrConsistencyError
+        );
+        assert!(err.message.contains("R_must ⊆ R_may"));
+    }
+
+    #[test]
+    fn assert_must_subset_may_accepts_covered_hyper() {
+        use crate::clts::TransitionModality;
+        // Same shape, but a MayOnly s0 → s2 makes both hyper targets may-successors
+        // of s0 (the primary s1 via the hyper edge itself, s2 via the may-edge).
+        let mut b = Clts::<DefaultStateIdx, DefaultLabelIdx>::builder();
+        for i in 0..3 {
+            b.state(format!("s{i}"));
+        }
+        b.initial("s0");
+        let step = b.labels().intern(["step"]).unwrap();
+        let ids: Vec<_> = (0..3)
+            .map(|i| b.state_id_or_insert(format!("s{i}")).unwrap())
+            .collect();
+        b.transition_ids_with_modality(ids[0], &[step], ids[2], TransitionModality::MayOnly);
+        let hyper: smallvec::SmallVec<[_; 4]> = smallvec::smallvec![ids[1], ids[2]];
+        b.transition_ids_with_modality(
+            ids[0],
+            &[step],
+            ids[1],
+            TransitionModality::must_hyper(hyper),
+        );
+        let clts = b.build().expect("builds");
+        assert!(
+            assert_must_subset_may(&clts).is_ok(),
+            "a hyper-must whose targets are all may-successors is well-formed"
+        );
     }
 }

--- a/crates/mununu-core/src/adapter/btor2/shadow.rs
+++ b/crates/mununu-core/src/adapter/btor2/shadow.rs
@@ -1,30 +1,36 @@
-//! XL.3b — BTOR2 1-step `__past` shadow-register synthesis (Tier-2 SVA history).
+//! XL.3b — BTOR2 `__past` shadow shift-register synthesis (Tier-2 SVA history).
 //!
 //! The slang translator (XL.3a) lowers `$past`/`$stable`/`$changed`/`$rose`/
-//! `$fell` to atoms over a shadow signal `<base>__past`, and reports the needed
-//! base signals in [`crate::adapter::slang::translate::TranslationReport::required_shadows`].
+//! `$fell` to atoms over shadow signals `<base>__past`, `<base>__past2`, … and
+//! reports the needed base signals — with the deepest history depth each — in
+//! [`crate::adapter::slang::translate::TranslationReport::required_shadows`].
 //! This module is the model half of that contract: it augments the BTOR2 design
-//! with a 1-step flop per base so those atoms bind.
+//! with a `depth`-stage shift register per base so those atoms bind.
 //!
-//! For each base `b` resolving to a state cell **or a primary input** of sort
-//! `S`, the augmentation appends (with fresh NIDs above the current max):
+//! For each base `b` at depth `k`, resolving to a state cell **or a primary
+//! input** of sort `S`, the augmentation appends a `k`-stage chain (with fresh
+//! NIDs above the current max):
 //!
 //! ```text
-//! <n1> state <S> b__past
-//! <n2> next  <S> <n1> <b_nid>          ; next(b__past) = b  → b__past(t+1) = b(t)
-//! <n3> init  <S> <n1> <b_init_value>   ; only when b itself has an init
+//! <s1> state <S> b__past                ; b, one cycle ago
+//! <n1> next  <S> <s1> <b_nid>           ; next(b__past)  = b
+//! <s2> state <S> b__past2               ; b, two cycles ago
+//! <n2> next  <S> <s2> <s1>              ; next(b__past2) = b__past
+//! …                                     ; up to b__past{k}
+//! <i>  init  <S> <sj> <b_init_value>    ; each stage — see below
 //! ```
 //!
-//! `next(b__past) = b` makes `b__past` hold `b`'s previous-cycle value at every
-//! cycle ≥ 1. The `init` mirrors `b`'s own reset value, so at cycle 0
-//! `b__past == b`, making `$stable` true / `$rose`/`$fell` false at the first
-//! cycle — the standard "no history before the first clock edge" convention.
+//! `next(b__pastⱼ) = b__past(ⱼ₋₁)` (stage 1 samples `b`) makes `b__pastⱼ` hold
+//! `b`'s value `j` cycles ago at every cycle ≥ `j`. Each stage's `init` mirrors
+//! `b`'s own reset value, so before the chain has filled (cycles `< j` for stage
+//! `j`) `$past(b, j)` reads that reset value — the standard "no history before
+//! the first clock edges" convention, generalised from 1 cycle to `k`. Depth 1
+//! keeps the historical bare `b__past` name (backward compatible).
 //!
-//! A **primary input** base gets the same flop with no `init`: an input has no
-//! reset value to mirror, so `b__past` is unconstrained at cycle 0. That is the
-//! faithful reading of `$past` before the first clock edge, which SVA leaves
-//! undefined. It also matters in practice — `$past` of an input is what every
-//! data-integrity property is written over:
+//! A **primary input** base has no reset value to mirror, so every stage is
+//! pinned to an explicit zero (see the SOUNDNESS note in
+//! [`augment_with_past_shadows`] for why zero, not free). It matters in practice
+//! — `$past` of an input is what every data-integrity property is written over:
 //!
 //! ```systemverilog
 //! (push && !pop && cnt_q == 0) |=> (d0_q == $past(din))
@@ -47,19 +53,37 @@ use crate::adapter::btor2::ast::{Btor2File, Nid, Node, Operand};
 use crate::adapter::btor2::parser;
 use crate::adapter::{AdapterError, AdapterErrorKind};
 
-/// Augment BTOR2 `content` with a 1-step `<base>__past` shadow flop for each
-/// base signal in `bases`. Returns the augmented BTOR2 text.
+/// The stage-`stage` shadow name for a base — the XL.3 naming contract shared
+/// with the translator's `slang::translate::past_shadow_name`. Stage 1 keeps the
+/// historical bare `<base>__past` (backward compatible); stage `k ≥ 2` is
+/// `<base>__past{k}`. The two functions MUST agree — they are the two halves of
+/// one contract (`$past(x, k)` lowers to `x__pastk`, which this chain provides).
+fn shadow_stage_name(base: &str, stage: u32) -> String {
+    if stage <= 1 {
+        format!("{base}__past")
+    } else {
+        format!("{base}__past{stage}")
+    }
+}
+
+/// Augment BTOR2 `content` with a `depth`-stage `<base>__past` shadow shift chain
+/// for each `(base, depth)` in `bases`. Returns the augmented BTOR2 text.
 ///
-/// - A base that already has a `<base>__past` state is skipped (idempotent), so
-///   re-augmenting is a no-op.
-/// - A base resolves to a state cell or a primary input. A state cell's `init`
-///   is mirrored onto the shadow; an input has none to mirror, so its shadow is
-///   unconstrained at cycle 0 (SVA leaves `$past` undefined there).
+/// - A base that already has a stage-1 `<base>__past` state is skipped
+///   (idempotent, so re-augmenting the same base is a no-op); this assumes the
+///   prior augmentation used a depth ≥ this one, which the caller guarantees by
+///   passing each base once with its deepest required depth.
+/// - A base resolves to a state cell or a primary input. Every stage mirrors the
+///   state cell's `init`; an input has none to mirror, so every stage is pinned
+///   to zero (SVA leaves `$past` undefined before the first `k` clock edges).
 /// - A base that resolves to neither is an error (the `$past`/`$stable` atom
 ///   would never bind) — never silently dropped.
-/// - `bases` is deduplicated internally; order of appended flops follows first
-///   appearance.
-pub fn augment_with_past_shadows(content: &str, bases: &[&str]) -> Result<String, AdapterError> {
+/// - `bases` is deduplicated by name internally; order of appended chains follows
+///   first appearance.
+pub fn augment_with_past_shadows(
+    content: &str,
+    bases: &[(&str, u32)],
+) -> Result<String, AdapterError> {
     if bases.is_empty() {
         return Ok(content.to_string());
     }
@@ -80,23 +104,24 @@ pub fn augment_with_past_shadows(content: &str, bases: &[&str]) -> Result<String
     let mut appended: Vec<String> = Vec::new();
     let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
 
-    for &base in bases {
+    for &(base, depth) in bases {
         if !seen.insert(base) {
             continue; // dedup repeated bases
         }
-        let shadow_symbol = format!("{base}__past");
-        if existing_state_symbols.contains(shadow_symbol.as_str()) {
+        let depth = depth.max(1);
+        let stage1_symbol = shadow_stage_name(base, 1);
+        if existing_state_symbols.contains(stage1_symbol.as_str()) {
             continue; // already augmented — idempotent
         }
 
         // A base is either a state cell or a primary input. Both are legitimate
-        // `$past` sources and both produce the same `next(shadow) = source`
-        // flop; they differ only in where the shadow's cycle-0 value comes from.
+        // `$past` sources and both produce the same `next(shadow) = source` shift;
+        // they differ only in where each shadow stage's cycle-0 value comes from.
         let source = resolve_shadow_source(&file, base).ok_or_else(|| AdapterError {
             kind: AdapterErrorKind::UnsupportedConstruct,
             message: format!(
                 "adapter/btor2/shadow: base signal `{base}` resolves to neither a BTOR2 state \
-                 cell nor a primary input, so its `{shadow_symbol}` shadow flop cannot be \
+                 cell nor a primary input, so its `{stage1_symbol}` shadow chain cannot be \
                  synthesised (the Tier-2 history atom would never bind). Check the SVA signal \
                  name matches a register or a module input."
             ),
@@ -108,8 +133,9 @@ pub fn augment_with_past_shadows(content: &str, bases: &[&str]) -> Result<String
         // so the zero an input shadow inits from is allocated FIRST — everything
         // appended here sits above every pre-existing NID, and allocating it after
         // the state would emit a model the external oracle rejects while mununu's
-        // own order-agnostic parser read it happily. A state cell's init needs no
-        // such care: it reuses the source's own value node, already far below.
+        // own order-agnostic parser read it happily. One zero is shared by every
+        // stage. A state cell's init needs no such care: it reuses the source's
+        // own value node, already far below.
         let mut zero_nid = None;
         if matches!(source, ShadowSource::PrimaryInput { .. }) {
             zero_nid = Some(next_nid);
@@ -117,76 +143,89 @@ pub fn augment_with_past_shadows(content: &str, bases: &[&str]) -> Result<String
             next_nid += 1;
         }
 
-        let shadow_state = next_nid;
-        next_nid += 1;
-        let shadow_next = next_nid;
-        next_nid += 1;
+        // The init value every stage mirrors: the state cell's own init (or none);
+        // computed once, reused across all stages of the chain.
+        let source_init = match source {
+            ShadowSource::StateCell { nid, .. } => file.lines.iter().find_map(|l| match &l.node {
+                Node::Init { state, value, .. } if *state == nid => Some(*value),
+                _ => None,
+            }),
+            ShadowSource::PrimaryInput { .. } => None,
+        };
 
-        appended.push(format!("{shadow_state} state {sort_nid} {shadow_symbol}"));
-        // next(shadow) = source's current value (referenced by the source NID).
-        appended.push(format!(
-            "{shadow_next} next {sort_nid} {shadow_state} {}",
-            source.nid()
-        ));
+        // Build the shift chain: stage 1 samples the source; stage j (j ≥ 2)
+        // samples stage j-1, so stage j holds the source's value j cycles ago.
+        let mut prev_value_nid = source.nid();
+        for stage in 1..=depth {
+            let symbol = shadow_stage_name(base, stage);
+            let shadow_state = next_nid;
+            next_nid += 1;
+            let shadow_next = next_nid;
+            next_nid += 1;
+            appended.push(format!("{shadow_state} state {sort_nid} {symbol}"));
+            // next(stageⱼ) = stage(ⱼ₋₁)'s current value (stage 1 = the source).
+            appended.push(format!(
+                "{shadow_next} next {sort_nid} {shadow_state} {prev_value_nid}"
+            ));
 
-        match source {
-            // Mirror the state cell's init so cycle 0 has `shadow == source` — the
-            // "no history before the first clock edge" convention. A source with
-            // no init leaves the shadow init-less too, which keeps the pair
-            // consistent under whatever a given engine does with an init-less
-            // cell: they move together or not at all.
-            ShadowSource::StateCell { nid, .. } => {
-                let source_init = file.lines.iter().find_map(|l| match &l.node {
-                    Node::Init { state, value, .. } if *state == nid => Some(*value),
-                    _ => None,
-                });
-                if let Some(init) = source_init {
+            match source {
+                // Mirror the state cell's init onto EVERY stage, so before the
+                // chain fills (cycles < j for stage j) `$past(b, j)` reads b's
+                // reset value — the "no history before the first clock edges"
+                // convention, generalised from 1 cycle to k. A source with no
+                // init leaves the stage init-less too, keeping the pair consistent
+                // under whatever a given engine does with an init-less cell.
+                ShadowSource::StateCell { .. } => {
+                    if let Some(init) = source_init {
+                        let shadow_init = next_nid;
+                        next_nid += 1;
+                        appended.push(format!(
+                            "{shadow_init} init {sort_nid} {shadow_state} {}",
+                            operand_text(init)
+                        ));
+                    }
+                }
+
+                // SOUNDNESS: an input has no init to mirror, so each stage's
+                // pre-fill value is CHOSEN — pinned to zero rather than left free.
+                //
+                // Free would be the more faithful reading of SVA, where `$past` is
+                // undefined before the first clock edges. It is not a choice this
+                // adapter can make: an init-less state cell means different things
+                // to different engines. The cube and exact engines default it to 0
+                // (`state_cell_init_values` / `initial_state_bdd`, per the
+                // `setundef -zero` power-up); the reachability portfolio leaves it
+                // FREE, per BTOR2's nondeterministic-init semantics. That is
+                // exactly the verdict DISAGREEMENT `reset_init::inject_zero_init`
+                // exists to close — and it cannot close this one, because it runs
+                // on the pre-augmentation BTOR2, before this appends the shadow. A
+                // free shadow would escape the mitigation by construction.
+                //
+                // What is given up is bounded, and observable in only one shape.
+                // The lift puts a `|=>` consequent under a `[]`, so it is evaluated
+                // only at states with a predecessor. For depth 1 that fully hides
+                // the invented value; for depth k the chain takes k cycles to
+                // fill, so a `$past(input, k)` under a single `[]` still reads the
+                // invented zero for the first k-1 cycles after reset (an over-
+                // approximation bounded to those cycles). A `|->` consequent reads
+                // it at the initial state too. Every later cycle is exact — a real
+                // added flop, not an abstraction. Pinning matches the power-up the
+                // rest of the adapter already assumes, so every engine decides one
+                // model.
+                //
+                // Full argument, per-engine ledger, and why no engine may assume
+                // stutter equivalence here: docs/design/past-shadow-soundness.md
+                ShadowSource::PrimaryInput { .. } => {
+                    let zero = zero_nid.expect("an input source allocates its zero above");
                     let shadow_init = next_nid;
                     next_nid += 1;
                     appended.push(format!(
-                        "{shadow_init} init {sort_nid} {shadow_state} {}",
-                        operand_text(init)
+                        "{shadow_init} init {sort_nid} {shadow_state} {zero}"
                     ));
                 }
             }
 
-            // SOUNDNESS: an input has no init to mirror, so the shadow's cycle-0
-            // value is CHOSEN — pinned to zero rather than left free.
-            //
-            // Free would be the more faithful reading of SVA, where `$past` is
-            // undefined before the first clock edge. It is not a choice this
-            // adapter can make: an init-less state cell means different things to
-            // different engines. The cube and exact engines default it to 0
-            // (`state_cell_init_values` / `initial_state_bdd`, per the
-            // `setundef -zero` power-up); the reachability portfolio leaves it
-            // FREE, per BTOR2's nondeterministic-init semantics. That is exactly
-            // the verdict DISAGREEMENT `reset_init::inject_zero_init` exists to
-            // close — and it cannot close this one, because it runs on the
-            // pre-augmentation BTOR2, before `augment_with_past_shadows` appends
-            // the shadow. A free shadow would escape the mitigation by
-            // construction.
-            //
-            // What is given up is bounded, and observable in only one shape. The
-            // lift puts a `|=>` consequent under a `[]`, so it is evaluated only
-            // at states that HAVE a predecessor — where the shadow holds a value
-            // the design actually drove. A `|->` consequent is evaluated at the
-            // initial state too, and there it reads this invented zero. So every
-            // data-integrity property (`|=>` by construction) is unaffected; a
-            // `|->` over `$past` of an input is not, and its cycle-0 verdict does
-            // not transfer to hardware. Every later cycle is exact — a real added
-            // flop, not an abstraction. Pinning also matches the power-up the rest
-            // of the adapter already assumes, so every engine decides one model.
-            //
-            // Full argument, per-engine ledger, and why no engine may assume
-            // stutter equivalence here: docs/design/past-shadow-soundness.md
-            ShadowSource::PrimaryInput { .. } => {
-                let zero = zero_nid.expect("an input source allocates its zero above");
-                let shadow_init = next_nid;
-                next_nid += 1;
-                appended.push(format!(
-                    "{shadow_init} init {sort_nid} {shadow_state} {zero}"
-                ));
-            }
+            prev_value_nid = shadow_state; // the next stage samples this stage
         }
     }
 
@@ -324,7 +363,7 @@ mod tests {
 
     #[test]
     fn augment_appends_state_next_init_for_a_base() {
-        let out = augment_with_past_shadows(COUNTER, &["s"]).expect("augments");
+        let out = augment_with_past_shadows(COUNTER, &[("s", 1)]).expect("augments");
         let file = parser::parse(&out).expect("augmented btor2 parses");
         let symbols = parser::collect_symbols(&file);
         // A new state `s__past` of the same sort (1) exists.
@@ -362,7 +401,7 @@ mod tests {
     fn shadow_captures_previous_cycle_value() {
         // The soundness proof: after one step from s = 5, the shadow holds 5
         // (s's *previous* value) while s advances to 6.
-        let out = augment_with_past_shadows(COUNTER, &["s"]).expect("augments");
+        let out = augment_with_past_shadows(COUNTER, &[("s", 1)]).expect("augments");
         let file = parser::parse(&out).expect("parse");
         let regs = HashMap::from([("s".to_string(), 5u128)]);
         let next =
@@ -380,13 +419,84 @@ mod tests {
     fn cycle0_shadow_equals_source_init() {
         // init mirroring makes $stable true at cycle 0: with s reset to 0, the
         // shadow also resets to 0, so `s == s__past` holds at the first cycle.
-        let out = augment_with_past_shadows(COUNTER, &["s"]).expect("augments");
+        let out = augment_with_past_shadows(COUNTER, &[("s", 1)]).expect("augments");
         let file = parser::parse(&out).expect("parse");
         // honor_init: read the init values both cells reset to.
         let s_init = init_value(&file, "s");
         let shadow_init = init_value(&file, "s__past");
         assert_eq!(s_init, shadow_init, "shadow init mirrors source init");
         assert_eq!(s_init, Some(0));
+    }
+
+    #[test]
+    fn augment_builds_a_k_stage_chain_for_depth_gt_1() {
+        // `$past(s, 3)` needs a 3-stage shift chain: s__past ← s, s__past2 ←
+        // s__past, s__past3 ← s__past2. Verify the stage names, the chain wiring,
+        // and that each stage mirrors the source's init (so `$past(s, j)` reads
+        // the reset value before the chain fills).
+        let out = augment_with_past_shadows(COUNTER, &[("s", 3)]).expect("augments depth 3");
+        let file = parser::parse(&out).expect("augmented btor2 parses");
+        let symbols = parser::collect_symbols(&file);
+        let state_nid = |sym: &str| -> Option<Nid> {
+            file.lines.iter().find_map(|l| match &l.node {
+                Node::State { .. } if symbols.get(&l.nid).map(String::as_str) == Some(sym) => {
+                    Some(l.nid)
+                }
+                _ => None,
+            })
+        };
+        let src = state_nid("s").expect("source s");
+        let s1 = state_nid("s__past").expect("stage 1 = s__past");
+        let s2 = state_nid("s__past2").expect("stage 2 = s__past2");
+        let s3 = state_nid("s__past3").expect("stage 3 = s__past3");
+        // Chain wiring: next(s__past)=s, next(s__past2)=s__past, next(s__past3)=s__past2.
+        let next_of = |state: Nid| -> Option<Nid> {
+            file.lines.iter().find_map(|l| match &l.node {
+                Node::Next {
+                    state: st, value, ..
+                } if *st == state => Some(value.nid()),
+                _ => None,
+            })
+        };
+        assert_eq!(next_of(s1), Some(src), "next(s__past) = s");
+        assert_eq!(next_of(s2), Some(s1), "next(s__past2) = s__past");
+        assert_eq!(next_of(s3), Some(s2), "next(s__past3) = s__past2");
+        // Every stage mirrors the source's init (s resets to 0), so each reads the
+        // reset value before its own history has accrued.
+        for stage in ["s__past", "s__past2", "s__past3"] {
+            assert_eq!(
+                init_value(&file, stage),
+                Some(0),
+                "{stage} must mirror the source init"
+            );
+        }
+        // Stage 1 captures the source after one step (deeper stages fill later).
+        use std::collections::HashMap;
+        let regs = HashMap::from([("s".to_string(), 5u128)]);
+        let nxt =
+            crate::adapter::btor2::bit_blast::simulate_one_step(&file, &regs, &HashMap::new())
+                .expect("simulate");
+        assert_eq!(nxt.get("s__past").copied(), Some(5), "stage 1 took s");
+    }
+
+    #[test]
+    fn depth_1_is_backward_compatible_with_the_bare_name() {
+        // Depth 1 must still emit exactly `s__past` (no suffix) — the name every
+        // pre-existing model and `$stable`/`$rose`/`$fell` lowering depends on.
+        let out = augment_with_past_shadows(COUNTER, &[("s", 1)]).expect("augments");
+        let file = parser::parse(&out).expect("parses");
+        let symbols = parser::collect_symbols(&file);
+        let names: std::collections::HashSet<&str> = file
+            .lines
+            .iter()
+            .filter(|l| matches!(l.node, Node::State { .. }))
+            .filter_map(|l| symbols.get(&l.nid).map(String::as_str))
+            .collect();
+        assert!(names.contains("s__past"), "depth 1 = bare s__past");
+        assert!(
+            !names.contains("s__past1"),
+            "depth 1 must NOT emit a suffixed s__past1"
+        );
     }
 
     // A design whose only `$past` source is a primary INPUT:
@@ -401,7 +511,8 @@ mod tests {
         // The case that made every data-integrity property unverifiable: the
         // translator asks for `din__past`, and before this the augmentation
         // refused because `din` is an input rather than a state cell.
-        let out = augment_with_past_shadows(INPUT_SOURCE, &["din"]).expect("input base accepted");
+        let out =
+            augment_with_past_shadows(INPUT_SOURCE, &[("din", 1)]).expect("input base accepted");
         let file = parser::parse(&out).expect("augmented model parses");
         let symbols = parser::collect_symbols(&file);
 
@@ -437,7 +548,7 @@ mod tests {
         // exists to prevent — and that pass runs before this one, so it cannot
         // cover a shadow appended afterwards. Pinning here is what keeps the
         // engines deciding the same model.
-        let out = augment_with_past_shadows(INPUT_SOURCE, &["din"]).expect("augment");
+        let out = augment_with_past_shadows(INPUT_SOURCE, &[("din", 1)]).expect("augment");
         let file = parser::parse(&out).expect("parse");
         assert_eq!(
             init_value(&file, "din__past"),
@@ -453,7 +564,7 @@ mod tests {
         // model that reads fine in-process and is rejected by the external oracle
         // — a disagreement that would surface as a portfolio failure, not as a
         // parse error here.
-        let out = augment_with_past_shadows(INPUT_SOURCE, &["din"]).expect("augment");
+        let out = augment_with_past_shadows(INPUT_SOURCE, &[("din", 1)]).expect("augment");
         let file = parser::parse(&out).expect("parse");
         let symbols = parser::collect_symbols(&file);
         let shadow_nid = file
@@ -483,7 +594,7 @@ mod tests {
         // walk were tried first, that distant `q` would shadow the wrong signal
         // while an `input` line carries the name exactly. Exact beats fuzzy.
         let aliased = "1 sort bitvec 8\n                       2 input 1 din\n                       3 state 1 q\n                       4 next 1 3 2\n                       5 output 3 din\n";
-        let out = augment_with_past_shadows(aliased, &["din"]).expect("augment");
+        let out = augment_with_past_shadows(aliased, &[("din", 1)]).expect("augment");
         let file = parser::parse(&out).expect("parse");
         let symbols = parser::collect_symbols(&file);
         let shadow_nid = file
@@ -505,7 +616,7 @@ mod tests {
         // symbol-distance heuristic stays authoritative when a name could
         // mean either.
         let both = "1 sort bitvec 8\n2 input 1 s\n3 state 1 s\n4 next 1 3 2\n";
-        let out = augment_with_past_shadows(both, &["s"]).expect("augment");
+        let out = augment_with_past_shadows(both, &[("s", 1)]).expect("augment");
         let file = parser::parse(&out).expect("parse");
         let symbols = parser::collect_symbols(&file);
         let state_nid = file
@@ -532,7 +643,8 @@ mod tests {
 
     #[test]
     fn missing_base_is_an_error_not_silent() {
-        let err = augment_with_past_shadows(COUNTER, &["nonexistent"]).expect_err("must error");
+        let err =
+            augment_with_past_shadows(COUNTER, &[("nonexistent", 1)]).expect_err("must error");
         assert_eq!(err.kind, AdapterErrorKind::UnsupportedConstruct);
         // Asserts the INTENT — the message names the signal and says it did
         // not resolve — rather than an exact phrase. The wording changed when
@@ -547,8 +659,8 @@ mod tests {
 
     #[test]
     fn augmentation_is_idempotent() {
-        let once = augment_with_past_shadows(COUNTER, &["s"]).expect("augment 1");
-        let twice = augment_with_past_shadows(&once, &["s"]).expect("augment 2");
+        let once = augment_with_past_shadows(COUNTER, &[("s", 1)]).expect("augment 1");
+        let twice = augment_with_past_shadows(&once, &[("s", 1)]).expect("augment 2");
         assert_eq!(once, twice, "re-augmenting an existing shadow is a no-op");
     }
 
@@ -564,7 +676,7 @@ mod tests {
         // evaluator's on-demand `s == s__past` ($stable) comparison atom binds
         // against the lifted Clts. (8 state bits — well under MAX_STATE_BITS.)
         use crate::adapter::AdapterOptions;
-        let out = augment_with_past_shadows(COUNTER, &["s"]).expect("augment");
+        let out = augment_with_past_shadows(COUNTER, &[("s", 1)]).expect("augment");
         let lifted = crate::adapter::btor2::bit_blast::translate(&out, &AdapterOptions::default())
             .expect("bit-blast lift of the augmented model");
         let has_shadow = lifted

--- a/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
+++ b/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
@@ -237,6 +237,63 @@ where
     }
 }
 
+/// Is the source cube's predicate conjunction PROVEN satisfiable: `∃ s. ⋀_i src_i`?
+///
+/// Returns `true` only when Z3 finds a concrete state satisfying every source
+/// predicate of the cube (`SatResult::Sat`). An **infeasible** (empty) cube
+/// (`Unsat`) corresponds to no concrete state, and the concrete transition
+/// relation is total — so the must-checks ([`smt_per_target_must_check`] and the
+/// STS-IR seam's ∀∃ / hyper forms) all fabricate a vacuous `Must` out of it
+/// (`src ∧ trans ∧ ¬tgt` is trivially UNSAT when `src` is UNSAT). That vacuous
+/// `Sharp` edge is the root of the R.2.5b false-`Violated` / `TritBdd` panic on
+/// `$past` models (`docs/design/past-shadow-soundness.md` §6): a cube like
+/// `din == V ∧ din__past == V'` with contradictory dimensions on one register is
+/// empty, yet promotes a must-edge. Callers gate must-promotion on this check so
+/// no must-edge is created out of a proven-empty cube.
+///
+/// SOUNDNESS — the conservative direction is **not** to promote. `Unsat` (proven
+/// empty) and `Unknown` / an unresolved predicate register (cannot prove feasible)
+/// both return `false`: dropping a must-edge is always sound (must is an
+/// under-approximation used by diamonds and refutation; fewer must-edges can only
+/// weaken a definite verdict to ⊥, never flip it). Cube feasibility is a small
+/// quantifier-free BV/AUFBV query, so `Unknown` is vanishingly rare in practice.
+///
+/// **Caller must hold a [`z3::with_z3_config`] scope.**
+pub fn smt_source_cube_proven_feasible<P>(
+    view: &Btor2SmtView,
+    src_bits: u64,
+    predicates: &[P],
+    nid_map: &HashMap<String, Nid>,
+    timeout_ms: u32,
+) -> bool
+where
+    P: PredicateLike,
+{
+    let mut src_constraints: Vec<z3::ast::Bool> = Vec::new();
+    for (i, pred) in predicates.iter().enumerate() {
+        let polarity = (src_bits >> i) & 1 == 1;
+        // An unresolved register — cannot prove feasible; conservatively drop
+        // (the must-check itself already returns Unknown for the same reason).
+        let Some(c) = build_pred_constraint(view, nid_map, pred, false, polarity) else {
+            return false;
+        };
+        src_constraints.push(c);
+    }
+
+    let solver = z3::Solver::new();
+    let mut params = z3::Params::new();
+    params.set_u32("timeout", timeout_ms);
+    if let Some(rl) = cube_smt_rlimit() {
+        params.set_u32("rlimit", rl);
+    }
+    solver.set_params(&params);
+    for c in &src_constraints {
+        solver.assert(c);
+    }
+    // Only a definite SAT proves the cube non-empty; Unsat / Unknown → drop.
+    matches!(solver.check(), z3::SatResult::Sat)
+}
+
 /// Tiny trait surface so the must-edge check can consume either
 /// `PredicateSpec` (from `kmts_lift`) or test-local predicate types
 /// without taking on a kmts_lift dependency here.

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -1029,43 +1029,69 @@ impl BddBitBlaster {
             .unwrap();
 
         // The FEASIBLE present cubes `∃x. A(x,p)` — the cubes some concrete
-        // register state inhabits. Used to restrict `R_must` (below) and to
-        // scope the verdict tally (R-F5.4.2) to materialisable abstract states.
+        // register state inhabits. Used to restrict `R_must` (below) and to scope
+        // the verdict tally (R-F5.4.2) to materialisable abstract states. Kept as
+        // `reg_cube` (unchanged) — the two-player GAME relation depends on this
+        // exact value; the input-predicate hazard is handled by disabling `R_must`
+        // on the standard path (below), not by re-scoping `feasible_present`.
         let feasible_present = a.exists(&reg_cube).unwrap();
 
-        // R_must, when requested. `A → φ` is `¬A ∨ φ`.
+        // SOUNDNESS (must ⊆ may fix, symbolic engine) — must-edges are DISABLED
+        // (may-only, `r_must = None`) when a predicate is over an INPUT.
         //
-        // A vacuously-empty (unsatisfiable) source cube yields `¬A ≡ ⊤` there,
-        // so the ∀ would make it a must-edge to *every* cube — breaking the KMTS
-        // invariant `R_must ⊆ R_may` (an empty cube has no may-edge). We
-        // intersect with `feasible_present`: must-edges only leave inhabited
-        // abstract states (the lift never materialises an infeasible cube), so
-        // `R_must ⊆ R_may` holds globally over the whole `2^k` cube space —
-        // which the R-F5.4.1 evaluator relies on (`box.must ⊆ box.may`).
-        let r_must = must.map(|sem| {
-            let raw = match sem {
-                MustSemantics::ForallExists => {
-                    // ∀x. ( A(x,p) → ∃i. A'(x,i,p') )
-                    let exists_i = a_prime.exists(&input_cube).unwrap();
-                    a.not()
-                        .unwrap()
-                        .or(&exists_i)
-                        .unwrap()
-                        .forall(&reg_cube)
-                        .unwrap()
-                }
-                MustSemantics::ForallForall => {
-                    // ∀(x ∪ i). ( A(x,p) → A'(x,i,p') )
-                    a.not()
-                        .unwrap()
-                        .or(&a_prime)
-                        .unwrap()
-                        .forall(&xi_cube)
-                        .unwrap()
-                }
-            };
-            raw.and(&feasible_present).unwrap()
-        });
+        // An input is both a present *observable* (the predicate reads it) and the
+        // transition *nondeterminism* (the ∃-input in the ∀∃ must-edge) — the same
+        // conflation that makes the exact ROBDD engine refuse an input atom. Here
+        // it leaves the constructed `raw` must-relation with input vars in its
+        // support, so `R_must ⊄ R_may` and `box.must ⊄ box.may` trips
+        // `TritBdd::from_parts` (a debug panic; a wrong verdict in release). Rather
+        // than fabricate a must-edge whose semantics are ill-defined, fall back to
+        // the may-only KMTS: definite HOLDS still transfers (may over-approximation
+        // + safety), and a refutation lands on ⊥ — the honest "abstraction can't
+        // decide", never a spurious VIOLATED. `A` depends on an input iff
+        // quantifying inputs changes feasibility.
+        //
+        // This applies ONLY to the standard (`Control::All`) relation, where inputs
+        // are demonic transition nondeterminism and box_pre trips on the dirty
+        // support. The TWO-PLAYER GAME relation (`controllable.is_some()`) models
+        // inputs explicitly as env/ctrl moves and *requires* `r_must` for the
+        // controllable predecessor (`AbstractRelation::evaluate`); it does not go
+        // through the box_pre panic, so it keeps its must-relation unchanged.
+        let inputs_in_predicates = feasible_present != a.exists(&xi_cube).unwrap();
+        let r_must = if inputs_in_predicates && controllable.is_none() {
+            None
+        } else {
+            must.map(|sem| {
+                let raw = match sem {
+                    MustSemantics::ForallExists => {
+                        // ∀x. ( A(x,p) → ∃i. A'(x,i,p') )
+                        let exists_i = a_prime.exists(&input_cube).unwrap();
+                        a.not()
+                            .unwrap()
+                            .or(&exists_i)
+                            .unwrap()
+                            .forall(&reg_cube)
+                            .unwrap()
+                    }
+                    MustSemantics::ForallForall => {
+                        // ∀(x ∪ i). ( A(x,p) → A'(x,i,p') )
+                        a.not()
+                            .unwrap()
+                            .or(&a_prime)
+                            .unwrap()
+                            .forall(&xi_cube)
+                            .unwrap()
+                    }
+                };
+                // A vacuously-empty (unsatisfiable) source cube yields `¬A ≡ ⊤`
+                // there, so the ∀ would make it a must-edge to *every* cube —
+                // breaking `R_must ⊆ R_may` (an empty cube has no may-edge).
+                // Intersecting with `feasible_present` keeps must-edges leaving
+                // only inhabited cubes, so `R_must ⊆ R_may` holds globally over
+                // the `2^k` cube space (the R-F5.4.1 evaluator relies on it).
+                raw.and(&feasible_present).unwrap()
+            })
+        };
 
         // P2.5-F — retain the concrete game pieces when a controllable partition was requested.
         let game = controllable.map(|_| GamePieces {

--- a/crates/mununu-core/src/adapter/slang/translate.rs
+++ b/crates/mununu-core/src/adapter/slang/translate.rs
@@ -100,13 +100,19 @@ pub struct UnsupportedAssertion {
 
 /// XL.3 (Tier-2): a base signal whose previous-cycle value a translated
 /// assertion needs. The BTOR2 model-augmentation step (XL.3b) must synthesise a
-/// 1-step shadow flop named `<base>__past` of this width — `next(<base>__past)
-/// = <base>` — so the `<base>__past` atoms the translator emits actually bind.
+/// `depth`-stage shadow shift chain for it — `next(<base>__past) = <base>`,
+/// `next(<base>__past2) = <base>__past`, … up to `<base>__past{depth}` — so the
+/// shadow atoms the translator emits (`past_shadow_name(base, k)` for every
+/// `k <= depth`) actually bind. `depth` is the DEEPEST history any assertion
+/// reads for this base; the chain covers every shallower `$past(base, j)` too.
 /// Reported only for *successfully* translated assertions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShadowSignal {
     pub base: String,
     pub width: u32,
+    /// Deepest `$past` depth read for `base` (1 for `$stable`/`$rose`/… and
+    /// bare `$past(base)`; `k` for `$past(base, k)`).
+    pub depth: u32,
 }
 
 /// A reset signal recognized in a `disable iff (...)` guard: the input to pin
@@ -346,18 +352,31 @@ fn resolve_enum_refs(node: &Value, enums: &std::collections::HashMap<String, i64
 fn collect_shadow_signals(node: &Value, out: &mut Vec<ShadowSignal>) {
     match node {
         Value::Object(map) => {
+            let sub = map.get("subroutine").and_then(Value::as_str);
             if map.get("kind").and_then(Value::as_str) == Some("Call")
                 && matches!(
-                    map.get("subroutine").and_then(Value::as_str),
+                    sub,
                     Some("$past" | "$stable" | "$changed" | "$rose" | "$fell")
                 )
-                && let Ok((base, width)) = call_arg_signal(node)
-                && !out.iter().any(|s| s.base == base)
             {
-                out.push(ShadowSignal {
-                    base: base.to_string(),
-                    width,
-                });
+                // `$past` carries a depth; the others are depth-1. Record the
+                // DEEPEST depth per base (the shift chain covers all shallower).
+                let resolved = if sub == Some("$past") {
+                    past_call_arg(node).ok()
+                } else {
+                    call_arg_signal(node).ok().map(|(b, w)| (b, w, 1))
+                };
+                if let Some((base, width, depth)) = resolved {
+                    if let Some(existing) = out.iter_mut().find(|s| s.base == base) {
+                        existing.depth = existing.depth.max(depth);
+                    } else {
+                        out.push(ShadowSignal {
+                            base: base.to_string(),
+                            width,
+                            depth,
+                        });
+                    }
+                }
             }
             for v in map.values() {
                 collect_shadow_signals(v, out);
@@ -606,7 +625,7 @@ fn bool_expr(expr: &Value) -> Result<String, String> {
             match sub {
                 "$stable" | "$changed" => {
                     let (sig, _w) = call_arg_signal(expr)?;
-                    let shadow = past_shadow_name(sig);
+                    let shadow = past_shadow_name(sig, 1);
                     let cmp = if sub == "$stable" { "==" } else { "!=" };
                     Ok(format!("({sig} {cmp} {shadow})"))
                 }
@@ -618,17 +637,18 @@ fn bool_expr(expr: &Value) -> Result<String, String> {
                              {sub} on 1-bit signals only"
                         ));
                     }
-                    let shadow = past_shadow_name(sig);
+                    let shadow = past_shadow_name(sig, 1);
                     Ok(if sub == "$rose" {
                         format!("({sig} && (!({shadow})))") // 1 now, 0 last cycle
                     } else {
                         format!("((!({sig})) && {shadow})") // 0 now, 1 last cycle
                     })
                 }
-                // `$past(x)` is a value; in boolean position a vector → `!= 0`.
+                // `$past(x[, k])` is a value; in boolean position a vector → `!= 0`.
+                // `k` (default 1) selects the depth-`k` shadow along the shift chain.
                 "$past" => {
-                    let (sig, w) = call_arg_signal(expr)?;
-                    let shadow = past_shadow_name(sig);
+                    let (sig, w, depth) = past_call_arg(expr)?;
+                    let shadow = past_shadow_name(sig, depth);
                     Ok(if w > 1 {
                         format!("({shadow} != 0)")
                     } else {
@@ -881,11 +901,21 @@ fn reduction_to_cmp(operand: &Value, op: &str, need_all_ones: bool) -> Result<St
     Ok(format!("({sig} {op} {rhs})"))
 }
 
-/// The `__past` shadow-register name for a base signal — the XL.3 naming
-/// contract shared with the BTOR2 model-augmentation step (XL.3b synthesises a
-/// 1-step flop with `next(<base>__past) = <base>` so the atom binds).
-fn past_shadow_name(base: &str) -> String {
-    format!("{base}__past")
+/// The `__past` shadow-register name for a base signal at history `depth` — the
+/// XL.3 naming contract shared with the BTOR2 model-augmentation step (XL.3b
+/// synthesises a `depth`-stage shift chain `next(<base>__past) = <base>`,
+/// `next(<base>__past2) = <base>__past`, … so the atom binds).
+///
+/// Depth 1 keeps the historical bare `<base>__past` (backward compatible with
+/// `$past`/`$stable`/`$rose`/`$fell` and every existing model); depth `k ≥ 2`
+/// (from `$past(x, k)`) is `<base>__past{k}`. `shadow::shadow_stage_name` MUST
+/// mirror this exactly — the two are the two halves of one naming contract.
+fn past_shadow_name(base: &str, depth: u32) -> String {
+    if depth <= 1 {
+        format!("{base}__past")
+    } else {
+        format!("{base}__past{depth}")
+    }
 }
 
 /// True if `expr` (modulo `Conversion` peeling) is a `$past(...)` call.
@@ -896,13 +926,13 @@ fn is_past_call(expr: &Value) -> bool {
 }
 
 /// A comparison operand that resolves to a mu-calc atom name: a plain signal, or
-/// `$past(signal)` → its `__past` shadow. `None` for anything else.
+/// `$past(signal[, k])` → its depth-`k` `__past` shadow. `None` for anything else.
 fn cmp_signal_atom(expr: &Value) -> Option<String> {
     let expr = unwrap(expr);
     if is_past_call(expr) {
-        return call_arg_signal(expr)
+        return past_call_arg(expr)
             .ok()
-            .map(|(sig, _)| past_shadow_name(sig));
+            .map(|(sig, _, depth)| past_shadow_name(sig, depth));
     }
     signal_name(expr).ok().map(|s| s.to_string())
 }
@@ -934,9 +964,11 @@ fn add_signal_literal(expr: &Value) -> Option<(String, u64)> {
     None
 }
 
-/// A Tier-2 history call (`$past`/`$stable`/`$changed`/`$rose`/`$fell`) takes
-/// exactly one signal argument; return its `(name, width)`. Rejects depth>1
-/// `$past` (≥2 args), multi-arg forms, and non-signal arguments.
+/// A single-signal Tier-2 call (`$stable`/`$changed`/`$rose`/`$fell`, and the
+/// one-hot `$onehot`/`$onehot0`) takes exactly one signal argument; return its
+/// `(name, width)`. These are inherently previous-cycle / current-cycle forms, so
+/// a second (depth) argument is rejected here. `$past` — the only depth-carrying
+/// history call — goes through [`past_call_arg`] instead.
 fn call_arg_signal(call: &Value) -> Result<(&str, u32), String> {
     let sub = call
         .get("subroutine")
@@ -948,13 +980,53 @@ fn call_arg_signal(call: &Value) -> Result<(&str, u32), String> {
         .ok_or_else(|| format!("{sub} without an argument list"))?;
     if args.len() != 1 {
         return Err(format!(
-            "{sub} with {} arguments; Tier-2 supports single-signal depth-1 history only",
+            "{sub} with {} arguments; this Tier-2 call takes a single signal \
+             (only `$past` carries a depth argument)",
             args.len()
         ));
     }
     let arg = unwrap(&args[0]);
     let sig = signal_name(arg).map_err(|_| format!("{sub} argument is not a plain signal"))?;
     Ok((sig, signal_width(arg)))
+}
+
+/// `$past(signal[, depth])` — Tier-2 history with an optional constant depth `k`
+/// (default 1). Returns `(name, width, depth)`. A second argument is the history
+/// depth: a constant integer literal ≥ 1 (`$past(x, 3)` = "x, three cycles ago").
+/// The XL.3b augmentation builds a `depth`-stage shift chain so the shadow atom
+/// [`past_shadow_name`]`(name, depth)` binds. Rejects depth 0 / negative, a
+/// non-literal depth, more than two arguments, and a non-signal first argument.
+fn past_call_arg(call: &Value) -> Result<(&str, u32, u32), String> {
+    let sub = call
+        .get("subroutine")
+        .and_then(Value::as_str)
+        .unwrap_or("$past");
+    let args = call
+        .get("arguments")
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("{sub} without an argument list"))?;
+    if args.is_empty() || args.len() > 2 {
+        return Err(format!(
+            "{sub} with {} arguments; expected `$past(signal[, depth])`",
+            args.len()
+        ));
+    }
+    let arg = unwrap(&args[0]);
+    let sig =
+        signal_name(arg).map_err(|_| format!("{sub} first argument is not a plain signal"))?;
+    let depth = if args.len() == 2 {
+        let d = sv_integer(unwrap(&args[1]))
+            .ok_or_else(|| format!("{sub} depth argument must be a constant integer literal"))?;
+        if d < 1 {
+            return Err(format!(
+                "{sub} depth {d} is not >= 1 (a $past depth is a positive number of cycles)"
+            ));
+        }
+        d as u32
+    } else {
+        1
+    };
+    Ok((sig, signal_width(arg), depth))
 }
 
 /// `~x` in boolean position: logical-not on a 1-bit operand; a vector `~x` is a
@@ -1649,17 +1721,46 @@ mod tests {
     }
 
     #[test]
-    fn xl3_past_depth_gt_1_is_rejected() {
-        // `$past(x, 2)` — two arguments → out of Tier-2 (depth-1 only).
-        let call = serde_json::json!({
+    fn xl3_past_depth_k_lowers_to_the_suffixed_shadow() {
+        // `$past(x, 2)` — depth 2 now lowers to the stage-2 shadow `x__past2`
+        // (Tier-1 k-deep history). Bare `$past(x)` / depth 1 stays `x__past`.
+        let two = serde_json::json!({
             "kind": "Call", "subroutine": "$past",
             "arguments": [
                 {"kind": "NamedValue", "symbol": "1 x", "type": "logic"},
                 {"kind": "IntegerLiteral", "value": "2", "constant": "2"}
             ]
         });
-        let err = bool_expr(&call).expect_err("depth>1 must reject");
-        assert!(err.contains("depth-1"), "got: {err}");
+        assert_eq!(bool_expr(&two).expect("depth 2 accepted"), "x__past2");
+        let one = serde_json::json!({
+            "kind": "Call", "subroutine": "$past",
+            "arguments": [{"kind": "NamedValue", "symbol": "1 x", "type": "logic"}]
+        });
+        assert_eq!(bool_expr(&one).expect("depth 1 accepted"), "x__past");
+    }
+
+    #[test]
+    fn xl3_past_depth_zero_and_stable_with_depth_are_rejected() {
+        // `$past(x, 0)` — a depth must be a positive number of cycles.
+        let zero = serde_json::json!({
+            "kind": "Call", "subroutine": "$past",
+            "arguments": [
+                {"kind": "NamedValue", "symbol": "1 x", "type": "logic"},
+                {"kind": "IntegerLiteral", "value": "0", "constant": "0"}
+            ]
+        });
+        let err = bool_expr(&zero).expect_err("depth 0 must reject");
+        assert!(err.contains(">= 1"), "got: {err}");
+        // `$stable(x, 2)` — only `$past` carries a depth argument.
+        let stable2 = serde_json::json!({
+            "kind": "Call", "subroutine": "$stable",
+            "arguments": [
+                {"kind": "NamedValue", "symbol": "1 x", "type": "logic"},
+                {"kind": "IntegerLiteral", "value": "2", "constant": "2"}
+            ]
+        });
+        let err = bool_expr(&stable2).expect_err("$stable depth must reject");
+        assert!(err.contains("single signal"), "got: {err}");
     }
 
     #[test]
@@ -1789,14 +1890,16 @@ mod tests {
             vec![
                 ShadowSignal {
                     base: "state_q".into(),
-                    width: 6
+                    width: 6,
+                    depth: 1
                 },
                 ShadowSignal {
                     base: "v".into(),
-                    width: 1
+                    width: 1,
+                    depth: 1
                 },
             ],
-            "required_shadows must dedup by base + carry width"
+            "required_shadows must dedup by base + carry width + depth"
         );
     }
 

--- a/crates/mununu-core/src/adapter/slang/translate.rs
+++ b/crates/mununu-core/src/adapter/slang/translate.rs
@@ -51,11 +51,12 @@
 //! `x ∈ {0,1,2,4,…}` / `x ∈ {1,2,4,…}` (one `Or`-of-`Cmp` atom). Anything still
 //! outside the fragment — bit-arithmetic, bit-select indexing (`sig[i]`),
 //! reduction-or/xor (`|x`, `^x`), system calls (`$isunknown`, `$countones`),
-//! multi-element `##` chains (`a ##1 b ##2 c`), `[*n]` repetition, sequence
-//! *antecedents* (`a ##1 c |-> …`), etc. — is **rejected with a reason, never
-//! silently dropped** (claims-integrity), and every emitted formula is validated
-//! through the mu-calculus parser as a safety net. (A single `##k` / `##[m:n]`
-//! delayed boolean *consequent* is supported — XL.4, `consequent_expr`.)
+//! unbounded `##[m:$]` / `[*n:$]`, goto `[->n]` / non-consecutive `[=n]`
+//! repetition, and sequence *antecedents* (`a ##1 c |-> …`), etc. — is **rejected
+//! with a reason, never silently dropped** (claims-integrity), and every emitted
+//! formula is validated through the mu-calculus parser as a safety net. (Bounded
+//! sequence *consequents* — `##k`/`##[m:n]` delays, fixed `[*n]` repetition, and
+//! multi-element `##` chains of booleans — ARE supported: XL.4, `consequent_expr`.)
 //!
 //! [XL.0]: ../../../../.claude/plans/measurements/XL-0-sva-parser-spike-2026-06-26.md
 
@@ -525,113 +526,298 @@ fn property_body(
         // antecedent is out of fragment (Tier-3).
         "Binary" => {
             let op = spec.get("op").and_then(Value::as_str).unwrap_or("?");
-            let l = simple_bool(child(spec, "left")?)?;
-            let r = consequent_expr(child(spec, "right")?)?;
-            match op {
-                "OverlappedImplication" => Ok(format!("(!({l}) || {r})")),
-                "NonOverlappedImplication" => Ok(format!("(!({l}) || [] {r})")),
-                other => Err(format!("unsupported property operator: {other}")),
-            }
+            let conseq = consequent_expr(child(spec, "right")?)?;
+            // The consequent aligns to the antecedent's match end; `|=>` delays it
+            // one further cycle. `|->` evaluates it there directly.
+            let conseq = match op {
+                "OverlappedImplication" => conseq,
+                "NonOverlappedImplication" => format!("[] {conseq}"),
+                other => return Err(format!("unsupported property operator: {other}")),
+            };
+            antecedent_implies(child(spec, "left")?, &conseq)
         }
         "Simple" => bool_expr(child(spec, "expr")?),
         other => Err(format!("unsupported property kind: {other}")),
     }
 }
 
-/// An `AssertionExpr` expected to be a boolean leaf (`Simple`) — Tier-1.
-fn simple_bool(spec: &Value) -> Result<String, String> {
-    match spec.get("kind").and_then(Value::as_str) {
-        Some("Simple") => bool_expr(child(spec, "expr")?),
-        other => Err(format!(
-            "unsupported operand (Tier-1 expects a boolean, got {other:?})"
-        )),
-    }
-}
+/// The maximum cycle any bounded-sequence unroll may reach — each cycle is a
+/// modality, so a runaway `##[m:$]` / `[*n:$]` (slang encodes `$` as a string
+/// `max`, caught earlier) or an absurd fixed count is rejected rather than
+/// exploding the formula.
+const MAX_SEQ_UNROLL: u64 = 64;
 
-/// XL.4 — an implication *consequent*: a boolean leaf (`Simple`), OR a bounded
-/// cycle-delay of a boolean (`##k b` / `##[m:n] b`), which slang serialises as a
-/// single-element `SequenceConcat`:
+/// XL.4 — an implication *consequent*: a boolean leaf (`Simple`), a bounded
+/// cycle-delay (`##k b` / `##[m:n] b`), a bounded consecutive repetition
+/// (`b[*n]`), or a bounded multi-element `##` chain of length-1 boolean elements
+/// (`b ##1 c ##2 d`). slang serialises these as a `Simple` (optionally with a
+/// `repetition` field) or a `SequenceConcat` (`elements: [{sequence, min, max}]`,
+/// cumulative gap delays — verified against slang 11.0.0 `--ast-json`).
 ///
-/// ```json
-/// { "kind": "SequenceConcat",
-///   "elements": [ { "sequence": { "kind": "Simple", … }, "min": k, "max": k } ] }
-/// ```
+/// Lowering (all sound: `[]φ = ∀ may-successors`, so a definite verdict transfers,
+/// Bruns–Godefroid — the boxes only lengthen the still-step-exact window):
+/// - fixed `##k b` → `[]…[] b` (k boxes); range `##[m:n] b` → `[]^m(b||[](b||…))`;
+/// - `b[*n]` → `(b && [](b && … && [] b))` (n consecutive);
+/// - `b ##δ₁ c ##δ₂ d` → `b && []^δ₁(c && []^δ₂ d)` (each element length-1).
 ///
-/// Fixed delay `##k b` → `[]…[] b` (k boxes); range `##[m:n] b` →
-/// `[]^m ( b || [](b || … || [] b) )` — "b holds at some cycle in [m,n]". Both
-/// compose with the implication's own `[]` (`|=>` adds one). A multi-element
-/// concat (`a ##1 b ##2 c`), a non-boolean delayed sub-sequence, `[*n]`
-/// repetition, or a sequence *antecedent* are out of fragment (Tier-3) and are
-/// rejected with a reason — never silently dropped.
+/// Out of fragment (Tier-3b — rejected with a reason, never dropped): unbounded
+/// `##[m:$]` / `[*n:$]` (needs a sequence automaton), goto `[->n]` / non-
+/// consecutive `[=n]` repetition, a repetition or nested sub-sequence *inside* a
+/// multi-element chain (would need length composition), and sequence
+/// *antecedents* (`a ##1 b |-> …` — handled in the `Binary` arm, still boolean).
 fn consequent_expr(spec: &Value) -> Result<String, String> {
     match spec.get("kind").and_then(Value::as_str) {
-        Some("Simple") => bool_expr(child(spec, "expr")?),
+        // A boolean leaf, possibly with a consecutive repetition (`b[*n]`).
+        Some("Simple") => seq_leaf(spec),
         Some("SequenceConcat") => {
             let elements = spec
                 .get("elements")
                 .and_then(Value::as_array)
                 .ok_or("SequenceConcat without an `elements` array")?;
-            if elements.len() != 1 {
-                return Err(format!(
-                    "multi-element sequence (a `##` chain of {} elements) is out of fragment; \
-                     XL.4 supports a single `##k b` / `##[m:n] b` delayed boolean consequent",
-                    elements.len()
-                ));
+            if elements.is_empty() {
+                return Err("empty SequenceConcat".into());
             }
-            let el = &elements[0];
-            let seq = el
-                .get("sequence")
-                .ok_or("sequence element without a `sequence`")?;
-            let b = simple_bool(seq).map_err(|e| {
-                format!("the delayed sub-sequence must be a boolean (`##k <bool>`); {e}")
-            })?;
-            let min = el
-                .get("min")
-                .and_then(Value::as_u64)
-                .ok_or("sequence element without a `min` delay")?;
-            let max = el
-                .get("max")
-                .and_then(Value::as_u64)
-                .ok_or("sequence element without a `max` delay")?;
-            if max < min {
-                return Err(format!("sequence delay range max {max} < min {min}"));
+            if elements.len() == 1 {
+                // `##k <seq>` / `##[m:n] <seq>` — a single delayed sub-sequence
+                // (a boolean, or a consecutive repetition of one).
+                let el = &elements[0];
+                let seq = el
+                    .get("sequence")
+                    .ok_or("sequence element without a `sequence`")?;
+                let leaf = seq_leaf(seq)?;
+                let (min, max) = elem_delay(el)?;
+                Ok(delayed(&leaf, min, max))
+            } else {
+                // A multi-element `##` chain. To keep every element's cycle offset
+                // unambiguous, each element must be a length-1 boolean (no
+                // repetition / nested sub-sequence — those compose lengths, Tier-3b).
+                let mut leaves: Vec<String> = Vec::with_capacity(elements.len());
+                let mut delays: Vec<(u32, u32)> = Vec::with_capacity(elements.len());
+                for el in elements {
+                    let seq = el
+                        .get("sequence")
+                        .ok_or("sequence element without a `sequence`")?;
+                    if seq.get("kind").and_then(Value::as_str) != Some("Simple")
+                        || seq.get("repetition").is_some()
+                    {
+                        return Err("a multi-element `##` chain element must be a length-1 \
+                             boolean (a repetition or nested sub-sequence inside a chain \
+                             needs length composition — Tier-3b)"
+                            .into());
+                    }
+                    leaves.push(bool_expr(child(seq, "expr")?)?);
+                    delays.push(elem_delay(el)?);
+                }
+                // Fold from the last element: S(i) = leafᵢ && delayed(S(i+1), gapᵢ₊₁),
+                // then prefix the first element's own gap.
+                let n = leaves.len();
+                let mut s = leaves[n - 1].clone();
+                for i in (1..n).rev() {
+                    let (min, max) = delays[i];
+                    s = format!("({} && {})", leaves[i - 1], delayed(&s, min, max));
+                }
+                let (min0, max0) = delays[0];
+                Ok(delayed(&s, min0, max0))
             }
-            // Bounded-unroll cap: each cycle is a modality; a runaway `##[0:$]`
-            // (unbounded, slang encodes `$` as a very large max) or an absurd
-            // fixed delay is rejected rather than exploding the formula.
-            const MAX_DELAY: u64 = 64;
-            if max > MAX_DELAY {
-                return Err(format!(
-                    "sequence delay {max} exceeds the bounded-unroll cap {MAX_DELAY} \
-                     (an unbounded `##[m:$]` or a very deep `##k` is out of fragment)"
-                ));
-            }
-            Ok(delayed_bool(&b, min as u32, max as u32))
         }
         other => Err(format!(
-            "unsupported implication consequent (expected a boolean or a `##k`/`##[m:n]` \
-             delayed boolean, got {other:?})"
+            "unsupported implication consequent (expected a boolean, a `##k`/`##[m:n]` \
+             delayed boolean, a `b[*n]` repetition, or a `##` chain of booleans, got {other:?})"
         )),
     }
 }
 
-/// Lower `##[min:max] b` (a delayed boolean) to nested `[]` modalities. Fixed
-/// delay (`min == max == k`) → `[]…[] b` (k boxes). Range → `[]^min ( b || [](b
-/// || … || [] b) )` with `(max-min)` extra `|| []` levels — "b holds at some
-/// cycle in [min,max]". SOUNDNESS: over the may-relation `[]φ = ∀ may-succ φ`, so
-/// a definite verdict transfers (Bruns–Godefroid), exactly as the shipped `|=>`
-/// single-`[]` case; more boxes only lengthen the (still step-exact) window.
-fn delayed_bool(b: &str, min: u32, max: u32) -> String {
-    // Innermost first: b at the deepest cycle; wrap `(b || [] …)` (max-min) times
-    // to admit any cycle in the window, then prefix `min` boxes for the offset.
+/// A single sequence leaf: a `Simple` boolean, optionally with a **consecutive**
+/// repetition (`b[*n]` → n consecutive cycles). Returns a "matches starting here"
+/// formula. Rejects goto / non-consecutive / range / unbounded repetition (Tier-3b).
+fn seq_leaf(seq: &Value) -> Result<String, String> {
+    if seq.get("kind").and_then(Value::as_str) != Some("Simple") {
+        return Err(format!(
+            "nested sequence element (expected a boolean leaf, got {:?}) — Tier-3b",
+            seq.get("kind").and_then(Value::as_str)
+        ));
+    }
+    let b = bool_expr(child(seq, "expr")?)?;
+    match seq.get("repetition") {
+        None => Ok(b),
+        Some(rep) => lower_repetition(&b, rep),
+    }
+}
+
+/// The fixed consecutive count `n` of a `[*n]` repetition. Only fixed consecutive
+/// (`min == max == n`, n ≥ 1) is in fragment; a range `[*m:n]`, unbounded `[*n:$]`
+/// (slang `max` is the string `"$"` → not a `u64`), goto `[->n]`, or non-
+/// consecutive `[=n]` need a sequence automaton (Tier-3b) and are rejected.
+fn fixed_consecutive_count(rep: &Value) -> Result<u32, String> {
+    let kind = rep.get("kind").and_then(Value::as_str).unwrap_or("?");
+    if kind != "Consecutive" {
+        return Err(format!(
+            "`{kind}` repetition (goto `[->n]` / non-consecutive `[=n]`) needs a \
+             sequence automaton — Tier-3b"
+        ));
+    }
+    let (Some(min), Some(max)) = (
+        rep.get("min").and_then(Value::as_u64),
+        rep.get("max").and_then(Value::as_u64),
+    ) else {
+        return Err("unbounded repetition `[*n:$]` needs a sequence automaton — Tier-3b".into());
+    };
+    if min != max {
+        return Err(format!(
+            "range repetition `[*{min}:{max}]` needs a sequence automaton — Tier-3b; \
+             a fixed `[*n]` is supported"
+        ));
+    }
+    if min == 0 {
+        return Err("empty repetition `[*0]` is out of fragment".into());
+    }
+    if max > MAX_SEQ_UNROLL {
+        return Err(format!(
+            "repetition count {max} exceeds the unroll cap {MAX_SEQ_UNROLL}"
+        ));
+    }
+    Ok(min as u32)
+}
+
+/// Lower a consecutive repetition `b[*n]` → `(b && [](b && … && [] b))` — b held n
+/// consecutive cycles (a "matches starting here" formula).
+fn lower_repetition(b: &str, rep: &Value) -> Result<String, String> {
+    let n = fixed_consecutive_count(rep)?;
     let mut out = b.to_string();
+    for _ in 1..n {
+        out = format!("({b} && [] {out})");
+    }
+    Ok(out)
+}
+
+/// The `(min, max)` cycle-delay of a `SequenceConcat` element, validated against
+/// the unroll cap and the `max ≥ min` invariant. An unbounded `$` (a string `max`)
+/// is not a `u64` and is rejected as Tier-3b.
+fn elem_delay(el: &Value) -> Result<(u32, u32), String> {
+    let (Some(min), Some(max)) = (
+        el.get("min").and_then(Value::as_u64),
+        el.get("max").and_then(Value::as_u64),
+    ) else {
+        return Err("unbounded `##[m:$]` delay needs a sequence automaton — Tier-3b".into());
+    };
+    if max < min {
+        return Err(format!("sequence delay range max {max} < min {min}"));
+    }
+    if max > MAX_SEQ_UNROLL {
+        return Err(format!(
+            "sequence delay {max} exceeds the bounded-unroll cap {MAX_SEQ_UNROLL}"
+        ));
+    }
+    Ok((min as u32, max as u32))
+}
+
+/// Lower `##[min:max] f` (a delayed sub-formula `f`) to nested `[]` modalities.
+/// Fixed (`min == max == k`) → `[]…[] f` (k boxes). Range → `[]^min ( f || [](f ||
+/// … || [] f) )` — "f matches at some cycle in [min,max]". SOUNDNESS: over the
+/// may-relation `[]φ = ∀ may-succ φ`, so a definite verdict transfers
+/// (Bruns–Godefroid), exactly as the shipped `|=>` single-`[]` case. `f` may be a
+/// compound sub-sequence formula (already parenthesised).
+fn delayed(f: &str, min: u32, max: u32) -> String {
+    let mut out = f.to_string();
     for _ in 0..(max - min) {
-        out = format!("({b} || [] {out})");
+        out = format!("({f} || [] {out})");
     }
     for _ in 0..min {
         out = format!("[] {out}");
     }
     out
+}
+
+/// Prefix `n` box modalities: `[] [] … f`.
+fn nest_boxes(n: u32, f: &str) -> String {
+    let mut out = f.to_string();
+    for _ in 0..n {
+        out = format!("[] {out}");
+    }
+    out
+}
+
+/// XL.5 — an implication whose *antecedent* may be a bounded sequence:
+/// `<antecedent> |-> <conseq>`, where `conseq` is the already-lowered consequent
+/// (aligned to the antecedent's match end; the caller adds the `|=>` extra `[]`).
+/// A boolean antecedent gives the shipped `(!a || conseq)`; a fixed-delay `##`
+/// chain / fixed `[*n]` gives the nested implication
+/// `!e₀ || []^δ₁(!e₁ || []^δ₂(… || conseq))` — "whenever the antecedent matches,
+/// the consequent holds at the match end". SOUNDNESS: the antecedent atoms sit in
+/// negative position under boxes evaluated ∀-may; the whole is an ordinary
+/// mu-calculus formula the KMTS evaluator decides soundly (definite verdicts
+/// transfer). A RANGE delay / range repetition in an antecedent creates multiple
+/// match ends (Tier-3b) and is rejected in [`antecedent_elements`].
+fn antecedent_implies(left: &Value, conseq: &str) -> Result<String, String> {
+    let elems = antecedent_elements(left)?;
+    let n = elems.len();
+    // Innermost: the last antecedent element implies the consequent at its cycle.
+    let mut acc = format!("(!({}) || {conseq})", elems[n - 1].0);
+    // Walk back, prefixing each preceding element's gap-to-the-next.
+    for i in (1..n).rev() {
+        let (b, _) = &elems[i - 1];
+        let gap = elems[i].1;
+        acc = format!("(!({b}) || {})", nest_boxes(gap, &acc));
+    }
+    // The first element's own leading gap (usually 0).
+    Ok(nest_boxes(elems[0].1, &acc))
+}
+
+/// Flatten a bounded FIXED-delay antecedent into `(boolean, gap-before)` length-1
+/// elements: a boolean → one element; a fixed `a[*n]` → n elements (gaps
+/// `0,1,…,1`); a fixed `##` chain of booleans → one element per link. Rejects
+/// range delays / range repetition (multiple match ends — Tier-3b), goto/non-
+/// consecutive/unbounded repetition, and nested sub-sequences.
+fn antecedent_elements(left: &Value) -> Result<Vec<(String, u32)>, String> {
+    match left.get("kind").and_then(Value::as_str) {
+        Some("Simple") => {
+            let b = bool_expr(child(left, "expr")?)?;
+            match left.get("repetition") {
+                None => Ok(vec![(b, 0)]),
+                Some(rep) => {
+                    let n = fixed_consecutive_count(rep)?;
+                    Ok((0..n)
+                        .map(|i| (b.clone(), if i == 0 { 0 } else { 1 }))
+                        .collect())
+                }
+            }
+        }
+        Some("SequenceConcat") => {
+            let elements = left
+                .get("elements")
+                .and_then(Value::as_array)
+                .ok_or("SequenceConcat without an `elements` array")?;
+            let mut v = Vec::with_capacity(elements.len());
+            for el in elements {
+                let seq = el
+                    .get("sequence")
+                    .ok_or("sequence element without a `sequence`")?;
+                if seq.get("kind").and_then(Value::as_str) != Some("Simple")
+                    || seq.get("repetition").is_some()
+                {
+                    return Err("a sequence-antecedent element must be a length-1 boolean \
+                         (a repetition or nested sub-sequence in an antecedent is Tier-3b)"
+                        .into());
+                }
+                let (min, max) = elem_delay(el)?;
+                if min != max {
+                    return Err(format!(
+                        "a range delay `##[{min}:{max}]` in an ANTECEDENT creates multiple \
+                         match ends — Tier-3b; a fixed `##k` antecedent is supported"
+                    ));
+                }
+                v.push((bool_expr(child(seq, "expr")?)?, min));
+            }
+            if v.is_empty() {
+                return Err("empty SequenceConcat antecedent".into());
+            }
+            Ok(v)
+        }
+        other => Err(format!(
+            "unsupported implication antecedent (expected a boolean or a fixed `##` chain \
+             / `[*n]`, got {other:?})"
+        )),
+    }
 }
 
 /// Translate a boolean `Expression` into mu-calculus atom/connective text.
@@ -1390,30 +1576,158 @@ mod tests {
     }
 
     #[test]
-    fn xl4_multi_element_and_deep_delay_rejected() {
-        // A two-element `##` chain is a sequence (Tier-3) — rejected, not dropped.
-        let multi = serde_json::json!({
+    fn xl5_multi_element_chain_consequent() {
+        // a |-> b ##1 c ##2 d  →  b now, c at +1, d at +3 (cumulative gaps).
+        // slang shape: elements [{b,0,0},{c,1,1},{d,2,2}] (captured from slang 11.0.0).
+        let spec = serde_json::json!({
             "kind": "Binary", "op": "OverlappedImplication",
             "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
             "right": {"kind": "SequenceConcat", "elements": [
-                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}, "min":1, "max":1},
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}, "min":0, "max":0},
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "3 c"}}, "min":1, "max":1},
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "4 d"}}, "min":2, "max":2}
+            ]}
+        });
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
+        assert!(
+            f.contains("(b && [] (c && [] [] d))"),
+            "multi-element chain: {f}"
+        );
+        crate::mu_calculus::parser::parse(&f).expect("parses");
+    }
+
+    #[test]
+    fn xl5_consecutive_repetition_consequent() {
+        // a |-> c[*3]  →  c held 3 consecutive cycles. slang shape: Simple(c) with
+        // repetition {Consecutive, min:3, max:3} (captured from slang 11.0.0).
+        let spec = serde_json::json!({
+            "kind": "Binary", "op": "OverlappedImplication",
+            "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
+            "right": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 c"},
+                      "repetition": {"kind": "Consecutive", "min": 3, "max": 3}}
+        });
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
+        assert!(
+            f.contains("(c && [] (c && [] c))"),
+            "c[*3] consecutive: {f}"
+        );
+        crate::mu_calculus::parser::parse(&f).expect("parses");
+    }
+
+    #[test]
+    fn xl5_out_of_fragment_sequences_rejected() {
+        let mk = |right: serde_json::Value| {
+            serde_json::json!({
+                "kind": "Binary", "op": "OverlappedImplication",
+                "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
+                "right": right
+            })
+        };
+        // Unbounded repetition `c[*1:$]` — slang encodes `$` as a string max.
+        let unb = mk(serde_json::json!({
+            "kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 c"},
+            "repetition": {"kind": "Consecutive", "min": 1, "max": "$"}
+        }));
+        let err = property_body(&unb, &TranslateOptions::default(), &mut Vec::new())
+            .expect_err("unbounded must reject");
+        assert!(err.contains("Tier-3b"), "got: {err}");
+        // Range repetition `c[*1:3]` — Tier-3b.
+        let rng = mk(serde_json::json!({
+            "kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 c"},
+            "repetition": {"kind": "Consecutive", "min": 1, "max": 3}
+        }));
+        let err = property_body(&rng, &TranslateOptions::default(), &mut Vec::new())
+            .expect_err("range repetition must reject");
+        assert!(err.contains("Tier-3b"), "got: {err}");
+        // A repetition INSIDE a multi-element chain — length composition, Tier-3b.
+        let chain_rep = mk(serde_json::json!({
+            "kind": "SequenceConcat", "elements": [
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"},
+                              "repetition": {"kind": "Consecutive", "min": 2, "max": 2}}, "min":0, "max":0},
                 {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "3 c"}}, "min":1, "max":1}
-            ]}
-        });
-        let err = property_body(&multi, &TranslateOptions::default(), &mut Vec::new())
-            .expect_err("multi-element must reject");
-        assert!(err.contains("multi-element"), "got: {err}");
-        // A delay past the unroll cap is rejected (no formula explosion / `##[m:$]`).
-        let deep = serde_json::json!({
+            ]
+        }));
+        let err = property_body(&chain_rep, &TranslateOptions::default(), &mut Vec::new())
+            .expect_err("repetition in a chain must reject");
+        assert!(err.contains("Tier-3b"), "got: {err}");
+    }
+
+    #[test]
+    fn xl5_sequence_antecedent() {
+        // (a ##1 b) |-> c  →  a → X(b → c)  →  (!(a) || [] (!(b) || c)).
+        // slang shape: left = SequenceConcat[{a,0,0},{b,1,1}] (captured from slang).
+        let spec = serde_json::json!({
             "kind": "Binary", "op": "OverlappedImplication",
-            "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
-            "right": {"kind": "SequenceConcat", "elements": [
-                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}, "min":100, "max":100}
-            ]}
+            "left": {"kind": "SequenceConcat", "elements": [
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}}, "min":0, "max":0},
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}, "min":1, "max":1}
+            ]},
+            "right": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "3 c"}}
         });
-        let err = property_body(&deep, &TranslateOptions::default(), &mut Vec::new())
-            .expect_err("deep delay must reject");
-        assert!(err.contains("cap"), "got: {err}");
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
+        assert!(
+            f.contains("(!(a) || [] (!(b) || c))"),
+            "seq antecedent: {f}"
+        );
+        crate::mu_calculus::parser::parse(&f).expect("parses");
+    }
+
+    #[test]
+    fn xl5_repetition_antecedent_and_nonoverlap() {
+        // a[*3] |=> c  →  (a∧Xa∧XXa) → XXX c  →  nested with the |=> extra [].
+        let spec = serde_json::json!({
+            "kind": "Binary", "op": "NonOverlappedImplication",
+            "left": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"},
+                     "repetition": {"kind": "Consecutive", "min": 3, "max": 3}},
+            "right": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 c"}}
+        });
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
+        assert!(
+            f.contains("(!(a) || [] (!(a) || [] (!(a) || [] c)))"),
+            "a[*3] |=> c: {f}"
+        );
+        crate::mu_calculus::parser::parse(&f).expect("parses");
+    }
+
+    #[test]
+    fn xl5_range_antecedent_rejected() {
+        // (a ##[1:2] b) |-> c — a range delay in an ANTECEDENT has multiple match
+        // ends (Tier-3b), rejected.
+        let spec = serde_json::json!({
+            "kind": "Binary", "op": "OverlappedImplication",
+            "left": {"kind": "SequenceConcat", "elements": [
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}}, "min":0, "max":0},
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}, "min":1, "max":2}
+            ]},
+            "right": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "3 c"}}
+        });
+        let err = property_body(&spec, &TranslateOptions::default(), &mut Vec::new())
+            .expect_err("range antecedent must reject");
+        assert!(err.contains("Tier-3b"), "got: {err}");
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/slang/translate.rs
+++ b/crates/mununu-core/src/adapter/slang/translate.rs
@@ -12,6 +12,8 @@
 //! | `assert property (b)` | `nu X. (b && [] X)` (AG b) |
 //! | `a \|-> b` | `nu X. ((!a \|\| b) && [] X)` (AG(a→b)) |
 //! | `a \|=> b` | `nu X. ((!a \|\| [] b) && [] X)` (AG(a→AX b)) |
+//! | `a \|-> ##k b` (XL.4) | `nu X. ((!a \|\| []…[] b) && [] X)` — k boxes (AG(a→AXᵏ b)) |
+//! | `a \|-> ##[m:n] b` (XL.4) | `nu X. ((!a \|\| []ᵐ(b\|\|[](b\|\|…\|\|[]b))) && [] X)` — b within [m,n] |
 //! | `cover property (b)` | `mu X. (b \|\| <> X)` (EF b) |
 //! | `cover property (b)` **recoverability lens** (XL.2) | `nu Y. ((mu X. (b \|\| <> X)) && [] Y)` (AG EF b) |
 //! | `disable iff (r) P` | gate the body: `(r \|\| body)` (vacuous while disabled) |
@@ -49,9 +51,11 @@
 //! `x ∈ {0,1,2,4,…}` / `x ∈ {1,2,4,…}` (one `Or`-of-`Cmp` atom). Anything still
 //! outside the fragment — bit-arithmetic, bit-select indexing (`sig[i]`),
 //! reduction-or/xor (`|x`, `^x`), system calls (`$isunknown`, `$countones`),
-//! sequences (`##`, `[*n]`), etc. — is **rejected with a reason, never silently
-//! dropped** (claims-integrity), and every emitted formula is validated through the
-//! mu-calculus parser as a safety net.
+//! multi-element `##` chains (`a ##1 b ##2 c`), `[*n]` repetition, sequence
+//! *antecedents* (`a ##1 c |-> …`), etc. — is **rejected with a reason, never
+//! silently dropped** (claims-integrity), and every emitted formula is validated
+//! through the mu-calculus parser as a safety net. (A single `##k` / `##[m:n]`
+//! delayed boolean *consequent* is supported — XL.4, `consequent_expr`.)
 //!
 //! [XL.0]: ../../../../.claude/plans/measurements/XL-0-sva-parser-spike-2026-06-26.md
 
@@ -515,11 +519,14 @@ fn property_body(
             let cond = bool_expr(cond_node)?;
             Ok(format!("({cond} || {inner})"))
         }
-        // `a |-> b` / `a |=> b` — left/right are boolean (Tier-1 `Simple`).
+        // `a |-> <conseq>` / `a |=> <conseq>` — a boolean antecedent (Tier-1
+        // `Simple`) implies a boolean OR a bounded cycle-delay consequent
+        // (`##k b` / `##[m:n] b`, XL.4). The antecedent stays boolean; a sequence
+        // antecedent is out of fragment (Tier-3).
         "Binary" => {
             let op = spec.get("op").and_then(Value::as_str).unwrap_or("?");
             let l = simple_bool(child(spec, "left")?)?;
-            let r = simple_bool(child(spec, "right")?)?;
+            let r = consequent_expr(child(spec, "right")?)?;
             match op {
                 "OverlappedImplication" => Ok(format!("(!({l}) || {r})")),
                 "NonOverlappedImplication" => Ok(format!("(!({l}) || [] {r})")),
@@ -539,6 +546,92 @@ fn simple_bool(spec: &Value) -> Result<String, String> {
             "unsupported operand (Tier-1 expects a boolean, got {other:?})"
         )),
     }
+}
+
+/// XL.4 — an implication *consequent*: a boolean leaf (`Simple`), OR a bounded
+/// cycle-delay of a boolean (`##k b` / `##[m:n] b`), which slang serialises as a
+/// single-element `SequenceConcat`:
+///
+/// ```json
+/// { "kind": "SequenceConcat",
+///   "elements": [ { "sequence": { "kind": "Simple", … }, "min": k, "max": k } ] }
+/// ```
+///
+/// Fixed delay `##k b` → `[]…[] b` (k boxes); range `##[m:n] b` →
+/// `[]^m ( b || [](b || … || [] b) )` — "b holds at some cycle in [m,n]". Both
+/// compose with the implication's own `[]` (`|=>` adds one). A multi-element
+/// concat (`a ##1 b ##2 c`), a non-boolean delayed sub-sequence, `[*n]`
+/// repetition, or a sequence *antecedent* are out of fragment (Tier-3) and are
+/// rejected with a reason — never silently dropped.
+fn consequent_expr(spec: &Value) -> Result<String, String> {
+    match spec.get("kind").and_then(Value::as_str) {
+        Some("Simple") => bool_expr(child(spec, "expr")?),
+        Some("SequenceConcat") => {
+            let elements = spec
+                .get("elements")
+                .and_then(Value::as_array)
+                .ok_or("SequenceConcat without an `elements` array")?;
+            if elements.len() != 1 {
+                return Err(format!(
+                    "multi-element sequence (a `##` chain of {} elements) is out of fragment; \
+                     XL.4 supports a single `##k b` / `##[m:n] b` delayed boolean consequent",
+                    elements.len()
+                ));
+            }
+            let el = &elements[0];
+            let seq = el
+                .get("sequence")
+                .ok_or("sequence element without a `sequence`")?;
+            let b = simple_bool(seq).map_err(|e| {
+                format!("the delayed sub-sequence must be a boolean (`##k <bool>`); {e}")
+            })?;
+            let min = el
+                .get("min")
+                .and_then(Value::as_u64)
+                .ok_or("sequence element without a `min` delay")?;
+            let max = el
+                .get("max")
+                .and_then(Value::as_u64)
+                .ok_or("sequence element without a `max` delay")?;
+            if max < min {
+                return Err(format!("sequence delay range max {max} < min {min}"));
+            }
+            // Bounded-unroll cap: each cycle is a modality; a runaway `##[0:$]`
+            // (unbounded, slang encodes `$` as a very large max) or an absurd
+            // fixed delay is rejected rather than exploding the formula.
+            const MAX_DELAY: u64 = 64;
+            if max > MAX_DELAY {
+                return Err(format!(
+                    "sequence delay {max} exceeds the bounded-unroll cap {MAX_DELAY} \
+                     (an unbounded `##[m:$]` or a very deep `##k` is out of fragment)"
+                ));
+            }
+            Ok(delayed_bool(&b, min as u32, max as u32))
+        }
+        other => Err(format!(
+            "unsupported implication consequent (expected a boolean or a `##k`/`##[m:n]` \
+             delayed boolean, got {other:?})"
+        )),
+    }
+}
+
+/// Lower `##[min:max] b` (a delayed boolean) to nested `[]` modalities. Fixed
+/// delay (`min == max == k`) → `[]…[] b` (k boxes). Range → `[]^min ( b || [](b
+/// || … || [] b) )` with `(max-min)` extra `|| []` levels — "b holds at some
+/// cycle in [min,max]". SOUNDNESS: over the may-relation `[]φ = ∀ may-succ φ`, so
+/// a definite verdict transfers (Bruns–Godefroid), exactly as the shipped `|=>`
+/// single-`[]` case; more boxes only lengthen the (still step-exact) window.
+fn delayed_bool(b: &str, min: u32, max: u32) -> String {
+    // Innermost first: b at the deepest cycle; wrap `(b || [] …)` (max-min) times
+    // to admit any cycle in the window, then prefix `min` boxes for the offset.
+    let mut out = b.to_string();
+    for _ in 0..(max - min) {
+        out = format!("({b} || [] {out})");
+    }
+    for _ in 0..min {
+        out = format!("[] {out}");
+    }
+    out
 }
 
 /// Translate a boolean `Expression` into mu-calculus atom/connective text.
@@ -1243,6 +1336,84 @@ mod tests {
         .expect("translates");
         assert!(f.contains("[] b"), "|=> must put b under a next ([]): {f}");
         crate::mu_calculus::parser::parse(&f).expect("parses");
+    }
+
+    #[test]
+    fn xl4_fixed_cycle_delay_consequent() {
+        // a |-> ##2 b  →  b two cycles later ([] [] b). slang shape: right =
+        // SequenceConcat { elements: [{ sequence: Simple(b), min:2, max:2 }] }
+        // (captured from real slang 11.0.0 --ast-json).
+        let spec = serde_json::json!({
+            "kind": "Binary",
+            "op": "OverlappedImplication",
+            "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
+            "right": {"kind": "SequenceConcat", "elements": [
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}},
+                 "min": 2, "max": 2}
+            ]}
+        });
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
+        assert!(f.contains("(!(a) || [] [] b)"), "##2 → two boxes: {f}");
+        crate::mu_calculus::parser::parse(&f).expect("parses");
+    }
+
+    #[test]
+    fn xl4_bounded_range_delay_consequent() {
+        // a |=> ##[1:3] b  →  b somewhere in the window, plus one [] from |=>.
+        let spec = serde_json::json!({
+            "kind": "Binary",
+            "op": "NonOverlappedImplication",
+            "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
+            "right": {"kind": "SequenceConcat", "elements": [
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}},
+                 "min": 1, "max": 3}
+            ]}
+        });
+        let f = translate_one(
+            &spec,
+            SvaKind::Assert,
+            &TranslateOptions::default(),
+            &mut Vec::new(),
+        )
+        .expect("translates");
+        assert!(
+            f.contains("[] [] (b || [] (b || [] b))"),
+            "range [1:3] under |=>: {f}"
+        );
+        crate::mu_calculus::parser::parse(&f).expect("parses");
+    }
+
+    #[test]
+    fn xl4_multi_element_and_deep_delay_rejected() {
+        // A two-element `##` chain is a sequence (Tier-3) — rejected, not dropped.
+        let multi = serde_json::json!({
+            "kind": "Binary", "op": "OverlappedImplication",
+            "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
+            "right": {"kind": "SequenceConcat", "elements": [
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}, "min":1, "max":1},
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "3 c"}}, "min":1, "max":1}
+            ]}
+        });
+        let err = property_body(&multi, &TranslateOptions::default(), &mut Vec::new())
+            .expect_err("multi-element must reject");
+        assert!(err.contains("multi-element"), "got: {err}");
+        // A delay past the unroll cap is rejected (no formula explosion / `##[m:$]`).
+        let deep = serde_json::json!({
+            "kind": "Binary", "op": "OverlappedImplication",
+            "left":  {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "1 a"}},
+            "right": {"kind": "SequenceConcat", "elements": [
+                {"sequence": {"kind": "Simple", "expr": {"kind": "NamedValue", "symbol": "2 b"}}, "min":100, "max":100}
+            ]}
+        });
+        let err = property_body(&deep, &TranslateOptions::default(), &mut Vec::new())
+            .expect_err("deep delay must reject");
+        assert!(err.contains("cap"), "got: {err}");
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1913,11 +1913,11 @@ pub(crate) fn prepare_model(
         e.message = format!("verify_auto: parse lifted BTOR2: {}", e.message);
         e
     })?;
-    let shadow_bases: Vec<&str> = extraction
+    let shadow_bases: Vec<(&str, u32)> = extraction
         .required_shadows
         .iter()
-        .map(|s| s.base.as_str())
-        .filter(|b| crate::adapter::btor2::can_shadow(&pre_file, b))
+        .filter(|s| crate::adapter::btor2::can_shadow(&pre_file, &s.base))
+        .map(|s| (s.base.as_str(), s.depth))
         .collect();
     let btor2 = augment_with_past_shadows(&btor2, &shadow_bases)?;
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1464,6 +1464,7 @@ fn sv_extract_sva_handler_impl(
             .map(|s| ShadowSignalView {
                 base: s.base.clone(),
                 width: s.width,
+                depth: s.depth,
             })
             .collect(),
     };

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1419,6 +1419,9 @@ pub struct UnsupportedAssertionView {
 pub struct ShadowSignalView {
     pub base: String,
     pub width: u32,
+    /// Deepest `$past` history depth synthesised for `base` (1 for the
+    /// depth-1 family; `k` for `$past(base, k)`).
+    pub depth: u32,
 }
 
 /// XL.6b — automated SVA verification endpoint (`POST /api/v1/sv/verify-auto`).

--- a/crates/mununu-core/src/mu_calculus/symbolic.rs
+++ b/crates/mununu-core/src/mu_calculus/symbolic.rs
@@ -175,6 +175,17 @@ pub struct TritBdd {
 
 impl TritBdd {
     /// `(must, may)` directly (debug-asserts `must ⊑ may`).
+    ///
+    /// SOUNDNESS (must ⊆ may fix, Tier 0) — this check stays a `debug_assert!`
+    /// because it runs on the hot modal path (once per node per fixpoint
+    /// iteration) and a per-node BDD `and` in release would cost real time. The
+    /// **release** guarantee of the underlying invariant now comes one layer up,
+    /// once per lift, from `adapter::btor2::kmts_lift::assert_must_subset_may`,
+    /// which rejects a KMTS whose `R_must ⊄ R_may` with an `IrConsistencyError`
+    /// before it ever reaches this constructor. Given a well-formed KMTS the
+    /// operators preserve `must ⊑ may` (see §5 of docs/design/past-shadow-
+    /// soundness.md), so this assert should never fire; it remains as the debug
+    /// tripwire that a future operator change did not break preservation.
     pub fn from_parts(must: BDDFunction, may: BDDFunction) -> Self {
         debug_assert!(
             must.and(&may).unwrap() == must,

--- a/docs/design/past-shadow-soundness.md
+++ b/docs/design/past-shadow-soundness.md
@@ -33,6 +33,12 @@ n+1   next  <sort> n <b>
 n+2   init  <sort> n <v>        ; v = b's own init (state base) or zero (input base)
 ```
 
+`$past(b, k)` (k ≥ 2) gains a **k-stage shift chain** instead — `b__past ← b`,
+`b__past2 ← b__past`, … `b__past{k}` — so `b__past{j}` holds b's value j cycles
+ago. Each stage is init'd the same way as the 1-stage case (below). Everything
+that follows is written for one stage; each stage of a chain is an independent
+history variable and the argument composes over them.
+
 `b` is either a BTOR2 state cell or a primary input;
 [`resolve_shadow_source`](../../crates/mununu-core/src/adapter/btor2/shadow.rs)
 tries a unique exact state symbol, then an exact input symbol, then the
@@ -103,6 +109,16 @@ Pinned by `only_a_same_cycle_past_reads_the_invented_history` in
 [`tests/past_shadow_input_e2e.rs`](../../crates/mununu-core/tests/past_shadow_input_e2e.rs),
 so a future change to the lift that moved the atom out from under `[]` would fail
 a test rather than silently widen the approximation.
+
+**Depth k generalises the window, not the argument.** A depth-1 shadow is invented
+only at cycle 0, so the single `[]` of `|=>` hides it completely. A depth-k chain
+takes k cycles to fill, so `$past(input, k)` reads the invented zero for the first
+k-1 post-reset cycles *even under a `[]`* — the approximation is bounded to those
+cycles rather than eliminated. For a **register** base this is not an approximation
+at all: those cycles read the source's reset value, which is exactly the SVA
+"before the first k clock edges" convention. So k-deep `$past` of a *register* is
+exact everywhere; k-deep `$past` of an *input* carries a k-1-cycle post-reset
+window where a definite verdict may not transfer (depth 1 = the cycle-0 case above).
 
 ## 4. Why the input shadow is pinned rather than left free
 

--- a/docs/design/past-shadow-soundness.md
+++ b/docs/design/past-shadow-soundness.md
@@ -157,6 +157,27 @@ about it; §6 is what happens when it is not met.
 
 ## 6. Two defects this surfaced
 
+> **Update (2026-08-28) — fixed at the lift.** The root cause below (a must-edge
+> created without enforcing `R_must ⊆ R_may`) is now closed in
+> [`kmts_lift.rs`](../../crates/mununu-core/src/adapter/btor2/kmts_lift.rs) by three
+> composing changes: (A) the `SmtAllPairs` standard-must arm restricts the ∀∃
+> must-image to the emitted `may_edges` (`must_edges_over`) instead of the full
+> grid, so a vacuous must out of an empty src — which the ∃-witness may-check never
+> emits — can no longer be promoted; (B) `apply_sampled_must_inference` proves each
+> candidate source cube feasible (`smt_source_cube_proven_feasible`, `∃ s. ⋀ src_i`)
+> and drops must-promotion out of the proven-empty ones, closing the sampling path
+> where the canonical representative fabricates a may-edge for an unsatisfiable cube;
+> (C) `assert_must_subset_may` runs once per lift (release included) and returns an
+> `IrConsistencyError` if any `MustHyperOnly` target is not a may-successor, rather
+> than letting an inconsistent KMTS reach `TritBdd::from_parts`. Unit-tested in
+> `kmts_lift.rs` (`must_subset_may_no_vacuous_must_from_unsat_cube_{all_pairs,sampling}`,
+> `assert_must_subset_may_{rejects,accepts}_*`). The `from_parts` `debug_assert!`
+> stays as the debug tripwire (§5); the release guarantee is now (C).
+>
+> The table below is the **pre-fix** measurement. Re-run the `$past` e2e in the
+> `mununu-sva` image to confirm each `Violated`/`panic` entry flips to a sound
+> verdict on the real design (host runs cannot exercise the slang path).
+
 Both are **pre-existing** and reproduce identically on a *register*-sourced
 `$past`, so neither comes from input support. A property with no `$past` is
 unaffected in both postures. All three designs below are correct.
@@ -211,8 +232,8 @@ step-collapsing optimisation must exclude models carrying `__past` shadows, or
 | reach portfolio (btormc / pono / Boolector) | **Exact.** Consumes the BTOR2 directly; the shadow is a real flop. Requires the `init` value's NID to precede the state's — see §4. |
 | exact-symbolic (ROBDD, 2-valued) | **Exact** on the augmented model. Independently refuses any property whose atom names a primary input (`push \|=> …`), because it leaves inputs free and a formula pinning one would decouple antecedent from consequent. It says so and skips rather than guessing. |
 | explicit / symbolic cube, `must_edge_inference: Off` | **Sound for HOLDS** (may over-approximation + safety). Cannot refute a data-dependent violation; reports ⊥. |
-| explicit / symbolic cube, must-edge inference on | **Unsound today** — §6. |
-| `symbolic_engine: true` | **Panics** on any `$past` model in debug; inconsistent `TritBdd` in release — §6. |
+| explicit / symbolic cube, must-edge inference on | **Sound at the lift (2026-08-28, §6 update box)** — the vacuous must out of an empty cube that caused the false `Violated` is no longer created, and `assert_must_subset_may` gates any residual. e2e confirmation in `mununu-sva` pending. Was **unsound** pre-fix — §6. |
+| `symbolic_engine: true` | **No longer fed an inconsistent KMTS (2026-08-28)** — the lift enforces `R_must ⊆ R_may` before `TritBdd::from_parts`, so the debug panic / release miscompute of §6 cannot arise from a `$past` model. Was **panic (debug) / wrong verdict (release)** pre-fix — §6. |
 
 ## 9. What is argued vs verified vs gap
 
@@ -222,10 +243,16 @@ step-collapsing optimisation must exclude models carrying `__past` shadows, or
   model are pinned by tests in `tests/past_shadow_input_e2e.rs`, run against live
   slang + yosys in the `mununu-sva` image.
 - **Measured** (§6): the two defects, and the ⊥ ceiling for refutation, reproduced
-  across four engine postures and two data widths.
-- **Gap**: `R_must ⊆ R_may` is not enforced where must-edges are created. Fixing that
-  is what would turn the ⊥ in §6 into a definite VIOLATED, and is the single change
-  that would most improve `$past` coverage.
+  across four engine postures and two data widths (pre-fix).
+- **Gap — CLOSED at the lift (2026-08-28, §6 update box).** `R_must ⊆ R_may` is now
+  enforced where must-edges are created: the ∀∃ must is restricted to the emitted
+  may-relation (Fix A), proven-empty source cubes are excluded from must-promotion
+  (Fix B), and a per-lift `assert_must_subset_may` rejects any residual containment
+  violation before the evaluator (Fix C). Mechanism-level unit tests pass; the
+  remaining confirmation is the e2e `$past` reproduction in the `mununu-sva` image
+  (host runs cannot exercise slang), which should show the §6 `Violated`/`panic`
+  entries turn into a sound `holds`/`violated`, and a genuine data-dependent
+  violation reach a definite `VIOLATED` rather than ⊥.
 
 ## 10. References
 

--- a/docs/design/past-shadow-soundness.md
+++ b/docs/design/past-shadow-soundness.md
@@ -190,9 +190,27 @@ about it; §6 is what happens when it is not met.
 > `assert_must_subset_may_{rejects,accepts}_*`). The `from_parts` `debug_assert!`
 > stays as the debug tripwire (§5); the release guarantee is now (C).
 >
-> The table below is the **pre-fix** measurement. Re-run the `$past` e2e in the
-> `mununu-sva` image to confirm each `Violated`/`panic` entry flips to a sound
-> verdict on the real design (host runs cannot exercise the slang path).
+> **Update (2026-08-28, part 2) — the symbolic engine had a SEPARATE path.**
+> (A)–(C) fix the cube / `kmts_lift` must-edge inference (the explicit + cube
+> engines). The `symbolic` engine builds its **own** may/must abstraction in
+> [`symbolic_bitblast.rs`](../../crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs)
+> (`AbstractRelation`), which (A)–(C) do not touch — and an **e2e run in the
+> `mununu-sva` image caught it still panicking** on a `$past` data-integrity
+> property (`push |=> stored == $past(din)`). Root cause: an **input predicate**
+> (`push`) makes the abstraction depend on an input var, which is both a present
+> *observable* and the transition *nondeterminism* — the same conflation the exact
+> ROBDD engine refuses an input atom over. It left `R_must`'s BDD support dirty, so
+> `box.must ⊄ box.may`. Fix (D): `AbstractRelation::build` now detects an
+> input-predicate abstraction (quantifying inputs changes feasibility) and falls
+> back to **may-only** (`r_must = None`) — sound (definite HOLDS transfers;
+> refutation → ⊥), no panic, no wrong verdict. `feasible_present` also now
+> quantifies inputs (`xi_cube`), a no-op for register-only predicates.
+>
+> The table below is the **pre-fix** measurement. The `$past` e2e was run in the
+> `mununu-sva` image (that is what caught (D)); a register-`$past` / `##k` design
+> now decides cleanly (see the XL.4/XL.5 e2e). A `push |=> stored == $past(din)`
+> input-antecedent property is may-only (⊥ under abstraction, or decided by the
+> reach portfolio) — sound, never a spurious `Violated`/panic.
 
 Both are **pre-existing** and reproduce identically on a *register*-sourced
 `$past`, so neither comes from input support. A property with no `$past` is
@@ -248,8 +266,8 @@ step-collapsing optimisation must exclude models carrying `__past` shadows, or
 | reach portfolio (btormc / pono / Boolector) | **Exact.** Consumes the BTOR2 directly; the shadow is a real flop. Requires the `init` value's NID to precede the state's — see §4. |
 | exact-symbolic (ROBDD, 2-valued) | **Exact** on the augmented model. Independently refuses any property whose atom names a primary input (`push \|=> …`), because it leaves inputs free and a formula pinning one would decouple antecedent from consequent. It says so and skips rather than guessing. |
 | explicit / symbolic cube, `must_edge_inference: Off` | **Sound for HOLDS** (may over-approximation + safety). Cannot refute a data-dependent violation; reports ⊥. |
-| explicit / symbolic cube, must-edge inference on | **Sound at the lift (2026-08-28, §6 update box)** — the vacuous must out of an empty cube that caused the false `Violated` is no longer created, and `assert_must_subset_may` gates any residual. e2e confirmation in `mununu-sva` pending. Was **unsound** pre-fix — §6. |
-| `symbolic_engine: true` | **No longer fed an inconsistent KMTS (2026-08-28)** — the lift enforces `R_must ⊆ R_may` before `TritBdd::from_parts`, so the debug panic / release miscompute of §6 cannot arise from a `$past` model. Was **panic (debug) / wrong verdict (release)** pre-fix — §6. |
+| explicit / symbolic cube, must-edge inference on | **Sound at the lift (2026-08-28, §6 update box, A–C)** — the vacuous must out of an empty cube that caused the false `Violated` is no longer created, and `assert_must_subset_may` gates any residual. Was **unsound** pre-fix — §6. |
+| `symbolic` engine (`symbolic_bitblast::AbstractRelation`) | **Sound (2026-08-28, §6 update box, D)** — an input-predicate abstraction now falls back to may-only (`r_must = None`) instead of building a support-dirty `R_must`; definite HOLDS transfers, refutation → ⊥. e2e-confirmed in `mununu-sva` (this is the path that still panicked after A–C). Was **panic (debug) / wrong verdict (release)** pre-fix — §6. |
 
 ## 9. What is argued vs verified vs gap
 

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -194,9 +194,14 @@ works when you want the intermediate BTOR2.)
 
 ### 3. Coverage is a fragment, and verdicts are honest
 
-The SVA translator supports a defined fragment (implication `|->` / `|=>`, `$past`
+The SVA translator supports a defined fragment (implication `|->` / `|=>` with a
+boolean or a bounded cycle-delay consequent `##k b` / `##[m:n] b`, `$past`
 (including a depth `$past(x, k)`, k ≥ 1) / `$stable` / `$rose` / `$fell`, `$onehot`
-/ `$onehot0`, …); assertions outside it come back in the `unsupported` list.
+/ `$onehot0`, …); assertions outside it come back in the `unsupported` list. A
+cycle-delay consequent lowers to nested `[]` — `a |-> ##2 b` → `AG(a → AX² b)`,
+`a |-> ##[1:3] b` → "b within the window" — so a definite verdict transfers just
+like the plain `|=>` (one `[]`) case. Multi-element `##` chains, `[*n]`
+repetition, and sequence *antecedents* remain out of fragment.
 
 The history functions work over a **register or a primary input**. That second
 half matters more than it sounds: it is what makes a data-integrity property —

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -194,14 +194,20 @@ works when you want the intermediate BTOR2.)
 
 ### 3. Coverage is a fragment, and verdicts are honest
 
-The SVA translator supports a defined fragment (implication `|->` / `|=>` with a
-boolean or a bounded cycle-delay consequent `##k b` / `##[m:n] b`, `$past`
-(including a depth `$past(x, k)`, k ≥ 1) / `$stable` / `$rose` / `$fell`, `$onehot`
-/ `$onehot0`, …); assertions outside it come back in the `unsupported` list. A
-cycle-delay consequent lowers to nested `[]` — `a |-> ##2 b` → `AG(a → AX² b)`,
-`a |-> ##[1:3] b` → "b within the window" — so a definite verdict transfers just
-like the plain `|=>` (one `[]`) case. Multi-element `##` chains, `[*n]`
-repetition, and sequence *antecedents* remain out of fragment.
+The SVA translator supports a defined fragment (implication `|->` / `|=>` over
+**bounded sequences** on either side, `$past` (including a depth `$past(x, k)`,
+k ≥ 1) / `$stable` / `$rose` / `$fell`, `$onehot` / `$onehot0`, …); assertions
+outside it come back in the `unsupported` list. The bounded-sequence layer covers
+cycle delays (`##k`, `##[m:n]`), fixed consecutive repetition (`b[*n]`), and
+multi-element `##` chains of booleans (`a |-> b ##1 c ##2 d`) — in the consequent
+*and*, at fixed delays, the antecedent (`(a ##1 b) |-> c`, `a[*n] |-> c`). Each
+lowers to nested `[]` — `a |-> ##2 b` → `AG(a → AX² b)`; `(a ##1 b) |-> c` →
+`AG(a → AX(b → c))` — so a definite verdict transfers just like the plain `|=>`
+(one `[]`) case. What stays out of fragment (rejected with a reason, never
+dropped — it needs a SERE→automaton subsystem): **unbounded** `##[m:$]` / `[*n:$]`,
+**goto** `[->n]` / **non-consecutive** `[=n]` repetition, range delays/repetition
+*inside* a multi-element chain or in an antecedent, and repetition/nesting inside
+a chain element.
 
 The history functions work over a **register or a primary input**. That second
 half matters more than it sounds: it is what makes a data-integrity property —

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -194,9 +194,9 @@ works when you want the intermediate BTOR2.)
 
 ### 3. Coverage is a fragment, and verdicts are honest
 
-The SVA translator supports a defined fragment (implication `|->` / `|=>`, `$past` /
-`$stable` / `$rose` / `$fell`, `$onehot` / `$onehot0`, …); assertions outside it come
-back in the `unsupported` list.
+The SVA translator supports a defined fragment (implication `|->` / `|=>`, `$past`
+(including a depth `$past(x, k)`, k ≥ 1) / `$stable` / `$rose` / `$fell`, `$onehot`
+/ `$onehot0`, …); assertions outside it come back in the `unsupported` list.
 
 The history functions work over a **register or a primary input**. That second
 half matters more than it sounds: it is what makes a data-integrity property —
@@ -209,27 +209,33 @@ input.
 (push && !pop && cnt_q == 0) |=> (d0_q == $past(din))
 ```
 
-Each `$past` base becomes a real 1-step flop in the model (`next(b__past) = b`),
-so the verdict transfers to the concrete design. This is a **history variable** —
-its next value is a function of the present, nothing in the design reads it, and
-so the augmented system is a conservative extension of the original: it can
-neither create nor destroy a counterexample. The base may be a register or a
-primary **input**; both produce the same flop.
+Each `$past` base becomes a real flop in the model (`next(b__past) = b`), so the
+verdict transfers to the concrete design. `$past(x, k)` becomes a **k-stage shift
+chain** (`b__past ← b`, `b__past2 ← b__past`, … `b__past{k}`); the common
+`$past(x)` is the 1-stage case. Each stage is a **history variable** — its next
+value is a function of the present, nothing in the design reads it, so the
+augmented system is a conservative extension of the original: it can neither
+create nor destroy a counterexample (the argument composes stage by stage). The
+base may be a register or a primary **input**; both produce the same chain.
 
-Only the initial state needs care, because a history variable has no value before
-the first transition. A state cell's shadow mirrors its `init`, giving
-`b__past == b` at cycle 0. An input has no `init` to mirror, so **its shadow is
-pinned to an explicit zero** rather than left free: an init-less BTOR2 cell reads
-as 0 to the cube and exact engines but stays free for the reachability portfolio,
-and that split is a verdict disagreement, not a nuance.
+Only the initial cycles need care, because a history variable has no value before
+the first transition. A state cell's stages mirror its `init`, so before the chain
+fills (cycles `< j` for stage `j`) `$past(b, j)` reads `b`'s reset value. An input
+has no `init` to mirror, so **every stage is pinned to an explicit zero** rather
+than left free: an init-less BTOR2 cell reads as 0 to the cube and exact engines
+but stays free for the reachability portfolio, and that split is a verdict
+disagreement, not a nuance.
 
-That invented value is read **only by a property that reads `$past` in the same
-cycle as its trigger**. The lift settles it structurally: `|=>` places the atom
-under a `[]`, so it is evaluated only at states that have a predecessor — where
-the shadow holds a value the design actually drove — while `|->` evaluates it at
-the initial state too. So every data-integrity property, which is `|=>` by
-construction, is unaffected; a `|->` property over `$past` of an input reads an
-invented cycle-0 history and its verdict there does not transfer.
+That invented value is read only in the first few cycles after reset. The lift
+settles it structurally: `|=>` places the atom under a `[]`, so it is evaluated
+only at states that have a predecessor — for depth 1 that fully hides the invented
+value, while `|->` evaluates it at the initial state too. So a depth-1
+data-integrity property (`|=>` by construction) is unaffected; a `|->` property
+over `$past` of an input reads an invented cycle-0 history and its verdict there
+does not transfer. For a **depth-k** `$past` of an input the chain takes k cycles
+to fill, so even under a `[]` the first k-1 post-reset cycles read the invented
+zero — an over-approximation bounded to those cycles (a register base reads its
+reset value there, which is the SVA convention, not an approximation).
 
 Two caveats that used to be about `$past` under must-edge inference. Both are now
 fixed at the lift (2026-08-28): the abstraction enforces the KMTS invariant

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -231,13 +231,17 @@ the initial state too. So every data-integrity property, which is `|=>` by
 construction, is unaffected; a `|->` property over `$past` of an input reads an
 invented cycle-0 history and its verdict there does not transfer.
 
-Two caveats that are **not** about the shadow's source. `must_edge_inference` is
-unsound on any `$past` model today (it can report `violated` for a correct
-design), and `--engine symbolic` aborts on one; both reproduce on a
-register-sourced `$past`. Leave must-edge inference off, which is the default.
+Two caveats that used to be about `$past` under must-edge inference. Both are now
+fixed at the lift (2026-08-28): the abstraction enforces the KMTS invariant
+`R_must ⊆ R_may` where must-edges are created — it no longer fabricates a must-edge
+out of an unsatisfiable predicate cube, and a per-lift check rejects any residual
+containment violation before it reaches an engine. So `must_edge_inference` no
+longer reports a spurious `violated` for a correct `$past` design, and
+`--engine symbolic` no longer aborts on one. (Default is still must-edge inference
+off, which was already sound for `holds`.)
 [`docs/design/past-shadow-soundness.md`](design/past-shadow-soundness.md) carries
-the full argument, the per-engine ledger, and why no engine may ever assume
-stutter equivalence here.
+the full argument, the per-engine ledger, the §6 fix note, and why no engine may
+ever assume stutter equivalence here.
 
 Some designs hit the abstraction ceiling and return
 `unknown`. Crucially, **a `holds` or `violated` verdict is sound** (Bruns–Godefroid


### PR DESCRIPTION
Extends the SVA fragment (k-deep `$past`, bounded cycle-delay sequences) and fixes
two `R_must ⊆ R_may` soundness holes the container e2e surfaced. 5 commits:

- **`0607be3` fix(kmts) — R_must ⊆ R_may at the lift.** The cube must-edge
  post-pass created `Sharp`/`MustHyperOnly` edges out of unsatisfiable cubes
  (vacuous ∀∃/∀∀), breaking `R_must ⊆ R_may` → false `Violated` / `TritBdd` panic
  on `$past` models. Restricts the ∀∃ must to the emitted `may_edges`, gates on a
  proven-feasible source cube, and adds an always-on lift-time `assert_must_subset_may`.
- **`b67dd67` feat(sva) — k-deep `$past(x, k)`.** A k-stage shadow shift chain;
  history-variable soundness composes per stage. (+ UI depth field, mununu-ui#68.)
- **`7704350` feat(sva) — `##k` / `##[m:n]` delayed-boolean consequents (XL.4).**
- **`d550749` feat(sva) — bounded sequence layer (XL.5):** multi-element `##`
  chains, fixed `[*n]` repetition, and fixed-delay sequence *antecedents*. Unbounded
  `##[m:$]`/`[*n:$]`, goto/non-consecutive repetition stay rejected-with-reason (Tier-3b).
- **`10a4e11` fix(symbolic) — may-only fallback on input predicates.** The `symbolic`
  engine builds its own may/must abstraction the kmts_lift fix doesn't touch; an
  input predicate left `R_must`'s support dirty → the same panic. Falls back to
  may-only on the standard path (game path unchanged). Corrects the Tier-0 doc overclaim.

**Validation.** Host: full `mununu-core` lib suite green (2410+), 7/7 two-player
game tests, targeted xl3/xl4/xl5 + must⊆may unit tests. **e2e in the `mununu-sva`
image (real slang + yosys)**: `##k`/`##[m:n]`/chains/`[*n]`/antecedents → HOLDS,
0 unsupported; a `$past` data-integrity property (`push |=> stored == $past(din)`)
+ a depth-2 `$past(din,2)` → HOLDS with no panic (this is what caught the symbolic
overclaim). Every soundness claim is nested-`[]` over the may-relation, so definite
verdicts transfer (Bruns–Godefroid).

Docs updated: `docs/verifying-rtl.md`, `docs/design/past-shadow-soundness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)