### PR TITLE
feat(sv): `sv mutate` — named structural mutations + verdict-flip property adequacy (#468a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,7 @@ The load-bearing rules at a glance:
 
 - **Models from source, not documentation.** Models written from API docs are "design pattern demonstrations," never findings about the real system.
 - **Planted bugs are demos, not findings.** Language must reflect this.
+- **Mutations are property-adequacy, not bug findings.** `sv mutate` injects a *deliberate* structural fault to test whether the properties catch it; a flip measures the **spec's** adequacy, a non-flip is a vacuous property — never frame a mutation result as a discovered bug in the design.
 - **Severity honesty.** Distinguish vulnerability vs. correctness issue vs. structural gap vs. design-pattern violation.
 - **Reproduction path required.** Either a real-system test case or an explicit "structural, not yet reproduced" disclosure.
 - **Verification-first workflow.** The CTXDSL model + `mununu context eval` is the oracle, not human code reading.

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1480,6 +1480,13 @@ enum SvCommand {
     /// gate — surfaced in ~0.1 s before the minutes-long verify. Read-only, changes
     /// no verdict. Surface peer of `POST /api/v1/sv/lint`.
     Lint(SvLintArgs),
+    /// Apply a NAMED structural mutation to the design and re-verify, checking that
+    /// the property verdicts FLIP (property adequacy). A flip confirms a property
+    /// constrains the mutated behaviour; a property that does NOT flip is the
+    /// finding — the spec is vacuous w.r.t. that fault. `--list` enumerates the
+    /// available targets. This is a statement about the PROPERTIES, never a bug
+    /// report about the design. Surface peer of `POST /api/v1/sv/mutate`.
+    Mutate(SvMutateArgs),
 }
 
 #[derive(Args, Debug)]
@@ -1941,6 +1948,33 @@ struct SvCheckFsmArgs {
 struct SvLintArgs {
     #[command(flatten)]
     lift: SvLiftArgs,
+    #[command(flatten)]
+    ci: CiArgs,
+}
+
+/// Arguments for `mununu sv mutate` — apply a named structural mutation + re-verify.
+#[derive(Args, Debug)]
+struct SvMutateArgs {
+    #[command(flatten)]
+    lift: SvLiftArgs,
+    /// The mutation to apply: `stick:<reg>` (freeze a register) or
+    /// `drop-reset:<reg>` (remove a register's reset arm). Required unless `--list`.
+    #[arg(long, value_name = "stick:REG|drop-reset:REG")]
+    mutation: Option<String>,
+    /// Instead of mutating, list the available mutation TARGETS of the design
+    /// (every register → `stick`; every reset-mux register → `drop-reset`).
+    #[arg(long)]
+    list: bool,
+    /// Verification engine for the baseline + mutant runs (as `sv verify-auto`).
+    #[arg(long, value_enum, default_value_t = EngineArg::PortfolioSequential)]
+    engine: EngineArg,
+    /// Disable reset-gating (keep the reset a free input). Default: reset-gated.
+    #[arg(long)]
+    no_gate_reset: bool,
+    /// Must-edge inference — `smt-hyper-must` gives sound νμ verdicts (needed for a
+    /// recoverability property to flip under `drop-reset`). Default `off`.
+    #[arg(long, value_enum, default_value_t = MustEdgeInferenceArg::Off)]
+    must_edge_inference: MustEdgeInferenceArg,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -3600,6 +3634,8 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         rescue_bottom_safety: !args.no_rescue,
         rescue_bottom_liveness: !args.no_rescue,
         rescue_bottom_recoverability: !args.no_rescue,
+        // `sv verify-auto` verifies the design as-lifted; mutation is the `sv mutate` verb's job.
+        mutation: None,
     };
 
     let report = verify_auto(&sources, &yopts, &opts)
@@ -5444,6 +5480,7 @@ fn handle_sv(command: SvCommand) -> Result<(), String> {
         SvCommand::VerifyRecoverability(args) => sv_verify_recoverability(args),
         SvCommand::CheckFsm(args) => sv_check_fsm(args),
         SvCommand::Lint(args) => sv_lint(args),
+        SvCommand::Mutate(args) => sv_mutate(args),
     }
 }
 
@@ -5701,6 +5738,111 @@ fn sv_lint(args: SvLintArgs) -> Result<(), String> {
     // A finding is the lint's `violated`; a clean run is `holds`. Reuses the shared
     // CI gate so `--fail-on {violated|unknown|none}` behaves like the verify verbs.
     let worst = if findings.is_empty() {
+        "holds"
+    } else {
+        "violated"
+    };
+    ci_gate_exit(worst, args.ci.fail_on);
+    Ok(())
+}
+
+/// `mununu sv mutate` — apply a named structural mutation + re-verify, checking the
+/// property verdicts flip (property adequacy), or (`--list`) enumerate the targets.
+/// A mutation caught by NO property maps to the `violated` CI verdict (a coverage
+/// gap), so the default `--fail-on violated` fails the build; `--fail-on none` is
+/// advisory. A `--list` run always exits 0.
+fn sv_mutate(args: SvMutateArgs) -> Result<(), String> {
+    use mununu_core::adapter::btor2::kmts_lift::MustEdgeInference;
+    use mununu_core::adapter::btor2::mutate::{Mutation, list_targets};
+    use mununu_core::adapter::slang::verify_auto::{
+        PortfolioMode, VerifyAutoOptions, mutate_and_compare,
+    };
+    use mununu_core::adapter::yosys::{YosysOptions, sv_to_btor2};
+
+    let file = args.lift.primary_display();
+    let lift = read_sv_lift(&args.lift)?;
+    let primary_name = std::path::Path::new(&file)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| "top.sv".to_string());
+    let mut sources: Vec<(String, String)> = vec![(primary_name, lift.source.clone())];
+    sources.extend(lift.additional_sources.iter().cloned());
+    let yopts = YosysOptions {
+        top: lift.top.clone(),
+        additional_sources: lift.additional_sources.clone(),
+        use_sv2v: lift.use_sv2v,
+        extra_include_dirs: lift.include_dirs.clone(),
+        frontend: lift.frontend,
+        ..Default::default()
+    };
+
+    // `--list` — lift once and enumerate the mutation targets (no verification).
+    if args.list {
+        let btor2 = sv_to_btor2(&lift.source, &yopts)
+            .map_err(|e| format!("sv mutate --list: {}", e.message))?;
+        let t = list_targets(&btor2)?;
+        let summary = serde_json::json!({
+            "file": file,
+            "targets": { "stick": t.stick, "drop_reset": t.drop_reset },
+        });
+        print_json_summary(&summary)?;
+        return Ok(());
+    }
+
+    let spec = args.mutation.as_deref().ok_or_else(|| {
+        "sv mutate: --mutation is required (or use --list to discover targets); \
+         expected `stick:<reg>` or `drop-reset:<reg>`"
+            .to_string()
+    })?;
+    let mutation = Mutation::parse(spec)?;
+
+    let must_edge_inference = match args.must_edge_inference {
+        MustEdgeInferenceArg::Off => MustEdgeInference::Off,
+        MustEdgeInferenceArg::SmtPerTarget => MustEdgeInference::SmtPerTarget,
+        MustEdgeInferenceArg::SmtPerTargetStandard => MustEdgeInference::SmtPerTargetStandard,
+        MustEdgeInferenceArg::SmtHyperMust => MustEdgeInference::SmtHyperMust,
+    };
+    let opts = VerifyAutoOptions {
+        must_edge_inference,
+        gate_reset: !args.no_gate_reset,
+        symbolic_engine: args.engine == EngineArg::Symbolic,
+        exact_symbolic: args.engine == EngineArg::ExactSymbolic,
+        portfolio: match args.engine {
+            EngineArg::PortfolioSequential => Some(PortfolioMode::Sequential),
+            EngineArg::PortfolioParallel => Some(PortfolioMode::Parallel),
+            _ => None,
+        },
+        ..Default::default()
+    };
+
+    let report = mutate_and_compare(&sources, &yopts, &opts, mutation)
+        .map_err(|e| format!("sv mutate: {}", e.message))?;
+
+    let properties: Vec<serde_json::Value> = report
+        .properties
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "name": p.name,
+                "baseline": p.baseline,
+                "mutant": p.mutant,
+                "flipped": p.flipped,
+            })
+        })
+        .collect();
+    let summary = serde_json::json!({
+        "file": file,
+        "mutation": report.mutation,
+        "flipped": report.flipped,
+        "unflipped": report.unflipped,
+        "properties": properties,
+    });
+    print_json_summary(&summary)?;
+
+    // A mutation caught by at least one property (some flip) is `holds`; a mutation
+    // NO property catches is `violated` (a coverage gap the CI gate should flag).
+    let worst = if report.flipped > 0 {
         "holds"
     } else {
         "violated"

--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -32,6 +32,7 @@ pub mod emit;
 pub mod kmts_lift;
 pub mod l2s_monitor;
 pub(crate) mod model_facts;
+pub mod mutate;
 pub mod native_bmc;
 #[cfg(feature = "boolector")]
 pub mod native_boolector;

--- a/crates/mununu-core/src/adapter/btor2/mutate.rs
+++ b/crates/mununu-core/src/adapter/btor2/mutate.rs
@@ -1,0 +1,289 @@
+//! BTOR2 structural mutation (#468) — apply a **named** fault to a lifted design
+//! and re-emit, so a verify pass can assert its property verdicts **flip**.
+//!
+//! This is the engine behind `sv mutate`: a mutation that flips a `holds` to
+//! `violated` confirms the property actually **constrains** the mutated behaviour;
+//! a mutation that does NOT flip it is the finding — a **vacuous** property or a
+//! dead line the spec never pins down. Per [claims-integrity §2], a mutation
+//! result is a statement about **property adequacy**, never a bug finding about the
+//! design.
+//!
+//! Every mutation is a pure `parse → mutate [`Node`] → `emit_btor2` round-trip
+//! (the emitter is a fixed point of the parser, so an untouched model re-emits
+//! byte-for-byte; only the mutated node changes). No lift is needed, so the core
+//! is unit-tested on a BTOR2 fixture in make-ci.
+
+use super::ast::{Btor2File, Nid, Node, Op, Operand};
+use super::bit_blast::resolve_btor2_constant;
+use super::parser::{self, collect_symbols};
+
+/// A named structural fault applied to a lifted BTOR2 design.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Mutation {
+    /// **Freeze** a register: replace its `next` value with the register's own
+    /// current value (identity), so it never updates. Universal — every register
+    /// with a `next` can be stuck.
+    Stick(String),
+    /// **Remove the reset arm**: a register whose `next` is a reset mux
+    /// `ite(rst, RESET, d)` is rewritten to the data branch `d`, so it no longer
+    /// returns to its reset value. Flips reset-dependent properties (recoverability).
+    DropReset(String),
+}
+
+impl Mutation {
+    /// The stable CLI/label spelling (`stick:<reg>` / `drop-reset:<reg>`).
+    pub fn as_label(&self) -> String {
+        match self {
+            Mutation::Stick(r) => format!("stick:{r}"),
+            Mutation::DropReset(r) => format!("drop-reset:{r}"),
+        }
+    }
+
+    /// Parse a `stick:<reg>` / `drop-reset:<reg>` selector (the CLI/API spelling).
+    pub fn parse(spec: &str) -> Result<Mutation, String> {
+        if let Some(reg) = spec.strip_prefix("stick:") {
+            reg_nonempty(reg).map(|r| Mutation::Stick(r.to_string()))
+        } else if let Some(reg) = spec.strip_prefix("drop-reset:") {
+            reg_nonempty(reg).map(|r| Mutation::DropReset(r.to_string()))
+        } else {
+            Err(format!(
+                "unknown mutation `{spec}` — expected `stick:<reg>` or `drop-reset:<reg>` \
+                 (see `sv mutate --list` for the available targets)"
+            ))
+        }
+    }
+}
+
+fn reg_nonempty(reg: &str) -> Result<&str, String> {
+    if reg.is_empty() {
+        Err("mutation target register name is empty".to_string())
+    } else {
+        Ok(reg)
+    }
+}
+
+/// The mutation targets available in a design — the `sv mutate --list` payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MutationTargets {
+    /// Every **named** register — a `stick:<reg>` target (sorted, deduped).
+    pub stick: Vec<String>,
+    /// Every named register whose `next` is a one-constant reset mux — a
+    /// `drop-reset:<reg>` target (sorted, deduped; a subset of `stick`).
+    pub drop_reset: Vec<String>,
+}
+
+/// Apply `m` to the BTOR2 text and return the mutated BTOR2 (round-trip via the
+/// emitter). Errors if the named register does not exist or the mutation does not
+/// apply to it (e.g. `drop-reset` on a register with no reset mux).
+pub fn apply_mutation(btor2: &str, m: &Mutation) -> Result<String, String> {
+    let mut file = parser::parse(btor2).map_err(|e| format!("BTOR2 parse: {}", e.message))?;
+    match m {
+        Mutation::Stick(reg) => apply_stick(&mut file, reg)?,
+        Mutation::DropReset(reg) => apply_drop_reset(&mut file, reg)?,
+    }
+    Ok(super::emit::emit_btor2(&file))
+}
+
+/// Enumerate the mutation targets in a lifted design (`sv mutate --list`).
+pub fn list_targets(btor2: &str) -> Result<MutationTargets, String> {
+    let file = parser::parse(btor2).map_err(|e| format!("BTOR2 parse: {}", e.message))?;
+    let symbols = collect_symbols(&file);
+    let mut stick: Vec<String> = Vec::new();
+    let mut drop_reset: Vec<String> = Vec::new();
+    for line in &file.lines {
+        if !matches!(line.node, Node::State { .. }) {
+            continue;
+        }
+        // Only NAMED registers are addressable targets (an anonymous split
+        // sub-cell has no stable handle).
+        let Some(name) = symbols.get(&line.nid) else {
+            continue;
+        };
+        stick.push(name.clone());
+        if reset_data_branch(&file, line.nid).is_some() {
+            drop_reset.push(name.clone());
+        }
+    }
+    stick.sort();
+    stick.dedup();
+    drop_reset.sort();
+    drop_reset.dedup();
+    Ok(MutationTargets { stick, drop_reset })
+}
+
+/// Resolve a user register NAME to its `state` line nid — directly (the symbol is
+/// on the `state` line) or via a `uext … 0 NAME` alias (`collect_symbols` attaches
+/// the alias name to the underlying state nid). `None` if no state cell carries it.
+fn resolve_state_nid(file: &Btor2File, name: &str) -> Option<Nid> {
+    let symbols = collect_symbols(file);
+    symbols.iter().find_map(|(nid, sym)| {
+        if sym == name && matches!(file.lookup(*nid)?.node, Node::State { .. }) {
+            Some(*nid)
+        } else {
+            None
+        }
+    })
+}
+
+/// Freeze a register: point its `next` at its own state nid (identity → frozen).
+fn apply_stick(file: &mut Btor2File, reg: &str) -> Result<(), String> {
+    let state_nid = resolve_state_nid(file, reg).ok_or_else(|| {
+        format!("stick: `{reg}` is not a register (no state cell in the lift carries that name)")
+    })?;
+    let mut found = false;
+    for l in file.lines.iter_mut() {
+        if let Node::Next { state, value, .. } = &mut l.node
+            && *state == state_nid
+        {
+            *value = Operand(state_nid);
+            found = true;
+        }
+    }
+    if found {
+        Ok(())
+    } else {
+        Err(format!(
+            "stick: register `{reg}` (nid {state_nid}) has no `next` line to freeze \
+             (it is already an undriven/free register)"
+        ))
+    }
+}
+
+/// Drop a register's reset arm: rewrite its reset-mux `next` to the data branch.
+fn apply_drop_reset(file: &mut Btor2File, reg: &str) -> Result<(), String> {
+    let state_nid = resolve_state_nid(file, reg).ok_or_else(|| {
+        format!("drop-reset: `{reg}` is not a register (no state cell carries that name)")
+    })?;
+    let data = reset_data_branch(file, state_nid).ok_or_else(|| {
+        format!(
+            "drop-reset: register `{reg}`'s next is not a one-constant reset mux \
+             (`ite(rst, RESET, d)`) — there is no reset arm to drop"
+        )
+    })?;
+    for l in file.lines.iter_mut() {
+        if let Node::Next { state, value, .. } = &mut l.node
+            && *state == state_nid
+        {
+            *value = data;
+        }
+    }
+    Ok(())
+}
+
+/// If `state_nid`'s `next` is a one-constant reset mux `ite(cond, then, else)`
+/// (exactly one branch a constant — the reset value), return the OTHER (data)
+/// branch operand; else `None`. Mirrors `fsm_scan::analyze_reset_mux`'s shape test
+/// (the constant branch is the reset value, whatever the polarity).
+fn reset_data_branch(file: &Btor2File, state_nid: Nid) -> Option<Operand> {
+    let next_val_nid = file.lines.iter().find_map(|l| match &l.node {
+        Node::Next { state, value, .. } if *state == state_nid => Some(value.nid()),
+        _ => None,
+    })?;
+    // Copy the two data operands out (Operand: Copy), releasing the file borrow
+    // before the constant lookups below.
+    let (then_op, else_op) = match file.lookup(next_val_nid).map(|l| &l.node) {
+        Some(Node::Op {
+            op: Op::Ite, args, ..
+        }) if args.len() == 3 => (args[1], args[2]),
+        _ => return None,
+    };
+    match (
+        resolve_btor2_constant(file, then_op.nid()),
+        resolve_btor2_constant(file, else_op.nid()),
+    ) {
+        (None, Some(_)) => Some(then_op), // reset in the `else` branch ⇒ data is `then`
+        (Some(_), None) => Some(else_op), // reset in the `then` branch ⇒ data is `else`
+        _ => None, // both-const / neither-const ⇒ not an unambiguous reset mux
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A 2-register design: `q` toggles (no reset mux); `r` is a reset mux
+    // `ite(rst, 0, d)` — reset in the THEN branch (active-high, reset value 0),
+    // data in the ELSE branch (`d`). Both named.
+    const FIXTURE: &str = "1 sort bitvec 1
+2 input 1 rst
+3 input 1 d
+4 state 1 q
+5 not 1 4
+6 next 1 4 5
+7 zero 1
+8 init 1 4 7
+9 state 1 r
+10 ite 1 2 7 3
+11 next 1 9 10
+12 init 1 9 7
+";
+
+    fn next_value_of(btor2: &str, state_nid: Nid) -> Nid {
+        let file = parser::parse(btor2).expect("parse mutated");
+        file.lines
+            .iter()
+            .find_map(|l| match &l.node {
+                Node::Next { state, value, .. } if *state == state_nid => Some(value.nid()),
+                _ => None,
+            })
+            .expect("a next for the state")
+    }
+
+    #[test]
+    fn stick_freezes_the_register_to_its_own_state() {
+        let out = apply_mutation(FIXTURE, &Mutation::Stick("q".into())).expect("stick q");
+        // next(q=4) now points at 4 (identity → frozen), was 5 (not q).
+        assert_eq!(next_value_of(&out, 4), 4);
+        // The other register is untouched.
+        assert_eq!(next_value_of(&out, 9), 10);
+    }
+
+    #[test]
+    fn drop_reset_rewrites_next_to_the_data_branch() {
+        let out = apply_mutation(FIXTURE, &Mutation::DropReset("r".into())).expect("drop-reset r");
+        // next(r=9) now points at the data branch `d` (nid 3), dropping the ite (10).
+        assert_eq!(next_value_of(&out, 9), 3);
+        // `q` untouched.
+        assert_eq!(next_value_of(&out, 4), 5);
+    }
+
+    #[test]
+    fn list_targets_reports_stick_for_all_named_and_drop_reset_for_reset_muxes() {
+        let t = list_targets(FIXTURE).expect("list");
+        assert_eq!(t.stick, vec!["q".to_string(), "r".to_string()]);
+        assert_eq!(
+            t.drop_reset,
+            vec!["r".to_string()],
+            "only the reset-mux register `r` is a drop-reset target; `q` toggles"
+        );
+    }
+
+    #[test]
+    fn stick_unknown_register_errors() {
+        assert!(apply_mutation(FIXTURE, &Mutation::Stick("nope".into())).is_err());
+    }
+
+    #[test]
+    fn drop_reset_on_a_non_reset_register_errors() {
+        // `q` has no reset mux (its next is `not q`), so there is nothing to drop.
+        assert!(apply_mutation(FIXTURE, &Mutation::DropReset("q".into())).is_err());
+    }
+
+    #[test]
+    fn mutation_parse_roundtrips_the_labels() {
+        assert_eq!(
+            Mutation::parse("stick:foo").unwrap(),
+            Mutation::Stick("foo".into())
+        );
+        assert_eq!(
+            Mutation::parse("drop-reset:bar").unwrap(),
+            Mutation::DropReset("bar".into())
+        );
+        assert_eq!(
+            Mutation::parse("stick:foo").unwrap().as_label(),
+            "stick:foo"
+        );
+        assert!(Mutation::parse("frobnicate:x").is_err());
+        assert!(Mutation::parse("stick:").is_err());
+    }
+}

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -82,6 +82,19 @@ pub enum VerifyOutcome {
     Skipped { reason: String },
 }
 
+impl VerifyOutcome {
+    /// The canonical `holds` / `violated` / `unknown` / `skipped` label — the
+    /// verdict vocabulary shared across surfaces (and the `sv mutate` flip oracle).
+    pub fn label(&self) -> &'static str {
+        match self {
+            VerifyOutcome::Holds => "holds",
+            VerifyOutcome::Violated { .. } => "violated",
+            VerifyOutcome::Unknown { .. } => "unknown",
+            VerifyOutcome::Skipped { .. } => "skipped",
+        }
+    }
+}
+
 /// One assertion's auto-verification result.
 #[derive(Debug, Clone)]
 pub struct PropertyVerdict {
@@ -789,6 +802,13 @@ pub struct VerifyAutoOptions {
     /// Only fires on the `AG EF (REG == VALUE)` shape. Default `true`; `--no-rescue` /
     /// API `rescue_bottom_recoverability: false` opts out.
     pub rescue_bottom_recoverability: bool,
+    /// #468 — apply a NAMED structural mutation to the prepared BTOR2 before
+    /// verification (`prepare_model`), so `sv mutate` can assert the property
+    /// verdicts FLIP (property adequacy). `None` (default) ⇒ no mutation, the model
+    /// is verified as-lifted. Set by the `sv mutate` driver only; the plain
+    /// `verify-auto` surfaces never populate it. See
+    /// [`crate::adapter::btor2::mutate`].
+    pub mutation: Option<crate::adapter::btor2::mutate::Mutation>,
 }
 
 /// PORTFOLIO scheduling mode — the budget knob for the multi-engine default.
@@ -846,6 +866,7 @@ impl Default for VerifyAutoOptions {
             rescue_bottom_safety: true,
             rescue_bottom_liveness: true,
             rescue_bottom_recoverability: true,
+            mutation: None,
         }
     }
 }
