### PR TITLE
fix(sv): abstain honestly on bit-blast OOM (#462) + reject unusable --config-value (#459)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -3522,16 +3522,33 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         MustEdgeInferenceArg::SmtPerTargetStandard => MustEdgeInference::SmtPerTargetStandard,
         MustEdgeInferenceArg::SmtHyperMust => MustEdgeInference::SmtHyperMust,
     };
-    // H.J.b — parse `SIGNAL=VALUE` config concretization entries; malformed
-    // entries are skipped (the pipeline only pins actual inputs).
+    // H.J.b — parse `SIGNAL=VALUE` config concretization entries. mununu#459: a
+    // malformed entry is a HARD error here (mirrors `--param` above), never a
+    // silent drop; a value that is not a decimal u64 (e.g. hex `0x1`) is rejected
+    // with a message naming the value. An unknown / non-input SIGNAL is caught
+    // downstream in `verify_auto` against the model's real primary inputs.
     let config_values: std::collections::HashMap<String, u64> = args
         .config_value
         .iter()
-        .filter_map(|e| {
-            let (name, val) = e.split_once('=')?;
-            Some((name.trim().to_string(), val.trim().parse::<u64>().ok()?))
+        .map(|e| {
+            let (name, val) = e
+                .split_once('=')
+                .ok_or_else(|| format!("malformed --config-value '{e}': expected SIGNAL=VALUE"))?;
+            let (name, val) = (name.trim(), val.trim());
+            if name.is_empty() {
+                return Err(format!(
+                    "malformed --config-value '{e}': SIGNAL must be non-empty"
+                ));
+            }
+            let value = val.parse::<u64>().map_err(|_| {
+                format!(
+                    "malformed --config-value '{e}': VALUE must be a decimal u64 \
+                     (got '{val}'); hex/0x, signed, and non-numeric values are not accepted"
+                )
+            })?;
+            Ok((name.to_string(), value))
         })
-        .collect();
+        .collect::<Result<std::collections::HashMap<_, _>, String>>()?;
     // H.H — parse `SIGNAL<=VALUE` (or `SIGNAL=VALUE`) counter-bound entries; both
     // spellings mean the inclusive upper bound `SIGNAL <= VALUE`.
     let counter_bounds: std::collections::HashMap<String, u64> = args

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -557,35 +557,59 @@ impl BddBitBlaster {
 
     // ---- Boolean gadgets (each mirrors a concrete `eval_op` arm) ----
 
-    fn xor(&self, a: &BDDFunction, b: &BDDFunction) -> BDDFunction {
+    fn xor(&self, a: &BDDFunction, b: &BDDFunction) -> Result<BDDFunction, String> {
         // (a ∧ ¬b) ∨ (¬a ∧ b) — kept crate-portable (oxidd exposes `.and/.or/.not`).
-        let lhs = a.and(&b.not().unwrap()).unwrap();
-        let rhs = a.not().unwrap().and(b).unwrap();
-        lhs.or(&rhs).unwrap()
+        // Every apply is `oom(...)?` so an arena-exhausting op ABSTAINS (Err) rather
+        // than `.unwrap()`-panicking / SIGABRT-ing on the exhausted-manager drop.
+        let lhs = oom(a.and(&oom(b.not())?))?;
+        let rhs = oom(oom(a.not())?.and(b))?;
+        oom(lhs.or(&rhs))
+    }
+
+    /// Build a `width`-bit result one bit at a time, checking the node budget after
+    /// each bit so a wide per-bit op (bitwise AND/OR/…) ABSTAINS at the budget with
+    /// arena headroom intact (mununu#462) instead of growing the shared BDD arena to
+    /// exhaustion mid-collect — where the exhausted-manager drop would SIGABRT.
+    fn map_bits_checked(
+        &self,
+        width: u32,
+        mut f: impl FnMut(usize) -> Result<BDDFunction, String>,
+    ) -> Result<BitVec, String> {
+        let mut out = BitVec::with_capacity(width as usize);
+        for i in 0..width as usize {
+            out.push(f(i)?);
+            self.check_node_budget()?;
+        }
+        Ok(out)
     }
 
     /// Ripple-carry adder over `width` bits: returns `(sum, carry_out)`.
-    /// Missing high bits of either operand read as `0`.
+    /// Missing high bits of either operand read as `0`. Each bit checks the node
+    /// budget (mirrors `Op::Ite`): the whole width builds inside one `eval_op`, so
+    /// the between-op guard cannot fire mid-loop; the per-bit check bounds growth to
+    /// a single adder stage, so a wide add ABSTAINS at the budget with arena
+    /// headroom intact instead of exhausting the manager (mununu#462).
     fn add_bits(
         &self,
         a: &[BDDFunction],
         b: &[BDDFunction],
         cin: BDDFunction,
         width: u32,
-    ) -> (BitVec, BDDFunction) {
+    ) -> Result<(BitVec, BDDFunction), String> {
         let mut carry = cin;
         let mut sum = Vec::with_capacity(width as usize);
         for i in 0..width as usize {
             let ai = a.get(i).cloned().unwrap_or_else(|| self.ff.clone());
             let bi = b.get(i).cloned().unwrap_or_else(|| self.ff.clone());
-            let axb = self.xor(&ai, &bi);
-            let s = self.xor(&axb, &carry);
+            let axb = self.xor(&ai, &bi)?;
+            let s = self.xor(&axb, &carry)?;
             // carry' = (ai ∧ bi) ∨ (carry ∧ (ai ⊕ bi))
-            let c = ai.and(&bi).unwrap().or(&carry.and(&axb).unwrap()).unwrap();
+            let c = oom(oom(ai.and(&bi))?.or(&oom(carry.and(&axb))?))?;
             sum.push(s);
             carry = c;
+            self.check_node_budget()?;
         }
-        (sum, carry)
+        Ok((sum, carry))
     }
 
     /// Barrel shifter: shift `a` by the VARIABLE amount `s` (a `width`-bit BitVec).
@@ -599,7 +623,7 @@ impl BddBitBlaster {
         width: u32,
         left: bool,
         arith: bool,
-    ) -> BitVec {
+    ) -> Result<BitVec, String> {
         let w = width as usize;
         let sign = if arith {
             a.get(w.wrapping_sub(1))
@@ -613,9 +637,9 @@ impl BddBitBlaster {
             .collect();
         for (k, sk) in s.iter().enumerate() {
             let sh = 1usize.checked_shl(k as u32).unwrap_or(usize::MAX); // 2^k, saturating
-            let nsk = sk.not().unwrap();
+            let nsk = oom(sk.not())?;
             cur = (0..w)
-                .map(|j| {
+                .map(|j| -> Result<BDDFunction, String> {
                     // The bit selected when s[k] is set (shift by 2^k this stage).
                     let shifted = if left {
                         // left: result[j] = (j ≥ 2^k) ? cur[j − 2^k] : 0
@@ -633,86 +657,82 @@ impl BddBitBlaster {
                         }
                     };
                     // result[j] = s[k] ? shifted : cur[j]
-                    sk.and(&shifted)
-                        .unwrap()
-                        .or(&nsk.and(&cur[j]).unwrap())
-                        .unwrap()
+                    oom(oom(sk.and(&shifted))?.or(&oom(nsk.and(&cur[j]))?))
                 })
-                .collect();
+                .collect::<Result<BitVec, String>>()?;
+            self.check_node_budget()?;
         }
-        cur
+        Ok(cur)
     }
 
-    /// OR-reduce a bit-vector to a single BDD (`|x`).
-    fn or_reduce(&self, bits: &[BDDFunction]) -> BDDFunction {
+    /// OR-reduce a bit-vector to a single BDD (`|x`). Budget-checked per bit so a
+    /// wide reduction ABSTAINS at the budget rather than exhausting the arena.
+    fn or_reduce(&self, bits: &[BDDFunction]) -> Result<BDDFunction, String> {
         let mut acc = self.ff.clone();
         for b in bits {
-            acc = acc.or(b).unwrap();
+            acc = oom(acc.or(b))?;
+            self.check_node_budget()?;
         }
-        acc
+        Ok(acc)
     }
 
-    /// AND-reduce a bit-vector to a single BDD (`&x`).
-    fn and_reduce(&self, bits: &[BDDFunction]) -> BDDFunction {
+    /// AND-reduce a bit-vector to a single BDD (`&x`). Budget-checked per bit.
+    fn and_reduce(&self, bits: &[BDDFunction]) -> Result<BDDFunction, String> {
         let mut acc = self.tt.clone();
         for b in bits {
-            acc = acc.and(b).unwrap();
+            acc = oom(acc.and(b))?;
+            self.check_node_budget()?;
         }
-        acc
+        Ok(acc)
     }
 
-    /// XOR-reduce a bit-vector to a single BDD (`^x`).
-    fn xor_reduce(&self, bits: &[BDDFunction]) -> BDDFunction {
+    /// XOR-reduce a bit-vector to a single BDD (`^x`). Budget-checked per bit.
+    fn xor_reduce(&self, bits: &[BDDFunction]) -> Result<BDDFunction, String> {
         let mut acc = self.ff.clone();
         for b in bits {
-            acc = self.xor(&acc, b);
+            acc = self.xor(&acc, b)?;
+            self.check_node_budget()?;
         }
-        acc
+        Ok(acc)
     }
 
     /// Structural bit-equality: AND of per-bit XNOR. Returns a 1-bit vector.
-    fn eq_bits(&self, a: &[BDDFunction], b: &[BDDFunction]) -> BitVec {
+    /// Budget-checked per bit (mununu#462): a wide equality over a large state cone
+    /// is the AND-reduction that blows the arena, so it ABSTAINS at the budget with
+    /// arena headroom intact instead of `.unwrap()`-panicking on OxiDD OutOfMemory.
+    fn eq_bits(&self, a: &[BDDFunction], b: &[BDDFunction]) -> Result<BitVec, String> {
         let n = a.len().max(b.len());
         let mut acc = self.tt.clone();
         for i in 0..n {
             let ai = a.get(i).cloned().unwrap_or_else(|| self.ff.clone());
             let bi = b.get(i).cloned().unwrap_or_else(|| self.ff.clone());
-            let xnor = self.xor(&ai, &bi).not().unwrap();
-            acc = acc.and(&xnor).unwrap();
+            let xnor = oom(self.xor(&ai, &bi)?.not())?;
+            acc = oom(acc.and(&xnor))?;
+            self.check_node_budget()?;
         }
-        vec![acc]
+        Ok(vec![acc])
     }
 
     /// Unsigned `a >= b`: the carry-out of `a + ¬b + 1` (borrow-free subtract).
-    fn uge(&self, a: &[BDDFunction], b: &[BDDFunction], width: u32) -> BDDFunction {
+    fn uge(&self, a: &[BDDFunction], b: &[BDDFunction], width: u32) -> Result<BDDFunction, String> {
         let not_b: BitVec = (0..width as usize)
-            .map(|i| {
-                b.get(i)
-                    .cloned()
-                    .unwrap_or_else(|| self.ff.clone())
-                    .not()
-                    .unwrap()
-            })
-            .collect();
-        let (_, cout) = self.add_bits(a, &not_b, self.tt.clone(), width);
-        cout
+            .map(|i| oom(b.get(i).cloned().unwrap_or_else(|| self.ff.clone()).not()))
+            .collect::<Result<BitVec, String>>()?;
+        let (_, cout) = self.add_bits(a, &not_b, self.tt.clone(), width)?;
+        Ok(cout)
     }
 
     /// Signed (two's-complement) `a < b`: if the signs differ, the negative operand (MSB set)
     /// is the smaller; if the signs match, unsigned `<` decides. `slt = (a_msb ⊕ b_msb) ? a_msb
     /// : (a <u b)`, with `a <u b = ¬(a ≥u b)`.
-    fn slt(&self, a: &[BDDFunction], b: &[BDDFunction], width: u32) -> BDDFunction {
+    fn slt(&self, a: &[BDDFunction], b: &[BDDFunction], width: u32) -> Result<BDDFunction, String> {
         let w = width as usize;
         let amsb = a.get(w - 1).cloned().unwrap_or_else(|| self.ff.clone());
         let bmsb = b.get(w - 1).cloned().unwrap_or_else(|| self.ff.clone());
-        let signs_differ = self.xor(&amsb, &bmsb);
-        let ult = self.uge(a, b, width).not().unwrap(); // a <u b
+        let signs_differ = self.xor(&amsb, &bmsb)?;
+        let ult = oom(self.uge(a, b, width)?.not())?; // a <u b
         // signs_differ ? amsb : ult
-        signs_differ
-            .and(&amsb)
-            .unwrap()
-            .or(&signs_differ.not().unwrap().and(&ult).unwrap())
-            .unwrap()
+        oom(oom(signs_differ.and(&amsb))?.or(&oom(oom(signs_differ.not())?.and(&ult))?))
     }
 
     // ---- R-F5.3b: predicate BDDs over the register-bit variables ----
@@ -748,15 +768,21 @@ impl BddBitBlaster {
 
     /// An unsigned comparison of two equal-width bit-vectors, as a 1-bit BDD.
     /// Mirrors [`crate::adapter::btor2::predicate_expr`]'s `cmp_apply` (unsigned).
-    fn cmp_bits(&self, a: &[BDDFunction], op: CmpOp, b: &[BDDFunction], width: u32) -> BDDFunction {
-        match op {
-            CmpOp::Eq => self.eq_bits(a, b).swap_remove(0),
-            CmpOp::Ne => self.eq_bits(a, b).swap_remove(0).not().unwrap(),
-            CmpOp::Ge => self.uge(a, b, width),
-            CmpOp::Lt => self.uge(a, b, width).not().unwrap(),
-            CmpOp::Le => self.uge(b, a, width), // a ≤ b ⟺ b ≥ a
-            CmpOp::Gt => self.uge(b, a, width).not().unwrap(), // a > b ⟺ ¬(b ≥ a)
-        }
+    fn cmp_bits(
+        &self,
+        a: &[BDDFunction],
+        op: CmpOp,
+        b: &[BDDFunction],
+        width: u32,
+    ) -> Result<BDDFunction, String> {
+        Ok(match op {
+            CmpOp::Eq => self.eq_bits(a, b)?.swap_remove(0),
+            CmpOp::Ne => oom(self.eq_bits(a, b)?.swap_remove(0).not())?,
+            CmpOp::Ge => self.uge(a, b, width)?,
+            CmpOp::Lt => oom(self.uge(a, b, width)?.not())?,
+            CmpOp::Le => self.uge(b, a, width)?, // a ≤ b ⟺ b ≥ a
+            CmpOp::Gt => oom(self.uge(b, a, width)?.not())?, // a > b ⟺ ¬(b ≥ a)
+        })
     }
 
     /// R-F5.3b — compile a [`PredicateExpr`] into a single BDD over the
@@ -790,7 +816,7 @@ impl BddBitBlaster {
                 let w = reg.len().max(64);
                 let a = self.zero_extend(reg, w);
                 let b = self.const_bits(*value as u128, w);
-                Ok(self.cmp_bits(&a, *op, &b, w as u32))
+                self.cmp_bits(&a, *op, &b, w as u32)
             }
             PredicateExpr::CmpReg { lhs, op, rhs } => {
                 let l = self.signal_bits(lhs).ok_or_else(|| unknown(lhs))?;
@@ -798,7 +824,7 @@ impl BddBitBlaster {
                 let w = l.len().max(r.len());
                 let a = self.zero_extend(l, w);
                 let b = self.zero_extend(r, w);
-                Ok(self.cmp_bits(&a, *op, &b, w as u32))
+                self.cmp_bits(&a, *op, &b, w as u32)
             }
             PredicateExpr::CmpRegAddend {
                 lhs,
@@ -814,19 +840,17 @@ impl BddBitBlaster {
                 // is `eval`'s modulus and equals the rhs register width here).
                 let rw = r.len();
                 let addend_bits = self.const_bits(*addend as u128, rw);
-                let (sum, _) = self.add_bits(r, &addend_bits, self.ff.clone(), rw as u32);
+                let (sum, _) = self.add_bits(r, &addend_bits, self.ff.clone(), rw as u32)?;
                 let w = l.len().max(rw);
                 let a = self.zero_extend(l, w);
                 let b = self.zero_extend(&sum, w);
-                Ok(self.cmp_bits(&a, *op, &b, w as u32))
+                self.cmp_bits(&a, *op, &b, w as u32)
             }
             PredicateExpr::And(a, b) => {
-                Ok(self.predicate_bdd(a)?.and(&self.predicate_bdd(b)?).unwrap())
+                oom(self.predicate_bdd(a)?.and(&self.predicate_bdd(b)?))
             }
-            PredicateExpr::Or(a, b) => {
-                Ok(self.predicate_bdd(a)?.or(&self.predicate_bdd(b)?).unwrap())
-            }
-            PredicateExpr::Not(a) => Ok(self.predicate_bdd(a)?.not().unwrap()),
+            PredicateExpr::Or(a, b) => oom(self.predicate_bdd(a)?.or(&self.predicate_bdd(b)?)),
+            PredicateExpr::Not(a) => oom(self.predicate_bdd(a)?.not()),
             PredicateExpr::Select { .. } => Err(
                 "exact-symbolic ROBDD cannot bit-blast an array-content (Select) predicate — it is \
                  SMT-only (predicate-cube path); the exact engine abstains on it"
@@ -1017,10 +1041,10 @@ impl BddBitBlaster {
                     .unwrap()
             };
             // p_i ⟺ pred  and  p'_i ⟺ pred_next  (via XNOR).
-            let iff_present = self.xor(&present[i], &pred).not().unwrap();
-            let iff_next = self.xor(&next[i], &pred_next).not().unwrap();
-            a = a.and(&iff_present).unwrap();
-            a_prime = a_prime.and(&iff_next).unwrap();
+            let iff_present = oom(self.xor(&present[i], &pred)?.not())?;
+            let iff_next = oom(self.xor(&next[i], &pred_next)?.not())?;
+            a = oom(a.and(&iff_present))?;
+            a_prime = oom(a_prime.and(&iff_next))?;
         }
 
         // R_may = ∃(x ∪ i). A ∧ A'   (fused relational product).
@@ -1720,96 +1744,88 @@ impl BvTermBackend for BddBitBlaster {
             // ---- Bitwise (result + operands all `width` bits) ----
             Op::Not => {
                 let a = read(0)?;
-                (0..width as usize).map(|i| a[i].not().unwrap()).collect()
+                self.map_bits_checked(width, |i| oom(a[i].not()))?
             }
             Op::And => {
                 let (a, b) = (read(0)?, read(1)?);
-                (0..width as usize)
-                    .map(|i| a[i].and(&b[i]).unwrap())
-                    .collect()
+                self.map_bits_checked(width, |i| oom(a[i].and(&b[i])))?
             }
             Op::Or => {
                 let (a, b) = (read(0)?, read(1)?);
-                (0..width as usize)
-                    .map(|i| a[i].or(&b[i]).unwrap())
-                    .collect()
+                self.map_bits_checked(width, |i| oom(a[i].or(&b[i])))?
             }
             Op::Xor => {
                 let (a, b) = (read(0)?, read(1)?);
-                (0..width as usize)
-                    .map(|i| self.xor(&a[i], &b[i]))
-                    .collect()
+                self.map_bits_checked(width, |i| self.xor(&a[i], &b[i]))?
             }
             Op::Nand => {
                 let (a, b) = (read(0)?, read(1)?);
-                (0..width as usize)
-                    .map(|i| a[i].and(&b[i]).unwrap().not().unwrap())
-                    .collect()
+                self.map_bits_checked(width, |i| oom(oom(a[i].and(&b[i]))?.not()))?
             }
             Op::Nor => {
                 let (a, b) = (read(0)?, read(1)?);
-                (0..width as usize)
-                    .map(|i| a[i].or(&b[i]).unwrap().not().unwrap())
-                    .collect()
+                self.map_bits_checked(width, |i| oom(oom(a[i].or(&b[i]))?.not()))?
             }
             Op::Xnor => {
                 let (a, b) = (read(0)?, read(1)?);
-                (0..width as usize)
-                    .map(|i| self.xor(&a[i], &b[i]).not().unwrap())
-                    .collect()
+                self.map_bits_checked(width, |i| oom(self.xor(&a[i], &b[i])?.not()))?
             }
 
             // ---- Arithmetic (two's-complement, wrap to `width`) ----
             Op::Add => {
                 let (a, b) = (read(0)?, read(1)?);
-                self.add_bits(&a, &b, self.ff.clone(), width).0
+                self.add_bits(&a, &b, self.ff.clone(), width)?.0
             }
             Op::Sub => {
                 // a − b = a + ¬b + 1
                 let (a, b) = (read(0)?, read(1)?);
-                let not_b: BitVec = (0..width as usize).map(|i| b[i].not().unwrap()).collect();
-                self.add_bits(&a, &not_b, self.tt.clone(), width).0
+                let not_b: BitVec = (0..width as usize)
+                    .map(|i| oom(b[i].not()))
+                    .collect::<Result<BitVec, String>>()?;
+                self.add_bits(&a, &not_b, self.tt.clone(), width)?.0
             }
             Op::Inc => {
                 let a = read(0)?;
-                self.add_bits(&a, &[], self.tt.clone(), width).0
+                self.add_bits(&a, &[], self.tt.clone(), width)?.0
             }
             Op::Dec => {
                 // a − 1 = a + (all ones) + 0
                 let a = read(0)?;
                 let ones: BitVec = (0..width as usize).map(|_| self.tt.clone()).collect();
-                self.add_bits(&a, &ones, self.ff.clone(), width).0
+                self.add_bits(&a, &ones, self.ff.clone(), width)?.0
             }
             Op::Neg => {
                 // −a = ¬a + 1
                 let a = read(0)?;
-                let not_a: BitVec = (0..width as usize).map(|i| a[i].not().unwrap()).collect();
-                self.add_bits(&not_a, &[], self.tt.clone(), width).0
+                let not_a: BitVec = (0..width as usize)
+                    .map(|i| oom(a[i].not()))
+                    .collect::<Result<BitVec, String>>()?;
+                self.add_bits(&not_a, &[], self.tt.clone(), width)?.0
             }
             Op::Mul => {
                 // Schoolbook shift-and-add: Σ_i (b[i] ? (a << i) : 0), truncated to `width`.
                 // O(width²) BDD adds — fine at the ≤ MAX_BITBLAST_BITS cone widths. Both
                 // operands + the result are `width` bits; the product wraps mod 2^width.
+                // Each partial + each `add_bits` is budget-checked, so a wide multiply
+                // ABSTAINS at the budget rather than exhausting the arena (mununu#462).
                 let (a, b) = (read(0)?, read(1)?);
                 let w = width as usize;
                 let mut acc: BitVec = vec![self.ff.clone(); w];
                 for i in 0..w {
                     let bi = b.get(i).cloned().unwrap_or_else(|| self.ff.clone());
                     // Partial product: (a << i) masked by b[i]. Bit j = (j ≥ i) ? a[j−i] ∧ b[i] : 0.
-                    let partial: BitVec = (0..w)
-                        .map(|j| {
-                            if j >= i {
-                                a.get(j - i)
-                                    .cloned()
-                                    .unwrap_or_else(|| self.ff.clone())
-                                    .and(&bi)
-                                    .unwrap()
-                            } else {
-                                self.ff.clone()
-                            }
-                        })
-                        .collect();
-                    acc = self.add_bits(&acc, &partial, self.ff.clone(), width).0;
+                    let partial: BitVec = self.map_bits_checked(width, |j| {
+                        if j >= i {
+                            oom(a
+                                .get(j - i)
+                                .cloned()
+                                .unwrap_or_else(|| self.ff.clone())
+                                .and(&bi))
+                        } else {
+                            Ok(self.ff.clone())
+                        }
+                    })?;
+                    acc = self.add_bits(&acc, &partial, self.ff.clone(), width)?.0;
                 }
                 acc
             }
@@ -1817,87 +1833,87 @@ impl BvTermBackend for BddBitBlaster {
             // ---- Variable shifts (barrel shifter, result + operands all `width` bits) ----
             Op::Sll => {
                 let (a, s) = (read(0)?, read(1)?);
-                self.barrel_shift(&a, &s, width, true, false)
+                self.barrel_shift(&a, &s, width, true, false)?
             }
             Op::Srl => {
                 let (a, s) = (read(0)?, read(1)?);
-                self.barrel_shift(&a, &s, width, false, false)
+                self.barrel_shift(&a, &s, width, false, false)?
             }
             Op::Sra => {
                 let (a, s) = (read(0)?, read(1)?);
-                self.barrel_shift(&a, &s, width, false, true)
+                self.barrel_shift(&a, &s, width, false, true)?
             }
 
             // ---- Equality / implication (1-bit result) ----
             Op::Eq | Op::Iff => {
                 let (a, b) = (read(0)?, read(1)?);
-                self.eq_bits(&a, &b)
+                self.eq_bits(&a, &b)?
             }
             Op::Neq => {
                 let (a, b) = (read(0)?, read(1)?);
-                vec![self.eq_bits(&a, &b)[0].not().unwrap()]
+                vec![oom(self.eq_bits(&a, &b)?[0].not())?]
             }
             Op::Implies => {
                 // ¬(|a) ∨ (|b)
                 let (a, b) = (read(0)?, read(1)?);
-                let a_bool = self.or_reduce(&a);
-                let b_bool = self.or_reduce(&b);
-                vec![a_bool.not().unwrap().or(&b_bool).unwrap()]
+                let a_bool = self.or_reduce(&a)?;
+                let b_bool = self.or_reduce(&b)?;
+                vec![oom(oom(a_bool.not())?.or(&b_bool))?]
             }
 
             // ---- Unsigned comparisons (1-bit result) ----
             Op::Ugte => {
                 let (a, b) = (read(0)?, read(1)?);
                 let w = a.len().max(b.len()) as u32;
-                vec![self.uge(&a, &b, w)]
+                vec![self.uge(&a, &b, w)?]
             }
             Op::Ult => {
                 let (a, b) = (read(0)?, read(1)?);
                 let w = a.len().max(b.len()) as u32;
-                vec![self.uge(&a, &b, w).not().unwrap()]
+                vec![oom(self.uge(&a, &b, w)?.not())?]
             }
             Op::Ugt => {
                 // a > b ⟺ b < a ⟺ ¬(b ≥ a)
                 let (a, b) = (read(0)?, read(1)?);
                 let w = a.len().max(b.len()) as u32;
-                vec![self.uge(&b, &a, w).not().unwrap()]
+                vec![oom(self.uge(&b, &a, w)?.not())?]
             }
             Op::Ulte => {
                 // a ≤ b ⟺ b ≥ a
                 let (a, b) = (read(0)?, read(1)?);
                 let w = a.len().max(b.len()) as u32;
-                vec![self.uge(&b, &a, w)]
+                vec![self.uge(&b, &a, w)?]
             }
 
             // ---- Signed comparisons (two's-complement, 1-bit result) ----
             Op::Slt => {
                 let (a, b) = (read(0)?, read(1)?);
                 let w = a.len().max(b.len()) as u32;
-                vec![self.slt(&a, &b, w)]
+                vec![self.slt(&a, &b, w)?]
             }
             Op::Sgt => {
                 // a > b ⟺ b < a
                 let (a, b) = (read(0)?, read(1)?);
                 let w = a.len().max(b.len()) as u32;
-                vec![self.slt(&b, &a, w)]
+                vec![self.slt(&b, &a, w)?]
             }
             Op::Sgte => {
                 // a ≥ b ⟺ ¬(a < b)
                 let (a, b) = (read(0)?, read(1)?);
                 let w = a.len().max(b.len()) as u32;
-                vec![self.slt(&a, &b, w).not().unwrap()]
+                vec![oom(self.slt(&a, &b, w)?.not())?]
             }
             Op::Slte => {
                 // a ≤ b ⟺ ¬(b < a)
                 let (a, b) = (read(0)?, read(1)?);
                 let w = a.len().max(b.len()) as u32;
-                vec![self.slt(&b, &a, w).not().unwrap()]
+                vec![oom(self.slt(&b, &a, w)?.not())?]
             }
 
             // ---- Reductions (1-bit result) ----
-            Op::Redor => vec![self.or_reduce(&read(0)?)],
-            Op::Redand => vec![self.and_reduce(&read(0)?)],
-            Op::Redxor => vec![self.xor_reduce(&read(0)?)],
+            Op::Redor => vec![self.or_reduce(&read(0)?)?],
+            Op::Redand => vec![self.and_reduce(&read(0)?)?],
+            Op::Redxor => vec![self.xor_reduce(&read(0)?)?],
 
             // ---- Structural rearrangement ----
             Op::Concat => {
@@ -2186,7 +2202,7 @@ impl BddBitBlaster {
     /// seeing unreachable stuck states: the verdict is checked from the *actual*
     /// modelled reset state, not an over-broad free-init set. `Holds` iff that
     /// initial state satisfies the property.
-    pub fn initial_state_bdd(&self, file: &Btor2File) -> BDDFunction {
+    pub fn initial_state_bdd(&self, file: &Btor2File) -> Result<BDDFunction, String> {
         // State-line nid → the value operand of its `init` line (if any).
         let mut init_value_nid: HashMap<Nid, Nid> = HashMap::new();
         for line in &file.lines {
@@ -2237,11 +2253,12 @@ impl BddBitBlaster {
                 .unwrap_or_else(|| vec![self.ff.clone(); cell.vars.len()]);
             for (var, val) in cell.vars.iter().zip(value_bits.iter()) {
                 // state_bit ⟺ value_bit  =  ¬(state_bit XOR value_bit)
-                let iff = self.xor(var, val).not().unwrap();
-                init = init.and(&iff).unwrap();
+                let iff = oom(self.xor(var, val)?.not())?;
+                init = oom(init.and(&iff))?;
+                self.check_node_budget()?;
             }
         }
-        init
+        Ok(init)
     }
 }
 
@@ -2819,7 +2836,7 @@ pub fn exact_bad_reachable(btor2_content: &str) -> Result<bool, String> {
     let mut atoms: HashMap<&str, BDDFunction> = HashMap::new();
     atoms.insert("BAD", bad);
     let reach = model.evaluate(&formula, &atoms)?;
-    let init = bb.initial_state_bdd(&file);
+    let init = bb.initial_state_bdd(&file)?;
     let reachable = init.and(&reach).unwrap() != bb.ff;
 
     // A REACHABLE verdict is always sound: the modelled reset (uninitialised
@@ -3128,7 +3145,7 @@ pub fn kmts_two_player_verdict(
         controllable.iter().map(|s| s.to_string()).collect();
     let rel = bb.abstract_game(&exprs, must_semantics, &ctrl)?;
     let verdict = rel.evaluate(formula, &names)?;
-    let init = bb.initial_state_bdd(&file);
+    let init = bb.initial_state_bdd(&file)?;
     Ok(rel.verdict_at_init(&verdict, &init))
 }
 
@@ -3170,7 +3187,7 @@ pub fn kmts_two_player_verdict_cegar(
     let ctrl: std::collections::HashSet<String> =
         controllable.iter().map(|s| s.to_string()).collect();
     let exact = bb.exact_model_partitioned(&ctrl); // the concrete pre-image (WP) operator for refinement
-    let init = bb.initial_state_bdd(&file);
+    let init = bb.initial_state_bdd(&file)?;
 
     // The predicate set: the named formula atoms first (evaluate binds atom name → index by position),
     // then the anonymous CEGAR refinement predicates.
@@ -3415,7 +3432,7 @@ fn exact_symbolic_verdict_with_witness_inner(
         .collect();
 
     let sat = exact.evaluate(formula, &atoms)?;
-    let init = bb.initial_state_bdd(&file);
+    let init = bb.initial_state_bdd(&file)?;
     // Holds iff init ⊆ sat, i.e. no initial state violates φ.
     let violating = init.and(&sat.not().unwrap()).unwrap();
     if violating == *exact.ff() {
@@ -3507,7 +3524,7 @@ pub fn exact_env_strategy(btor2_content: &str, good: &str) -> Result<EnvStrategy
         Ok(b) => b,
         Err(e) => return Ok(EnvStrategyOutcome::Inapplicable(e)),
     };
-    let init = bb.initial_state_bdd(&file);
+    let init = bb.initial_state_bdd(&file)?;
 
     let r = exact.ef_region(&good_bdd);
     let s = exact.env_maintain_region(&r);
@@ -4302,7 +4319,7 @@ impl BddBitBlaster {
         let exact = self.exact_model();
         let stall = self.eg_not_p(&exact, p);
         // A stall state that is also initial ⇒ AF p is violated from reset.
-        let init = self.initial_state_bdd(file);
+        let init = self.initial_state_bdd(file).ok()?;
         let bad = init.and(&stall).unwrap();
         if bad == self.ff {
             return None;
@@ -4345,7 +4362,7 @@ impl BddBitBlaster {
             layers.push(next);
         }
         let can_reach = layers.last().unwrap().clone();
-        let init = self.initial_state_bdd(file);
+        let init = self.initial_state_bdd(file).ok()?;
         let bad = init.and(&can_reach).unwrap();
         if bad == self.ff {
             return None;
@@ -4418,7 +4435,7 @@ impl BddBitBlaster {
             }
             layers.push(next);
         }
-        let init = self.initial_state_bdd(file);
+        let init = self.initial_state_bdd(file).ok()?;
         let bad = init.and(layers.last().unwrap()).unwrap();
         if bad == self.ff {
             return None; // the trap is unreachable ⇒ AG EF p holds
@@ -4485,7 +4502,7 @@ impl BddBitBlaster {
             }
             layers.push(next);
         }
-        let init = self.initial_state_bdd(file);
+        let init = self.initial_state_bdd(file).ok()?;
         let reachable = init.and(layers.last().unwrap()).unwrap();
         if reachable == self.ff {
             return None; // good unreachable from init
@@ -4545,7 +4562,7 @@ impl BddBitBlaster {
             layers.push(next);
         }
         let winning = layers.last().unwrap().clone();
-        let init = self.initial_state_bdd(file);
+        let init = self.initial_state_bdd(file).ok()?;
         if init.and(&winning).unwrap() == self.ff {
             return None; // good unreachable from init — no strategy
         }
@@ -4693,7 +4710,7 @@ impl BddBitBlaster {
             }
             layers.push(next);
         }
-        let init = self.initial_state_bdd(file);
+        let init = self.initial_state_bdd(file).ok()?;
         let bad = init.and(layers.last().unwrap()).unwrap();
         if bad == self.ff {
             return None; // the env cannot force the play into the stall from reset.
@@ -4805,7 +4822,11 @@ impl BddBitBlaster {
                 .find(|&k| mt.and(&layers[k]).unwrap() != self.ff)
                 .unwrap_or(0) as u32
         };
-        let init = self.initial_state_bdd(file);
+        // An OOM-abstained init (mununu#462) degrades to the empty state set → an
+        // empty ranking → the caller finds no strategy (a sound abstain, not a panic).
+        let init = self
+            .initial_state_bdd(file)
+            .unwrap_or_else(|_| self.ff.clone());
         let mut frontier: Vec<BTreeMap<String, u128>> = Vec::new();
         {
             let mut r = init.clone();
@@ -5017,7 +5038,7 @@ impl BddBitBlaster {
             }
             w = attr;
         }
-        let init = self.initial_state_bdd(file);
+        let init = self.initial_state_bdd(file).ok()?;
         if init.and(&w).unwrap() == self.ff {
             return None; // unrealizable Büchi → the env starvation lasso is the witness, not a strategy
         }
@@ -5089,7 +5110,7 @@ impl BddBitBlaster {
         {
             return None;
         }
-        let init = self.initial_state_bdd(file);
+        let init = self.initial_state_bdd(file).ok()?;
         let realizable = init.and(&winning).unwrap() != self.ff;
         // The winner's region: the controller lives inside the attractor; the environment lives outside it
         // (by determinacy of the reachability game, ¬attractor is the environment's winning region).

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -365,6 +365,42 @@ enum NotePosture {
     Cube,
 }
 
+/// mununu#459 — partition user `--config-value` pins into (applied, unusable).
+///
+/// A pin is **applied** if the config pass pinned it (`pinned_configs`) or reset-gating already
+/// pinned it to the SAME value (`reset_pinned`). It is **unusable** if its name is not a primary
+/// input of the lifted model (misspelled, or a state/output/optimized-away signal), or — a real
+/// input — it was already tied to a DIFFERENT constant (a conflict with reset-gating). An unusable
+/// pin is a caller mistake the caller must see: it is surfaced as a hard error, never silently
+/// dropped to verify a different question than the one asked. Pure (no lift) so it is unit-testable.
+fn partition_config_pins(
+    config_pins: &[(String, u64)],
+    model_input_names: &std::collections::HashSet<String>,
+    pinned_configs: &std::collections::HashSet<String>,
+    reset_pinned: &std::collections::HashSet<String>,
+) -> (Vec<(String, u64)>, Vec<String>) {
+    let mut applied: Vec<(String, u64)> = Vec::new();
+    let mut unusable: Vec<String> = Vec::new();
+    for (name, value) in config_pins {
+        let tag = format!("{name}={value}");
+        if pinned_configs.contains(&tag) || reset_pinned.contains(&tag) {
+            applied.push((name.clone(), *value));
+        } else if !model_input_names.contains(name) {
+            unusable.push(format!(
+                "`{tag}` — `{name}` is not a primary input of the lifted model"
+            ));
+        } else {
+            // A real input, but the config pass could not pin it to `value` — it is already tied
+            // to a different constant (typically by reset-gating).
+            unusable.push(format!(
+                "`{tag}` — `{name}` is a primary input but is already pinned to a different \
+                 constant (e.g. reset-gating); reconcile the two"
+            ));
+        }
+    }
+    (applied, unusable)
+}
+
 fn build_notes(
     report: &AutoVerifyReport,
     must_edge_inference: MustEdgeInference,
@@ -1975,9 +2011,34 @@ pub(crate) fn prepare_model(
         .collect();
     let btor2 = augment_with_past_shadows(&btor2, &shadow_bases)?;
 
+    // mununu#459 — snapshot the model's real primary-input names BEFORE any pinning
+    // rewrites them to constants, so a user `--config-value` can be validated
+    // against them below. A `<nid> input <sid> <symbol>` line names a pinnable
+    // input; a bare `<nid> input <sid>` (no symbol) or a comment cannot be pinned.
+    let model_input_names: std::collections::HashSet<String> = btor2
+        .lines()
+        .filter_map(|l| {
+            let mut t = l.split_whitespace();
+            let _nid = t.next()?;
+            if t.next()? != "input" {
+                return None;
+            }
+            let _sid = t.next()?;
+            match t.next()? {
+                ";" => None,
+                sym => Some(sym.to_string()),
+            }
+        })
+        .collect();
+
     // Pin recognized reset inputs inactive (the model-level half of reset-gating).
     let (btor2, pinned_resets) =
         crate::adapter::btor2::pin::pin_inputs_to_constants(&btor2, &reset_pins);
+    // A reset pin that coincides (`name=value`) with a user config pin counts as
+    // that config pin being in effect (mununu#459 completeness); capture the set
+    // before `pinned_resets` moves into the diagnostics.
+    let reset_pinned_set: std::collections::HashSet<String> =
+        pinned_resets.iter().cloned().collect();
     report.diagnostics.gated_resets = pinned_resets;
 
     // H.J.b — pin user-supplied config inputs to constants (same mechanism as reset-gating).
@@ -1992,13 +2053,44 @@ pub(crate) fn prepare_model(
     };
     let (btor2, pinned_configs) =
         crate::adapter::btor2::pin::pin_inputs_to_constants(&btor2, &config_pins);
-    let applied_config_values: Vec<(String, u64)> = pinned_configs
-        .iter()
-        .filter_map(|s| {
-            let (n, val) = s.split_once('=')?;
-            Some((n.to_string(), val.trim().parse::<u64>().ok()?))
-        })
-        .collect();
+    // mununu#459 — a user config pin must name a real primary input AND take effect.
+    // Partition the requested pins into applied (by the config pass, or already
+    // pinned to the SAME value by reset-gating) vs unusable, and error on any
+    // unusable pin rather than silently verifying a different question than asked.
+    let applied_config_set: std::collections::HashSet<String> =
+        pinned_configs.iter().cloned().collect();
+    let (applied_config_values, unusable) = partition_config_pins(
+        &config_pins,
+        &model_input_names,
+        &applied_config_set,
+        &reset_pinned_set,
+    );
+    if !unusable.is_empty() {
+        let mut inputs: Vec<&str> = model_input_names.iter().map(String::as_str).collect();
+        inputs.sort_unstable();
+        let hint = if inputs.is_empty() {
+            "the lifted model has no primary inputs".to_string()
+        } else if inputs.len() > 24 {
+            format!(
+                "{} primary inputs, e.g. {}, …",
+                inputs.len(),
+                inputs[..24].join(", ")
+            )
+        } else {
+            format!("primary inputs: {}", inputs.join(", "))
+        };
+        return Err(AdapterError {
+            kind: AdapterErrorKind::UnsupportedConstruct,
+            location: None,
+            message: format!(
+                "--config-value: {} pin(s) could not be applied — a config pin must name a \
+                 real primary input and take effect, it is never silently dropped (mununu#459). \
+                 {}. ({hint})",
+                unusable.len(),
+                unusable.join("; "),
+            ),
+        });
+    }
 
     Ok(Prepared::Model(Box::new(PreparedModel {
         btor2,
@@ -2965,6 +3057,53 @@ fn liveness_rescue_note(name: &str, verdict: &str, engines: &[&str]) -> Verifica
 
 #[cfg(test)]
 mod tests {
+    /// mununu#459 — `partition_config_pins` classifies user pins into applied vs unusable. A pin
+    /// is applied when the config pass pins it OR reset-gating already pinned it to the same value;
+    /// it is unusable when its name is not a model input (misspelled / non-input) or, being a real
+    /// input, it conflicts with an existing constant. The unusable set becomes a hard error
+    /// upstream — never a silent drop that verifies a different question than the one asked.
+    #[test]
+    fn config_pins_partition_applied_vs_unusable() {
+        use std::collections::HashSet;
+        let inputs: HashSet<String> = ["rst_n", "mode", "clk"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let config_pins = vec![
+            ("mode".to_string(), 3u64),  // applied by the config pass
+            ("rst_n".to_string(), 1u64), // already pinned by reset-gating (same value) → applied
+            ("bogus".to_string(), 0u64), // not a model input → unusable (misspelled / non-input)
+            ("clk".to_string(), 0u64), // real input, but reset pinned it to a DIFFERENT value → conflict
+        ];
+        let pinned_configs: HashSet<String> = ["mode=3"].iter().map(|s| s.to_string()).collect();
+        let reset_pinned: HashSet<String> =
+            ["rst_n=1", "clk=1"].iter().map(|s| s.to_string()).collect();
+        let (applied, unusable) =
+            super::partition_config_pins(&config_pins, &inputs, &pinned_configs, &reset_pinned);
+        assert_eq!(
+            applied,
+            vec![("mode".to_string(), 3), ("rst_n".to_string(), 1)],
+            "mode (config pass) + rst_n (reset pin to the same value) are applied"
+        );
+        assert_eq!(
+            unusable.len(),
+            2,
+            "bogus (non-input) + clk (value conflict) are unusable: {unusable:?}"
+        );
+        assert!(
+            unusable
+                .iter()
+                .any(|u| u.contains("bogus") && u.contains("not a primary input")),
+            "an unknown/misspelled name reports 'not a primary input': {unusable:?}"
+        );
+        assert!(
+            unusable
+                .iter()
+                .any(|u| u.contains("clk") && u.contains("already pinned")),
+            "a real input pinned to a different constant reports a conflict: {unusable:?}"
+        );
+    }
+
     /// A.4 — a `Violated` bare `EF p` (reachability) yields the unreachable-target
     /// witness: no path (`prefix`/`cycle` empty), the target atoms naming what the
     /// design never reaches. A recoverability (`AG EF`) shape is not a bare `EF` and

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1536,16 +1536,36 @@ fn sv_verify_auto_handler_impl(
         Some("smt-hyper-must") => MustEdgeInference::SmtHyperMust,
         _ => MustEdgeInference::Off,
     };
-    // H.J.b — parse `"signal=value"` config concretization entries; malformed
-    // entries are skipped (the pipeline only pins actual inputs anyway).
+    // H.J.b — parse `"signal=value"` config concretization entries. mununu#459: a
+    // malformed entry is a 400 (mirrors `params` above), never a silent drop; a
+    // value that is not a decimal u64 (e.g. hex `0x1`) is rejected by name. An
+    // unknown / non-input signal is caught downstream in `verify_auto` against the
+    // model's real primary inputs.
     let config_values: std::collections::HashMap<String, u64> = request
         .config_values
         .iter()
-        .filter_map(|e| {
-            let (name, val) = e.split_once('=')?;
-            Some((name.trim().to_string(), val.trim().parse::<u64>().ok()?))
+        .map(|e| {
+            let (name, val) = e.split_once('=').ok_or_else(|| ApiError::BadRequest {
+                message: format!("malformed config_values entry '{e}'"),
+                details: Some("expected \"SIGNAL=VALUE\"".into()),
+            })?;
+            let (name, val) = (name.trim(), val.trim());
+            if name.is_empty() {
+                return Err(ApiError::BadRequest {
+                    message: format!("malformed config_values entry '{e}'"),
+                    details: Some("SIGNAL must be non-empty".into()),
+                });
+            }
+            let value = val.parse::<u64>().map_err(|_| ApiError::BadRequest {
+                message: format!("malformed config_values entry '{e}'"),
+                details: Some(format!(
+                    "VALUE must be a decimal u64 (got '{val}'); hex/0x, signed, \
+                     and non-numeric values are not accepted"
+                )),
+            })?;
+            Ok((name.to_string(), value))
         })
-        .collect();
+        .collect::<Result<std::collections::HashMap<_, _>, ApiError>>()?;
     // H.H — parse `"signal<=value"` (or `"signal=value"`) counter-bound entries;
     // both spellings mean the inclusive upper bound `signal <= value`.
     let counter_bounds: std::collections::HashMap<String, u64> = request
@@ -4447,6 +4467,30 @@ members = ["x"]
             .await
             .expect_err("malformed config_values must be rejected");
         assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    /// mununu#459 — a `sv verify-auto` `config_values` entry whose VALUE is not a decimal u64
+    /// (e.g. hex `0x1`) is a 400 that names the value, returned BEFORE the (heavy) lift — never a
+    /// silent drop that verifies a different question than the one asked. (Unknown / non-input
+    /// SIGNAL names are caught downstream against the model's real inputs; see
+    /// `verify_auto::tests::config_pins_partition_applied_vs_unusable`.)
+    #[test]
+    fn sv_verify_auto_handler_rejects_hex_config_value() {
+        use crate::api::models::SvVerifyAutoRequest;
+        let request: SvVerifyAutoRequest = serde_json::from_value(serde_json::json!({
+            "source": "module m(input logic clk, input logic rst); endmodule\n",
+            "config_values": ["rst=0x1"],
+        }))
+        .expect("request deserializes");
+        let err = sv_verify_auto_handler_impl(request)
+            .expect_err("a hex config_values value must be rejected, not silently dropped");
+        match err {
+            ApiError::BadRequest { details, .. } => assert!(
+                details.as_deref().is_some_and(|d| d.contains("decimal")),
+                "the 400 must explain the value is not a decimal u64: {details:?}"
+            ),
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
     }
 
     /// cegar-extraction Stage 2 — the SV-direct CEGAR endpoint rejects an

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -358,7 +358,18 @@ fn skip_over_cap_notes(report: &AutoVerifyReport, design_btor2: &str) -> Vec<Ver
     let facts = ModelFacts::new(&file);
     let mut notes = Vec::new();
     for prop in &report.properties {
-        if !matches!(prop.outcome, VerifyOutcome::Skipped { .. }) {
+        let VerifyOutcome::Skipped { reason } = &prop.outcome else {
+            continue;
+        };
+        // mununu#462 — a bit-blast that ABSTAINED (BDD arena exhausted) mid-evaluation, rather
+        // than at admission: name the cone's state-bit width and the width lever (`--param`).
+        // This is the state-bit-count analogue of the skip-diameter-bound note. Matches both the
+        // cube-path oom() string and the exact-build string (both contain "arena exhausted").
+        if reason.contains("arena exhausted") {
+            let cone_bits = crate::mu_calculus::parser::parse(&prop.formula)
+                .map(|f| facts.cone_vs_cap(&formula_seed_atoms(&f)).0)
+                .unwrap_or(0);
+            notes.push(bitblast_oom_skip_note(&prop.name, cone_bits));
             continue;
         }
         let Ok(formula) = crate::mu_calculus::parser::parse(&prop.formula) else {
@@ -457,6 +468,40 @@ fn diameter_bound_skip_note(name: &str, counter_log2: u32) -> VerificationNote {
                  escalation / the recoverability rescue), not register reduction or input \
                  concretization — and if the descent is not well-founded toward the target, the \
                  property is a genuine diameter wall (an honest ⊥)."
+            .into(),
+        items: Vec::new(),
+    }
+}
+
+/// mununu#462 — the bit-blast OOM Skip note: a property whose BDD bit-blast exhausted its node
+/// arena mid-evaluation (not at admission), so the engine ABSTAINED (Skipped) rather than
+/// `.unwrap()`-panicking / SIGABRT-ing and taking the WHOLE run — and every OTHER property still
+/// reports. Names the cone's state-bit width and points at the width lever (`--param`, which
+/// re-elaborates with a smaller parameterised counter/register so its bits fit) and the fallback
+/// (`--engine explicit`). The state-bit-count analogue of `diameter_bound_skip_note`. Advisory
+/// only (a note, never a verdict change).
+fn bitblast_oom_skip_note(name: &str, cone_bits: u32) -> VerificationNote {
+    let cone = if cone_bits > 0 {
+        format!("~{cone_bits}-bit state cone")
+    } else {
+        "wide state cone".to_string()
+    };
+    VerificationNote {
+        kind: "skip-bitblast-oom".into(),
+        level: NoteLevel::ScopeCaveat,
+        summary: format!(
+            "`{name}`: Skipped — the BDD bit-blast exhausted its node arena on a {cone} (a SIZE \
+             threshold, not a malformed input); the engine abstained on this property so every \
+             other property in the run still reports."
+        ),
+        detail: "The symbolic engine bit-blasts a property's cone-of-influence into a BDD; a wide \
+                 counter/register cone (e.g. several 32-bit counters, each doubled by its `$past` \
+                 shadow) can outgrow the node budget mid-fixpoint. This is a size threshold — \
+                 shrink the state and it decides. The direct lever is `--param NAME=VALUE`, which \
+                 re-elaborates the design with a smaller width parameter (e.g. `--param \
+                 BW_WIDTH=4`) so the counter bits fit the arena; the verdict is then scoped to that \
+                 parameter value. The engine-level fallback is `--engine explicit`. Only this \
+                 property abstained — the rest of the run is unaffected."
             .into(),
         items: Vec::new(),
     }
@@ -818,6 +863,88 @@ mod tests {
             n.detail.contains("--config-value") && n.detail.contains("INPUT-inflated"),
             "detail must point at --config-value on an input-inflated cone: {}",
             n.detail
+        );
+    }
+
+    // ---- mununu#462: the bit-blast OOM Skip note ---------------------------------------------
+
+    #[test]
+    fn bitblast_oom_skip_emits_size_note_and_spares_other_properties() {
+        // A report where ONE property abstained with an "arena exhausted" reason (the bit-blast
+        // OOM), alongside a DECIDED property. The classifier emits exactly one `skip-bitblast-oom`
+        // note — naming the cone size + `--param` — for the abstained property, and NONE for the
+        // decided one: the whole point of mununu#462 is that one over-budget property no longer
+        // taints (or crashes) the rest of the run.
+        use crate::adapter::slang::translate::SvaKind;
+        use crate::adapter::slang::verify_auto::PropertyVerdict;
+        // A 300-bit self-incrementing register → a measurable wide cone for `big == 0`.
+        let btor2 = "\
+1 sort bitvec 300
+2 sort bitvec 1
+3 state 1 big
+4 one 1
+5 add 1 3 4
+6 next 1 3 5
+";
+        let report = AutoVerifyReport {
+            properties: vec![
+                PropertyVerdict {
+                    name: "p_wide".into(),
+                    kind: SvaKind::Assert,
+                    formula: "mu X.(big == 0 || <> X)".into(),
+                    outcome: VerifyOutcome::Skipped {
+                        reason: "CEGAR error: symbolic bit-blaster: BDD arena exhausted \
+                                 (OxiDD OutOfMemory) — the cone does not compress to a tractable \
+                                 BDD; use `--engine explicit`"
+                            .into(),
+                    },
+                    seeded_predicates: Vec::new(),
+                    counterexample: None,
+                },
+                PropertyVerdict {
+                    name: "p_ok".into(),
+                    kind: SvaKind::Assert,
+                    formula: "big == 0".into(),
+                    outcome: VerifyOutcome::Holds,
+                    seeded_predicates: Vec::new(),
+                    counterexample: None,
+                },
+            ],
+            unsupported: Vec::new(),
+            diagnostics: Default::default(),
+            notes: Vec::new(),
+        };
+        let notes = skip_over_cap_notes(&report, btor2);
+        let oom: Vec<_> = notes
+            .iter()
+            .filter(|n| n.kind == "skip-bitblast-oom")
+            .collect();
+        assert_eq!(
+            oom.len(),
+            1,
+            "exactly one bit-blast-OOM note — for the abstained property only, not the decided one"
+        );
+        let n = oom[0];
+        assert!(
+            n.summary.contains("p_wide"),
+            "note names the abstained property: {}",
+            n.summary
+        );
+        assert!(
+            n.summary.contains("bit") && n.summary.contains("300"),
+            "summary names the state-bit size: {}",
+            n.summary
+        );
+        assert!(
+            n.detail.contains("--param"),
+            "detail points at the --param width lever: {}",
+            n.detail
+        );
+        assert!(
+            !notes
+                .iter()
+                .any(|nn| nn.kind == "skip-bitblast-oom" && nn.summary.contains("p_ok")),
+            "a decided property must not receive a bit-blast-OOM note",
         );
     }
 

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -143,6 +143,30 @@ parameter of the design is a hard **error** (it lists the declared parameters),
 never a silent drop; the applied overrides are echoed as a `parameter-override`
 scope note — the verdicts are scoped to those values.
 
+`--param` is also the remedy for a **bit-blast size wall**: several wide counters
+(e.g. six 32-bit counters, each doubled by its `$past` shadow) can push a
+property's state cone past the BDD node budget, so the symbolic engine **abstains**
+on that one property with a `skip-bitblast-oom` note (naming the cone's bit width)
+rather than crashing the run — the other properties still report. Shrink a width
+parameter (`--param BW_WIDTH=4`) so the counters fit, or fall back to
+`--engine explicit`. This is a size threshold, not a malformed input.
+
+> Source of truth: [`bitblast_oom_skip_note`](../crates/mununu-core/src/planner/mod.rs) — surface: (CLI+API+UI)
+
+### Pinning a config input: `--config-value`
+
+> Source of truth: [`partition_config_pins`](../crates/mununu-core/src/adapter/slang/verify_auto.rs) — surface: (CLI+API+UI)
+
+`--config-value SIGNAL=VALUE` (API `config_values: [...]`) pins a primary input to
+a decimal constant and substitutes it into every formula atom, scoping the verdicts
+to that value (a `config-concretization` note lists the applied pins). A pin that
+mununu **cannot apply** is a hard **error**, never a silent drop that would verify a
+different question than the one asked: a non-decimal value (`rst_n=0x1` — decimal
+`u64` only) is rejected at parse; a `SIGNAL` that is not a primary input of the
+lifted model (misspelled, or a state/output/optimized-away name) is rejected against
+the model's real inputs. Every applied pin — including one that coincides with an
+auto-detected reset pin — is echoed in the `config-concretization` note.
+
 ---
 
 ## Driving it from an external agent (e.g. an agent writing RTL)


### PR DESCRIPTION
Fixes two monono-filed issues — both "mununu knows something went wrong and does not say so in a way a consumer can act on." Neither is a soundness bug.

## #462 — the symbolic bit-blast panicked instead of abstaining
`Result::unwrap` on OxiDD `OutOfMemory` at `eq_bits` took the **whole** `sv verify-auto` run down (no property got a verdict). Root cause: the arithmetic / comparison / reduction / shift BDD helpers (`eq_bits`, `uge`, `slt`, `add_bits`, `cmp_bits`, the reduces, `barrel_shift`, the per-bit bitwise `eval_op` arms) used raw `.unwrap()` that **bypassed the node-budget guard**, so a wide cone exhausted the arena mid-op — a plain panic on the cube path, an uncatchable SIGABRT-on-drop of the exhausted manager on the exact path.

**Fix:** thread `Result` through the whole helper family, routing every BDD apply through `oom(...)?` and calling `check_node_budget()?` each iteration (the same pattern `Op::Ite` already used), so the arena never actually exhausts and the engine returns a clean `Err` → the per-property loop degrades it to `Skipped` and **every other property still reports**. A new `skip-bitblast-oom` planner note names the cone's state-bit width and points at `--param` / `--engine explicit` (mirrors `skip-diameter-bound`).

**Consumer-facing:** `sv verify-auto` no longer crashes on a too-large model — it exits with the ordinary verdict-based code; the over-budget property is `"outcome": "skipped"` (reason contains `arena exhausted (OxiDD OutOfMemory)`); a `skip-bitblast-oom` note is added (one *new* note kind; no existing note format changed).

## #459 — a dropped `--config-value` was silent
A pin mununu could not apply was silently discarded, so the run verified a **different question** than asked (monono pins `rst_n=1` to check out of reset; a dropped pin makes the gate green while verifying reset-asserted behaviour).

**Fix** (mirrors the `--param` error-on-unapplicable pattern): a non-decimal value (hex `0x1`) is a hard error at parse (CLI + API 400); a `SIGNAL` that is not a primary input of the lifted model is a hard error against the model's real inputs (pure, unit-tested `partition_config_pins`); applied pins — including one coinciding with an auto-reset pin — are echoed **completely** in the `config-concretization` note.

**Consumer-facing:**
- hex/non-decimal → CLI exit `1` (`malformed --config-value '…': VALUE must be a decimal u64 …`); API HTTP `400`.
- unknown / non-input signal → CLI exit `1` (`--config-value: N pin(s) could not be applied … is not a primary input of the lifted model. (primary inputs: …)`); API HTTP `400`.
- `config-concretization` note format **unchanged** (`items: ["sig=v"]`) but now **complete** — fixes a false-negative for a reset-coinciding pin, so `verify/lib.sh` can drop its grep workaround and rely on the non-zero exit / 400.

## Surface & validation
No new user surface — both harden the existing `sv verify-auto` surface (the UI already sends `config_values` and surfaces API errors). CLI + API + UI parity.

- `make ci` green (fmt + `clippy --workspace --all-targets -D warnings` + workspace tests, which unify `api`+`ast-extract`).
- New tests: `partition_config_pins` (unknown / non-input / conflict), the hex-value API 400, the `skip-bitblast-oom` note + others-spared; plus the existing graceful-abstain regressions.
- **e2e in the `mununu-sva` image on the real monono `mem_sched` repro:** `BW_WIDTH=32` (the documented panic case) now exits `0` with honest per-property abstains instead of panicking; `BW_WIDTH=4` decides all counters. Both #459 error scenarios verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)