### PR TITLE
fix(coi): NID-indexed cone keeps anonymous split sub-registers (monono#partsel follow-up)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/dep_graph.rs
+++ b/crates/mununu-core/src/adapter/btor2/dep_graph.rs
@@ -211,16 +211,11 @@ pub fn resolve_atom_to_terminals(file: &Btor2File, atom: &str) -> Option<HashSet
 /// the reduction into an unsound over-approximation. This mirrors the
 /// closure in [`super::bit_blast`]'s `cone_slice`.
 pub fn state_cone_nids(file: &Btor2File, atoms: &[String]) -> HashSet<Nid> {
-    let (cone, symbols) = cone_symbols(file, atoms);
-    // Map cone state symbols back to their state-line NIDs.
+    // The state subset of the cone's leaves (NID-indexed — keeps anonymous cells).
+    let leaves = cone_reachable_leaves(file, atoms);
     file.states()
-        .filter(|l| {
-            symbols
-                .get(&l.nid)
-                .map(|sym| cone.contains(sym))
-                .unwrap_or(false)
-        })
         .map(|l| l.nid)
+        .filter(|nid| leaves.contains(nid))
         .collect()
 }
 
@@ -233,85 +228,91 @@ pub fn state_cone_nids(file: &Btor2File, atoms: &[String]) -> HashSet<Nid> {
 /// influence any atom, so pinning it to a constant is sound (same COI argument as
 /// [`state_cone_nids`], extended to the input frame).
 pub fn cone_leaf_nids(file: &Btor2File, atoms: &[String]) -> HashSet<Nid> {
-    let (cone, symbols) = cone_symbols(file, atoms);
-    file.lines
-        .iter()
-        .filter(|l| matches!(l.node, Node::State { .. } | Node::Input { .. }))
-        .filter(|l| {
-            symbols
-                .get(&l.nid)
-                .map(|sym| cone.contains(sym))
-                .unwrap_or(false)
-        })
-        .map(|l| l.nid)
-        .collect()
+    cone_reachable_leaves(file, atoms)
 }
 
-/// Shared core of [`state_cone_nids`] / [`cone_leaf_nids`]: the full cone-of-influence SYMBOL
-/// set (state + input) of `atoms`, closed under the data-flow dependency relation AND
-/// `constraint` / `fair` / `justice` co-occurrence. Returns the cone plus the `collect_symbols`
-/// map (reused by the callers to map symbols back to NIDs). See [`state_cone_nids`]'s SOUNDNESS
-/// note — with the constraint/fairness closure this is an EXACT reduction (not an approximation).
-fn cone_symbols(file: &Btor2File, atoms: &[String]) -> (HashSet<String>, HashMap<Nid, String>) {
-    use crate::adapter::partition::coi::cone_of_influence;
-
+/// Shared core of [`state_cone_nids`] / [`cone_leaf_nids`]: the cone-of-influence
+/// **leaf NIDs** (every `state` + `input` cell reached) of `atoms`, closed under
+/// the data-flow dependency relation AND `constraint` / `fair` / `justice`
+/// co-occurrence.
+///
+/// # Why NID-indexed, not symbol-indexed (monono#partsel COI fix)
+///
+/// The reachability runs directly over the BTOR2 operand DAG (node NIDs), NOT
+/// over a symbol dep graph. The previous symbol-keyed pipeline
+/// ([`DepGraphBuilder::build`] + `cone_of_influence`) recorded only cells that
+/// [`parser::collect_symbols`] could NAME, and dropped every **anonymous** cell
+/// (a `state`/`input` line with no symbol — line 86's `if let Some(sym)`
+/// filter). The yosys-slang lift of a partial register assignment (`q[idx] <= d`
+/// on a packed 2-D reg) splits `q` into anonymous `state` sub-cells; the
+/// symbol-keyed cone could not keep them, so the bit-blaster pinned them to their
+/// init value and **froze the register** (a spurious `Holds`). Working over NIDs
+/// keeps anonymous cells — every node has a NID — so a split sub-register is now
+/// modelled and its property decides.
+///
+/// # SOUNDNESS
+///
+/// BTOR2 operand edges are precise (each edge is a real dependency), so backward
+/// reachability yields the EXACT influence cone: it never drops a cell that
+/// influences an atom, so pinning every out-of-cone leaf to a constant is
+/// verdict-preserving for the full mu-calculus over `atoms` (CLAUDE.md
+/// §Soundness — the COI "exact / free / sound" abstraction). Closure has two
+/// halves, both walked, both load-bearing:
+/// - **temporal**: for every `state` reached, its `next` function's cone (an
+///   out-of-cone leaf feeding a kept register's `next` would otherwise be pinned
+///   wrongly). `init` is (near-always) a constant and is left unfollowed,
+///   matching the previous Next-only closure.
+/// - **assume/fairness**: a `constraint`/`fair`/`justice` whose COMBINATIONAL
+///   cone touches the current cone restricts the reachable state space, so its
+///   signals join the cone (the selective pullback below). Omitting it would
+///   silently drop an assumption and turn the reduction unsound.
+///
+/// Time O(N + E) integer reachability (a dense `seen`/`leaves` over line NIDs),
+/// no per-symbol `String` hashing / dep-graph allocation.
+fn cone_reachable_leaves(file: &Btor2File, atoms: &[String]) -> HashSet<Nid> {
     let symbols = parser::collect_symbols(file);
-    let deps = file.build();
 
-    // Seed the cone with each atom's terminal symbols. An atom the BTOR2
-    // doesn't name (no `output`/`state`/`input`/`op` symbol matches)
-    // falls back to seeding with the bare atom string — matching the
-    // cluster-COI seed-resolution convention (R4W-3.5b).
-    let mut seeds: HashSet<String> = HashSet::new();
-    for atom in atoms {
-        match resolve_atom_to_terminals(file, atom) {
-            Some(terminals) => seeds.extend(terminals),
-            None => {
-                seeds.insert(atom.clone());
-            }
+    // state NID -> its `next` value operand (one pass). `init` is intentionally
+    // NOT followed (near-always constant; matches the old Next-only closure).
+    let mut next_val: HashMap<Nid, Nid> = HashMap::new();
+    for line in &file.lines {
+        if let Node::Next { state, value, .. } = &line.node {
+            next_val.insert(*state, value.nid());
         }
     }
 
-    let mut cone = cone_of_influence(&seeds, &deps);
+    // Seed from each atom's BINDING node(s) — the node the atom actually reads.
+    // Reaching the anonymous split sub-cells requires seeding from the register-
+    // name alias / reconstruction, not from pre-resolved (nameable) terminals.
+    let mut work: Vec<Nid> = Vec::new();
+    for atom in atoms {
+        seed_binding_nids(file, &symbols, atom, &mut work);
+    }
 
-    // Constraint / fairness pullback (R46-6a) — close the cone over
-    // assumption + fairness coupling, mirroring `cone_slice`. Any
-    // `constraint` / `fair` / `justice` line whose terminal symbols touch
-    // the current cone pulls all of its terminals into the seed set;
-    // recompute and iterate to a fixpoint. `seeds` grows monotonically and
-    // is bounded by the symbol count, so this terminates.
+    let mut seen: HashSet<Nid> = HashSet::new();
+    let mut leaves: HashSet<Nid> = HashSet::new();
+    drain_cone(file, &next_val, &mut work, &mut seen, &mut leaves);
+
+    // Selective constraint / fair / justice pullback (R46-6a): a constraint whose
+    // COMBINATIONAL cone shares a leaf with the current cone joins it; iterate to
+    // a fixpoint (`pulled` grows monotonically, bounded by the constraint count).
+    let mut pulled: HashSet<Nid> = HashSet::new();
     loop {
         let mut grew = false;
         for line in &file.lines {
-            let mut terminals: HashSet<String> = HashSet::new();
-            let mut visited = HashSet::new();
-            match &line.node {
-                Node::Constraint { signal } | Node::Fair { signal } => {
-                    collect_operand_terminals(
-                        file,
-                        signal.nid(),
-                        &symbols,
-                        &mut terminals,
-                        &mut visited,
-                    );
-                }
-                Node::Justice { signals } => {
-                    for sig in signals {
-                        collect_operand_terminals(
-                            file,
-                            sig.nid(),
-                            &symbols,
-                            &mut terminals,
-                            &mut visited,
-                        );
-                    }
-                }
+            let sigs: Vec<Nid> = match &line.node {
+                Node::Constraint { signal } | Node::Fair { signal } => vec![signal.nid()],
+                Node::Justice { signals } => signals.iter().map(|s| s.nid()).collect(),
                 _ => continue,
-            }
-            if terminals.iter().any(|t| cone.contains(t)) {
-                let before = seeds.len();
-                seeds.extend(terminals);
-                if seeds.len() != before {
+            };
+            for sig in sigs {
+                if pulled.contains(&sig) {
+                    continue;
+                }
+                let comb = cone_combinational_leaf_nids(file, sig);
+                if comb.iter().any(|n| leaves.contains(n)) {
+                    pulled.insert(sig);
+                    work.push(sig);
                     grew = true;
                 }
             }
@@ -319,10 +320,116 @@ fn cone_symbols(file: &Btor2File, atoms: &[String]) -> (HashSet<String>, HashMap
         if !grew {
             break;
         }
-        cone = cone_of_influence(&seeds, &deps);
+        drain_cone(file, &next_val, &mut work, &mut seen, &mut leaves);
     }
 
-    (cone, symbols)
+    leaves
+}
+
+/// Drain `work`, closing the cone under combinational fan-in AND the temporal
+/// `state -> next` edge. Collects every `State`/`Input` NID reached — NAMED OR
+/// ANONYMOUS. Cf. [`cone_reachable_leaves`].
+fn drain_cone(
+    file: &Btor2File,
+    next_val: &HashMap<Nid, Nid>,
+    work: &mut Vec<Nid>,
+    seen: &mut HashSet<Nid>,
+    leaves: &mut HashSet<Nid>,
+) {
+    while let Some(nid) = work.pop() {
+        if !seen.insert(nid) {
+            continue;
+        }
+        let Some(line) = file.lookup(nid) else {
+            continue;
+        };
+        match &line.node {
+            Node::State { .. } => {
+                leaves.insert(nid);
+                if let Some(&v) = next_val.get(&nid) {
+                    work.push(v);
+                }
+            }
+            Node::Input { .. } => {
+                leaves.insert(nid);
+            }
+            Node::Op { args, .. } => work.extend(args.iter().map(|a| a.nid())),
+            Node::Init { value, .. } | Node::Next { value, .. } => work.push(value.nid()),
+            Node::Bad { signal }
+            | Node::Constraint { signal }
+            | Node::Fair { signal }
+            | Node::Output { signal, .. } => work.push(signal.nid()),
+            Node::Justice { signals } => work.extend(signals.iter().map(|s| s.nid())),
+            Node::Const { .. } | Node::Sort { .. } => {}
+        }
+    }
+}
+
+/// The **combinational** fan-in leaves of `start`: follow `Op` args (and value /
+/// signal edges) but STOP at each `state`/`input` cell — do NOT follow a state's
+/// `next`. The NID counterpart of [`collect_operand_terminals`] that keeps
+/// anonymous cells; used by [`cone_reachable_leaves`]'s constraint pullback to
+/// decide whether a constraint's cone touches the current cone.
+fn cone_combinational_leaf_nids(file: &Btor2File, start: Nid) -> HashSet<Nid> {
+    let mut seen: HashSet<Nid> = HashSet::new();
+    let mut leaves: HashSet<Nid> = HashSet::new();
+    let mut work: Vec<Nid> = vec![start];
+    while let Some(nid) = work.pop() {
+        if !seen.insert(nid) {
+            continue;
+        }
+        let Some(line) = file.lookup(nid) else {
+            continue;
+        };
+        match &line.node {
+            Node::State { .. } | Node::Input { .. } => {
+                leaves.insert(nid);
+            }
+            Node::Op { args, .. } => work.extend(args.iter().map(|a| a.nid())),
+            Node::Init { value, .. } | Node::Next { value, .. } => work.push(value.nid()),
+            Node::Bad { signal }
+            | Node::Constraint { signal }
+            | Node::Fair { signal }
+            | Node::Output { signal, .. } => work.push(signal.nid()),
+            Node::Justice { signals } => work.extend(signals.iter().map(|s| s.nid())),
+            Node::Const { .. } | Node::Sort { .. } => {}
+        }
+    }
+    leaves
+}
+
+/// Resolve a formula atom `name` to the BTOR2 node(s) it BINDS to, pushing their
+/// NIDs onto `work` as cone seeds — mirroring how the bit-blaster's `signal_bits`
+/// resolves a name: a `state`/`input` cell carrying that symbol (directly or via
+/// a [`parser::collect_symbols`] alias), an `Op` whose own symbol is `name` (the
+/// `uext … 0 NAME` register-name alias), or a named `output`'s signal. Seeding
+/// from the binding node — not from pre-resolved terminal symbols — is what lets
+/// the cone reach the ANONYMOUS split sub-cells a register-name reconstruction is
+/// built from. A name the BTOR2 doesn't carry adds no seed (a degenerate empty
+/// cone, as before — such atoms are refused / unbindable elsewhere).
+fn seed_binding_nids(
+    file: &Btor2File,
+    symbols: &HashMap<Nid, String>,
+    name: &str,
+    work: &mut Vec<Nid>,
+) {
+    for line in &file.lines {
+        match &line.node {
+            Node::State { .. } | Node::Input { .. }
+                if symbols.get(&line.nid).map(String::as_str) == Some(name) =>
+            {
+                work.push(line.nid);
+            }
+            Node::Op {
+                symbol: Some(s), ..
+            } if s == name => work.push(line.nid),
+            Node::Output {
+                symbol: Some(s),
+                signal,
+            } if s == name => work.push(signal.nid()),
+            _ => {}
+        }
+    }
 }
 
 /// Collect the COI seed set for a BTOR2 file from its intrinsic

--- a/crates/mununu-core/src/adapter/btor2/parser.rs
+++ b/crates/mununu-core/src/adapter/btor2/parser.rs
@@ -582,40 +582,30 @@ pub fn cone_reaches_input(file: &Btor2File, start: Nid) -> bool {
 }
 
 /// monono#partsel soundness guard — does the combinational cone rooted at `start`
-/// reach an **anonymous** leaf: a primary `input` or a `state` cell that
-/// [`collect_symbols`] could not name?
+/// reach an **anonymous** (symbol-less) primary `input`?
 ///
 /// A properly-lifted, flattened design names every real primary input after its
-/// top-module port (`clk`, `rst_n`, …) and names every register (directly or via
-/// a width-matched `uext … 0 NAME` alias). An **anonymous** leaf is therefore an
-/// artifact of the RTL front-end, and the yosys-slang lift of a **partial
-/// register assignment** (`q[hi:lo] <= d` / `q[idx] <= d` on a packed 2-D reg)
-/// produces two anonymous-leaf shapes, both aliased back to the register name `q`
-/// through a width-16 `uext … 0 q` the width filter drops off the narrow cells:
+/// top-module port (`clk`, `rst_n`, …). An **anonymous** `input` — a
+/// `<nid> input <sort>` line with no trailing symbol — is therefore never a real
+/// port: it is a net the RTL front-end left *undriven* and modelled as a free
+/// (havoc-each-cycle) variable. The yosys-slang lift of a plain-vector **partial
+/// register assignment** (`q[hi:lo] <= d`) produces exactly this: the register's
+/// *unwritten* bits become anonymous free `input`s that are `concat`-ed back into
+/// a signal aliased to the register name `q`. A predicate over `q` then reads
+/// those free inputs and mis-decides (a spurious `Holds` on a reachably non-zero
+/// register), so callers REFUSE it.
 ///
-/// - **undriven free inputs** — the register's *unwritten* bits become
-///   symbol-less `input`s (havoc each cycle); a predicate over `q` then reads
-///   those free inputs and mis-decides (a spurious `Holds` on a non-zero
-///   register). This is the plain-vector `q[11:8] <= d` case.
-/// - **anonymous split sub-registers** — the written slice(s) become symbol-less
-///   `state` cells; the SYMBOL-keyed cone-of-influence
-///   ([`crate::adapter::btor2::dep_graph::cone_leaf_nids`]) cannot keep an
-///   un-named cell, so it is (mis)classified out-of-cone and pinned to its init
-///   value → **frozen at 0** → the same spurious `Holds`. This is the packed 2-D
-///   `p_q[idx] <= d` case.
-///
-/// A **named** input or register is a cone leaf and stops the walk — the walk
-/// never descends into a register's `next` function, so a legitimate
-/// combinational function of a *named* register or a *named* input port
-/// (`ready = valid_i && state_q`) is NOT flagged. Callers REFUSE a property whose
-/// atom reaches an anonymous leaf (an honest, recoverable `unsupported` / skip)
-/// rather than emit the unsound verdict. Narrower than [`cone_reaches_input`],
-/// which fires on any (named) input too.
-pub fn cone_reaches_anonymous_leaf(
-    file: &Btor2File,
-    symbols: &HashMap<Nid, String>,
-    start: Nid,
-) -> bool {
+/// Deliberately narrower than [`cone_reaches_input`] (which fires on named ports
+/// too) AND narrower than the anonymous-*state* case: an anonymous split
+/// sub-*register* (the packed-2-D `q[idx] <= d` shape) is now KEPT and modelled by
+/// the NID-indexed cone-of-influence
+/// ([`crate::adapter::btor2::dep_graph::cone_leaf_nids`]), so that case DECIDES
+/// rather than being refused — only the genuinely havoc free-input case (which is
+/// an over-approximation the engines cannot soundly decide for all properties)
+/// trips this guard. A **named** input or any register cell stops the walk (the
+/// walk never descends into a register's `next`), so a legitimate combinational
+/// of a named port / register is not flagged.
+pub fn cone_reaches_anonymous_input(file: &Btor2File, start: Nid) -> bool {
     let mut seen: std::collections::HashSet<Nid> = std::collections::HashSet::new();
     let mut work: Vec<Nid> = vec![start];
     while let Some(nid) = work.pop() {
@@ -626,11 +616,9 @@ pub fn cone_reaches_anonymous_leaf(
             continue;
         };
         match &line.node {
-            // A symbol-less input (undriven-net havoc) or state cell (an anonymous
-            // split sub-register the symbol-keyed COI freezes) is the pathology.
-            Node::Input { .. } | Node::State { .. } if !symbols.contains_key(&nid) => return true,
-            // A NAMED input or register is a sound cone leaf — stop (never recurse
-            // into a register's `next`, which would reach inputs everywhere).
+            // A symbol-less input is the undriven-net (havoc) artifact.
+            Node::Input { symbol: None, .. } => return true,
+            // A named input, or ANY register cell, is a sound cone leaf — stop.
             Node::Input { .. } | Node::State { .. } | Node::Const { .. } | Node::Sort { .. } => {}
             Node::Op { args, .. } => {
                 for a in args {
@@ -653,21 +641,17 @@ pub fn cone_reaches_anonymous_leaf(
 }
 
 /// monono#partsel soundness guard — does the signal a property atom binds to
-/// `NAME` reach an anonymous leaf (an undriven free input, or an anonymous split
-/// sub-register the cone-of-influence freezes)?
+/// `NAME` reach an anonymous (undriven-register-bit) free input?
 ///
 /// Resolves `NAME` to its candidate binding node(s) — a `state` cell of that
 /// name, an `Op` carrying `NAME` as its own symbol (the `uext … 0 NAME`
 /// register-name alias Yosys emits), or a named `output` — and reports whether
-/// any of them [`cone_reaches_anonymous_leaf`]. A **faithful state cell** of
-/// `NAME` (read_verilog / sv2v lift) has a cone that is just the named state
-/// leaf, so this returns false — a real register is never flagged. It fires only
-/// for the broken partial-assignment lift, where `NAME` binds to a `concat` over
-/// the register's split-off anonymous cells (free-input bits and/or anonymous
-/// sub-registers).
-///
-/// See [`cone_reaches_anonymous_leaf`] for why refusing such a property is sound.
-pub fn signal_reaches_anonymous_leaf(file: &Btor2File, name: &str) -> bool {
+/// any of them [`cone_reaches_anonymous_input`]. A **faithful state cell** of
+/// `NAME` (read_verilog / sv2v lift), and an **anonymous split sub-register** the
+/// NID-indexed COI now keeps, both return false — only the plain-vector
+/// partial-write shape whose unwritten bits are modelled as free inputs is
+/// flagged.
+pub fn signal_reaches_anonymous_input(file: &Btor2File, name: &str) -> bool {
     let symbols = collect_symbols(file);
     file.lines.iter().any(|l| {
         let node = match &l.node {
@@ -681,7 +665,7 @@ pub fn signal_reaches_anonymous_leaf(file: &Btor2File, name: &str) -> bool {
             } if s == name => signal.nid(),
             _ => return false,
         };
-        cone_reaches_anonymous_leaf(file, &symbols, node)
+        cone_reaches_anonymous_input(file, node)
     })
 }
 
@@ -1278,10 +1262,10 @@ mod tests {
     }
 
     #[test]
-    fn cone_reaches_anonymous_leaf_ignores_named_ports() {
+    fn cone_reaches_anonymous_input_ignores_named_ports() {
         // monono#partsel — `anon` (nid 3) is an ANONYMOUS input (an undriven
         // register bit under the slang partial-assignment lift); `named` (nid 2) is
-        // a real port. `cone_reaches_anonymous_leaf` fires only for the anonymous
+        // a real port. `cone_reaches_anonymous_input` fires only for the anonymous
         // one — a legitimate combinational of a NAMED input must NOT be refused.
         let src = "1 sort bitvec 1\n\
                    2 input 1 named\n\
@@ -1292,21 +1276,20 @@ mod tests {
                    7 not 1 4 f_state\n\
                    8 next 1 4 4\n";
         let file = parse(src).expect("parse");
-        let syms = collect_symbols(&file);
         // Reaches an ANONYMOUS input.
         assert!(
-            cone_reaches_anonymous_leaf(&file, &syms, 6),
+            cone_reaches_anonymous_input(&file, 6),
             "f_anon reaches nid 3"
         );
         // Reaches only a NAMED input — not the pathology.
         assert!(
-            !cone_reaches_anonymous_leaf(&file, &syms, 5),
+            !cone_reaches_anonymous_input(&file, 5),
             "f_named reaches only the named port `named`"
         );
         // Reaches only a NAMED state.
         assert!(
-            !cone_reaches_anonymous_leaf(&file, &syms, 7),
-            "f_state reaches only the named register `q`"
+            !cone_reaches_anonymous_input(&file, 7),
+            "f_state reaches only the register `q`"
         );
         // But `cone_reaches_input` (the broad one) fires for BOTH input cases — the
         // narrower guard is what avoids over-refusing named-input combinationals.
@@ -1314,43 +1297,35 @@ mod tests {
     }
 
     #[test]
-    fn cone_reaches_anonymous_leaf_flags_anonymous_split_subregisters() {
-        // monono#partsel (packed 2-D `p[idx] <= d`) — the register `p` is split
-        // into ANONYMOUS `state` cells (nid 3, 4) whose width-16 name-alias the
-        // width filter drops; the symbol-keyed COI then freezes them. An atom over
-        // the reconstruction (nid 5) must be flagged even though NO input is in the
-        // cone.
+    fn cone_reaches_anonymous_input_ignores_anonymous_split_subregisters() {
+        // monono#partsel (packed 2-D `p[idx] <= d`) — `p` is split into ANONYMOUS
+        // `state` cells (nid 3, 4). The NID-indexed cone-of-influence now KEEPS
+        // those cells, so this case DECIDES rather than being refused: the
+        // input-only guard must NOT fire on a state-only reconstruction (no free
+        // input in the cone).
         let src = "1 sort bitvec 1\n\
                    2 sort bitvec 2\n\
                    3 state 1\n\
                    4 state 1\n\
                    5 concat 2 3 4\n\
                    6 uext 2 5 0 p\n\
-                   7 state 1 named\n\
-                   8 not 1 7 f_named_state\n\
                    9 next 1 3 3\n\
-                   10 next 1 4 4\n\
-                   11 next 1 7 7\n";
+                   10 next 1 4 4\n";
         let file = parse(src).expect("parse");
-        let syms = collect_symbols(&file);
-        // The reconstruction reaches the anonymous split sub-registers (nid 3, 4).
+        // Anonymous split sub-registers, NO input in the cone → not flagged.
         assert!(
-            cone_reaches_anonymous_leaf(&file, &syms, 5),
-            "the p reconstruction reaches anonymous split sub-registers"
+            !cone_reaches_anonymous_input(&file, 5),
+            "an anonymous-state split (no free input) is kept by the COI, not refused"
         );
-        // NO input in the cone — the broad `cone_reaches_input` does NOT fire, so
-        // only the anonymous-leaf guard catches this freeze mechanism.
         assert!(!cone_reaches_input(&file, 5));
-        // A combinational of a NAMED register is not flagged.
-        assert!(!cone_reaches_anonymous_leaf(&file, &syms, 8));
     }
 
     #[test]
-    fn signal_reaches_anonymous_leaf_via_alias_and_output() {
+    fn signal_reaches_anonymous_input_via_alias_and_output() {
         // A register `q` whose name is carried by a `uext … 0 q` alias over a concat
-        // that mixes an anonymous input (the partial-write shape) is flagged; a
-        // faithful state cell `r` is not. An output over the poisoned signal is
-        // flagged; an output over the faithful state is not.
+        // that mixes an anonymous INPUT (the plain-vector partial-write shape) is
+        // flagged; a faithful state cell `r` is not. An output over the poisoned
+        // signal is flagged; an output over the faithful state is not.
         let src = "1 sort bitvec 1\n\
                    2 input 1\n\
                    3 state 1 r\n\
@@ -1364,14 +1339,14 @@ mod tests {
                    11 next 1 3 3\n";
         let file = parse(src).expect("parse");
         assert!(
-            signal_reaches_anonymous_leaf(&file, "q"),
+            signal_reaches_anonymous_input(&file, "q"),
             "q aliases a concat mixing an anonymous input"
         );
         assert!(
-            !signal_reaches_anonymous_leaf(&file, "r"),
+            !signal_reaches_anonymous_input(&file, "r"),
             "r is a faithful state cell"
         );
-        assert!(signal_reaches_anonymous_leaf(&file, "q_out"));
-        assert!(!signal_reaches_anonymous_leaf(&file, "r_out"));
+        assert!(signal_reaches_anonymous_input(&file, "q_out"));
+        assert!(!signal_reaches_anonymous_input(&file, "r_out"));
     }
 }

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -3388,27 +3388,28 @@ fn exact_symbolic_verdict_with_witness_inner(
         ));
     }
 
-    // monono#partsel — the same soundness posture for an atom that binds to a SPLIT
-    // register (without being a bare input itself). The yosys-slang lift of a
-    // partial register assignment (`q[hi:lo] <= d`, or `q[idx] <= d` on a packed
-    // 2-D reg) splits `q` and aliases its name to a `concat` over anonymous cells:
-    // free inputs for the unwritten bits (havoc), and/or anonymous split
-    // sub-registers the symbol-keyed cone-of-influence freezes at 0. `q == 0` then
-    // reads those, and the fixpoint mis-decides (a spurious `Holds` on a register
+    // monono#partsel — the same soundness posture for an atom that binds to a
+    // signal reaching an anonymous free INPUT (without being a bare input itself).
+    // The yosys-slang lift of a plain-vector partial register assignment
+    // (`q[hi:lo] <= d`) models `q`'s unwritten bits as free inputs (havoc) and
+    // aliases its name to the `concat` that mixes them; `q == 0` then reads those
+    // free inputs and the fixpoint mis-decides (a spurious `Holds` on a register
     // that is reachably non-zero). Refuse rather than emit an unsound verdict — the
     // verify-auto driver skips such a property up front, and this guards the exact
     // engine's other callers (the differential oracle, `btor2 verify`). A faithful
-    // state cell of that name (read_verilog / sv2v lift) is never flagged.
+    // state cell (read_verilog / sv2v) and an anonymous split sub-register the
+    // NID-indexed COI keeps (packed-2-D `q[idx] <= d`) are both NOT flagged — the
+    // latter now decides.
     if let Some(bad) = seed_regs
         .iter()
-        .find(|r| crate::adapter::btor2::parser::signal_reaches_anonymous_leaf(&file, r))
+        .find(|r| crate::adapter::btor2::parser::signal_reaches_anonymous_input(&file, r))
     {
         return Err(format!(
-            "exact MC: atom `{bad}` binds to a register the RTL front-end SPLIT while lifting \
-             a partial assignment (`{bad}[…] <= …`) — its bits become anonymous cells \
-             (undriven free inputs and/or split sub-registers the model cannot faithfully \
-             track). A state predicate over it would be unsound, so it is refused. Re-lift \
-             with the read_verilog / sv2v front-end, which models `{bad}` faithfully."
+            "exact MC: atom `{bad}` binds to a signal whose unwritten bits the RTL front-end \
+             left undriven (modelled as free inputs) — the yosys-slang lift of a plain-vector \
+             partial assignment (`{bad}[hi:lo] <= …`). A state predicate over it reads those \
+             havoc inputs and would be unsound, so it is refused. Re-lift with the \
+             read_verilog / sv2v front-end, which models `{bad}` faithfully."
         ));
     }
 
@@ -6923,15 +6924,15 @@ mod tests {
         // does not. The combinational output `o_partsel` (a function of `a_q`) is
         // caught too; `o_concat` (a function of the faithful `b_q`) is not.
         assert!(
-            parser::signal_reaches_anonymous_leaf(&file, "a_q"),
+            parser::signal_reaches_anonymous_input(&file, "a_q"),
             "a_q binds to a concat mixing undriven free inputs"
         );
         assert!(
-            !parser::signal_reaches_anonymous_leaf(&file, "b_q"),
+            !parser::signal_reaches_anonymous_input(&file, "b_q"),
             "b_q is a faithful state cell — never flagged"
         );
-        assert!(parser::signal_reaches_anonymous_leaf(&file, "o_partsel"));
-        assert!(!parser::signal_reaches_anonymous_leaf(&file, "o_concat"));
+        assert!(parser::signal_reaches_anonymous_input(&file, "o_partsel"));
+        assert!(!parser::signal_reaches_anonymous_input(&file, "o_concat"));
 
         // The exact engine REFUSES `a_q` (Err) rather than emit the pre-fix spurious
         // `Holds`; it still decides the faithful `b_q` as `Violated` (b_q takes `val`
@@ -6950,21 +6951,22 @@ mod tests {
         );
     }
 
-    /// monono#partsel, second freeze mechanism — a PACKED 2-D partial write
-    /// (`p[idx] <= d`) splits the register into ANONYMOUS `state` sub-cells with NO
-    /// free inputs (`p` aliases a width-2 `concat` of two width-1 anonymous states,
-    /// so the width filter drops the name off both). The symbol-keyed
-    /// cone-of-influence cannot keep an un-named cell, so it pins the sub-cells to
-    /// their init 0 → `p` is frozen at 0 → the engine used to answer a spurious
-    /// `Holds` for `AG (p == 0)` even though `p[0] <= d` makes it reachably non-zero.
-    /// The guard flags the anonymous split sub-registers (no input needed) and the
-    /// exact engine REFUSES. `q` (a faithful named register) still decides.
+    /// monono#partsel COI fix — a PACKED 2-D partial write (`p[idx] <= d`) splits
+    /// the register into ANONYMOUS `state` sub-cells with NO free inputs (`p`
+    /// aliases a width-2 `concat` of two width-1 anonymous states, so the width
+    /// filter drops the name off both). The OLD symbol-keyed cone-of-influence
+    /// could not keep an un-named cell, so it pinned the sub-cells to their init 0
+    /// → `p` frozen at 0 → a spurious `Holds` for `AG (p == 0)`. The NID-indexed
+    /// COY ([`crate::adapter::btor2::dep_graph::cone_leaf_nids`]) now KEEPS the
+    /// anonymous sub-cells, so `AG (p == 0)` DECIDES `Violated` (`p[0] <= d` makes
+    /// it reachably non-zero) — no free input, so the guard does not refuse it.
+    /// `q` (a faithful named register) also decides.
     #[test]
-    fn exact_refuses_packed_split_register_frozen_by_coi() {
+    fn exact_decides_packed_split_register_via_nid_cone() {
         // p = concat(anon-state-5, anon-state-6); alias `uext 4 7 0 p` is width 2,
         // states are width 1 → width filter drops `p` off them → both anonymous.
         // p[0] (state 5) <= d (a named input), p[1] (state 6) <= 0; both init 0.
-        // `q` (state 8) is a faithful named 1-bit register that toggles.
+        // `q` (state 14) is a faithful named 1-bit register that toggles.
         const PACKED_SPLIT: &str = "1 sort bitvec 1
 2 one 1 rst_n
 3 input 1 d
@@ -6984,27 +6986,27 @@ mod tests {
 17 init 1 14 9
 ";
         let file = parser::parse(PACKED_SPLIT).expect("parse");
-        // `p` reaches anonymous split sub-registers (no input in the cone).
+        // `p` reaches anonymous split sub-registers but NO free input — the
+        // input-only guard does not fire, so the property is DECIDED, not refused.
         assert!(
-            parser::signal_reaches_anonymous_leaf(&file, "p"),
-            "p reconstructs from anonymous split sub-registers"
+            !parser::signal_reaches_anonymous_input(&file, "p"),
+            "an anonymous-state split (no free input) is kept by the COI, not refused"
         );
-        assert!(
-            !parser::signal_reaches_anonymous_leaf(&file, "q"),
-            "q is a faithful named register"
-        );
-        // Exact REFUSES `AG(p==0)` (would be a spurious frozen-Holds); still decides
-        // the faithful `q` (`EF(q==1)` is reachable — q toggles from 0).
+        assert!(!parser::signal_reaches_anonymous_input(&file, "q"));
+        // Exact DECIDES `AG(p==0)` = Violated: the NID cone keeps the anonymous
+        // sub-cells, so `p[0] <= d` (d free) reaches a non-zero `p`.
         let ag_p = crate::mu_calculus::parser::parse("nu X. ((p == 0) and [] X)").unwrap();
         let ef_q = crate::mu_calculus::parser::parse("mu Y. ((q == 1) or <> Y)").unwrap();
-        assert!(
-            exact_symbolic_verdict(PACKED_SPLIT, &ag_p).is_err(),
-            "AG(p==0) must be REFUSED, not a silent frozen Holds"
+        assert_eq!(
+            exact_symbolic_verdict(PACKED_SPLIT, &ag_p),
+            Ok(ExactVerdict::Violated),
+            "AG(p==0) must now DECIDE Violated — the NID cone keeps the anonymous \
+             split sub-cells instead of freezing them"
         );
         assert_eq!(
             exact_symbolic_verdict(PACKED_SPLIT, &ef_q),
             Ok(ExactVerdict::Holds),
-            "EF(q==1) on the faithful named register still decides"
+            "EF(q==1) on the faithful named register also decides"
         );
     }
 

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -851,19 +851,20 @@ struct Seeded {
 }
 
 /// monono#partsel soundness guard — the first register/signal name a formula's
-/// predicate atoms reference that binds to a signal reaching an ANONYMOUS leaf (an
-/// undriven-register-bit free input, or an anonymous split sub-register the
-/// cone-of-influence freezes), or `None` when the formula is sound to decide.
+/// predicate atoms reference that binds to a signal reaching an ANONYMOUS
+/// (undriven-register-bit) free input, or `None` when the formula is sound to
+/// decide.
 ///
-/// The yosys-slang lift of a partial register assignment (`q[hi:lo] <= d`, or
-/// `q[idx] <= d` on a packed 2-D reg) splits the register: the register name `q`
-/// aliases a `concat` over anonymous cells — free `input`s for its unwritten bits
-/// and/or anonymous split sub-`state`s (see
-/// [`parser::signal_reaches_anonymous_leaf`]). A predicate atom over `q` — a
-/// register atom (`q == 0`) or a combinational output of it (`o = (q != 0)`) — is
-/// then not a sound state predicate and every engine mis-decides it (a spurious
-/// `HOLDS` on a reachably-non-zero register). Callers refuse (skip) the property
-/// rather than emit that verdict.
+/// The yosys-slang lift of a plain-vector partial register assignment
+/// (`q[hi:lo] <= d`) models the register's *unwritten* bits as free `input`s and
+/// aliases the register name `q` to the `concat` that mixes them (see
+/// [`parser::signal_reaches_anonymous_input`]). A predicate atom over `q` — a
+/// register atom (`q == 0`) or a combinational output of it (`o = (q != 0)`) —
+/// then reads those free inputs (havoc) and mis-decides (a spurious `HOLDS` on a
+/// reachably-non-zero register). Callers refuse (skip) rather than emit that
+/// verdict. The packed-2-D `q[idx] <= d` split (anonymous sub-*registers*, no
+/// free inputs) is NOT flagged here — the NID-indexed cone-of-influence keeps
+/// those cells, so that case now DECIDES.
 ///
 /// Bare atoms are admitted (`parse_predicate_atom_bool` reads `o_partsel` as
 /// `o_partsel != 0`), so a combinational-output property is caught as well as a
@@ -887,7 +888,7 @@ fn formula_atom_over_undriven_register(
     names.sort();
     names
         .into_iter()
-        .find(|n| crate::adapter::btor2::parser::signal_reaches_anonymous_leaf(file, n))
+        .find(|n| crate::adapter::btor2::parser::signal_reaches_anonymous_input(file, n))
 }
 
 /// The minimal H.1 (+ H.B) — derive cube predicates from a formula's
@@ -2373,19 +2374,19 @@ pub(crate) fn verify_auto_impl(
 
         // monono#partsel soundness guard (all engines). Refuse — rather than
         // silently mis-decide — a property whose atom binds to a signal reaching an
-        // ANONYMOUS leaf. The yosys-slang lift of a partial register assignment
-        // (`q[hi:lo] <= d`, or `q[idx] <= d` on a packed 2-D reg) SPLITS the
-        // register and aliases the register name `q` to a `concat` over anonymous
-        // cells — free `input`s for its unwritten bits (havoc), and/or anonymous
-        // split sub-`state`s the symbol-keyed cone-of-influence freezes at 0. A
-        // state predicate over `q` (or over a combinational output of it, e.g.
-        // `q != 0`) is then NOT sound and every engine returns a spurious definite
-        // verdict (the reported `HOLDS` on a reachable-non-zero register — monono's
-        // planted-bug canary). Refusing is honest and recoverable (a downstream gate
-        // fails on `skipped`, never on a false HOLDS); the read_verilog / sv2v
-        // front-end (`--frontend verilog --preprocess-sv2v`) models the register
-        // faithfully and decides it. Runs BEFORE any engine so the cube, exact,
-        // symbolic and explicit paths are all covered uniformly.
+        // ANONYMOUS free `input`. The yosys-slang lift of a plain-vector partial
+        // register assignment (`q[hi:lo] <= d`) models the register's unwritten bits
+        // as free inputs (havoc) and aliases the register name `q` to the `concat`
+        // that mixes them; a state predicate over `q` (or a combinational output of
+        // it, `q != 0`) then reads those free inputs and every engine returns a
+        // spurious definite verdict (the reported `HOLDS` on a reachable-non-zero
+        // register — monono's planted-bug canary). Refusing is honest and
+        // recoverable (a downstream gate fails on `skipped`, never on a false HOLDS);
+        // the read_verilog / sv2v front-end models the register faithfully and
+        // decides it. Runs BEFORE any engine so cube, exact, symbolic and explicit
+        // are covered uniformly. (The packed-2-D `q[idx] <= d` split — anonymous
+        // sub-*registers*, no free inputs — is NOT refused: the NID-indexed
+        // cone-of-influence keeps those cells, so that case now decides.)
         if let Some(reg) = formula_atom_over_undriven_register(&formula, &file) {
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
@@ -2393,12 +2394,11 @@ pub(crate) fn verify_auto_impl(
                 formula: formula_str.clone(),
                 outcome: VerifyOutcome::Skipped {
                     reason: format!(
-                        "property references `{reg}`, which the RTL front-end SPLIT while \
-                         lifting a partial register assignment (`{reg}[…] <= …`) — its bits \
-                         become anonymous cells (undriven free inputs and/or split \
-                         sub-registers the model cannot faithfully track), so a verdict over \
-                         it would be unsound and it is refused rather than silently decided. \
-                         Re-lift with the read_verilog / sv2v front-end \
+                        "property references `{reg}`, whose unwritten bits the RTL front-end \
+                         left undriven (modelled as free inputs) while lifting a partial \
+                         register assignment (`{reg}[hi:lo] <= …`) — a verdict over it would \
+                         read those havoc inputs and be unsound, so it is refused rather than \
+                         silently decided. Re-lift with the read_verilog / sv2v front-end \
                          (`--frontend verilog --preprocess-sv2v`), which models `{reg}` \
                          faithfully."
                     ),
@@ -7209,19 +7209,23 @@ endmodule
     }
 
     /// monono#partsel — the partial-register-assignment soundness fix, end-to-end
-    /// through `verify_auto`. Four 16-bit registers, each reachably non-zero, each
-    /// written a different way; `a_q[11:8] <= val` is the partial write.
+    /// through `verify_auto`. Five registers, each reachably non-zero, each written
+    /// a different way.
     ///
-    /// Under the **slang** front-end, `a_q`'s unwritten bits become free inputs (see
-    /// [`crate::adapter::btor2::parser::signal_reaches_anonymous_input`]), so a
-    /// verdict over `a_q` would be unsound — verify_auto must now **Skip** it rather
-    /// than emit the reported spurious `HOLDS`. `b_q` / `c_q` / `d_q` are faithful
-    /// registers and are decided `Violated`.
+    /// Under the **slang** front-end, the two partial-write shapes lift differently:
+    /// - `a_q[11:8] <= val` (plain vector) — the unwritten bits become anonymous
+    ///   free `input`s (havoc); a verdict would read them, so verify_auto **Skips**
+    ///   it (never the reported spurious `HOLDS`).
+    /// - `p_q[idx] <= val` (packed 2-D) — the register splits into anonymous
+    ///   `state` sub-cells with NO free inputs; the NID-indexed cone-of-influence
+    ///   now KEEPS them, so this **decides `Violated`** (the COI fix — previously it
+    ///   was frozen/Skipped). `b_q` / `c_q` / `d_q` are faithful ⇒ `Violated`.
     ///
-    /// Under the **read_verilog + sv2v** front-end, `a_q` lifts to one faithful
-    /// state cell, so ALL FOUR are decided `Violated` — the correct outcome, and the
-    /// guard does not over-refuse the faithful lift. Together these pin both the fix
-    /// (no silent HOLDS) and its precision (the good path still decides).
+    /// Under the **read_verilog + sv2v** front-end, every register lifts to one
+    /// faithful state cell, so ALL FIVE are decided `Violated` — the guard does not
+    /// over-refuse the faithful lift. Together these pin the fix (no silent HOLDS),
+    /// its precision (the good path still decides), and the COI fix (packed-2-D now
+    /// decides on slang instead of being frozen).
     #[test]
     #[ignore = "requires slang + sv2v + yosys (mununu-sva image)"]
     fn e2e_partsel_partial_write_refused_on_slang_decided_on_sv2v() {
@@ -7285,21 +7289,25 @@ endmodule
                 .clone()
         };
 
-        // slang: a_q (free-input split) AND p_q (anonymous-sub-register split) both
-        // REFUSED (Skipped) — no silent HOLDS; the faithful three Violated.
+        // slang: `a_q` (plain-vector split → free inputs) is REFUSED (Skipped) — no
+        // silent HOLDS. `p_q` (packed-2-D split → anonymous sub-registers, NO free
+        // inputs) now DECIDES Violated via the NID-indexed COI. The faithful three
+        // decide Violated.
         let slang = run(crate::adapter::yosys::SvFrontend::Slang, false);
-        for reg in ["a_q == 0", "p_q == 0"] {
-            assert!(
-                matches!(outcome_of(&slang, reg), VerifyOutcome::Skipped { .. }),
-                "slang: AG({reg}) must be Skipped (partial-write register split by the \
-                 lift), never a silent Holds; got {:?}",
-                outcome_of(&slang, reg)
-            );
-        }
-        for reg in ["b_q == 0", "c_q == 0", "d_q == 0"] {
+        assert!(
+            matches!(
+                outcome_of(&slang, "a_q == 0"),
+                VerifyOutcome::Skipped { .. }
+            ),
+            "slang: AG(a_q==0) must be Skipped (unwritten bits are free inputs), never \
+             a silent Holds; got {:?}",
+            outcome_of(&slang, "a_q == 0")
+        );
+        for reg in ["b_q == 0", "c_q == 0", "d_q == 0", "p_q == 0"] {
             assert!(
                 matches!(outcome_of(&slang, reg), VerifyOutcome::Violated { .. }),
-                "slang: AG({reg}) is a faithful register ⇒ Violated; got {:?}",
+                "slang: AG({reg}) must be Violated (faithful register, or packed-2-D split \
+                 kept by the NID COI); got {:?}",
                 outcome_of(&slang, reg)
             );
         }


### PR DESCRIPTION
Follow-up to #464. That PR **refused** (skipped) properties over slang-split partial-write registers. This one makes the **packed-2-D** split (`p[idx] <= d`) actually **decide** instead of freeze, by fixing the cone-of-influence.

## Root cause (the 2nd freeze mechanism)

The bit-blaster keep-set was computed over **symbols** (`collect_symbols` + a symbol dep graph), which structurally cannot represent an **anonymous** cell — a `state`/`input` line `collect_symbols` couldn't name (dropped by the `if let Some(sym)` filter at `dep_graph.rs:86`). The yosys-slang lift of `p[idx] <= d` splits the register into anonymous `state` sub-cells; the symbol-keyed cone dropped them → the bit-blaster pinned them to init → the register **froze at 0** → a spurious `Holds`.

## Fix

Replace `cone_symbols` with a **NID-indexed** backward reachability over the BTOR2 operand DAG (`cone_reachable_leaves`): seed from each atom's binding node, follow combinational fan-in + the temporal `state → next` edge, keep the selective `constraint`/`fair`/`justice` pullback, and collect every `state`/`input` NID reached — **named or anonymous**. Every node has a NID, so a split sub-register is now kept and modelled.

- **Sound**: BTOR2 operand edges are precise ⇒ the EXACT influence cone (never drops a relevant leaf; pinning out-of-cone stays verdict-preserving).
- **Competitive**: same O(N+E), integer `HashSet<Nid>` reachability instead of per-symbol `String` hashing + dep-graph allocation; drops the repeated `collect_symbols` per cone.
- **Coordinated guard narrowing**: anonymous *states* are now decidable, so the partsel guard narrows to anonymous-**input** only (`signal_reaches_anonymous_input`). The plain-vector `q[hi:lo] <= d` case (unwritten bits = free-input havoc) is still refused; the packed-2-D `q[idx] <= d` case now **decides**.

`cone_leaf_nids` / `state_cone_nids` keep their signatures — every caller (exact engine keep-set, recoverability, model_facts, bit_blast, symbolic_engine) gets the fix uniformly; `partition::coi` (multi-module clustering) is untouched.

## Verdicts (slang frontend, Reproducer B)

| form | before (#464) | after |
|---|---|---|
| faithful (`q<=val`, `q[idx]<=1`, `q[idx*4+:4]<=val`, concat) | VIOLATED | VIOLATED |
| `q[11:8] <= val` (plain vector → free inputs) | skipped | skipped |
| `p_q[idx] <= val` (packed 2-D → anon sub-regs) | skipped | **VIOLATED** |
| `p_q[2] <= val`, packed `case` (→ free inputs) | skipped | skipped |

read_verilog / sv2v unchanged (all VIOLATED).

## Validation

- Host lib **2432 pass / 0 fail** (no verdict change on any faithful case); clippy + fmt clean.
- `mununu-sva` e2e: partsel (`p_q` decides VIOLATED, `a_q` skipped, sv2v all VIOLATED), `uart_tx` + `csrng` unchanged.
- wall-class matrix **2 pass / 0 fail** (soundness invariant — no verdict contradicts an oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)