### PR TITLE
feat(sv): `sv mutate` targeting layer — off-by-one + invert-cond (#468b)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -5784,7 +5784,12 @@ fn sv_mutate(args: SvMutateArgs) -> Result<(), String> {
         let t = list_targets(&btor2)?;
         let summary = serde_json::json!({
             "file": file,
-            "targets": { "stick": t.stick, "drop_reset": t.drop_reset },
+            "targets": {
+                "stick": t.stick,
+                "drop_reset": t.drop_reset,
+                "off_by_one": t.off_by_one,
+                "invert_cond": t.invert_cond,
+            },
         });
         print_json_summary(&summary)?;
         return Ok(());

--- a/crates/mununu-core/src/adapter/btor2/mutate.rs
+++ b/crates/mununu-core/src/adapter/btor2/mutate.rs
@@ -13,7 +13,7 @@
 //! byte-for-byte; only the mutated node changes). No lift is needed, so the core
 //! is unit-tested on a BTOR2 fixture in make-ci.
 
-use super::ast::{Btor2File, Nid, Node, Op, Operand};
+use super::ast::{Btor2File, ConstValue, Nid, Node, Op, Operand, Sort};
 use super::bit_blast::resolve_btor2_constant;
 use super::parser::{self, collect_symbols};
 
@@ -28,30 +28,94 @@ pub enum Mutation {
     /// `ite(rst, RESET, d)` is rewritten to the data branch `d`, so it no longer
     /// returns to its reset value. Flips reset-dependent properties (recoverability).
     DropReset(String),
+    /// **Perturb a comparison bound** in a register's fanout by `delta` (±1): the
+    /// `Const` a register is compared against (`cnt < 8` → `cnt < 9`). `const_nid`
+    /// disambiguates when the register is compared against more than one constant;
+    /// `None` requires a unique bound. The classic off-by-one fault — flips a
+    /// threshold/boundary property.
+    OffByOne {
+        reg: String,
+        const_nid: Option<Nid>,
+        delta: i64,
+    },
+    /// **Invert a named 1-bit condition** at every use site (flip the sign of every
+    /// operand referencing it, reusing BTOR2's `-N` bit-not shorthand). Flips a
+    /// property whose truth depends on the guard's polarity.
+    InvertCond(String),
 }
 
 impl Mutation {
-    /// The stable CLI/label spelling (`stick:<reg>` / `drop-reset:<reg>`).
+    /// The stable CLI/label spelling (`stick:<reg>` / `drop-reset:<reg>` /
+    /// `off-by-one:<reg>[@<nid>][:±delta]` / `invert-cond:<sig>`).
     pub fn as_label(&self) -> String {
         match self {
             Mutation::Stick(r) => format!("stick:{r}"),
             Mutation::DropReset(r) => format!("drop-reset:{r}"),
+            Mutation::OffByOne {
+                reg,
+                const_nid,
+                delta,
+            } => {
+                let at = const_nid.map(|n| format!("@{n}")).unwrap_or_default();
+                let sign = if *delta >= 0 { "+" } else { "" };
+                format!("off-by-one:{reg}{at}:{sign}{delta}")
+            }
+            Mutation::InvertCond(s) => format!("invert-cond:{s}"),
         }
     }
 
-    /// Parse a `stick:<reg>` / `drop-reset:<reg>` selector (the CLI/API spelling).
+    /// Parse a `stick:<reg>` / `drop-reset:<reg>` /
+    /// `off-by-one:<reg>[@<const_nid>][:±1]` / `invert-cond:<sig>` selector.
     pub fn parse(spec: &str) -> Result<Mutation, String> {
         if let Some(reg) = spec.strip_prefix("stick:") {
             reg_nonempty(reg).map(|r| Mutation::Stick(r.to_string()))
         } else if let Some(reg) = spec.strip_prefix("drop-reset:") {
             reg_nonempty(reg).map(|r| Mutation::DropReset(r.to_string()))
+        } else if let Some(rest) = spec.strip_prefix("off-by-one:") {
+            parse_off_by_one(rest)
+        } else if let Some(sig) = spec.strip_prefix("invert-cond:") {
+            reg_nonempty(sig).map(|s| Mutation::InvertCond(s.to_string()))
         } else {
             Err(format!(
-                "unknown mutation `{spec}` — expected `stick:<reg>` or `drop-reset:<reg>` \
+                "unknown mutation `{spec}` — expected `stick:<reg>`, `drop-reset:<reg>`, \
+                 `off-by-one:<reg>[@<const_nid>][:±1]`, or `invert-cond:<sig>` \
                  (see `sv mutate --list` for the available targets)"
             ))
         }
     }
+}
+
+/// Parse the `off-by-one:` tail: `<reg>[@<const_nid>][:±delta]` (default delta +1).
+fn parse_off_by_one(rest: &str) -> Result<Mutation, String> {
+    // Split off an optional `:±delta` suffix (delta is a signed integer).
+    let (head, delta) = match rest.rsplit_once(':') {
+        Some((h, d)) => {
+            let delta = d.parse::<i64>().map_err(|_| {
+                format!("off-by-one: delta `{d}` must be a signed integer (e.g. `:+1` or `:-1`)")
+            })?;
+            if delta == 0 {
+                return Err("off-by-one: delta must be non-zero".to_string());
+            }
+            (h, delta)
+        }
+        None => (rest, 1),
+    };
+    // Split off an optional `@<const_nid>` disambiguator.
+    let (reg, const_nid) = match head.split_once('@') {
+        Some((r, n)) => {
+            let nid = n
+                .parse::<Nid>()
+                .map_err(|_| format!("off-by-one: `@{n}` — const_nid must be an integer"))?;
+            (r, Some(nid))
+        }
+        None => (head, None),
+    };
+    let reg = reg_nonempty(reg)?;
+    Ok(Mutation::OffByOne {
+        reg: reg.to_string(),
+        const_nid,
+        delta,
+    })
 }
 
 fn reg_nonempty(reg: &str) -> Result<&str, String> {
@@ -70,6 +134,12 @@ pub struct MutationTargets {
     /// Every named register whose `next` is a one-constant reset mux — a
     /// `drop-reset:<reg>` target (sorted, deduped; a subset of `stick`).
     pub drop_reset: Vec<String>,
+    /// Every named register compared against ≥1 constant — an `off-by-one:<reg>`
+    /// target (sorted, deduped).
+    pub off_by_one: Vec<String>,
+    /// Every named 1-bit signal (register alias / combinational output) — an
+    /// `invert-cond:<sig>` target (sorted, deduped).
+    pub invert_cond: Vec<String>,
 }
 
 /// Apply `m` to the BTOR2 text and return the mutated BTOR2 (round-trip via the
@@ -80,6 +150,12 @@ pub fn apply_mutation(btor2: &str, m: &Mutation) -> Result<String, String> {
     match m {
         Mutation::Stick(reg) => apply_stick(&mut file, reg)?,
         Mutation::DropReset(reg) => apply_drop_reset(&mut file, reg)?,
+        Mutation::OffByOne {
+            reg,
+            const_nid,
+            delta,
+        } => apply_off_by_one(&mut file, reg, *const_nid, *delta)?,
+        Mutation::InvertCond(sig) => apply_invert_cond(&mut file, sig)?,
     }
     Ok(super::emit::emit_btor2(&file))
 }
@@ -90,6 +166,7 @@ pub fn list_targets(btor2: &str) -> Result<MutationTargets, String> {
     let symbols = collect_symbols(&file);
     let mut stick: Vec<String> = Vec::new();
     let mut drop_reset: Vec<String> = Vec::new();
+    let mut off_by_one: Vec<String> = Vec::new();
     for line in &file.lines {
         if !matches!(line.node, Node::State { .. }) {
             continue;
@@ -103,12 +180,47 @@ pub fn list_targets(btor2: &str) -> Result<MutationTargets, String> {
         if reset_data_branch(&file, line.nid).is_some() {
             drop_reset.push(name.clone());
         }
+        if !compare_bounds_over_state(&file, line.nid).is_empty() {
+            off_by_one.push(name.clone());
+        }
     }
-    stick.sort();
-    stick.dedup();
-    drop_reset.sort();
-    drop_reset.dedup();
-    Ok(MutationTargets { stick, drop_reset })
+
+    // invert-cond targets — every named 1-bit signal (a `state`/`Op` alias or an
+    // `Output`), the same name universe `sv lint` scans, filtered to width 1.
+    let mut invert_cond: Vec<String> = Vec::new();
+    for line in &file.lines {
+        let name = match &line.node {
+            Node::State {
+                symbol: Some(s), ..
+            }
+            | Node::Op {
+                symbol: Some(s), ..
+            }
+            | Node::Output {
+                symbol: Some(s), ..
+            } => s,
+            _ => continue,
+        };
+        if let Some((_, 1)) = resolve_signal(&file, name) {
+            invert_cond.push(name.clone());
+        }
+    }
+
+    for v in [
+        &mut stick,
+        &mut drop_reset,
+        &mut off_by_one,
+        &mut invert_cond,
+    ] {
+        v.sort();
+        v.dedup();
+    }
+    Ok(MutationTargets {
+        stick,
+        drop_reset,
+        off_by_one,
+        invert_cond,
+    })
 }
 
 /// Resolve a user register NAME to its `state` line nid — directly (the symbol is
@@ -194,6 +306,244 @@ fn reset_data_branch(file: &Btor2File, state_nid: Nid) -> Option<Operand> {
         (None, Some(_)) => Some(then_op), // reset in the `else` branch ⇒ data is `then`
         (Some(_), None) => Some(else_op), // reset in the `then` branch ⇒ data is `else`
         _ => None, // both-const / neither-const ⇒ not an unambiguous reset mux
+    }
+}
+
+// ── off-by-one (comparison-bound perturbation) ─────────────────────────────────
+
+/// Is `op` a comparison producing a 1-bit result (the ops an off-by-one bound
+/// lives on)? There is no exposed predicate for this set, so it is spelled here.
+fn is_comparison(op: Op) -> bool {
+    matches!(
+        op,
+        Op::Ult
+            | Op::Ulte
+            | Op::Slt
+            | Op::Slte
+            | Op::Ugt
+            | Op::Ugte
+            | Op::Sgt
+            | Op::Sgte
+            | Op::Eq
+            | Op::Neq
+    )
+}
+
+/// True if `state_nid` is in the COMBINATIONAL cone of `start` (stops at state
+/// cells and inputs — does not cross a state's `next`, which is sequential depth).
+fn cone_reaches_state(file: &Btor2File, start: Nid, state_nid: Nid) -> bool {
+    let mut seen: std::collections::HashSet<Nid> = std::collections::HashSet::new();
+    let mut work = vec![start];
+    while let Some(nid) = work.pop() {
+        if nid == state_nid {
+            return true;
+        }
+        if !seen.insert(nid) {
+            continue;
+        }
+        if let Some(line) = file.lookup(nid)
+            && let Node::Op { args, .. } = &line.node
+        {
+            for a in args {
+                work.push(a.nid());
+            }
+        }
+    }
+    false
+}
+
+/// Every `<reg> <cmp> <const>` comparison in the fanout of `state_nid`: the
+/// `(compare_nid, const_nid, const_value)` of each comparison op with exactly one
+/// constant operand whose OTHER operand's cone reaches the register.
+fn compare_bounds_over_state(file: &Btor2File, state_nid: Nid) -> Vec<(Nid, Nid, u64)> {
+    let mut out = Vec::new();
+    for line in &file.lines {
+        let Node::Op { op, args, .. } = &line.node else {
+            continue;
+        };
+        if !is_comparison(*op) || args.len() != 2 {
+            continue;
+        }
+        let (a, b) = (args[0], args[1]);
+        let (const_nid, const_val, other) = match (
+            resolve_btor2_constant(file, a.nid()),
+            resolve_btor2_constant(file, b.nid()),
+        ) {
+            (Some(v), None) => (a.nid(), v, b.nid()),
+            (None, Some(v)) => (b.nid(), v, a.nid()),
+            _ => continue, // both / neither constant ⇒ not a register-vs-const bound
+        };
+        if cone_reaches_state(file, other, state_nid) {
+            out.push((line.nid, const_nid, const_val));
+        }
+    }
+    out
+}
+
+fn fmt_bounds(bounds: &[(Nid, Nid, u64)]) -> String {
+    bounds
+        .iter()
+        .map(|(_, cn, v)| format!("@{cn}(={v})"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Perturb a `Const` register bound by `delta` (±1), re-encoding it as `constd`
+/// (the sort — and so the width — is preserved). A perturbation below 0 is an error.
+fn apply_off_by_one(
+    file: &mut Btor2File,
+    reg: &str,
+    const_nid: Option<Nid>,
+    delta: i64,
+) -> Result<(), String> {
+    let state_nid = resolve_state_nid(file, reg)
+        .ok_or_else(|| format!("off-by-one: `{reg}` is not a register (no state cell)"))?;
+    let bounds = compare_bounds_over_state(file, state_nid);
+    let target = match const_nid {
+        Some(n) => {
+            if !bounds.iter().any(|(_, cn, _)| *cn == n) {
+                return Err(format!(
+                    "off-by-one: @{n} is not a comparison-bound constant in the fanout of `{reg}` \
+                     — candidates: {}",
+                    fmt_bounds(&bounds)
+                ));
+            }
+            n
+        }
+        None => match bounds.as_slice() {
+            [] => {
+                return Err(format!(
+                    "off-by-one: found no `{reg} <cmp> <const>` comparison to perturb"
+                ));
+            }
+            [(_, cn, _)] => *cn,
+            many => {
+                return Err(format!(
+                    "off-by-one: `{reg}` is compared against {} constants — ambiguous; \
+                     disambiguate with `off-by-one:{reg}@<const_nid>`. Candidates: {}",
+                    many.len(),
+                    fmt_bounds(many)
+                ));
+            }
+        },
+    };
+
+    let cur = resolve_btor2_constant(file, target)
+        .ok_or_else(|| format!("off-by-one: nid {target} is not a resolvable constant"))?;
+    let new = cur as i128 + delta as i128;
+    if new < 0 {
+        return Err(format!(
+            "off-by-one: perturbing the bound {cur} by {delta} would go below 0"
+        ));
+    }
+    for l in file.lines.iter_mut() {
+        if l.nid == target
+            && let Node::Const { value, .. } = &mut l.node
+        {
+            *value = ConstValue::Dec(new);
+            return Ok(());
+        }
+    }
+    Err(format!("off-by-one: nid {target} is not a `const` node"))
+}
+
+// ── invert-cond (named 1-bit condition polarity flip) ──────────────────────────
+
+/// Resolve a named signal to its value nid + bit width — a `state`/`Op` alias
+/// (value at the line's nid) or an `Output` (value at the observed signal's nid).
+fn resolve_signal(file: &Btor2File, name: &str) -> Option<(Nid, u32)> {
+    for line in &file.lines {
+        let value_nid = match &line.node {
+            Node::State {
+                symbol: Some(s), ..
+            } if s == name => line.nid,
+            Node::Op {
+                symbol: Some(s), ..
+            } if s == name => line.nid,
+            Node::Output {
+                symbol: Some(s),
+                signal,
+            } if s == name => signal.nid(),
+            _ => continue,
+        };
+        if let Some(w) = nid_width(file, value_nid) {
+            return Some((value_nid, w));
+        }
+    }
+    None
+}
+
+/// The bit width of the value produced at `nid` (via its sort line). `None` for a
+/// node that produces no bit-vector value (or an array sort).
+fn nid_width(file: &Btor2File, nid: Nid) -> Option<u32> {
+    let sort_nid = match &file.lookup(nid)?.node {
+        Node::Input { sort, .. }
+        | Node::State { sort, .. }
+        | Node::Const { sort, .. }
+        | Node::Op { sort, .. } => *sort,
+        _ => return None,
+    };
+    match &file.lookup(sort_nid)?.node {
+        Node::Sort {
+            sort: Sort::BitVec { width },
+        } => Some(*width),
+        _ => None,
+    }
+}
+
+/// Invert a named 1-bit condition at EVERY use site — flip the sign of every
+/// operand referencing its value nid (BTOR2's `-N` bit-not shorthand), skipping the
+/// value's own defining line. Errors if the signal is missing, not 1-bit, or unused.
+fn apply_invert_cond(file: &mut Btor2File, sig: &str) -> Result<(), String> {
+    let (sig_nid, width) = resolve_signal(file, sig)
+        .ok_or_else(|| format!("invert-cond: `{sig}` is not a named signal in the lift"))?;
+    if width != 1 {
+        return Err(format!(
+            "invert-cond: `{sig}` is {width} bits wide — only a 1-bit condition can be inverted \
+             (a wider `-N` is a bitwise-not, not a boolean flip)"
+        ));
+    }
+    let mut flipped = 0usize;
+    for l in file.lines.iter_mut() {
+        if l.nid == sig_nid {
+            continue; // never flip the signal's own inputs — only its consumers
+        }
+        flip_operands_to(&mut l.node, sig_nid, &mut flipped);
+    }
+    if flipped == 0 {
+        return Err(format!(
+            "invert-cond: `{sig}` (nid {sig_nid}) has no use sites to invert"
+        ));
+    }
+    Ok(())
+}
+
+/// Flip the sign of every operand of `node` whose absolute nid is `target`
+/// (`+target` ↔ `-target`), counting each flip.
+fn flip_operands_to(node: &mut Node, target: Nid, counter: &mut usize) {
+    let mut flip = |op: &mut Operand| {
+        if op.nid() == target {
+            op.0 = -op.0;
+            *counter += 1;
+        }
+    };
+    match node {
+        Node::Op { args, .. } => {
+            for a in args {
+                flip(a);
+            }
+        }
+        Node::Init { value, .. } | Node::Next { value, .. } => flip(value),
+        Node::Bad { signal }
+        | Node::Constraint { signal }
+        | Node::Fair { signal }
+        | Node::Output { signal, .. } => flip(signal),
+        Node::Justice { signals } => {
+            for s in signals {
+                flip(s);
+            }
+        }
+        Node::Sort { .. } | Node::Input { .. } | Node::State { .. } | Node::Const { .. } => {}
     }
 }
 
@@ -285,5 +635,148 @@ mod tests {
         );
         assert!(Mutation::parse("frobnicate:x").is_err());
         assert!(Mutation::parse("stick:").is_err());
+    }
+
+    // ── #468b targeting mutations ──────────────────────────────────────────────
+
+    // A 4-bit counter `cnt` that increments while `cnt < 8` and freezes at 8. The
+    // bound `8` (nid 7) is the off-by-one target; the guard `below` = `cnt < 8`
+    // (nid 8, a named 1-bit op) drives the `ite` at nid 9 and is the invert-cond
+    // target.
+    const BOUNDED_COUNTER: &str = "1 sort bitvec 1
+2 sort bitvec 4
+3 input 1 en
+4 state 2 cnt
+5 one 2
+6 add 2 4 5
+7 constd 2 8
+8 ult 1 4 7 below
+9 ite 2 8 6 4
+10 next 2 4 9
+11 zero 2
+12 init 2 4 11
+";
+
+    #[test]
+    fn off_by_one_perturbs_the_unique_compare_bound() {
+        let out = apply_mutation(BOUNDED_COUNTER, &Mutation::parse("off-by-one:cnt").unwrap())
+            .expect("off-by-one cnt");
+        let file = parser::parse(&out).expect("parse mutated");
+        // The bound const (nid 7) moved 8 → 9 (+1 default); width preserved.
+        assert_eq!(resolve_btor2_constant(&file, 7), Some(9));
+    }
+
+    #[test]
+    fn off_by_one_honors_a_negative_delta() {
+        let out = apply_mutation(
+            BOUNDED_COUNTER,
+            &Mutation::parse("off-by-one:cnt:-1").unwrap(),
+        )
+        .expect("off-by-one cnt -1");
+        let file = parser::parse(&out).expect("parse");
+        assert_eq!(resolve_btor2_constant(&file, 7), Some(7));
+    }
+
+    #[test]
+    fn off_by_one_on_a_register_with_no_bound_errors() {
+        // `q` (from FIXTURE) is never compared against a constant.
+        assert!(apply_mutation(FIXTURE, &Mutation::parse("off-by-one:q").unwrap()).is_err());
+    }
+
+    #[test]
+    fn invert_cond_flips_the_named_guard_at_its_use_site() {
+        let out = apply_mutation(
+            BOUNDED_COUNTER,
+            &Mutation::parse("invert-cond:below").unwrap(),
+        )
+        .expect("invert-cond below");
+        let file = parser::parse(&out).expect("parse mutated");
+        // The `ite` at nid 9 selected on `below` (nid 8); after inversion its
+        // selector operand is negated (`-8`, the BTOR2 bit-not shorthand).
+        let sel = file
+            .lines
+            .iter()
+            .find_map(|l| match &l.node {
+                Node::Op {
+                    op: Op::Ite, args, ..
+                } if l.nid == 9 => Some(args[0]),
+                _ => None,
+            })
+            .expect("the ite at nid 9");
+        assert_eq!(sel.nid(), 8, "still the same signal");
+        assert!(sel.is_negated(), "the guard operand must be inverted (-8)");
+    }
+
+    #[test]
+    fn invert_cond_rejects_a_multibit_signal() {
+        // `cnt` is 4 bits — not a boolean condition.
+        assert!(
+            apply_mutation(
+                BOUNDED_COUNTER,
+                &Mutation::parse("invert-cond:cnt").unwrap()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn invert_cond_unknown_signal_errors() {
+        assert!(
+            apply_mutation(
+                BOUNDED_COUNTER,
+                &Mutation::parse("invert-cond:nope").unwrap()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn list_targets_includes_off_by_one_and_invert_cond() {
+        let t = list_targets(BOUNDED_COUNTER).expect("list");
+        assert!(t.stick.contains(&"cnt".to_string()));
+        assert_eq!(
+            t.off_by_one,
+            vec!["cnt".to_string()],
+            "cnt is compared against a constant bound"
+        );
+        assert!(
+            t.invert_cond.contains(&"below".to_string()),
+            "the 1-bit guard `below` is an invert-cond target; got {:?}",
+            t.invert_cond
+        );
+        assert!(
+            !t.invert_cond.contains(&"cnt".to_string()),
+            "the 4-bit `cnt` is not a 1-bit condition"
+        );
+    }
+
+    #[test]
+    fn targeting_mutation_labels_round_trip() {
+        assert_eq!(
+            Mutation::parse("off-by-one:cnt").unwrap(),
+            Mutation::OffByOne {
+                reg: "cnt".into(),
+                const_nid: None,
+                delta: 1
+            }
+        );
+        assert_eq!(
+            Mutation::parse("off-by-one:cnt@7:-1").unwrap(),
+            Mutation::OffByOne {
+                reg: "cnt".into(),
+                const_nid: Some(7),
+                delta: -1
+            }
+        );
+        assert_eq!(
+            Mutation::parse("invert-cond:below").unwrap(),
+            Mutation::InvertCond("below".into())
+        );
+        assert_eq!(
+            Mutation::parse("off-by-one:cnt@7:-1").unwrap().as_label(),
+            "off-by-one:cnt@7:-1"
+        );
+        assert!(Mutation::parse("off-by-one:cnt:0").is_err());
+        assert!(Mutation::parse("off-by-one:cnt:bad").is_err());
     }
 }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1449,6 +1449,8 @@ fn sv_mutate_handler_impl(request: SvMutateRequest) -> ApiResult<Json<SvMutateRe
             targets: Some(SvMutateTargets {
                 stick: t.stick,
                 drop_reset: t.drop_reset,
+                off_by_one: t.off_by_one,
+                invert_cond: t.invert_cond,
             }),
             properties: Vec::new(),
             flipped: 0,

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1398,6 +1398,10 @@ pub struct SvMutateTargets {
     pub stick: Vec<String>,
     /// Every named register whose next is a reset mux — a `drop-reset:<reg>` target.
     pub drop_reset: Vec<String>,
+    /// Every named register compared against a constant — an `off-by-one:<reg>` target.
+    pub off_by_one: Vec<String>,
+    /// Every named 1-bit signal — an `invert-cond:<sig>` target.
+    pub invert_cond: Vec<String>,
 }
 
 /// One property's baseline-vs-mutant verdict in a [`SvMutateResponse`].

--- a/crates/mununu-core/tests/differential_oracle_e2e.rs
+++ b/crates/mununu-core/tests/differential_oracle_e2e.rs
@@ -1776,3 +1776,63 @@ fn e2e_sv_mutate_stick_flips_recoverability() {
         "the mutation must be caught by ≥1 property"
     );
 }
+
+// #468b off-by-one — a counter that wraps at 8 (`cnt == 8 → 0`). `AG (cnt != 9)`
+// HOLDS on the design as-lifted (cnt maxes at 8). `off-by-one:cnt` perturbs the
+// wrap bound `cnt == 8` to `cnt == 9`, so the counter now reaches 9 before wrapping
+// → the property FLIPS to Violated. Validates the targeting transform through the
+// real lift + verify.
+const WRAP_CTR_SV: &str = r#"module wrapctr (
+  input  logic       clk_i,
+  input  logic       rst_ni,
+  output logic [3:0] cnt_o
+);
+  logic [3:0] cnt;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)          cnt <= 4'd0;
+    else if (cnt == 4'd8) cnt <= 4'd0;
+    else                  cnt <= cnt + 4'd1;
+  end
+  assign cnt_o = cnt;
+endmodule
+"#;
+
+#[test]
+#[ignore = "requires slang + sv2v + yosys (mununu-sva image); run with --ignored"]
+fn e2e_sv_mutate_off_by_one_flips_a_threshold_property() {
+    use mununu_core::adapter::btor2::mutate::Mutation;
+    use mununu_core::adapter::slang::verify_auto::mutate_and_compare;
+
+    let src = format!("// @mununu_guarantee nu X. ((cnt != 9) and [] X)\n{WRAP_CTR_SV}");
+    let sources = [("wrapctr.sv".to_string(), src)];
+    let yopts = YosysOptions {
+        top: Some("wrapctr".to_string()),
+        use_sv2v: true,
+        ..Default::default()
+    };
+    let base_opts = VerifyAutoOptions {
+        exact_symbolic: true,
+        config_values: [("rst_ni".to_string(), 1u64)].into_iter().collect(),
+        ..Default::default()
+    };
+
+    let report = mutate_and_compare(
+        &sources,
+        &yopts,
+        &base_opts,
+        Mutation::parse("off-by-one:cnt").expect("parse off-by-one:cnt"),
+    )
+    .expect("mutate_and_compare runs baseline + mutant");
+
+    let flip = report
+        .properties
+        .iter()
+        .find(|p| p.baseline == "holds")
+        .expect("AG(cnt!=9) holds at baseline (cnt wraps at 8)");
+    assert!(
+        flip.flipped && flip.mutant == "violated",
+        "moving the wrap bound 8→9 must FLIP AG(cnt!=9) holds→violated; got baseline={} mutant={}",
+        flip.baseline,
+        flip.mutant
+    );
+}

--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -131,4 +131,12 @@ mununu sv mutate rtl/counter.sv --mutation stick:cnt --engine exact-symbolic
 mununu sv mutate rtl/fsm.sv --mutation drop-reset:state_q --no-gate-reset --engine exact-symbolic
 ```
 
-The mutation catalog is `stick:<reg>` (freeze a register at its reset value) and `drop-reset:<reg>` (remove a register's reset arm). A mutation caught by no property maps to the `violated` CI verdict (`--fail-on none` makes it advisory); a mutation that names a missing register or does not apply is a hard error, never a silent no-op.
+The mutation catalog is `stick:<reg>` (freeze a register at its reset value), `drop-reset:<reg>` (remove a register's reset arm), `off-by-one:<reg>[@<const_nid>][:±1]` (perturb a comparison bound the register is checked against, e.g. `cnt < 8` → `cnt < 9`), and `invert-cond:<sig>` (invert a named 1-bit guard at every use site). `sv mutate --list` enumerates all four target classes. A mutation caught by no property maps to the `violated` CI verdict (`--fail-on none` makes it advisory); a mutation that names a missing register or does not apply is a hard error, never a silent no-op.
+
+```bash
+# Perturb a threshold and re-verify:
+mununu sv mutate rtl/counter.sv --mutation off-by-one:cnt --engine exact-symbolic
+
+# Invert a named guard:
+mununu sv mutate rtl/fsm.sv --mutation invert-cond:ready --engine exact-symbolic
+```

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -384,13 +384,26 @@ This is a statement about the **properties**, never a bug report about the desig
 (see [`policies/claims-integrity.md`](policies/claims-integrity.md) §2) — a mutation is
 a deliberately-injected fault, not a discovered one.
 
-The mutation catalog (structural, no source-line targeting needed):
+The mutation catalog — two **structural** (no targeting) and two **targeted** (a
+named-signal + structural-cone resolution, never a source line, which the sv2v lift
+does not preserve):
 
 - **`stick:<reg>`** — freeze a register at its reset value (`next(reg) := reg`).
   Universal; flips any property that depends on the register progressing.
 - **`drop-reset:<reg>`** — remove a register's reset arm (rewrite its reset mux
   `ite(rst, RESET, d)` to the data branch `d`). Flips a reset-dependent property;
   needs the reset **free** (`--no-gate-reset`) to have effect.
+- **`off-by-one:<reg>[@<const_nid>][:±1]`** — perturb by ±1 the constant a register
+  is compared against (`cnt < 8` → `cnt < 9`); the classic boundary fault. The bound
+  is found by walking the comparison cone in the register's fanout; when the register
+  is compared against more than one constant the error lists the candidates and
+  `@<const_nid>` disambiguates. Default delta `+1`.
+- **`invert-cond:<sig>`** — invert a named **1-bit** condition at every use site
+  (flip the polarity of every operand referencing it, via BTOR2's `-N` bit-not
+  shorthand). Flips a property whose truth depends on the guard's polarity.
+
+`sv mutate --list` enumerates all four target classes (`stick` / `drop_reset` /
+`off_by_one` / `invert_cond`).
 
 ```bash
 mununu sv mutate counter.sv --mutation stick:cnt --engine exact-symbolic   # exit 2 ⇒ no property caught it


### PR DESCRIPTION
## `sv mutate` targeting layer — off-by-one + invert-cond (monono#468, PR #468b)

The second half of #468 (follows #473 = #468a, the operator + structural mutations). This adds the two **targeted** mutations, which need RTL↔BTOR2 site resolution rather than a whole-register structural rewrite. Targeting is by **named signal + structural cone**, never a source line (the sv2v lift does not preserve source lines on the read_verilog path).

### The two mutations

- **`off-by-one:<reg>[@<const_nid>][:±1]`** — perturb by ±1 the constant a register is compared against (`cnt < 8` → `cnt < 9`), the classic boundary fault. The bound is found by walking the comparison cone in the register's fanout (`compare_bounds_over_state`: a comparison op with exactly one constant operand whose other operand's combinational cone reaches the register). Re-encoded as `constd` so the width is preserved. Unique bound applies; multiple constants **error** listing the candidates, and `@<const_nid>` disambiguates. Default delta `+1`.
- **`invert-cond:<sig>`** — invert a named **1-bit** condition at every use site by flipping the sign of every operand referencing its value nid (BTOR2's `-N` bit-not shorthand). Rejects a wider signal (a `-N` there is a bitwise-not, not a boolean flip) and a signal with no consumers.

### Surface parity

The specs flow through the existing `--mutation` string field, so only the **discovery** grows: `MutationTargets` gains `off_by_one` + `invert_cond`; the CLI `--list` JSON, API `SvMutateTargets`, and UI (mununu-ui #72) all carry the two new target classes. Docs: the mutation catalog in `docs/verifying-rtl.md` + `docs/cli-cookbook.md` extended to four mutations.

### Tests
- 8 new make-ci unit tests: off-by-one perturbs the unique bound / honours `:-1` / errors with no bound; invert-cond flips the guard at its use site / rejects a multi-bit signal / errors on unknown or unused; `--list` includes both classes; the labels round-trip.
- `#[ignore]` e2e `e2e_sv_mutate_off_by_one_flips_a_threshold_property` — a wrap-at-8 counter where moving the `cnt == 8` bound to `cnt == 9` flips `AG(cnt != 9)` holds→violated (validates the targeting transform through the real lift in the mununu-sva image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
