### PR TITLE
feat(sv): `sv lint` — CI-time preflight for partial-write registers the lift can't keep (#469)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1472,6 +1472,14 @@ enum SvCommand {
     /// reach a value outside its enum (an unambiguous bug). Surface peer of
     /// `POST /api/v1/sv/check-fsm`.
     CheckFsm(SvCheckFsmArgs),
+    /// Lift SV and report — at CI time (~lift cost, no model checking) — every
+    /// register whose partial-write lift the verifier cannot keep faithfully
+    /// (monono#partsel): a plain-vector `q[hi:lo] <= d` whose unwritten bits the
+    /// front-end models as free inputs. These are exactly the registers a state
+    /// predicate would be *refused* on (skipped, never mis-decided) by the formal
+    /// gate — surfaced in ~0.1 s before the minutes-long verify. Read-only, changes
+    /// no verdict. Surface peer of `POST /api/v1/sv/lint`.
+    Lint(SvLintArgs),
 }
 
 #[derive(Args, Debug)]
@@ -1924,6 +1932,15 @@ struct SvCheckFsmArgs {
     /// Max state-register width to treat as an FSM (wider = datapath/counter, skipped).
     #[arg(long, value_name = "BITS", default_value_t = mununu_core::adapter::fsm_scan::DEFAULT_FSM_MAX_WIDTH)]
     max_width: u32,
+    #[command(flatten)]
+    ci: CiArgs,
+}
+
+/// Arguments for `mununu sv lint` — the CI-time partial-write preflight.
+#[derive(Args, Debug)]
+struct SvLintArgs {
+    #[command(flatten)]
+    lift: SvLiftArgs,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -5426,6 +5443,7 @@ fn handle_sv(command: SvCommand) -> Result<(), String> {
         SvCommand::VerifyLivenessAll(args) => sv_verify_liveness_all(args),
         SvCommand::VerifyRecoverability(args) => sv_verify_recoverability(args),
         SvCommand::CheckFsm(args) => sv_check_fsm(args),
+        SvCommand::Lint(args) => sv_lint(args),
     }
 }
 
@@ -5645,6 +5663,48 @@ fn sv_check_fsm(args: SvCheckFsmArgs) -> Result<(), String> {
     print_json_summary(&summary)?;
 
     let worst = worst_verdict(findings.iter().map(|f| PropertyVerdict::as_str(f.verdict)));
+    ci_gate_exit(worst, args.ci.fail_on);
+    Ok(())
+}
+
+/// `mununu sv lint` — lift SV then report the partial-write registers the verifier
+/// cannot keep faithfully (monono#partsel). CI-time preflight; changes no verdict.
+/// A finding maps to the `violated` CI verdict, so the default `--fail-on violated`
+/// fails the build when the lift is unfaithful; `--fail-on none` makes it advisory.
+fn sv_lint(args: SvLintArgs) -> Result<(), String> {
+    use mununu_core::adapter::sv_verify::sv_lint_registers;
+
+    let file = args.lift.primary_display();
+    let findings = sv_lint_registers(&read_sv_lift(&args.lift)?)?;
+
+    let signals: Vec<serde_json::Value> = findings
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "signal": f.signal,
+                "kind": f.kind.as_str(),
+            })
+        })
+        .collect();
+    let registers_flagged = findings
+        .iter()
+        .filter(|f| f.kind == mununu_core::adapter::sv_verify::SvLintSignalKind::Register)
+        .count();
+    let summary = serde_json::json!({
+        "file": file,
+        "signals_flagged": findings.len(),
+        "registers_flagged": registers_flagged,
+        "findings": signals,
+    });
+    print_json_summary(&summary)?;
+
+    // A finding is the lint's `violated`; a clean run is `holds`. Reuses the shared
+    // CI gate so `--fail-on {violated|unknown|none}` behaves like the verify verbs.
+    let worst = if findings.is_empty() {
+        "holds"
+    } else {
+        "violated"
+    };
     ci_gate_exit(worst, args.ci.fail_on);
     Ok(())
 }

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -503,11 +503,11 @@ endmodule
         let findings = sv_lint_registers(&lift).expect("lint lifts + scans the design");
         let names: Vec<&str> = findings.iter().map(|f| f.signal.as_str()).collect();
         assert!(
-            names.iter().any(|n| *n == "a_q"),
+            names.contains(&"a_q"),
             "the partial-write register a_q must be flagged; got {names:?}"
         );
         assert!(
-            !names.iter().any(|n| *n == "b_q"),
+            !names.contains(&"b_q"),
             "the fully-written register b_q is faithful and must NOT be flagged; got {names:?}"
         );
     }

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -171,6 +171,112 @@ pub fn sv_check_fsm(
     crate::adapter::fsm_scan::fsm_encoding_scan(&btor2, max_width)
 }
 