@@ -1764,6 +1785,91 @@ pub(crate) fn merge_portfolio_reports(
     Ok(merged)
 }
 
+/// One property's baseline-vs-mutant verdict under a mutation (`sv mutate`).
+#[derive(Debug, Clone)]
+pub struct PropertyFlip {
+    /// The property (assertion) name — the join key between baseline and mutant.
+    pub name: String,
+    /// The canonical verdict on the design as-lifted.
+    pub baseline: String,
+    /// The canonical verdict on the mutated design.
+    pub mutant: String,
+    /// `baseline != mutant` — the mutation was *caught* by this property.
+    pub flipped: bool,
+}
+
+/// The result of an `sv mutate` run: whether a NAMED structural mutation flips the
+/// property verdicts. A **flip** confirms the property constrains the mutated
+/// behaviour; an **unflipped** property is the property-adequacy finding — the
+/// spec does not pin that fault down (vacuous w.r.t. the mutation). Per
+/// [claims-integrity §2] this is a statement about the PROPERTIES, never a bug
+/// report about the design.
+#[derive(Debug, Clone)]
+pub struct MutateReport {
+    /// The applied mutation's label (`stick:<reg>` / `drop-reset:<reg>`).
+    pub mutation: String,
+    /// Per-property baseline-vs-mutant comparison (baseline order).
+    pub properties: Vec<PropertyFlip>,
+    /// Number of properties the mutation flipped (caught it).
+    pub flipped: usize,
+    /// Number the mutation did NOT flip (the adequacy finding).
+    pub unflipped: usize,
+}
+
+/// `sv mutate` core — verify the design **twice** (as-lifted baseline, then with
+/// `mutation` applied in `prepare_model`) and diff the per-property verdicts by
+/// name. A mutation that names a missing register / does not apply is a hard error
+/// from the mutant lift (never a silent no-op). `base_opts.mutation` is ignored
+/// (forced `None` for the baseline, `Some(mutation)` for the mutant).
+pub fn mutate_and_compare(
+    sources: &[(String, String)],
+    yosys_opts: &YosysOptions,
+    base_opts: &VerifyAutoOptions,
+    mutation: crate::adapter::btor2::mutate::Mutation,
+) -> Result<MutateReport, AdapterError> {
+    let mut baseline_opts = base_opts.clone();
+    baseline_opts.mutation = None;
+    let baseline = verify_auto(sources, yosys_opts, &baseline_opts)?;
+
+    let mut mutant_opts = base_opts.clone();
+    mutant_opts.mutation = Some(mutation.clone());
+    let mutant = verify_auto(sources, yosys_opts, &mutant_opts)?;
+
+    let mutant_by_name: std::collections::HashMap<&str, &VerifyOutcome> = mutant
+        .properties
+        .iter()
+        .map(|p| (p.name.as_str(), &p.outcome))
+        .collect();
+
+    let properties: Vec<PropertyFlip> = baseline
+        .properties
+        .iter()
+        .map(|b| {
+            let baseline = b.outcome.label();
+            // A property present at baseline but absent from the mutant reads as
+            // `skipped` (the mutation dropped it) — still a flip if baseline was definite.
+            let mutant = mutant_by_name
+                .get(b.name.as_str())
+                .map_or("skipped", |o| o.label());
+            PropertyFlip {
+                name: b.name.clone(),
+                baseline: baseline.to_string(),
+                mutant: mutant.to_string(),
+                flipped: baseline != mutant,
+            }
+        })
+        .collect();
+
+    let flipped = properties.iter().filter(|p| p.flipped).count();
+    let unflipped = properties.len() - flipped;
+    Ok(MutateReport {
+        mutation: mutation.as_label(),
+        properties,
+        flipped,
+        unflipped,
+    })
+}
+
 pub fn verify_auto(
     sources: &[(String, String)],
     yosys_opts: &YosysOptions,
@@ -2187,6 +2293,22 @@ pub(crate) fn prepare_model(
             ),
         });
     }
