### PR TITLE
feat(exact): name which budget an exact-symbolic ⊥ hit + the knob to raise (#467)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,3 +461,7 @@ Reference and how-to material — read when the task calls for it, not on every 
 | Variable | Purpose |
 |---|---|
 | `RUST_LOG=mununu=info` | Enable logging |
+| `MUNUNU_BDD_MAX_BITS` | Exact-symbolic engine **bit cap** — max register+input bits in the property cone before it abstains (`abstained on the BIT CAP`). Raise for a wider cone. |
+| `MUNUNU_BDD_ARENA_NODES` | Exact-symbolic engine **node budget** — the OxiDD arena size, which scales the live-BDD-node budget before it abstains (`abstained on the NODE budget`). Raise (e.g. 4×) for a cone that does not compress. |
+| `MUNUNU_BDD_ITER_BUDGET` | Exact-symbolic engine **fixpoint iteration budget** — the μ/ν pre-image step cap before it abstains (`abstained on the ITERATION budget`) on a large reachable diameter. |
+| `MUNUNU_BDD_TIME_BUDGET_MS` | Exact-symbolic engine **wall-clock budget** for the fixpoint (default `10000`; `0` disables) before it abstains (`abstained on the WALL-CLOCK budget`). |

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -305,8 +305,9 @@ impl BddBitBlaster {
         if total_bits > cap {
             return Err(format!(
                 "symbolic bit-blaster: design has {total_bits} register+input bits \
-                 (> {cap}) after cone-of-influence restriction (R-F5.6) — the \
-                 property's cone is too wide to bit-blast; use `--engine explicit`"
+                 (> {cap}) after cone-of-influence restriction (R-F5.6) — abstained on the BIT CAP; \
+                 the property's cone is too wide to bit-blast; raise MUNUNU_BDD_MAX_BITS, or use \
+                 `--engine explicit`"
             ));
         }
 
@@ -478,8 +479,9 @@ impl BddBitBlaster {
             Err(_) => {
                 return Err(
                     "exact bit-blaster: BDD arena exhausted during build (a wide op overran \
-                            the node budget in one apply) — the cone does not compress to a \
-                            tractable BDD; use `--engine explicit`"
+                            the node budget in one apply) — abstained on the NODE budget; the cone \
+                            does not compress to a tractable BDD; raise MUNUNU_BDD_ARENA_NODES, or \
+                            use `--engine explicit`"
                         .into(),
                 );
             }
@@ -1679,8 +1681,9 @@ impl AbstractRelation {
 #[inline]
 fn oom<T, E: std::fmt::Debug>(r: Result<T, E>) -> Result<T, String> {
     r.map_err(|_e| {
-        "symbolic bit-blaster: BDD arena exhausted (OxiDD OutOfMemory) — the cone does not compress \
-         to a tractable BDD; use `--engine explicit`"
+        "symbolic bit-blaster: BDD arena exhausted (OxiDD OutOfMemory) — abstained on the NODE \
+         budget; the cone does not compress to a tractable BDD; raise MUNUNU_BDD_ARENA_NODES, or \
+         use `--engine explicit`"
             .to_string()
     })
 }
@@ -2122,8 +2125,9 @@ impl BddBitBlaster {
             .with_manager_shared(|m| m.approx_num_inner_nodes());
         if live > self.node_budget {
             return Err(format!(
-                "symbolic bit-blaster: BDD node budget exceeded ({live} > {} live nodes) — the \
-                 property's cone does not compress to a tractable BDD; use `--engine explicit`",
+                "abstained on the NODE budget ({live} of {} live BDD nodes) — the property's cone \
+                 does not compress to a tractable BDD; raise MUNUNU_BDD_ARENA_NODES (which scales \
+                 the node budget), or use `--engine explicit`",
                 self.node_budget
             ));
         }
@@ -2584,8 +2588,9 @@ impl ExactModel {
             self.iters.set(n);
             if n > self.iter_budget {
                 return Err(format!(
-                    "symbolic bit-blaster: fixpoint iteration budget exceeded ({n} > {}) — the \
-                     property's reachable diameter is too large to bit-blast; use `--engine explicit`",
+                    "symbolic bit-blaster: abstained on the ITERATION budget ({n} > {}) — the \
+                     property's reachable diameter is too large to bit-blast; raise \
+                     MUNUNU_BDD_ITER_BUDGET, or use `--engine explicit`",
                     self.iter_budget
                 ));
             }
@@ -2602,9 +2607,10 @@ impl ExactModel {
                 && std::time::Instant::now() > dl
             {
                 return Err(format!(
-                    "symbolic bit-blaster: exact time budget exceeded (fixpoint still iterating at \
-                     {n} steps) — the property's reachable diameter is too large to bit-blast in \
-                     the wall-clock budget; use `--engine explicit`"
+                    "symbolic bit-blaster: abstained on the WALL-CLOCK budget (fixpoint still \
+                     iterating at {n} steps) — the property's reachable diameter is too large to \
+                     decide in the time budget; raise MUNUNU_BDD_TIME_BUDGET_MS (default 10000 ms; \
+                     0 disables), or use `--engine explicit`"
                 ));
             }
             bindings.insert(var, x.clone());
@@ -3243,7 +3249,8 @@ fn verdict_with_witness_catching(
     .unwrap_or_else(|_| {
         Err(
             "symbolic bit-blaster: BDD arena overflow while building the transition relation \
-             (the cone does not compress to a tractable BDD); use `--engine explicit`"
+             — abstained on the NODE budget (the cone does not compress to a tractable BDD); \
+             raise MUNUNU_BDD_ARENA_NODES, or use `--engine explicit`"
                 .to_string(),
         )
     })
@@ -7212,6 +7219,13 @@ mod tests {
             err.contains("register+input bits") && err.contains("300"),
             "the error must name the bit count + cap so a caller can degrade to \
              Skipped; got: {err}"
+        );
+        // #467 — the abstention names WHICH budget was hit and the KNOB to raise, so
+        // a consumer acts without blind trial-and-error across the three budgets.
+        assert!(
+            err.contains("BIT CAP") && err.contains("MUNUNU_BDD_MAX_BITS"),
+            "the abstention must name the budget (BIT CAP) + its knob \
+             (MUNUNU_BDD_MAX_BITS); got: {err}"
         );
     }
 

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -151,6 +151,15 @@ rather than crashing the run — the other properties still report. Shrink a wid
 parameter (`--param BW_WIDTH=4`) so the counters fit, or fall back to
 `--engine explicit`. This is a size threshold, not a malformed input.
 
+The exact engine has **four** independent budgets, and an abstention **names which
+one it hit and the knob to raise** — `BIT CAP` (`MUNUNU_BDD_MAX_BITS`), `NODE`
+budget (`MUNUNU_BDD_ARENA_NODES`, which scales the OxiDD arena), `ITERATION`
+budget (`MUNUNU_BDD_ITER_BUDGET`, the μ/ν fixpoint step cap), and `WALL-CLOCK`
+(`MUNUNU_BDD_TIME_BUDGET_MS`, default 10 s). Bit count cannot see the reachable
+*diameter*, so a cone that fits the bit cap can still abstain on the iteration or
+wall-clock budget — the message distinguishes the four so the remedy is not blind
+trial-and-error.
+
 > Source of truth: [`bitblast_oom_skip_note`](../crates/mununu-core/src/planner/mod.rs) — surface: (CLI+API+UI)
 
 ### Pinning a config input: `--config-value`


### PR DESCRIPTION
Closes #467.

## Problem
An exact-symbolic abstention reported a cell count but not **which** of the engine's four budgets it hit, nor the knob to raise. Bit count cannot see the reachable **diameter**, so a cone that fits the bit cap can still abstain on the iteration or wall-clock budget — three budgets got tried blind, in the wrong order, and an inconclusive run was reported upstream as "raising the arena did not help" when it was simply a run not allowed to finish. The existing `skip-diameter-bound` note is the model.

## Fix
Each abstention now names the budget **and** its env knob:

| budget | knob |
|---|---|
| `BIT CAP` | `MUNUNU_BDD_MAX_BITS` |
| `NODE` (BDD/arena) | `MUNUNU_BDD_ARENA_NODES` |
| `ITERATION` | `MUNUNU_BDD_ITER_BUDGET` |
| `WALL-CLOCK` | `MUNUNU_BDD_TIME_BUDGET_MS` (default 10000 ms; 0 disables) |

Enriched at the source (`check_node_budget`, the arena-exhaustion / OoM / build-backstop strings, the iteration + wall-clock guards, the bit-cap reject), so the per-property `reason` carries it to every surface. The `"arena exhausted"` / `"register+input bits"` substrings the planner + tests route on are **preserved** — routing unchanged.

## Verdicts
**None change.** Message-only.

## Tests + docs
- `d1_7_exact_verdict_over_bit_cap_degrades_gracefully` now also asserts the bit-cap abstention names `BIT CAP` + `MUNUNU_BDD_MAX_BITS` (race-free, no env mutation). Host lib 2432/0; clippy clean.
- Docs: the four knobs added to CLAUDE.md's Environment Variables table + `docs/verifying-rtl.md`'s abstention section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)