+/// Whether a lint finding names a state register (or its alias) or a
+/// combinational output derived from one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SvLintSignalKind {
+    /// A state register — the root of the finding: the RTL front-end left some of
+    /// its bits undriven (modelled as free inputs).
+    Register,
+    /// A combinational output that reads such a register — flagged downstream of a
+    /// `Register` finding (a property over it would be refused for the same reason).
+    Output,
+}
+
+impl SvLintSignalKind {
+    /// The stable lowercase tag used across the CLI JSON / API / UI surfaces.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SvLintSignalKind::Register => "register",
+            SvLintSignalKind::Output => "output",
+        }
+    }
+}
+
+/// One `sv lint` finding — a named signal whose lift the engine cannot keep
+/// faithfully (monono#partsel): its cone reaches an ANONYMOUS free input, so a
+/// state predicate over it would be *refused* (skipped) by the verifier rather
+/// than mis-decided. See [`sv_lint_registers`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SvLintFinding {
+    /// The offending signal's symbol (register name or the combinational output).
+    pub signal: String,
+    /// Whether `signal` is the register itself or a downstream output.
+    pub kind: SvLintSignalKind,
+}
+
+/// `sv lint` — lift SV and report, at CI time (~lift cost, no bit-blast / no
+/// model checking), every register whose partial-write lift the verifier can NOT
+/// keep faithfully.
+///
+/// This is the read-only, cap-immune preflight for the monono#partsel soundness
+/// refusal shipped in #464/#465: the yosys-slang lift of a plain-vector partial
+/// register assignment (`q[hi:lo] <= d`) models `q`'s *unwritten* bits as free
+/// `input`s (havoc) and aliases the register name to the `concat` mixing them, so
+/// a state predicate over `q` reads those free inputs and would be unsound — the
+/// verifier *refuses* (skips) such a property up front
+/// ([`parser::signal_reaches_anonymous_input`]). `sv lint` surfaces exactly those
+/// registers *before* the ~minutes-long formal gate runs, so a design whose lift
+/// is unfaithful is caught in ~0.1 s. It changes **no verdict**: a faithful state
+/// cell (read_verilog / sv2v) and a packed-2-D `q[idx] <= d` split (anonymous
+/// *sub-registers*, no free inputs — the NID-indexed cone keeps them) are both
+/// NOT flagged; the latter decides.
+///
+/// Findings are deterministic (sorted by name, deduplicated); a name that is both
+/// a register alias and an output is reported once, as a `Register`.
+pub fn sv_lint_registers(lift: &SvLift) -> Result<Vec<SvLintFinding>, String> {
+    let btor2 = lift.lift()?;
+    lint_undriven_partial_writes(&btor2)
+}
+
+/// The pure BTOR2 core of [`sv_lint_registers`] — parse the flattened design and
+/// return every named register/output whose cone reaches an anonymous free input.
+/// Split out so the regression suite can exercise it on a captured BTOR2 fixture
+/// with no sv2v / Yosys on the host.
+fn lint_undriven_partial_writes(btor2: &str) -> Result<Vec<SvLintFinding>, String> {
+    use crate::adapter::btor2::ast::Node;
+    use crate::adapter::btor2::parser::signal_reaches_anonymous_input;
+
+    let file = parser::parse(btor2).map_err(|e| format!("BTOR2 parse: {e}"))?;
+
+    // Candidate name universe = exactly the names `signal_reaches_anonymous_input`
+    // can match on: State + Op(symbol) → a register (the partsel alias `a_q` is a
+    // `uext`/`concat` Op carrying the register's name), Output(symbol) → a
+    // combinational output. `Register` wins when a name appears as both.
+    let mut kinds: std::collections::BTreeMap<String, SvLintSignalKind> =
+        std::collections::BTreeMap::new();
+    for line in &file.lines {
+        let (name, kind) = match &line.node {
+            Node::State {
+                symbol: Some(s), ..
+            }
+            | Node::Op {
+                symbol: Some(s), ..
+            } => (s, SvLintSignalKind::Register),
+            Node::Output {
+                symbol: Some(s), ..
+            } => (s, SvLintSignalKind::Output),
+            _ => continue,
+        };
+        kinds
+            .entry(name.clone())
+            .and_modify(|k| {
+                if kind == SvLintSignalKind::Register {
+                    *k = SvLintSignalKind::Register;
+                }
+            })
+            .or_insert(kind);
+    }
+
+    // BTreeMap keeps the output sorted-by-name (deterministic).
+    Ok(kinds
+        .into_iter()
+        .filter(|(name, _)| signal_reaches_anonymous_input(&file, name))
+        .map(|(signal, kind)| SvLintFinding { signal, kind })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,6 +307,121 @@ mod tests {
     fn recoverability_rejects_malformed_target_before_lift() {
         let e = sv_verify_recoverability(&lift_of("module m; endmodule"), "not an atom !!");
         assert!(e.is_err(), "a malformed target must be rejected pre-lift");
+    }
+
+    // monono#partsel lint core — the yosys-slang lift of a plain-vector partial
+    // register assignment (`a_q[11:8] <= val`), captured verbatim so the
+    // regression runs in make-ci without slang. `a_q`'s unwritten bits are free
+    // `input`s (nid 17, 21) mixed into the `concat` its name aliases; `o_partsel`
+    // reads them. `b_q`/`c_q`/`d_q` (and their outputs) reach only the *named*
+    // `val` input — faithful, never flagged. `sv lint` reports exactly the pair
+    // the verifier would refuse: `a_q` (register) + `o_partsel` (output).
+    const SLANG_PARTSEL_LIFT: &str = r#"1 sort bitvec 1
+2 input 1 clk
+3 one 1 rst_n
+4 sort bitvec 4
+5 input 4 val
+6 sort bitvec 16
+7 const 6 0000000000000000
+8 state 6
+9 ite 6 3 8 7
+10 redor 1 9
+11 output 10 o_concat
+12 state 6
+13 ite 6 3 12 7
+14 redor 1 13
+15 output 14 o_lowconcat
+16 sort bitvec 8
+17 input 16
+18 const 4 0000
+19 state 4
+20 ite 4 3 19 18
+21 input 4
+22 sort bitvec 12
+23 concat 22 20 17
+24 concat 6 21 23
+25 redor 1 24
+26 output 25 o_partsel
+27 state 6
+28 ite 6 3 27 7
+29 redor 1 28
+30 output 29 o_plain
+31 uext 6 24 0 a_q
+32 uext 6 9 0 b_q
+33 uext 6 13 0 c_q
+34 uext 6 28 0 d_q
+35 slice 16 9 7 0
+36 concat 22 5 35
+37 slice 4 9 15 12
+38 concat 6 37 36
+39 ite 6 3 38 7
+40 next 6 8 39
+41 const 22 000000000000
+42 concat 6 41 5
+43 ite 6 3 42 7
+44 next 6 12 43
+45 ite 4 3 5 18
+46 next 4 19 45
+47 ite 6 3 42 7
+48 next 6 27 47
+49 constd 6 0
+50 init 6 8 49
+51 constd 6 0
+52 init 6 12 51
+53 constd 4 0
+54 init 4 19 53
+55 constd 6 0
+56 init 6 27 55
+"#;
+
+    #[test]
+    fn lint_reports_only_the_undriven_partial_write_signals() {
+        let findings =
+            lint_undriven_partial_writes(SLANG_PARTSEL_LIFT).expect("lint parses the BTOR2");
+        let names: Vec<&str> = findings.iter().map(|f| f.signal.as_str()).collect();
+        // Exactly the register whose unwritten bits are free inputs, plus the one
+        // output that reads it — deterministic, sorted, deduplicated.
+        assert_eq!(
+            names,
+            vec!["a_q", "o_partsel"],
+            "lint must flag the undriven partial-write register + its output, and \
+             NOTHING faithful (b_q/c_q/d_q reach only the named `val`)"
+        );
+        assert_eq!(
+            findings[0].kind,
+            SvLintSignalKind::Register,
+            "a_q is a register"
+        );
+        assert_eq!(
+            findings[1].kind,
+            SvLintSignalKind::Output,
+            "o_partsel is an output"
+        );
+    }
+
+    #[test]
+    fn lint_is_clean_when_every_register_is_faithful() {
+        // A fully-driven single register: no free inputs, no findings.
+        const FAITHFUL: &str = "1 sort bitvec 1
+2 input 1 d
+3 state 1 q
+4 next 1 3 2
+5 zero 1
+6 init 1 3 5
+";
+        let findings = lint_undriven_partial_writes(FAITHFUL).expect("lint parses");
+        assert!(
+            findings.is_empty(),
+            "a faithful register driven by a named input must not be flagged; got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn lint_rejects_malformed_btor2() {
+        assert!(
+            lint_undriven_partial_writes("not btor2 at all").is_err(),
+            "a malformed BTOR2 body must surface a parse error, not an empty pass"
+        );
     }
 
     // P2 industrial anchor — recoverability on REAL OpenTitan RTL. From every reachable
@@ -241,6 +462,53 @@ mod tests {
             PropertyVerdict::Holds,
             "AG EF idle must HOLD on the AES cipher-control FSM (every reachable state can \
              return to CIPHER_CTRL_IDLE); got {verdict:?}"
+        );
+    }
+
+    // monono#partsel — the real slang lift of a plain-vector partial register
+    // assignment. `a_q[11:8] <= val` leaves `a_q`'s other bits undriven → slang
+    // models them as free inputs → `sv lint` flags `a_q`; `b_q` is written in full
+    // → faithful → not flagged. The `--frontend slang` path is what produces the
+    // free-input shape (read_verilog/sv2v models it differently), so this pins the
+    // slang front end. Runs only in the mununu-sva image.
+    #[test]
+    #[ignore = "requires yosys-slang (mununu-sva docker image); run with --ignored"]
+    fn e2e_sv_lint_flags_slang_partial_write_register() {
+        const SRC: &str = r#"module partsel_lint (
+  input  logic       clk,
+  input  logic       rst_n,
+  input  logic [3:0] val
+);
+  logic [15:0] a_q;  // only [11:8] written -> unwritten bits are free inputs (slang)
+  logic [15:0] b_q;  // written in full -> faithful state cell
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      a_q <= '0;
+      b_q <= '0;
+    end else begin
+      a_q[11:8] <= val;
+      b_q       <= {12'b0, val};
+    end
+  end
+endmodule
+"#;
+        let lift = SvLift {
+            source: SRC.to_string(),
+            additional_sources: Vec::new(),
+            top: Some("partsel_lint".into()),
+            use_sv2v: false,
+            include_dirs: Vec::new(),
+            frontend: SvFrontend::Slang,
+        };
+        let findings = sv_lint_registers(&lift).expect("lint lifts + scans the design");
+        let names: Vec<&str> = findings.iter().map(|f| f.signal.as_str()).collect();
+        assert!(
+            names.iter().any(|n| *n == "a_q"),
+            "the partial-write register a_q must be flagged; got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| *n == "b_q"),
+            "the fully-written register b_q is faithful and must NOT be flagged; got {names:?}"
         );
     }
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1342,6 +1342,61 @@ fn sv_check_fsm_handler_impl(request: SvCheckFsmRequest) -> ApiResult<Json<Btor2
     }))
 }
 