+
+    // #468 — apply a named structural mutation to the fully-prepared BTOR2 (after
+    // reset/init/shadow/config-pin) so the `sv mutate` driver can assert the verdicts
+    // FLIP. A mutation that names a missing register or does not apply is a HARD error
+    // (never a silent no-op: a no-op mutant would spuriously read as a "no flip" =
+    // vacuous-property finding it is not). The plain verify-auto surfaces pass `None`.
+    let btor2 = match &opts.mutation {
+        Some(m) => crate::adapter::btor2::mutate::apply_mutation(&btor2, m).map_err(|message| {
+            AdapterError {
+                kind: AdapterErrorKind::UnsupportedConstruct,
+                location: None,
+                message: format!("sv mutate ({}): {message}", m.as_label()),
+            }
+        })?,
+        None => btor2,
+    };
 
     Ok(Prepared::Model(Box::new(PreparedModel {
         btor2,

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1397,6 +1397,120 @@ fn sv_lint_handler_impl(request: SvLintRequest) -> ApiResult<Json<SvLintResponse
     }))
 }
 
+/// #468 — apply a NAMED structural mutation and re-verify to check the property
+/// verdicts FLIP (property adequacy), or (with `list`) enumerate the available
+/// mutation targets. Surface peer of the CLI `mununu sv mutate`.
+pub async fn sv_mutate_handler(
+    Json(request): Json<SvMutateRequest>,
+) -> ApiResult<Json<SvMutateResponse>> {
+    blocking(move || sv_mutate_handler_impl(request)).await
+}
+
+fn sv_mutate_handler_impl(request: SvMutateRequest) -> ApiResult<Json<SvMutateResponse>> {
+    use crate::adapter::btor2::kmts_lift::MustEdgeInference;
+    use crate::adapter::btor2::mutate::{Mutation, list_targets};
+    use crate::adapter::slang::verify_auto::{
+        VerifyAutoOptions, engine_selection, mutate_and_compare,
+    };
+    use crate::adapter::yosys::{SvFrontend, YosysOptions, sv_to_btor2};
+
+    let mut sources: Vec<(String, String)> = vec![("top.sv".to_string(), request.source.clone())];
+    for f in &request.additional_sources {
+        sources.push((f.name.clone(), f.content.clone()));
+    }
+    let yopts = YosysOptions {
+        top: request.top.clone(),
+        additional_sources: request
+            .additional_sources
+            .iter()
+            .map(|f| (f.name.clone(), f.content.clone()))
+            .collect(),
+        use_sv2v: request.use_sv2v,
+        frontend: if request.use_slang {
+            SvFrontend::Slang
+        } else {
+            SvFrontend::Auto
+        },
+        ..Default::default()
+    };
+
+    // `list` mode — lift once and enumerate the targets (no verification).
+    if request.list {
+        let btor2 = sv_to_btor2(&request.source, &yopts).map_err(|e| ApiError::BadRequest {
+            message: format!("sv mutate --list: {}", e.message),
+            details: None,
+        })?;
+        let t = list_targets(&btor2).map_err(|message| ApiError::BadRequest {
+            message,
+            details: None,
+        })?;
+        return Ok(Json(SvMutateResponse {
+            mutation: None,
+            targets: Some(SvMutateTargets {
+                stick: t.stick,
+                drop_reset: t.drop_reset,
+            }),
+            properties: Vec::new(),
+            flipped: 0,
+            unflipped: 0,
+        }));
+    }
+
+    let mutation_spec = request
+        .mutation
+        .as_deref()
+        .ok_or_else(|| ApiError::BadRequest {
+            message: "sv mutate: `mutation` is required (or set `list` to discover targets)"
+                .to_string(),
+            details: Some("expected \"stick:<reg>\" or \"drop-reset:<reg>\"".into()),
+        })?;
+    let mutation = Mutation::parse(mutation_spec).map_err(|message| ApiError::BadRequest {
+        message,
+        details: None,
+    })?;
+
+    let must_edge_inference = match request.must_edge_inference.as_deref() {
+        Some("smt-per-target") => MustEdgeInference::SmtPerTarget,
+        Some("smt-per-target-standard") => MustEdgeInference::SmtPerTargetStandard,
+        Some("smt-hyper-must") => MustEdgeInference::SmtHyperMust,
+        _ => MustEdgeInference::Off,
+    };
+    let (engine_symbolic, engine_exact, engine_portfolio) =
+        engine_selection(request.engine.as_deref());
+    let base_opts = VerifyAutoOptions {
+        must_edge_inference,
+        gate_reset: request.gate_reset.unwrap_or(true),
+        symbolic_engine: engine_symbolic,
+        exact_symbolic: engine_exact,
+        portfolio: engine_portfolio,
+        ..Default::default()
+    };
+
+    let report = mutate_and_compare(&sources, &yopts, &base_opts, mutation).map_err(|e| {
+        ApiError::BadRequest {
+            message: format!("sv mutate: {}", e.message),
+            details: None,
+        }
+    })?;
+
+    Ok(Json(SvMutateResponse {
+        mutation: Some(report.mutation),
+        targets: None,
+        properties: report
+            .properties
+            .into_iter()
+            .map(|p| SvMutatePropertyFlip {
+                name: p.name,
+                baseline: p.baseline,
+                mutant: p.mutant,
+                flipped: p.flipped,
+            })
+            .collect(),
+        flipped: report.flipped,
+        unflipped: report.unflipped,
+    }))
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — SV-direct CEGAR in one call.
 ///
 /// Lifts SystemVerilog to a single flattened BTOR2 (sv2v + Yosys, the
@@ -1651,6 +1765,8 @@ fn sv_verify_auto_handler_impl(
         rescue_bottom_safety: request.rescue_bottom_safety.unwrap_or(true),
         rescue_bottom_liveness: request.rescue_bottom_liveness.unwrap_or(true),
         rescue_bottom_recoverability: request.rescue_bottom_recoverability.unwrap_or(true),
+        // `verify-auto` verifies the design as-lifted; mutation is the `sv mutate` verb's job.
+        mutation: None,
     };
 
     let report = verify_auto(&sources, &yopts, &opts).map_err(|e| ApiError::BadRequest {

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1349,6 +1349,85 @@ pub struct SvLintResponse {
     pub findings: Vec<SvLintFinding>,
 }
 
+/// Request for `POST /api/v1/sv/mutate` (#468) — apply a NAMED structural mutation
+/// and re-verify to check the property verdicts flip (property adequacy). Surface
+/// peer of the CLI `mununu sv mutate`.
+#[derive(Debug, Deserialize)]
+pub struct SvMutateRequest {
+    /// SystemVerilog primary source content.
+    pub source: String,
+    /// Additional SV sources (packages / includes).
+    #[serde(default)]
+    pub additional_sources: Vec<FileContent>,
+    /// Top module for the lift (auto-detect when omitted).
+    #[serde(default)]
+    pub top: Option<String>,
+    /// Run sv2v before Yosys. Default `false`.
+    #[serde(default)]
+    pub use_sv2v: bool,
+    /// Force the slang RTL front-end (`read_slang`). Default `false`.
+    #[serde(default)]
+    pub use_slang: bool,
+    /// The mutation to apply: `"stick:<reg>"` (freeze a register) or
+    /// `"drop-reset:<reg>"` (remove a register's reset arm). Required unless
+    /// `list` is true.
+    #[serde(default)]
+    pub mutation: Option<String>,
+    /// When true, ignore `mutation` and return the available mutation TARGETS
+    /// (the `--list` discovery mode) instead of running a mutation.
+    #[serde(default)]
+    pub list: bool,
+    /// Engine selector (as `verify-auto`): `"explicit"` | `"symbolic"` |
+    /// `"exact-symbolic"` | `"portfolio-sequential"` | `"portfolio-parallel"`.
+    /// Default (unspecified) ⇒ `portfolio-sequential`.
+    #[serde(default)]
+    pub engine: Option<String>,
+    /// Reset-gating (pin the reset inactive + inject the post-reset init). Default `true`.
+    #[serde(default)]
+    pub gate_reset: Option<bool>,
+    /// Must-edge inference (`"smt-hyper-must"` gives sound νμ verdicts for a
+    /// recoverability property under `drop-reset`). Default off.
+    #[serde(default)]
+    pub must_edge_inference: Option<String>,
+}
+
+/// The mutation targets available in a design (the `list` response payload).
+#[derive(Debug, Serialize)]
+pub struct SvMutateTargets {
+    /// Every named register — a `stick:<reg>` target.
+    pub stick: Vec<String>,
+    /// Every named register whose next is a reset mux — a `drop-reset:<reg>` target.
+    pub drop_reset: Vec<String>,
+}
+
+/// One property's baseline-vs-mutant verdict in a [`SvMutateResponse`].
+#[derive(Debug, Serialize)]
+pub struct SvMutatePropertyFlip {
+    /// The property (assertion) name.
+    pub name: String,
+    /// Canonical verdict on the design as-lifted.
+    pub baseline: String,
+    /// Canonical verdict on the mutated design.
+    pub mutant: String,
+    /// `baseline != mutant` — the mutation was caught by this property.
+    pub flipped: bool,
+}
+
+/// Response for `POST /api/v1/sv/mutate`.
+#[derive(Debug, Serialize)]
+pub struct SvMutateResponse {
+    /// The applied mutation's label (null on a `list` request).
+    pub mutation: Option<String>,
+    /// Available targets (present on a `list` request, null otherwise).
+    pub targets: Option<SvMutateTargets>,
+    /// Per-property flips (empty on a `list` request).
+    pub properties: Vec<SvMutatePropertyFlip>,
+    /// Count of properties the mutation flipped (caught it).
+    pub flipped: usize,
+    /// Count the mutation did NOT flip — the property-adequacy finding.
+    pub unflipped: usize,
+}
+
 /// cegar-extraction Stage 2 (2026-06-22) — request for the SV-direct
 /// CEGAR endpoint (`POST /api/v1/sv/cegar`). Mirrors the CLI
 /// `mununu sv cegar`: lifts SystemVerilog to a single flattened BTOR2

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -184,6 +184,10 @@ fn create_router() -> Router {
         // registers the verifier can't keep faithfully, no model checking. Surface
         // peer of the CLI `sv lint`.
         .route("/api/v1/sv/lint", post(handlers::sv_lint_handler))
+        // SV-direct mutation (#468) — apply a named structural fault + re-verify to
+        // check the property verdicts flip (property adequacy), or list targets.
+        // Surface peer of the CLI `sv mutate`.
+        .route("/api/v1/sv/mutate", post(handlers::sv_mutate_handler))
         .route(
             "/api/v1/verify/memory-check",
             post(handlers::memory_check_handler),

--- a/crates/mununu-core/tests/differential_oracle_e2e.rs
+++ b/crates/mununu-core/tests/differential_oracle_e2e.rs
@@ -1711,3 +1711,68 @@ fn e2e_reach_rescue_reducibility_census() {
         "==================================================================================\n"
     );
 }
+
+// ── #468 sv mutate — the end-to-end flip oracle ────────────────────────────────
+// A free-running 2-bit counter (`cnt`: 0→1→2→3→0 …). The recoverability property
+// `AG EF (cnt == 3)` HOLDS on the design as-lifted (from every reachable state the
+// counter cycles back through 3). A `stick:cnt` mutation freezes `cnt` at its reset
+// value 0 → `cnt == 3` is unreachable → the property FLIPS to Violated. This is the
+// property-adequacy signal `sv mutate` reports: the property genuinely constrains the
+// counter's progress, so the injected fault is caught. Exercises the whole seam:
+// VerifyAutoOptions.mutation → prepare_model → mutate::apply_mutation → verify → diff.
+const COUNTER3_SV: &str = r#"module counter3 (
+  input  logic       clk_i,
+  input  logic       rst_ni,
+  output logic [1:0] cnt_o
+);
+  logic [1:0] cnt;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) cnt <= 2'd0;
+    else         cnt <= cnt + 2'd1;
+  end
+  assign cnt_o = cnt;
+endmodule
+"#;
+
+#[test]
+#[ignore = "requires slang + sv2v + yosys (mununu-sva image); run with --ignored"]
+fn e2e_sv_mutate_stick_flips_recoverability() {
+    use mununu_core::adapter::btor2::mutate::Mutation;
+    use mununu_core::adapter::slang::verify_auto::mutate_and_compare;
+
+    let src = format!(
+        "// @mununu_guarantee nu Y. ((mu X. ((cnt == 3) or <> X)) and [] Y)\n{COUNTER3_SV}"
+    );
+    let sources = [("counter3.sv".to_string(), src)];
+    let yopts = YosysOptions {
+        top: Some("counter3".to_string()),
+        use_sv2v: true,
+        ..Default::default()
+    };
+    let base_opts = VerifyAutoOptions {
+        exact_symbolic: true,
+        config_values: [("rst_ni".to_string(), 1u64)].into_iter().collect(),
+        ..Default::default()
+    };
+
+    let report = mutate_and_compare(&sources, &yopts, &base_opts, Mutation::Stick("cnt".into()))
+        .expect("mutate_and_compare runs the baseline + mutant lifts");
+
+    assert_eq!(report.mutation, "stick:cnt");
+    let flip = report
+        .properties
+        .iter()
+        .find(|p| p.baseline == "holds")
+        .expect("the recoverability property holds at baseline");
+    assert!(
+        flip.flipped && flip.mutant == "violated",
+        "freezing cnt must FLIP AG EF(cnt==3) holds→violated (cnt stuck at 0 never reaches 3); \
+         got baseline={} mutant={}",
+        flip.baseline,
+        flip.mutant
+    );
+    assert!(
+        report.flipped >= 1,
+        "the mutation must be caught by ≥1 property"
+    );
+}

--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -113,3 +113,22 @@ mununu --quiet sv lint rtl/mod.sv --frontend slang --fail-on none
 ```
 
 The JSON on stdout lists each flagged `signal` with a `kind` of `"register"` (the root — the register itself) or `"output"` (a downstream combinational output of one). See [`docs/verifying-rtl.md`](verifying-rtl.md) for the soundness background (the monono#partsel guard).
+
+## Check that a design's properties are adequate (mutation testing)
+
+> Source of truth: [`mutate_and_compare`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L1824) — surface: (CLI+API+UI)
+
+`mununu sv mutate` applies a **named structural mutation** to a SystemVerilog design, re-verifies, and reports whether each property's verdict **flips**. A flip (`holds` → `violated`) confirms the property constrains the mutated behaviour; a property that does *not* flip is the finding — the spec is vacuous with respect to that fault. This is a statement about the **properties**, never a bug report about the design.
+
+```bash
+# Discover the mutation targets of a design (every register → stick; reset-mux registers → drop-reset):
+mununu sv mutate rtl/counter.sv --list
+
+# Freeze a register and re-verify — exit 2 if NO property catches the fault (a coverage gap):
+mununu sv mutate rtl/counter.sv --mutation stick:cnt --engine exact-symbolic
+
+# Remove a register's reset arm (needs the reset free for effect):
+mununu sv mutate rtl/fsm.sv --mutation drop-reset:state_q --no-gate-reset --engine exact-symbolic
+```
+
+The mutation catalog is `stick:<reg>` (freeze a register at its reset value) and `drop-reset:<reg>` (remove a register's reset arm). A mutation caught by no property maps to the `violated` CI verdict (`--fail-on none` makes it advisory); a mutation that names a missing register or does not apply is a hard error, never a silent no-op.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -369,6 +369,45 @@ the same reason). A finding maps to the shared CI gate's `violated` verdict, so 
 default `--fail-on violated` fails the build; `--fail-on none` makes it advisory. A
 clean design reports zero findings and exits `0`.
 
+## Are the properties adequate? `sv mutate`
+
+> Source of truth: [`mutate_and_compare`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L1824) — surface: (CLI+API+UI)
+
+A `holds` verdict is only as strong as the property that produced it — a **vacuous**
+property `holds` no matter what the design does. `sv mutate` measures that: it applies
+a **named structural mutation** to the design, re-verifies, and reports whether each
+property's verdict **flips**. A flip (`holds` → `violated`) confirms the property
+genuinely constrains the mutated behaviour; a property that does **not** flip is the
+finding — the spec is *vacuous with respect to that fault*.
+
+This is a statement about the **properties**, never a bug report about the design
+(see [`policies/claims-integrity.md`](policies/claims-integrity.md) §2) — a mutation is
+a deliberately-injected fault, not a discovered one.
+
+The mutation catalog (structural, no source-line targeting needed):
+
+- **`stick:<reg>`** — freeze a register at its reset value (`next(reg) := reg`).
+  Universal; flips any property that depends on the register progressing.
+- **`drop-reset:<reg>`** — remove a register's reset arm (rewrite its reset mux
+  `ite(rst, RESET, d)` to the data branch `d`). Flips a reset-dependent property;
+  needs the reset **free** (`--no-gate-reset`) to have effect.
+
+```bash
+mununu sv mutate counter.sv --mutation stick:cnt --engine exact-symbolic   # exit 2 ⇒ no property caught it
+mununu sv mutate counter.sv --list                                         # discover the targets
+```
+```jsonc
+// POST /api/v1/sv/mutate  { "source": …, "mutation": "stick:cnt", "engine": "exact-symbolic" } →
+{ "mutation": "stick:cnt", "targets": null, "flipped": 1, "unflipped": 0,
+  "properties": [ { "name": "recoverable", "baseline": "holds", "mutant": "violated", "flipped": true } ] }
+```
+
+A mutation caught by **no** property maps to the CI gate's `violated` (a coverage gap),
+so default `--fail-on violated` fails the build; `--fail-on none` is advisory. `--list`
+always exits `0`. A mutation that names a missing register — or does not apply (e.g.
+`drop-reset` on a register with no reset mux) — is a hard **error**, never a silent
+no-op (which would masquerade as an unflipped/adequacy finding).
+
 ## Using mununu in CI (GitHub Actions and friends)
 
 > Source of truth: [`FailOn` / `ci_exit_code`](../crates/mununu-cli/src/main.rs) — surface: CLI


### PR DESCRIPTION
## `sv mutate` — named structural mutations + verdict-flip property adequacy (monono#468, PR #468a)

Part of #468 (the mutation operator). This is **PR #468a** — the verb + machinery + the two **structural** mutations. The targeting layer (off-by-one / invert-cond, which need RTL↔BTOR2 site resolution) follows in **#468b**.

### Why

monono's downstream `tools/mk-burst-twins.py` hand-writes "faulty twin" RTL that silently drifts from the golden design. `sv mutate` replaces that with a first-class operation: apply a **named structural mutation**, re-verify, and report whether each property's verdict **flips**. A flip (`holds` → `violated`) confirms the property constrains the mutated behaviour; a property that does **not** flip is the finding — the spec is vacuous w.r.t. that fault. Per claims-integrity §2 this is a statement about the **properties** (property adequacy / mutation testing), never a bug report about the design.

### What

Mutation core (`adapter/btor2/mutate.rs`, pure `parse → mutate Node → emit_btor2` round-trip — unit-tested with no lift):
- **`stick:<reg>`** — freeze a register (`next(reg) := reg`); universal.
- **`drop-reset:<reg>`** — remove a register's reset arm (rewrite its reset mux `ite(rst, RESET, d)` to the data branch `d`); needs the reset free to have effect.
- name → state nid via the `collect_symbols` alias map; a missing register / a mutation that does not apply is a **hard error**, never a silent no-op (which would masquerade as an unflipped/adequacy finding).

Seam: `VerifyAutoOptions.mutation: Option<Mutation>` applied in `prepare_model` on the fully-prepared BTOR2 (after reset/init/shadow/config-pin), so the mutant is verified through the **same** pipeline as the baseline. `mutate_and_compare` runs verify_auto twice and diffs per-property outcomes by name.

### Surface parity (CLI + API + UI)
- **CLI** `mununu sv mutate <sv> --mutation stick:<reg> [--engine …] [--list]` (`SvCommand::Mutate`); JSON + the shared CI gate — a mutation **no** property catches maps to `violated` (a coverage gap), `--fail-on none` advisory; `--list` exits 0.
- **API** `POST /api/v1/sv/mutate` (`sv_mutate_handler`, `SvMutateRequest`/`SvMutateResponse`/`SvMutatePropertyFlip`/`SvMutateTargets`).
- **UI** (mununu-ui #71) — `runSvMutate` + `sv-mutate.test.ts`.
- **docs** — `sv mutate` sections in `docs/verifying-rtl.md` + `docs/cli-cookbook.md` (Source-of-truth anchors to `mutate_and_compare`); a CLAUDE.md claims-integrity line recording the "mutation = adequacy, never a finding" discipline.

### Tests
- 6 make-ci unit tests on the mutation core (stick / drop-reset / list / error paths / label round-trip).
- `#[ignore]` e2e `e2e_sv_mutate_stick_flips_recoverability` — a free-running counter where `stick:cnt` freezes it and flips `AG EF(cnt==3)` holds→violated (validates the whole seam in the mununu-sva image).
- **No existing verdict changes**: `mutation` defaults `None` on every verify-auto surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