+/// monono#partsel preflight (#469) — lift SV and report the partial-write
+/// registers the verifier cannot keep faithfully, with no model checking. Surface
+/// peer of the CLI `mununu sv lint`; read-only, changes no verdict.
+pub async fn sv_lint_handler(
+    Json(request): Json<SvLintRequest>,
+) -> ApiResult<Json<SvLintResponse>> {
+    blocking(move || sv_lint_handler_impl(request)).await
+}
+
+fn sv_lint_handler_impl(request: SvLintRequest) -> ApiResult<Json<SvLintResponse>> {
+    use crate::adapter::sv_verify::{SvLift, SvLintSignalKind, sv_lint_registers};
+
+    let lift = SvLift {
+        source: request.source,
+        additional_sources: request
+            .additional_sources
+            .into_iter()
+            .map(|f| (f.name, f.content))
+            .collect(),
+        top: request.top,
+        use_sv2v: request.use_sv2v,
+        // As with the other SV-direct handlers: the request stages include content
+        // by name, so an on-disk include-search dir is a CLI-only concept here.
+        include_dirs: Vec::new(),
+        frontend: if request.use_slang {
+            crate::adapter::yosys::SvFrontend::Slang
+        } else {
+            crate::adapter::yosys::SvFrontend::Auto
+        },
+    };
+
+    let findings = sv_lint_registers(&lift).map_err(|message| ApiError::BadRequest {
+        message,
+        details: None,
+    })?;
+
+    let registers_flagged = findings
+        .iter()
+        .filter(|f| f.kind == SvLintSignalKind::Register)
+        .count();
+    let findings = findings
+        .into_iter()
+        .map(|f| SvLintFinding {
+            signal: f.signal,
+            kind: f.kind.as_str().to_string(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Json(SvLintResponse {
+        signals_flagged: findings.len(),
+        registers_flagged,
+        findings,
+    }))
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — SV-direct CEGAR in one call.
 ///
 /// Lifts SystemVerilog to a single flattened BTOR2 (sv2v + Yosys, the

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1303,6 +1303,52 @@ pub struct SvCheckFsmRequest {
     pub max_width: u32,
 }
 
+/// Request for `POST /api/v1/sv/lint` — the SV-direct partial-write preflight.
+/// Lifts SystemVerilog and reports every register whose partial-write lift the
+/// verifier cannot keep faithfully (monono#partsel), with no model checking.
+/// Surface peer of the CLI `mununu sv lint`.
+#[derive(Debug, Deserialize)]
+pub struct SvLintRequest {
+    /// SystemVerilog primary source content.
+    pub source: String,
+    /// Additional SV sources (packages / includes).
+    #[serde(default)]
+    pub additional_sources: Vec<FileContent>,
+    /// Top module for the lift (auto-detect when omitted).
+    #[serde(default)]
+    pub top: Option<String>,
+    /// Run sv2v before Yosys. Default `false`.
+    #[serde(default)]
+    pub use_sv2v: bool,
+    /// Force the slang RTL front-end (`read_slang`). Requires the yosys-slang
+    /// plugin. Default `false`.
+    #[serde(default)]
+    pub use_slang: bool,
+}
+
+/// One `sv lint` finding — a named signal whose partial-write lift reaches an
+/// undriven (free-input) register bit, so a state predicate over it would be
+/// *refused* (skipped) by the verifier. Element of [`SvLintResponse`].
+#[derive(Debug, Serialize)]
+pub struct SvLintFinding {
+    /// The offending signal's symbol (register name or a combinational output of one).
+    pub signal: String,
+    /// `"register"` (the root — the register itself) | `"output"` (a downstream
+    /// combinational output that reads it).
+    pub kind: String,
+}
+
+/// Response for `POST /api/v1/sv/lint`.
+#[derive(Debug, Serialize)]
+pub struct SvLintResponse {
+    /// Number of named signals flagged (registers + downstream outputs).
+    pub signals_flagged: usize,
+    /// Number of the flagged signals that are state registers (the root findings).
+    pub registers_flagged: usize,
+    /// Per-signal findings (sorted by name).
+    pub findings: Vec<SvLintFinding>,
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — request for the SV-direct
 /// CEGAR endpoint (`POST /api/v1/sv/cegar`). Mirrors the CLI
 /// `mununu sv cegar`: lifts SystemVerilog to a single flattened BTOR2

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -180,6 +180,10 @@ fn create_router() -> Router {
         // SV-direct auto FSM illegal-encoding scan (lift + scan, one call). Surface peer
         // of the CLI `sv check-fsm` and the BTOR2-direct `/api/v1/btor2/check-fsm`.
         .route("/api/v1/sv/check-fsm", post(handlers::sv_check_fsm_handler))
+        // SV-direct partial-write preflight (monono#partsel) — lift + report the
+        // registers the verifier can't keep faithfully, no model checking. Surface
+        // peer of the CLI `sv lint`.
+        .route("/api/v1/sv/lint", post(handlers::sv_lint_handler))
         .route(
             "/api/v1/verify/memory-check",
             post(handlers::memory_check_handler),

--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -97,3 +97,19 @@ MUNUNU_CVC5_PATH=/opt/cvc5/bin/cvc5 mununu btor2 cegar --file design.btor2 --pre
 ```
 
 When `--predicate-source craig` is selected but CVC5 isn't found at runtime, mununu emits a structured warning + falls back to the WP heuristic automatically — the verification verdict is still computed; only the predicate-discovery mechanism is degraded. See [`docs/external-tools.md`](external-tools.md#cvc5) for full install instructions on macOS, Debian/Ubuntu, and the cross-platform GitHub release tarball.
+
+## Preflight a SystemVerilog design for unfaithful partial-write registers
+
+> Source of truth: [`sv_lint_registers`](../crates/mununu-core/src/adapter/sv_verify.rs#L228) — surface: (CLI+API+UI)
+
+`mununu sv lint` lifts a SystemVerilog design and reports — at CI time (~lift cost, **no** model checking, ~0.1 s) — every register whose partial-write lift the verifier cannot keep faithfully (a plain-vector `q[hi:lo] <= d` whose unwritten bits the front end models as free inputs). These are exactly the registers a state predicate would be *refused* on by the formal gate, surfaced *before* the minutes-long verify. It changes no verdict.
+
+```bash
+# Report the unfaithful partial-write registers; exit 2 if any (a CI gate).
+mununu --quiet sv lint rtl/mod.sv --frontend slang
+
+# Advisory (report-only, always exit 0):
+mununu --quiet sv lint rtl/mod.sv --frontend slang --fail-on none
+```
+
+The JSON on stdout lists each flagged `signal` with a `kind` of `"register"` (the root — the register itself) or `"output"` (a downstream combinational output of one). See [`docs/verifying-rtl.md`](verifying-rtl.md) for the soundness background (the monono#partsel guard).

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -333,6 +333,42 @@ portfolio engines) — an agent can trust a definite verdict and treat `unknown`
 
 ---
 
+## Preflight: `sv lint` — the partial-write registers the lift can't keep
+
+> Source of truth: [`sv_lint_registers`](../crates/mununu-core/src/adapter/sv_verify.rs#L228) — surface: (CLI+API+UI)
+
+Some SystemVerilog is **not lifted faithfully**, and the verifier is honest about
+it: a plain-vector partial register assignment (`q[hi:lo] <= d`) leaves `q`'s other
+bits undriven, so the yosys-slang front end models them as **free inputs** (havoc)
+and aliases the register name to the `concat` that mixes them. A state predicate
+over `q` would then read those free inputs, so the engine **refuses** (skips) such a
+property rather than emit an unsound verdict (the monono#partsel soundness guard —
+see [`recoverability-vs-sva.md`](design/recoverability-vs-sva.md)). The packed-2-D
+`q[idx] <= d` split (anonymous *sub-registers*, no free inputs) is kept and decides;
+a fully-written register is faithful.
+
+`sv lint` surfaces exactly those refusable registers **at CI time** — it lifts the
+design and scans it (~lift cost, **no** model checking, cap-immune, ~0.1 s) so an
+unfaithful lift is caught *before* the minutes-long formal gate runs. It **changes
+no verdict**; it is a read-only preflight.
+
+```bash
+mununu --quiet sv lint rtl/mod.sv --frontend slang        # exit 2 ⇒ a register can't be kept
+```
+
+```jsonc
+// POST /api/v1/sv/lint  →
+{ "signals_flagged": 2, "registers_flagged": 1,
+  "findings": [ { "signal": "a_q", "kind": "register" },     // the root
+                { "signal": "o_partsel", "kind": "output" } ] }   // a downstream output of it
+```
+
+`kind` is `"register"` (the root — the register whose bits are undriven) or
+`"output"` (a combinational output that reads one; a property over it is refused for
+the same reason). A finding maps to the shared CI gate's `violated` verdict, so the
+default `--fail-on violated` fails the build; `--fail-on none` makes it advisory. A
+clean design reports zero findings and exits `0`.
+
 ## Using mununu in CI (GitHub Actions and friends)
 
 > Source of truth: [`FailOn` / `ci_exit_code`](../crates/mununu-cli/src/main.rs) — surface: CLI


### PR DESCRIPTION
## `sv lint` — CI-time preflight for the partial-write registers the lift can't keep (monono#469)

Closes #469.

### Why

The monono#partsel soundness guard (#464/#465) **refuses** (skips) a state predicate over a register whose plain-vector partial assignment (`q[hi:lo] <= d`) leaves its other bits undriven — the yosys-slang lift models them as free `input`s (havoc) and aliases the register name to the `concat` mixing them, so a predicate over it reads havoc and would mis-decide. That refusal only surfaces during the **minutes-long** formal gate. Diagnosing the partsel bug cost ~a day partly because nothing answered *"which registers can't the lift keep?"* up front.

### What

`mununu sv lint` is that preflight. It lifts the design and scans it — **~lift cost, no model checking, cap-immune, ~0.1 s** — reporting every register whose cone reaches an anonymous free input, i.e. exactly the set the verifier would refuse. It **changes no verdict**. A faithful state cell (read_verilog / sv2v) and a packed-2-D `q[idx] <= d` split (anonymous sub-registers, no free inputs — the NID cone keeps them) are both **not** flagged; the latter decides.

```bash
mununu --quiet sv lint rtl/mod.sv --frontend slang   # exit 2 ⇒ a register can't be kept
```
```jsonc
// POST /api/v1/sv/lint →
{ "signals_flagged": 2, "registers_flagged": 1,
  "findings": [ { "signal": "a_q", "kind": "register" },       // the root
                { "signal": "o_partsel", "kind": "output" } ] } // a downstream output of it
```

A finding maps to the shared CI gate's `violated`, so default `--fail-on violated` fails the build; `--fail-on none` makes it advisory.

### Surface parity (CLI + API + UI)

- **core** — `sv_lint_registers` / `lint_undriven_partial_writes` (`adapter/sv_verify.rs`): enumerate every named `State`/`Op`-alias/`Output` symbol, filter by the shipped `parser::signal_reaches_anonymous_input` guard; deterministic (sorted, deduped), `Register` wins over `Output`.
- **CLI** — `mununu sv lint` (`SvCommand::Lint`); JSON summary + `ci_gate_exit`.
- **API** — `POST /api/v1/sv/lint` (`sv_lint_handler`, `SvLintRequest`/`SvLintResponse`/`SvLintFinding`).
- **UI** (mununu-ui #70) — `runSvLint` typed client + `sv-lint.test.ts`.
- **docs** — `sv lint` sections in `docs/verifying-rtl.md` + `docs/cli-cookbook.md`, each with a `Source of truth` anchor to `sv_lint_registers` (CLI+API+UI).

### Tests

- `lint_reports_only_the_undriven_partial_write_signals` (make-ci, on the captured slang BTOR2 fixture): flags `a_q` + `o_partsel`, not the faithful `b_q`/`c_q`/`d_q`.
- `lint_is_clean_when_every_register_is_faithful`, `lint_rejects_malformed_btor2`.
- `#[ignore]` `e2e_sv_lint_flags_slang_partial_write_register` — the real slang lift in the mununu-sva image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
