### PR TITLE
fix(sva): antecedent shadow-register synthesis for input-derived `|=>` (#476)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,6 +317,19 @@ The load-bearing rules at a glance:
 
 The full policy — with the abstraction-soundness procedure, the extraction-pipeline contract, the RTL evidence rules, the C-extractor unit-vs-end-to-end distinction, and the editorial framing rules for LinkedIn / Substack / talks — is at [`docs/policies/claims-integrity.md`](docs/policies/claims-integrity.md). Read it before publishing anything that references a real system.
 
+## Cross-Repo Impact Reporting
+
+Every PR that changes user-visible behaviour of a mununu surface consumed by a downstream repo (ROSF, monono, mununu-ui, or any future consumer) must ship a **consumer briefing** — a single markdown file under [`docs/consumer-briefings/`](docs/consumer-briefings/) — that names the consumers affected, explains what changed for them, and states which Docker images (if any) need rebuilding.
+
+The load-bearing rules at a glance:
+
+- **When it fires.** Verdict-value or verdict-message changes; JSON response-shape changes; CLI flag adds/removes/renames; HTTP route adds/removes; verdict-semantics changes (properties that used to `Skipped` now decide, `Holds` becomes `Violated` or vice versa — bugfixes count); subprocess-tool version bumps in `docker/Dockerfile*`; sidecar-schema changes.
+- **What the briefing contains.** Audience banner, TL;DR, per-consumer section (what to update, what to expect, report-parsing impact, Docker rebuild disposition, test-the-transition steps), a mandatory Docker-rebuild table (`Image | Impact | Rebuild required?` — no blanks, no "Maybe"), a shared footer, provenance (fix commit + issue + design doc + policy link), and a "not covered here" follow-ups list.
+- **Where it lives.** `docs/consumer-briefings/YYYY-MM-<slug>.md`. One file per PR that fires the policy; a multi-surface PR gets ONE briefing covering all changes so consumers read one document per adoption round.
+- **What is exempt.** Internal refactors that preserve every observable behaviour; test-only changes; doc changes that only clarify existing behaviour; changes to `REVIEW_LOG.md`, `ONBOARDING.md`, or `scratchpad/`.
+
+The full policy — trigger criteria, mandatory sections, standard Docker-rebuild verdict vocabulary, enforcement notes, and the historical context that motivated writing it down — is at [`docs/policies/cross-repo-impact.md`](docs/policies/cross-repo-impact.md). Read it before opening a PR that touches any mununu-consumer surface.
+
 ## Adapter / Emitter Capability Use
 
 The CLTS data model and CTXDSL grammar already express more than most adapters reach for. When writing or modifying an extractor, adapter, or emitter, prefer these primitives over re-encoding source-language features as state-name suffixes or parallel single-label edges.
@@ -451,6 +464,8 @@ Reference and how-to material — read when the task calls for it, not on every 
 - [`docs/adapters/extraction.md`](docs/adapters/extraction.md) — `.espec.json` extraction adapter, mode filtering, property templates.
 - [`docs/adapters/tlsf-aiger.md`](docs/adapters/tlsf-aiger.md) — Turn-based compound-label encoding for TLSF and AIGER.
 - [`docs/policies/claims-integrity.md`](docs/policies/claims-integrity.md) — Full claims-integrity policy (10 rules + editorial framing).
+- [`docs/policies/cross-repo-impact.md`](docs/policies/cross-repo-impact.md) — Cross-repo impact reporting: when a PR must ship a consumer briefing under `docs/consumer-briefings/`, mandatory sections, and the Docker-rebuild-disposition table format.
+- [`docs/design/antecedent-shadow-synthesis.md`](docs/design/antecedent-shadow-synthesis.md) — Antecedent shadow-register synthesis for SVA `|=>` with input-derived antecedents (mununu#476 fix).
 - [`docs/design/black-box-modules.md`](docs/design/black-box-modules.md) — Document A (foundations of black-box contracts).
 - [`docs/design/rtl-frontend-unification.md`](docs/design/rtl-frontend-unification.md) — Document B (SV frontends).
 - [`docs/design/contract-corpus-and-config.md`](docs/design/contract-corpus-and-config.md) — Document D (corpus + annotations).

--- a/crates/mununu-core/src/adapter/btor2/antecedent_shadow.rs
+++ b/crates/mununu-core/src/adapter/btor2/antecedent_shadow.rs
@@ -1,0 +1,701 @@
+//! Antecedent shadow-register synthesis for SVA `|=>` properties whose
+//! antecedent reaches primary inputs (directly or transitively via combinational
+//! logic). See [`docs/design/antecedent-shadow-synthesis.md`] for the full design
+//! and soundness argument.
+//!
+//! # Why this exists
+//!
+//! The exact-symbolic engine leaves primary inputs FREE — they are quantified
+//! out per modality step. Correct for state-only atoms; broken for `A |=> C`
+//! whose antecedent `A` reads inputs (directly or through combinational logic):
+//! `A@N` (antecedent evaluation) and `A@N+1` (the input driving the transition
+//! into cycle N+1) share the same physical signal but are decoupled by the
+//! per-step quantification, giving spurious verdicts.
+//!
+//! # The fix
+//!
+//! At SVA lift time, when `A |=> C` is being turned into a mu-calculus
+//! formula, analyse `A`. If `A`'s combinational cone reaches primary inputs
+//! (stopping at register boundaries — same walker as the [`super::parser::cone_inputs`]
+//! helper), synthesise an **antecedent shadow register** in the BTOR2:
+//!
+//! - New state cell `_mununu_antshadow_<N>` (fresh unique per synthesised atom).
+//! - Sort = A's sort (typically 1-bit Boolean).
+//! - `init = 0` — the SVA `|=>` semantics say cycle 0 has no prior antecedent,
+//!   so the obligation is trivially satisfied when the shadow reads false.
+//! - `next = A_nid` — the shadow samples A each cycle.
+//!
+//! Rewrite the lifted mu-calculus formula so the antecedent atom references
+//! `_mununu_antshadow_<N>` instead of `A`. Feed the augmented BTOR2 + rewritten
+//! formula to the exact engine.
+//!
+//! # Non-goal
+//!
+//! **This rewrite is not sound as a general engine-internal transformation.**
+//! Applying it to `mu Y. (A or <> Y)` (bare `EF A`) would shift semantics by
+//! one cycle. The shadow is safe only for the `|=>` shape, which the SVA lift
+//! knows about but the engine does not. Callers MUST only pass atoms they know
+//! are `|=>` antecedents.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use super::ast::{Btor2File, ConstValue, Line, Nid, Node, Operand, Sort};
+use super::parser::{collect_symbols, cone_inputs, signal_reaches_anonymous_input};
+
+/// Options for [`synthesize_shadows`].
+#[derive(Debug, Clone)]
+pub struct ShadowSynthOpts {
+    /// When `false`, no shadows are synthesised — every input-derived antecedent
+    /// atom is refused with [`RefusalReason::UserOptedOut`]. Used by the
+    /// `--no-antecedent-shadow` CLI flag and the `antecedent_shadow: false` API
+    /// field for debug / differential-oracle purposes.
+    pub enabled: bool,
+}
+
+impl Default for ShadowSynthOpts {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+/// A successfully synthesised shadow — one entry per input-derived antecedent
+/// atom that gets a shadow register. Surfaced in the verify-auto report so
+/// downstream consumers can see the engine's rewrite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowSynth {
+    /// The original antecedent atom (as it appeared in the mu-calc formula).
+    pub atom: String,
+    /// The synthesised state cell name.
+    pub shadow_name: String,
+    /// The primary inputs whose combinational cone the atom reaches
+    /// (sorted, deduped — determined by [`cone_inputs`]).
+    pub source_inputs: Vec<String>,
+}
+
+/// An antecedent atom that could not be shadowed — falls through to the
+/// engine's Phase A refusal for a definite skip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AntecedentRefusal {
+    pub atom: String,
+    pub reason: RefusalReason,
+}
+
+/// Why an antecedent atom did not receive a shadow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefusalReason {
+    /// The atom's sort is wider than 1 bit. SVA `|=>` antecedents are Boolean;
+    /// a wider atom is either language misuse or a multi-value pattern the
+    /// shadow would misrepresent.
+    NonBoolean { width: u32 },
+    /// An array/memory sort appears in the atom's cone (BTOR2 memory reads
+    /// havoc to free inputs — shadowing over a havoced array defeats the shadow).
+    ArrayInCone,
+    /// The atom is itself a primary input. Introducing a shadow that samples a
+    /// bare input is technically sound but the resulting property is
+    /// `AG(prev(A) → C)`, rarely what the author meant. Refuse and let the
+    /// author confirm the shape.
+    IsPrimaryInput,
+    /// The atom's cone reaches an anonymous free input (partial-write havoc
+    /// pattern — see [`signal_reaches_anonymous_input`]). Different soundness
+    /// posture; shadow-synth does not fix it.
+    ReachesAnonymousInput,
+    /// The atom name is not present in the BTOR2 symbol tables — cannot be
+    /// resolved to a NID for cone analysis.
+    NotFound,
+    /// The user disabled shadow-synth via `--no-antecedent-shadow` / API opt-out.
+    UserOptedOut,
+    /// The atom's cone does not reach any primary input — no shadow needed
+    /// (a state-only atom, which the exact engine already handles correctly).
+    /// Recorded as a refusal only so callers see we considered it; not an error.
+    StateOnly,
+}
+
+/// The augmented BTOR2 file + the atom rename map + per-atom outcomes.
+#[derive(Debug, Clone)]
+pub struct ShadowSynthResult {
+    /// BTOR2 file with `<state>` / `<init>` / `<next>` lines appended for each
+    /// synthesised shadow. All existing NIDs are preserved so any cone / atom
+    /// analysis computed on the original file remains valid.
+    pub augmented: Btor2File,
+    /// Original atom name → synthesised shadow name. Empty when no atom
+    /// qualified for a shadow. Callers must apply this rename to the mu-calc
+    /// formula before handing the pair to the engine.
+    pub renames: BTreeMap<String, String>,
+    /// One entry per successful shadow — for reporting.
+    pub shadows: Vec<ShadowSynth>,
+    /// One entry per atom that fell through (including `StateOnly` no-ops).
+    pub refused: Vec<AntecedentRefusal>,
+}
+
+/// For each `atom` in `antecedent_atoms` whose combinational cone reaches
+/// primary inputs, synthesise a shadow state cell in the returned BTOR2 file
+/// and record the rename. Atoms that cannot be shadowed (see [`RefusalReason`])
+/// appear in `refused` and are left unrewritten — the caller is expected to
+/// let them fall through to the engine's Phase A refusal.
+pub fn synthesize_shadows(
+    file: &Btor2File,
+    antecedent_atoms: &[String],
+    opts: ShadowSynthOpts,
+) -> ShadowSynthResult {
+    // Fast path: opt-out.
+    if !opts.enabled {
+        return ShadowSynthResult {
+            augmented: file.clone(),
+            renames: BTreeMap::new(),
+            shadows: vec![],
+            refused: antecedent_atoms
+                .iter()
+                .map(|a| AntecedentRefusal {
+                    atom: a.clone(),
+                    reason: RefusalReason::UserOptedOut,
+                })
+                .collect(),
+        };
+    }
+
+    // Name → NID resolution. `collect_symbols` covers Input, State, and
+    // Op-symbol aliases that resolve to a state. We additionally walk
+    // `Node::Output` symbols pointing at combinational signals (which
+    // `collect_symbols` intentionally skips — see the discussion in
+    // symbolic_bitblast.rs at the transitive-refusal guard).
+    let mut name_to_nid: HashMap<String, Nid> = collect_symbols(file)
+        .into_iter()
+        .map(|(nid, name)| (name, nid))
+        .collect();
+    for line in &file.lines {
+        if let Node::Output {
+            symbol: Some(s),
+            signal,
+        } = &line.node
+        {
+            name_to_nid.entry(s.clone()).or_insert(signal.nid());
+        }
+    }
+
+    // Primary-input name set for the exact-name refusal case.
+    let input_names: HashSet<String> = file
+        .inputs()
+        .filter_map(|l| match &l.node {
+            Node::Input {
+                symbol: Some(s), ..
+            } => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let mut shadows: Vec<ShadowSynth> = Vec::new();
+    let mut refused: Vec<AntecedentRefusal> = Vec::new();
+    let mut renames: BTreeMap<String, String> = BTreeMap::new();
+    let mut new_lines: Vec<Line> = Vec::new();
+
+    // Bookkeeping for NID allocation and shadow numbering.
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut shadow_counter: u32 = 0;
+
+    // A shared 1-bit `zero` const NID for shadow inits. Reused across all
+    // shadows to keep the emitted BTOR2 minimal. Lazily allocated on first
+    // shadow; None until we need one.
+    let mut zero_const_nid: Option<(Nid, Nid)> = None; // (const_nid, sort_nid)
+
+    for atom in antecedent_atoms {
+        // Case: atom is itself a primary input (deliberate refusal — see
+        // RefusalReason::IsPrimaryInput doc).
+        if input_names.contains(atom) {
+            refused.push(AntecedentRefusal {
+                atom: atom.clone(),
+                reason: RefusalReason::IsPrimaryInput,
+            });
+            continue;
+        }
+        // Case: name not resolvable.
+        let Some(&atom_nid) = name_to_nid.get(atom) else {
+            refused.push(AntecedentRefusal {
+                atom: atom.clone(),
+                reason: RefusalReason::NotFound,
+            });
+            continue;
+        };
+        // Case: cone reaches an anonymous free input (partial-write havoc).
+        if signal_reaches_anonymous_input(file, atom) {
+            refused.push(AntecedentRefusal {
+                atom: atom.clone(),
+                reason: RefusalReason::ReachesAnonymousInput,
+            });
+            continue;
+        }
+        // Cone analysis: which named primary inputs does the atom reach?
+        let source_inputs = cone_inputs(file, atom_nid);
+        if source_inputs.is_empty() {
+            // State-only atom — no shadow needed.
+            refused.push(AntecedentRefusal {
+                atom: atom.clone(),
+                reason: RefusalReason::StateOnly,
+            });
+            continue;
+        }
+        // Width / array check on the atom's sort.
+        let sort_nid = match sort_of_signal(file, atom_nid) {
+            Some(s) => s,
+            None => {
+                refused.push(AntecedentRefusal {
+                    atom: atom.clone(),
+                    reason: RefusalReason::NotFound,
+                });
+                continue;
+            }
+        };
+        let sort_line = file.lookup(sort_nid);
+        let Some(sort_line) = sort_line else {
+            refused.push(AntecedentRefusal {
+                atom: atom.clone(),
+                reason: RefusalReason::NotFound,
+            });
+            continue;
+        };
+        match &sort_line.node {
+            Node::Sort {
+                sort: Sort::BitVec { width },
+            } => {
+                if *width != 1 {
+                    refused.push(AntecedentRefusal {
+                        atom: atom.clone(),
+                        reason: RefusalReason::NonBoolean { width: *width },
+                    });
+                    continue;
+                }
+            }
+            Node::Sort {
+                sort: Sort::Array { .. },
+            } => {
+                refused.push(AntecedentRefusal {
+                    atom: atom.clone(),
+                    reason: RefusalReason::ArrayInCone,
+                });
+                continue;
+            }
+            _ => {
+                refused.push(AntecedentRefusal {
+                    atom: atom.clone(),
+                    reason: RefusalReason::NotFound,
+                });
+                continue;
+            }
+        }
+        // Cone-array check: does any node in the cone have an Array sort?
+        // (BTOR2 Read/Write nodes over array sorts would have been havoced by
+        // the caller if out-of-cone; an in-cone array is soundness-critical.)
+        if cone_touches_array(file, atom_nid) {
+            refused.push(AntecedentRefusal {
+                atom: atom.clone(),
+                reason: RefusalReason::ArrayInCone,
+            });
+            continue;
+        }
+
+        // All checks passed — synthesise the shadow.
+        // Lazily allocate the 1-bit sort + `zero` const. Both are reused across
+        // shadows within one synth pass. We ALSO scan the original file for a
+        // pre-existing 1-bit sort and a pre-existing 1-bit zero const so we do
+        // not append duplicates (yosys typically emits exactly one of each,
+        // and downstream passes prefer minimal BTOR2).
+        let (zero_nid, zero_sort_nid) = match zero_const_nid {
+            Some(z) => z,
+            None => {
+                let sort_nid_1bit = existing_1bit_sort_nid(file).unwrap_or_else(|| {
+                    let n = next_nid;
+                    next_nid += 1;
+                    new_lines.push(Line {
+                        nid: n,
+                        node: Node::Sort {
+                            sort: Sort::BitVec { width: 1 },
+                        },
+                        immediates: vec![],
+                        source_line: 0,
+                    });
+                    n
+                });
+                let const_nid =
+                    existing_1bit_zero_const_nid(file, sort_nid_1bit).unwrap_or_else(|| {
+                        let c = next_nid;
+                        next_nid += 1;
+                        new_lines.push(Line {
+                            nid: c,
+                            node: Node::Const {
+                                sort: sort_nid_1bit,
+                                value: ConstValue::Zero,
+                            },
+                            immediates: vec![],
+                            source_line: 0,
+                        });
+                        c
+                    });
+                zero_const_nid = Some((const_nid, sort_nid_1bit));
+                (const_nid, sort_nid_1bit)
+            }
+        };
+        // The shadow's sort MUST be 1-bit (we width-checked above). Prefer to
+        // reuse the atom's own sort NID when it's already a 1-bit sort — this
+        // keeps sort-NID reuse tight and matches what yosys typically emits.
+        let shadow_sort_nid = if sort_nid == zero_sort_nid {
+            sort_nid
+        } else {
+            zero_sort_nid
+        };
+
+        let shadow_name = format!("_mununu_antshadow_{}", shadow_counter);
+        shadow_counter += 1;
+
+        // state <sort> <shadow_name>
+        let state_nid = next_nid;
+        next_nid += 1;
+        new_lines.push(Line {
+            nid: state_nid,
+            node: Node::State {
+                sort: shadow_sort_nid,
+                symbol: Some(shadow_name.clone()),
+            },
+            immediates: vec![],
+            source_line: 0,
+        });
+        // init <sort> <state> <zero>
+        let init_line_nid = next_nid;
+        next_nid += 1;
+        new_lines.push(Line {
+            nid: init_line_nid,
+            node: Node::Init {
+                sort: shadow_sort_nid,
+                state: state_nid,
+                value: Operand(zero_nid),
+            },
+            immediates: vec![],
+            source_line: 0,
+        });
+        // next <sort> <state> <atom_nid>
+        let next_line_nid = next_nid;
+        next_nid += 1;
+        new_lines.push(Line {
+            nid: next_line_nid,
+            node: Node::Next {
+                sort: shadow_sort_nid,
+                state: state_nid,
+                value: Operand(atom_nid),
+            },
+            immediates: vec![],
+            source_line: 0,
+        });
+
+        renames.insert(atom.clone(), shadow_name.clone());
+        shadows.push(ShadowSynth {
+            atom: atom.clone(),
+            shadow_name,
+            source_inputs,
+        });
+    }
+
+    // Assemble the augmented file. Preserves all original NIDs and appends the
+    // new lines; the `by_nid` index is rebuilt.
+    let mut augmented_lines = file.lines.clone();
+    augmented_lines.extend(new_lines);
+    let by_nid: HashMap<Nid, usize> = augmented_lines
+        .iter()
+        .enumerate()
+        .map(|(i, l)| (l.nid, i))
+        .collect();
+    let augmented = Btor2File {
+        lines: augmented_lines,
+        by_nid,
+    };
+
+    ShadowSynthResult {
+        augmented,
+        renames,
+        shadows,
+        refused,
+    }
+}
+
+/// Look up the sort NID of the signal at `nid`. Follows one level of `Output`
+/// indirection (an Output's sort is its signal's sort, not the Output line's).
+fn sort_of_signal(file: &Btor2File, nid: Nid) -> Option<Nid> {
+    let line = file.lookup(nid)?;
+    match &line.node {
+        Node::Input { sort, .. }
+        | Node::State { sort, .. }
+        | Node::Const { sort, .. }
+        | Node::Op { sort, .. } => Some(*sort),
+        Node::Output { signal, .. } => sort_of_signal(file, signal.nid()),
+        _ => None,
+    }
+}
+
+/// Return the NID of an existing `sort bitvec 1` declaration, if any.
+fn existing_1bit_sort_nid(file: &Btor2File) -> Option<Nid> {
+    for line in &file.lines {
+        if let Node::Sort {
+            sort: Sort::BitVec { width: 1 },
+        } = &line.node
+        {
+            return Some(line.nid);
+        }
+    }
+    None
+}
+
+/// Return the NID of an existing 1-bit const whose value is 0 (either the
+/// `zero` keyword or a numeric literal that parses as zero). Lets shadow-synth
+/// reuse an already-present zero const instead of appending a duplicate.
+fn existing_1bit_zero_const_nid(file: &Btor2File, sort_nid_1bit: Nid) -> Option<Nid> {
+    for line in &file.lines {
+        if let Node::Const { sort, value } = &line.node
+            && *sort == sort_nid_1bit
+            && is_zero_const_value(value)
+        {
+            return Some(line.nid);
+        }
+    }
+    None
+}
+
+pub(crate) fn is_zero_const_value(v: &ConstValue) -> bool {
+    match v {
+        ConstValue::Zero => true,
+        ConstValue::One | ConstValue::Ones => false,
+        ConstValue::Bin(s) | ConstValue::Hex(s) => s.trim().chars().all(|c| c == '0'),
+        ConstValue::Dec(n) => *n == 0,
+    }
+}
+
+/// Does the combinational cone of `start` touch any node with an Array sort?
+/// Uses the same stop-at-register discipline as [`cone_inputs`].
+fn cone_touches_array(file: &Btor2File, start: Nid) -> bool {
+    let mut seen: HashSet<Nid> = HashSet::new();
+    let mut work: Vec<Nid> = vec![start];
+    while let Some(nid) = work.pop() {
+        if !seen.insert(nid) {
+            continue;
+        }
+        let Some(line) = file.lookup(nid) else {
+            continue;
+        };
+        // Check the node's own sort for arrays.
+        if let Some(sort_nid) = sort_of_signal(file, nid)
+            && let Some(sort_line) = file.lookup(sort_nid)
+            && matches!(
+                sort_line.node,
+                Node::Sort {
+                    sort: Sort::Array { .. }
+                }
+            )
+        {
+            return true;
+        }
+        match &line.node {
+            Node::State { .. } | Node::Input { .. } | Node::Const { .. } | Node::Sort { .. } => {}
+            Node::Op { args, .. } => {
+                for a in args {
+                    work.push(a.nid());
+                }
+            }
+            Node::Init { value, .. } | Node::Next { value, .. } => work.push(value.nid()),
+            Node::Bad { signal }
+            | Node::Constraint { signal }
+            | Node::Fair { signal }
+            | Node::Output { signal, .. } => work.push(signal.nid()),
+            Node::Justice { signals } => {
+                for s in signals {
+                    work.push(s.nid());
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::parser::parse as parse_btor2;
+    use super::*;
+
+    /// Positive: an atom `mem_rvalid_mine = mem_rvalid && got` — cone reaches
+    /// two primary inputs, no state, 1 bit. Should synthesise a shadow and
+    /// return a rename.
+    #[test]
+    fn synth_shadows_boolean_of_two_inputs() {
+        const BTOR2: &str = r#"
+1 sort bitvec 1
+2 input 1 mem_rvalid
+3 input 1 got
+4 state 1 q
+5 const 1 0
+6 init 1 4 5
+7 and 1 2 3
+8 output 7 mem_rvalid_mine
+9 next 1 4 2
+"#;
+        let file = parse_btor2(BTOR2).expect("parse");
+        let result = synthesize_shadows(
+            &file,
+            &["mem_rvalid_mine".to_string()],
+            ShadowSynthOpts::default(),
+        );
+        assert_eq!(result.shadows.len(), 1, "one shadow synthesised");
+        let shadow = &result.shadows[0];
+        assert_eq!(shadow.atom, "mem_rvalid_mine");
+        assert_eq!(shadow.shadow_name, "_mununu_antshadow_0");
+        assert_eq!(shadow.source_inputs, vec!["got", "mem_rvalid"]);
+        assert_eq!(
+            result.renames.get("mem_rvalid_mine").map(String::as_str),
+            Some("_mununu_antshadow_0"),
+        );
+        assert!(
+            result.refused.is_empty(),
+            "no fallback: {:?}",
+            result.refused
+        );
+        // Structural: the augmented file has original 9 lines + 3 shadow lines
+        // (state / init / next; the 1-bit const and sort are reused). Total 12.
+        assert_eq!(result.augmented.lines.len(), 12);
+        // The shadow state is a new Node::State with the shadow name.
+        let shadow_state = result
+            .augmented
+            .lines
+            .iter()
+            .find(|l| matches!(&l.node, Node::State { symbol: Some(s), .. } if s == "_mununu_antshadow_0"))
+            .expect("shadow state cell added");
+        // Its init is the `zero` const (NID 5).
+        let shadow_init = result
+            .augmented
+            .lines
+            .iter()
+            .find(|l| matches!(&l.node, Node::Init { state, .. } if *state == shadow_state.nid))
+            .expect("shadow init cell added");
+        if let Node::Init { value, .. } = &shadow_init.node {
+            let init_target = result
+                .augmented
+                .lookup(value.nid())
+                .expect("init target line");
+            match &init_target.node {
+                Node::Const { value, .. } => assert!(
+                    is_zero_const_value(value),
+                    "shadow init should point at a zero-valued const, got {:?}",
+                    value,
+                ),
+                other => panic!("shadow init should point at a Const, got {:?}", other),
+            }
+        }
+        // Its next samples the original atom NID (the `and` at NID 7).
+        let shadow_next = result
+            .augmented
+            .lines
+            .iter()
+            .find(|l| matches!(&l.node, Node::Next { state, .. } if *state == shadow_state.nid))
+            .expect("shadow next cell added");
+        if let Node::Next { value, .. } = &shadow_next.node {
+            assert_eq!(value.nid(), 7, "shadow next samples the `and` at NID 7");
+        }
+    }
+
+    /// State-only atom (`o = p + 1`): cone reaches no inputs, no shadow needed.
+    #[test]
+    fn synth_no_shadow_for_state_only_atom() {
+        const BTOR2: &str = r#"
+1 sort bitvec 4
+2 state 1 p
+3 one 1
+4 add 1 2 3
+5 output 4 o
+6 next 1 2 4
+7 const 1 0000
+8 init 1 2 7
+"#;
+        let file = parse_btor2(BTOR2).expect("parse");
+        let result = synthesize_shadows(&file, &["o".to_string()], ShadowSynthOpts::default());
+        assert!(result.shadows.is_empty(), "no shadow for state-only atom");
+        assert_eq!(result.renames.len(), 0);
+        assert_eq!(
+            result.refused,
+            vec![AntecedentRefusal {
+                atom: "o".to_string(),
+                reason: RefusalReason::StateOnly,
+            }],
+        );
+        // No mutation of the file.
+        assert_eq!(result.augmented.lines.len(), file.lines.len());
+    }
+
+    /// Atom that IS a primary input — refuse (author-confirmation case).
+    #[test]
+    fn synth_refuses_bare_primary_input_atom() {
+        const BTOR2: &str = r#"
+1 sort bitvec 1
+2 input 1 clr
+3 state 1 q
+4 const 1 0
+5 init 1 3 4
+6 next 1 3 2
+"#;
+        let file = parse_btor2(BTOR2).expect("parse");
+        let result = synthesize_shadows(&file, &["clr".to_string()], ShadowSynthOpts::default());
+        assert!(result.shadows.is_empty());
+        assert_eq!(
+            result.refused,
+            vec![AntecedentRefusal {
+                atom: "clr".to_string(),
+                reason: RefusalReason::IsPrimaryInput,
+            }],
+        );
+    }
+
+    /// User opt-out: no synthesis regardless of atom eligibility.
+    #[test]
+    fn synth_opt_out_refuses_all() {
+        const BTOR2: &str = r#"
+1 sort bitvec 1
+2 input 1 mem_rvalid
+3 input 1 got
+4 state 1 q
+5 const 1 0
+6 init 1 4 5
+7 and 1 2 3
+8 output 7 mem_rvalid_mine
+9 next 1 4 2
+"#;
+        let file = parse_btor2(BTOR2).expect("parse");
+        let result = synthesize_shadows(
+            &file,
+            &["mem_rvalid_mine".to_string()],
+            ShadowSynthOpts { enabled: false },
+        );
+        assert!(result.shadows.is_empty());
+        assert_eq!(result.refused.len(), 1);
+        assert_eq!(result.refused[0].reason, RefusalReason::UserOptedOut);
+        assert_eq!(result.augmented.lines.len(), file.lines.len());
+    }
+
+    /// Unknown atom name — NotFound refusal.
+    #[test]
+    fn synth_refuses_unknown_atom() {
+        const BTOR2: &str = r#"
+1 sort bitvec 1
+2 input 1 clr
+3 state 1 q
+4 const 1 0
+5 init 1 3 4
+6 next 1 3 2
+"#;
+        let file = parse_btor2(BTOR2).expect("parse");
+        let result = synthesize_shadows(
+            &file,
+            &["not_a_signal".to_string()],
+            ShadowSynthOpts::default(),
+        );
+        assert!(result.shadows.is_empty());
+        assert_eq!(
+            result.refused,
+            vec![AntecedentRefusal {
+                atom: "not_a_signal".to_string(),
+                reason: RefusalReason::NotFound,
+            }],
+        );
+    }
+}

--- a/crates/mununu-core/src/adapter/btor2/mod.rs
+++ b/crates/mununu-core/src/adapter/btor2/mod.rs
@@ -20,6 +20,7 @@
 //! - Multi-clock designs.
 
 pub mod abs_safety;
+pub mod antecedent_shadow;
 pub mod array_prophecy;
 pub mod ast;
 pub mod bad_monitor;

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -3264,6 +3264,42 @@ fn exact_symbolic_verdict_with_witness_inner(
     let file = crate::adapter::btor2::parser::parse(btor2_content)
         .map_err(|e| format!("adapter/btor2/exact MC: {}", e.message))?;
 
+    // mununu#476 — antecedent shadow-register synthesis. If the formula matches
+    // the canonical SVA `|=>` shape (Or(Not(Predicate(A)), Modal{Box, _})),
+    // synthesise a shadow state register for every antecedent atom `A` whose
+    // combinational cone reaches primary inputs. The augmented BTOR2 file +
+    // rewritten formula are then handed to the rest of this fn. Atoms that
+    // cannot be shadowed (see `RefusalReason`) fall through to the Phase A
+    // refusal below. See `docs/design/antecedent-shadow-synthesis.md` for the
+    // full design + soundness argument. `MUNUNU_NO_ANTECEDENT_SHADOW=1` opts out
+    // (differential-oracle / debug use).
+    let (file, rewritten_formula) = {
+        let opt_out = std::env::var("MUNUNU_NO_ANTECEDENT_SHADOW").is_ok();
+        let antecedents = crate::mu_calculus::detect_pipeimplies_antecedent_atoms(formula);
+        if !opt_out && !antecedents.is_empty() {
+            let synth = crate::adapter::btor2::antecedent_shadow::synthesize_shadows(
+                &file,
+                &antecedents,
+                crate::adapter::btor2::antecedent_shadow::ShadowSynthOpts::default(),
+            );
+            if synth.shadows.is_empty() {
+                (file, None)
+            } else {
+                let rewritten = crate::mu_calculus::substitute_predicates(formula, &synth.renames);
+                tracing::info!(
+                    n_shadows = synth.shadows.len(),
+                    "antecedent shadow-synth: rewrote {} input-derived antecedent atom(s) into shadow registers ({} atoms fell through to fallback refusal)",
+                    synth.shadows.len(),
+                    synth.refused.len(),
+                );
+                (synth.augmented, Some(rewritten))
+            }
+        } else {
+            (file, None)
+        }
+    };
+    let formula: &Formula = rewritten_formula.as_ref().unwrap_or(formula);
+
     // Register-name resolution: a user-visible name (`bit_cnt_q`) maps to the
     // canonical state-cell name the bit-blast binds against (`bit_cnt_d` after
     // yosys async2sync/flatten aliasing). Use the SOUND (Strict) alias resolution,
@@ -3393,6 +3429,66 @@ fn exact_symbolic_verdict_with_witness_inner(
              consequent and would report an unsound verdict. Use the default `explicit` \
              cube engine, or lift the antecedent through a shadow register."
         ));
+    }
+
+    // mununu#476 — transitive combinational fan-in guard. When the atom name is NOT
+    // itself a primary input but its combinational cone REACHES primary inputs (stopping
+    // at register boundaries), pinning the atom's value pins a function of those inputs
+    // — the same decoupling problem as pinning an input directly. Without this, a
+    // combinational-of-input signal like `y = a && (b == K)` used in an SVA `|=>`
+    // antecedent yields a definite `Violated (1 cell)` on correct RTL (see monono's
+    // `wb_mem_client`: `mem_rvalid_mine = mem_rvalid && (mem_rid == CLIENT_ID)`).
+    // Reuses [`crate::adapter::btor2::parser::cone_inputs`], which walks the
+    // combinational cone and stops at `Node::State` — so a combinational-of-STATE
+    // signal (which the previous refusal comment explicitly permits) is NOT flagged.
+    //
+    // Name-to-NID resolution has to cover THREE symbol sources:
+    //   1. Input / State symbols (via `collect_symbols`, Pass 1)
+    //   2. Op-symbol aliases that `collect_symbols` attaches to their driving state
+    //      (Pass 2 — Yosys's `uext _ _ 0 NAME` alias pattern)
+    //   3. Output-node symbols pointing at a combinational signal — NOT covered by
+    //      `collect_symbols` because they carry no state-alias intent. This is exactly
+    //      the case the guard needs to catch (a combinational-of-input `Output`).
+    let mut name_to_nid: std::collections::HashMap<String, crate::adapter::btor2::ast::Nid> =
+        crate::adapter::btor2::parser::collect_symbols(&file)
+            .into_iter()
+            .map(|(nid, name)| (name, nid))
+            .collect();
+    for line in &file.lines {
+        if let crate::adapter::btor2::ast::Node::Output {
+            symbol: Some(s),
+            signal,
+        } = &line.node
+        {
+            // An Output symbol refers to the underlying signal, not to the Output line's
+            // own NID. Use it only if there isn't already an Input/State mapping for the
+            // same name (Input/State takes precedence for the same-name edge case).
+            name_to_nid.entry(s.clone()).or_insert(signal.nid());
+        }
+    }
+    for reg in &seed_regs {
+        // Skip atoms already flagged by the exact-name refusal above.
+        if input_leaf_names.contains(reg) {
+            continue;
+        }
+        let Some(&nid) = name_to_nid.get(reg) else {
+            continue;
+        };
+        let derived_inputs = crate::adapter::btor2::parser::cone_inputs(&file, nid);
+        if !derived_inputs.is_empty() {
+            let inputs = derived_inputs
+                .iter()
+                .map(|n| format!("`{n}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(format!(
+                "exact MC: atom `{reg}` is combinationally driven by primary input(s) {inputs}. \
+                 The exact-symbolic engine leaves inputs free/quantified, so a temporal property \
+                 whose antecedent depends on inputs decouples the antecedent from its consequent \
+                 and would report an unsound verdict. Use the default `explicit` cube engine, or \
+                 lift the antecedent through a shadow register."
+            ));
+        }
     }
 
     // monono#partsel — the same soundness posture for an atom that binds to a
@@ -7579,6 +7675,117 @@ mod tests {
         assert!(
             err.contains("primary input") && err.contains("clr"),
             "diagnostic should name the offending input `clr`: {err}"
+        );
+    }
+
+    /// mununu#476 — a NAMED combinational signal whose cone reaches primary inputs
+    /// (without crossing a register boundary) is refused **when the formula does not
+    /// match the `|=>` shape** (bare `EF`, `AF`, etc.). This preserves soundness for
+    /// arbitrary user-authored mu-calc formulas whose semantics are not the SVA `|=>`
+    /// obligation. When the formula DOES match `|=>`, shadow-synthesis takes over
+    /// and the property decides (see
+    /// [`shadow_synth_flips_derived_input_antecedent_to_decided`]).
+    ///
+    /// Fixture mirrors monono's `wb_mem_client`: `mem_rvalid_mine = mem_rvalid && got`
+    /// where both `mem_rvalid` and `got` are primary inputs.
+    ///
+    /// Contrast [`exact_symbolic_refuses_primary_input_atom`] (name IS an input) and
+    /// [`predicate_binds_combinational_output`] (combinational of STATE — admitted).
+    #[test]
+    fn exact_symbolic_refuses_derived_input_atom() {
+        // `mem_rvalid_mine = mem_rvalid && got` — a named combinational Output whose
+        // cone reaches two primary inputs, no state. `q` is a spare latch so the model
+        // has state; the formula never reads it. Uses the `Node::Output` form (matching
+        // `predicate_binds_combinational_output` above) rather than an Op inline symbol,
+        // because Op-inline symbols are consumed as state aliases by `collect_symbols`.
+        const DERIVED_INPUT_BTOR2: &str = r#"
+1 sort bitvec 1
+2 input 1 mem_rvalid
+3 input 1 got
+4 state 1 q
+5 const 1 0
+6 init 1 4 5
+7 and 1 2 3
+8 output 7 mem_rvalid_mine
+9 next 1 4 2
+"#;
+        let formula =
+            crate::mu_calculus::parser::parse("mu Y. (mem_rvalid_mine or <> Y)").expect("formula");
+        let err = exact_symbolic_verdict(DERIVED_INPUT_BTOR2, &formula).expect_err(
+            "an atom over a combinational signal reaching primary inputs must be refused, \
+             not decided",
+        );
+        assert!(
+            err.contains("combinationally driven by primary input"),
+            "diagnostic should name the transitive-fan-in case: {err}"
+        );
+        assert!(
+            err.contains("mem_rvalid_mine"),
+            "diagnostic should name the offending atom `mem_rvalid_mine`: {err}"
+        );
+        assert!(
+            err.contains("mem_rvalid") && err.contains("got"),
+            "diagnostic should list every source primary input (mem_rvalid, got): {err}"
+        );
+    }
+
+    /// mununu#476 — Option C. The same monono `wb_mem_client` shape (an atom
+    /// combinationally driven by primary inputs) DECIDES when the surrounding
+    /// formula matches the canonical SVA `|=>` lift shape
+    /// `nu X. ((¬A ∨ □B) ∧ □X)`: the engine detects the shape, synthesises
+    /// a shadow state cell that samples `A` per cycle, rewrites the atom to
+    /// the shadow, and evaluates on the augmented model. This is the fix that
+    /// closes the coverage gap the Phase A refusal left open.
+    ///
+    /// The BTOR2 sets `q' = 0` unconditionally, so `[] (q == 0)` always Holds
+    /// and the whole property Holds after shadow-synth. Pre-Option C this
+    /// property would have been Skipped (via the Phase A refusal on
+    /// `mem_rvalid_mine`); post-Option C it Holds.
+    ///
+    /// Contrast [`exact_symbolic_refuses_derived_input_atom`] (same atom, but a
+    /// bare `mu Y. (a or <> Y)` — no `|=>` shape → refusal path still fires).
+    #[test]
+    fn shadow_synth_flips_derived_input_antecedent_to_decided() {
+        // Same combinational-of-inputs shape as monono's `wb_mem_client`, plus
+        // a spare state `q` whose next is const 0 (so `q == 0` always holds).
+        const BTOR2: &str = r#"
+1 sort bitvec 1
+2 input 1 mem_rvalid
+3 input 1 got
+4 state 1 q
+5 const 1 0
+6 init 1 4 5
+7 and 1 2 3
+8 output 7 mem_rvalid_mine
+9 next 1 4 5
+"#;
+        // Canonical SVA `mem_rvalid_mine |=> (q == 0)` lift shape.
+        let formula = crate::mu_calculus::parser::parse(
+            "nu X. ((not mem_rvalid_mine or [] (q == 0)) and [] X)",
+        )
+        .expect("formula");
+        let verdict = exact_symbolic_verdict(BTOR2, &formula)
+            .expect("shadow-synth on an SVA `|=>` shape should decide, not refuse");
+        assert_eq!(
+            verdict,
+            ExactVerdict::Holds,
+            "with shadow-synth, `mem_rvalid_mine |=> (q == 0)` where q'=0 always Holds",
+        );
+
+        // Opt-out (MUNUNU_NO_ANTECEDENT_SHADOW=1) restores the Phase A refusal
+        // even for `|=>` shapes — the differential-oracle / debug knob.
+        // SAFETY: single-threaded test; env-var mutation is scoped to this call.
+        unsafe {
+            std::env::set_var("MUNUNU_NO_ANTECEDENT_SHADOW", "1");
+        }
+        let err = exact_symbolic_verdict(BTOR2, &formula)
+            .expect_err("opt-out must revert to the Phase A transitive-fan-in refusal");
+        unsafe {
+            std::env::remove_var("MUNUNU_NO_ANTECEDENT_SHADOW");
+        }
+        assert!(
+            err.contains("combinationally driven by primary input"),
+            "opt-out refusal should still be the Phase A message: {err}"
         );
     }
 

--- a/crates/mununu-core/src/mu_calculus/mod.rs
+++ b/crates/mununu-core/src/mu_calculus/mod.rs
@@ -376,6 +376,87 @@ pub struct FormulaVar {
     pub name: String,
 }
 
+/// mununu#476 — detect antecedent atoms of the canonical `|=>` SVA lift shape.
+///
+/// The SVA lift of `A |=> B` emits (as a mu-calc string) `(!A || [] B)`, which
+/// the parser turns into `Or(Not(Predicate(A)), Modal { Box, _, ... })`. This
+/// helper walks the formula arena and returns every atom name that appears in
+/// the antecedent position of such a shape, deduped and sorted.
+///
+/// **Soundness note**: any formula of the shape `Or(Not(Predicate(A)), Box(B))`
+/// has `A → next B` semantics — the same as SVA `A |=> B` — regardless of source
+/// (SVA lift, hand-authored, other rewrite pass). So detecting the shape here and
+/// asking the caller to substitute `A` → `shadow(A)` (where `shadow` samples A per
+/// cycle) is verdict-preserving. See `docs/design/antecedent-shadow-synthesis.md`.
+///
+/// **Non-goal**: multi-atom antecedents like `(a && b) |=> c` — the AST shape is
+/// `Or(Not(And(Predicate(a), Predicate(b))), Box(_))`, not caught here. Those
+/// atoms fall through to the exact engine's Phase A refusal (still sound). A
+/// future extension can walk the negated Boolean tree; the current scope is the
+/// single-atom antecedent that dominates real SVA.
+pub fn detect_pipeimplies_antecedent_atoms(formula: &Formula) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for node in formula.nodes() {
+        let Node::Or(l, r) = node else {
+            continue;
+        };
+        for (ante_id, cons_id) in [(*l, *r), (*r, *l)] {
+            let Node::Not(inner) = formula.node(ante_id) else {
+                continue;
+            };
+            let Node::Predicate(name) = formula.node(*inner) else {
+                continue;
+            };
+            let Node::Modal {
+                kind: ModalKind::Box,
+                ..
+            } = formula.node(cons_id)
+            else {
+                continue;
+            };
+            out.push(name.clone());
+            break;
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Return a new [`Formula`] identical to `formula` except that every
+/// `Node::Predicate(name)` whose `name` appears in `subs` is replaced with
+/// `Node::Predicate(subs[name])`. Preserves the root, fixpoint variables,
+/// modality guards, and all NodeId indices — so callers who computed
+/// NodeId-referenced side data on `formula` may continue to use the new one.
+///
+/// Empty-`subs` fast path: returns a clone of `formula` (no rewrite work).
+///
+/// Callers: SVA-lift path in `symbolic_bitblast.rs::exact_symbolic_verdict`,
+/// after `antecedent_shadow::synthesize_shadows` returns a rename map.
+pub fn substitute_predicates(
+    formula: &Formula,
+    subs: &std::collections::BTreeMap<String, String>,
+) -> Formula {
+    if subs.is_empty() {
+        return formula.clone();
+    }
+    let new_nodes: Vec<Node> = formula
+        .nodes()
+        .iter()
+        .map(|node| match node {
+            Node::Predicate(name) => {
+                if let Some(replacement) = subs.get(name) {
+                    Node::Predicate(replacement.clone())
+                } else {
+                    node.clone()
+                }
+            }
+            _ => node.clone(),
+        })
+        .collect();
+    Formula::new(formula.root(), new_nodes, formula.vars().to_vec())
+}
+
 /// Typed μ-calculus node inside a [`Formula`] arena.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Node {
@@ -584,8 +665,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::PropertyClass;
     use super::parser;
+    use super::{Node, PropertyClass, detect_pipeimplies_antecedent_atoms, substitute_predicates};
 
     #[test]
     fn parses_basic_formula() {
@@ -741,6 +822,88 @@ mod tests {
                 .box_modality_count(),
             2
         );
+    }
+
+    /// mununu#476 — the `|=>` shape detector should identify the canonical
+    /// SVA-lift output `nu X. ((¬A ∨ □B) ∧ □X)` and return `A`.
+    #[test]
+    fn detect_pipeimplies_finds_canonical_lift_shape() {
+        let f = parser::parse("nu X. ((not a or [] b) and [] X)").unwrap();
+        assert_eq!(
+            detect_pipeimplies_antecedent_atoms(&f),
+            vec!["a".to_string()]
+        );
+    }
+
+    /// Detector is order-agnostic within an `Or` — `(<> _) || ¬A` counts too.
+    #[test]
+    fn detect_pipeimplies_order_agnostic() {
+        let f = parser::parse("nu X. (([] c or not b) and [] X)").unwrap();
+        assert_eq!(
+            detect_pipeimplies_antecedent_atoms(&f),
+            vec!["b".to_string()]
+        );
+    }
+
+    /// Non-`|=>` shapes (bare `EF`, bare box-only, no negated antecedent) return
+    /// nothing — the exact engine's Phase A refusal handles those.
+    #[test]
+    fn detect_pipeimplies_ignores_ef_shape() {
+        let f = parser::parse("mu Y. (a or <> Y)").unwrap();
+        assert!(detect_pipeimplies_antecedent_atoms(&f).is_empty());
+    }
+
+    /// `<>` (diamond) in the consequent is NOT the `|=>` shape (that's `A → EF B`,
+    /// not `A → next B`). Detector must not match.
+    #[test]
+    fn detect_pipeimplies_diamond_consequent_ignored() {
+        let f = parser::parse("(not a or <> b)").unwrap();
+        assert!(detect_pipeimplies_antecedent_atoms(&f).is_empty());
+    }
+
+    /// Multiple `|=>` conjuncts — a GR(1)-style property with several antecedents —
+    /// each antecedent is picked up. Result is sorted + deduped.
+    #[test]
+    fn detect_pipeimplies_multiple_antecedents() {
+        let f = parser::parse("nu X. (((not p or [] q) and (not r or [] s)) and [] X)").unwrap();
+        assert_eq!(
+            detect_pipeimplies_antecedent_atoms(&f),
+            vec!["p".to_string(), "r".to_string()],
+        );
+    }
+
+    /// `substitute_predicates` swaps the named predicates and leaves everything
+    /// else (variables, modality guards, non-substituted atoms) untouched.
+    #[test]
+    fn substitute_predicates_rewrites_named_atoms_only() {
+        use std::collections::BTreeMap;
+        let f = parser::parse("nu X. ((not mem_rvalid_mine or [] (q == 0)) and [] X)").unwrap();
+        let mut subs = BTreeMap::new();
+        subs.insert(
+            "mem_rvalid_mine".to_string(),
+            "_mununu_antshadow_0".to_string(),
+        );
+        let g = substitute_predicates(&f, &subs);
+        let atoms: Vec<&str> = g
+            .nodes()
+            .iter()
+            .filter_map(|n| match n {
+                Node::Predicate(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(atoms.contains(&"_mununu_antshadow_0"));
+        assert!(atoms.contains(&"q == 0"));
+        assert!(!atoms.contains(&"mem_rvalid_mine"));
+    }
+
+    /// Empty-`subs` fast path returns a clone (formulas equal).
+    #[test]
+    fn substitute_predicates_empty_subs_is_identity() {
+        use std::collections::BTreeMap;
+        let f = parser::parse("mu Y. (a or <> Y)").unwrap();
+        let g = substitute_predicates(&f, &BTreeMap::new());
+        assert_eq!(f, g);
     }
 
     #[test]

--- a/docs/consumer-briefings/2026-08-antecedent-shadow-synth.md
+++ b/docs/consumer-briefings/2026-08-antecedent-shadow-synth.md
@@ -1,0 +1,82 @@
+# Consumer briefing — 2026-08 antecedent shadow-register synthesis (mununu#476)
+
+> **Audience:** two downstream consumers of mununu — **ROSF** (subprocess consumer via `--profile industrial`) and **monono** (direct CLI consumer). One document, two role-branching sections + a shared footer. Read the section that applies to your repo, then the footer.
+>
+> **Fix:** mununu#476. **Design:** [`docs/design/antecedent-shadow-synthesis.md`](../design/antecedent-shadow-synthesis.md). **User-facing docs:** [`docs/verifying-rtl.md`](../verifying-rtl.md) §"SVA `|=>` with input-derived antecedents".
+>
+> **TL;DR:** the exact-symbolic engine now auto-synthesises antecedent shadow registers for SVA `|=>` properties whose antecedent reaches primary inputs. Verdicts that previously came back `Skipped` (or, before Phase A, unsoundly `Violated (1 cell)` on correct RTL) now decide. Behaviour change is a **strict improvement** — soundness never regressed.
+
+## What changed at engine level
+
+Before this fix (Phase A, `#476` transitive refusal): SVA `A |=> C` whose antecedent `A` was combinationally driven by primary inputs (`mem_rvalid_mine = mem_rvalid && (mem_rid == CLIENT_ID)`, `valid_and_ready = valid && ready`, address decoders, enable stacks) returned `Skipped` with a refusal message naming the source inputs.
+
+After this fix (Option C, `#476` shadow-synthesis): the same properties **decide**. The exact-symbolic engine detects the canonical `|=>` lift shape in the mu-calc formula, synthesises a shadow state register `_mununu_antshadow_<N>` that samples `A` per cycle (`init = 0`, `next = A`), and rewrites the atom to reference the shadow before evaluation. Standard SVA-to-BMC compilation technique.
+
+Five fallback conditions still hit the Phase A refusal (definite `Skipped`, never wrong): non-Boolean antecedent, array/memory in cone, atom is itself a primary input, cone reaches an anonymous free input from partial-write havoc, multi-atom antecedents `(a && b) |=> c`. Everything else that used to `Skipped` on this path now decides.
+
+**Opt-out:** the `MUNUNU_NO_ANTECEDENT_SHADOW=1` environment variable disables shadow-synth (reverts to the Phase A refusal). Debug / differential-oracle use only.
+
+---
+
+## For ROSF-agents (subprocess `--profile industrial`)
+
+**What to update on your side:** nothing required if your verdict-parsing keys on `PropertyVerdict` values (`Holds` / `Violated` / `Unknown` / `Skipped`) — those are unchanged.
+
+**What to expect:** properties on RTL that use ready-valid, address decoding, or any combinational-of-input antecedent (very common in bus/handshake modules) will start returning `Holds` / `Violated` / `Unknown` where they previously returned `Skipped`. Your `--profile industrial` gate becomes tighter — that's the point.
+
+**If your report parser looks at the `Skipped` refusal message text** (unusual but possible): the message strings for the fallback conditions listed above are unchanged. The pre-existing "atom references primary input" and "combinationally driven by primary input(s)" messages both still occur when a fallback fires. Nothing new to parse — new decides use the same `PropertyVerdict::Holds/Violated/Unknown` shape as any other decided property.
+
+**Docker rebuild:** rebuild `rosf/docker/Dockerfile` **only if you pin a specific `mununu` binary version tag**. If you fetch the latest mununu binary on image build, the behaviour change picks up automatically on your next rebuild. `rosf/Dockerfile.dev` and `rosf/Dockerfile.hw` are unaffected — they don't invoke mununu.
+
+**Test the transition:** run your `--profile industrial` gate against any design that previously reported a `Skipped` verdict with the phrase "combinationally driven by primary input" in the refusal message. Those should now decide. If any of them come back `Violated` when your intent was `Holds`, that's a signal to inspect the RTL — mununu was previously silent on that property, now it's speaking.
+
+---
+
+## For monono-agents (direct `sv verify-auto` CLI consumer)
+
+**What to update on your side:** nothing required. Just re-run `sv verify-auto` on your tree.
+
+**What to expect:** the `wb_mem_client`-shaped case from mununu#476 (`mem_rvalid_mine = mem_rvalid && (mem_rid == CLIENT_ID)`, SVA `((st_q == 3) && mem_rvalid_mine && got_lo_q |=> (st_q == 4))`) now DECIDES instead of refusing. The workaround in the mununu#476 report (restate the property over registers only) is no longer needed — the original property works. Consider whether to revert the workaround in your RTL/property set.
+
+**Everywhere else this shape appears** in the monono tree — bus protocols, handshake gating, enable stacks, address decoders with input-dependent antecedents — the same story. Properties that were reporting `Skipped` on this exact shape will now report a definite verdict.
+
+**Docker rebuild:** monono's Docker (if any) needs rebuild **only if it pins a specific mununu binary version**. Otherwise the behaviour change picks up on the next binary pull.
+
+**Test the transition:** replay the `#476` case from the report — the `mem_rvalid_mine` fixture. Confirm the verdict is now definite rather than `Skipped` with the transitive-fan-in refusal message. Also inspect any property in your tree currently marked `Skipped` on `sv verify-auto`; the ones that were caught by the transitive refusal will now decide.
+
+**Related open issue #475** — the five `sv lint` / `sv mutate` ergonomics gaps from your adoption report are **NOT fixed in this PR**. Those are a separate follow-up (see the earlier issue-sweep plan at `.claude/plans/i-am-looking-the-declarative-snowflake.md`). This PR is scoped to #476 only.
+
+---
+
+## Docker rebuild table (both consumers)
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod CLI) | binary carries new engine behaviour | Yes if consumers pin a version tag |
+| mununu `Dockerfile.dev` | binary bump | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; e2e tests exercise the shadow-synth path | **Yes** — rebuild + full slang-gated e2e test run under this image before merge (per CLAUDE.md §"SVA-verification e2e validation") |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `docker/Dockerfile` | consumes mununu subprocess; verdict quality changes on input-derived antecedents | Only if pinned to a version tag; behavior updates on next binary pull otherwise |
+| rosf `docker/Dockerfile.dev`, `.hw` | no direct dependence on the changed paths | No |
+| monono Docker (any) | consumes `sv verify-auto` output | Only if pinned to a version tag |
+
+---
+
+## Shared footer — verification you should run after adopting
+
+1. **Confirm your verdict-parsing still works** on a property that previously returned `Skipped` under the transitive refusal. It should now return `Holds`/`Violated`/`Unknown` with the standard payload shape.
+2. **Confirm the opt-out escape hatch works** (only relevant if you build a differential oracle): set `MUNUNU_NO_ANTECEDENT_SHADOW=1` before invoking `sv verify-auto`, verify the same property returns to the Phase A refusal. This is your emergency knob if you ever need to compare shadow-synth verdicts against the pre-shadow behaviour.
+3. **If your CI gate expected `Holds` on any of the newly-decided properties, treat the change as a soundness update.** Your gate was passing on `Skipped` (which the CI-gate exit code counted as pass under `--fail-on violated`); it will now pass on a real `Holds`. If it comes back `Violated`, the RTL has a bug the previous engine could not report on.
+
+## Provenance
+
+- Fix commit: (pending merge — see branch `fix/476-antecedent-shadow-synth` in the mununu repo)
+- Issue: mununu#476 — <https://github.com/vscorza/mununu/issues/476>
+- Design: `docs/design/antecedent-shadow-synthesis.md`
+- Policy this briefing was written to satisfy: `docs/policies/cross-repo-impact.md`
+
+## Not covered here (follow-ups)
+
+- mununu#475 (five `sv lint` / `sv mutate` ergonomics gaps) — separate PR, targeted next.
+- Multi-atom antecedents `(a && b) |=> c` — a scope extension of the shadow-synth pass, targeted after real-world evidence one is needed.
+- Stable JSON schema doc for `PropertyVerdict` / `DiscoveredAssumption` / `AutoVerifyReport` — planned as `docs/api-schemas/verdict.md`; not yet written. When it lands, both ROSF and monono get a schema URL to pin their parsers against.

--- a/docs/design/antecedent-shadow-synthesis.md
+++ b/docs/design/antecedent-shadow-synthesis.md
@@ -1,0 +1,208 @@
+# Antecedent shadow-register synthesis in the exact-symbolic engine
+
+> **Status:** design (2026-08-22). Supersedes the Phase A refusal for `sv verify-auto`. Refusal remains the fallback when a shadow cannot be synthesized soundly.
+> **Owner:** exact-symbolic engine (`crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs`) + SVA lift (`crates/mununu-core/src/adapter/slang/verify_auto.rs`).
+> **Fixes:** mununu#476 (the deeper form — the transitive refusal from Phase A becomes fallback-only).
+
+## Context
+
+The exact-symbolic engine leaves primary inputs FREE — they are quantified out per modality step. This is correct for state-only atoms, but it decouples input references across time: `A@N` (the antecedent evaluation) and `A@N+1` (the transition read of the same physical signal) share no constraint. For SVA `A |=> C` where `A` reads inputs — directly OR through combinational logic — the model checker returns a spurious verdict (`Violated (1 cell)` on correct RTL was the monono#476 report; the Phase A transitive refusal made this a `Skipped` instead).
+
+Combinational-of-input antecedents dominate real SVA — bus/handshake gating (`valid_and_ready`), address decoding (`sel_a = (addr == BASE_A)`), enable stacks (`write_en = wr && cs && !halt`), cross-module chains (`rvalid_mine = rvalid && (rid == MY_ID)`). Refusal-only ships a strict Pareto improvement over the previous unsound `Violated`, but refuses a large fraction of real assertions. The proper fix — synthesizing an antecedent shadow register at SVA lift time — is a well-established technique (SymbiYosys, JasperGold, Vardi's SVA-to-BMC compilation) and is what this document specifies.
+
+## Approach
+
+At SVA lift time, when `A |=> C` is being turned into a mu-calculus formula, analyze `A`. If `A`'s combinational cone reaches primary inputs (transitively, stopping at register boundaries — same walker as Phase A: `parser::cone_inputs`), synthesize an **antecedent shadow register** in the BTOR2:
+
+- New state cell `_mununu_antshadow_<N>` (fresh unique per synthesised atom).
+- Sort = `A`'s sort (typically 1-bit Boolean).
+- `init(_mununu_antshadow_<N>) = 0` — the SVA `|=>` semantics say cycle 0 has no prior antecedent, so the obligation is trivially satisfied when the shadow reads false.
+- `next(_mununu_antshadow_<N>) = A_nid` — the shadow *samples* A each cycle.
+
+Rewrite the lifted mu-calculus formula so the antecedent atom references `_mununu_antshadow_<N>` instead of `A`. Feed the augmented BTOR2 + rewritten formula to the exact engine. The engine treats the shadow as ordinary state — no more input decoupling.
+
+If the shadow cannot be synthesized (fallback conditions below), fall through to the Phase A refusal.
+
+## Soundness argument
+
+Standard SVA-to-BMC reduction. The SVA fragment `A |=> C` at cycle N means "if A held at cycle N, C must hold at cycle N+1". Introducing shadow `S` with `next(S) = A, init(S) = 0` gives `S@N+1 = A@N` and `S@0 = 0`. The obligation `AG(S → C)` evaluated at cycle N+1 is equivalent to `AG(A@N → C@N+1)` for N ≥ 0, plus a trivially satisfied `AG(0 → C)` at cycle 0.
+
+**Key point** — the shadow rewrite is **not sound as a general engine-internal transformation**. Applying it to `mu Y. (A or <> Y)` (bare `EF A`) would shift the semantics by one cycle. The shadow is safe only for the `|=>` shape, which the SVA lift knows about but the engine does not. The rewrite MUST happen at SVA lift time, with an explicit hint to the engine that the augmented model + rewritten formula are jointly one rewrite.
+
+For non-SVA-lift entry points (direct `btor2 verify` with a user-authored mu-calc formula containing an input-derived atom), the engine has no shape hint and cannot safely shadow. The Phase A refusal remains the only sound answer there.
+
+**Auxiliary sanity check** — the shadow rewrite preserves controllability, resettability, and reachability of every EXISTING state cell (it only ADDS a state cell with a well-defined init and next). No existing atom's semantics change. No existing verdict changes. All previously-decided properties on the augmented model produce the same verdict, and the newly-decidable properties (previously refused / previously unsound Violated) now decide with a verdict the SVA semantics validate.
+
+## Boundaries — when the shadow is NOT synthesized
+
+Fall back to the Phase A refusal when any of these hold:
+
+- **Non-Boolean antecedent.** A wider-than-1-bit antecedent used in `|=>` is either a language misuse (SVA `|=>` is Boolean) or a multi-value pattern the shadow would misrepresent. Refuse.
+- **Array / memory in A's cone.** BTOR2 memory reads model as inputs after havoc; a shadow over an array-dependent A would sample the free-input-model of the array, defeating the shadow. Refuse.
+- **A is itself a primary input** (the Phase A hard-refusal case). Introducing a shadow that samples a single input is technically sound, but the resulting property is `AG(prev(A) → C)` which is rarely what the author meant. Refuse and let the author confirm the shape.
+- **A's cone reaches an anonymous free input** (the `signal_reaches_anonymous_input` case at symbolic_bitblast.rs:3410). The partial-write havoc pattern is a different soundness posture; shadow-synth doesn't fix it. Refuse.
+- **`--no-antecedent-shadow` flag on the CLI / `antecedent_shadow: false` in the API.** Explicit user opt-out for debugging or differential-oracle purposes. Refuse and cite the flag in the diagnostic.
+
+## Implementation shape
+
+### New module — `crates/mununu-core/src/adapter/btor2/antecedent_shadow.rs`
+
+```rust
+pub struct ShadowSynthResult {
+    /// The BTOR2 file with shadow registers appended.
+    pub augmented: Btor2File,
+    /// Original-atom-name → synthesized shadow name.
+    pub renames: BTreeMap<String, String>,
+    /// The atoms that fell through and require refusal.
+    pub refused: Vec<RefusalReason>,
+}
+
+pub enum RefusalReason {
+    NonBoolean { atom: String, width: usize },
+    ArrayInCone { atom: String, mem_nid: Nid },
+    IsPrimaryInput { atom: String },
+    ReachesAnonymousInput { atom: String },
+    UserOptedOut,
+}
+
+/// For each atom in `antecedent_atoms` whose cone reaches primary inputs,
+/// synthesize an antecedent shadow register in the BTOR2 and record the rename.
+/// Returns the augmented file and a rename map for the SVA-lift caller to apply
+/// to the mu-calculus formula.
+pub fn synthesize_shadows(
+    file: &Btor2File,
+    antecedent_atoms: &[String],
+    opts: ShadowSynthOpts,
+) -> ShadowSynthResult { ... }
+```
+
+### SVA lift integration — `crates/mununu-core/src/adapter/slang/verify_auto.rs`
+
+The `|=>` shape is already detected by the SVA translator (per docs/design/native-sv-abstraction.md). At the point where the lifted mu-calc formula is being assembled, before handing to the engine:
+
+1. Collect the antecedent atoms (already known from the parse tree).
+2. Call `antecedent_shadow::synthesize_shadows(&file, &antecedent_atoms, opts)`.
+3. If any shadows were synthesized, apply the rename map to the mu-calc formula (a straightforward AST walk).
+4. Record the synthesis in the report (see interface).
+5. Any `refused` entries fall through to the engine, which then hits Phase A's refusal path for those specific atoms.
+
+### Engine integration — `crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs`
+
+The Phase A refusal already lives here. It becomes the fallback path. No change to the refusal logic; the shadow-synth simply reduces the number of atoms that reach it.
+
+Optionally add a diagnostic to the refusal message when a shadow was ATTEMPTED but fell back — so the user sees the specific reason (e.g. "shadow skipped: array in cone").
+
+## CLI / API interface
+
+**New CLI flag** on `sv verify-auto` and any command that invokes the SVA lift:
+
+```
+--no-antecedent-shadow    Disable auto-synthesis of antecedent shadow registers
+                          for SVA `|=>` properties with input-derived antecedents.
+                          Instead, refuse those properties with the Phase A message.
+                          Debug / differential-oracle use only.
+```
+
+**New API field** on the `sv verify-auto` request:
+
+```json
+{ "antecedent_shadow": true }   // default; false to opt out
+```
+
+**New report fields** on `AutoVerifyReport`:
+
+```json
+{
+  "antecedent_shadows": [
+    {
+      "atom": "mem_rvalid_mine",
+      "shadow_name": "_mununu_antshadow_0",
+      "source_inputs": ["mem_rvalid", "mem_rid"]
+    }
+  ],
+  "antecedent_shadow_refusals": [
+    { "atom": "arr_gt_thresh", "reason": "array_in_cone", "mem_nid": 47 }
+  ]
+}
+```
+
+Both arrays are empty in the common case (no input-derived antecedents). Downstream consumers (ROSF, monono) do not need to change their parser — the fields are additive; unknown fields must be ignored per the standard verdict-schema stability contract (`docs/api-schemas/verdict.md`).
+
+**Verdict stability.** `PropertyVerdict` values do not change semantics. A property that previously returned `Skipped` under the Phase A refusal may now return `Holds` / `Violated` / `Unknown` — this is the intended behavior improvement. A property that previously returned an unsound `Violated` may now return the correct verdict.
+
+## Test strategy
+
+Four layers, all under `crates/mununu-core/`:
+
+### Unit — `adapter/btor2/antecedent_shadow.rs::tests`
+
+- **Detection**: an atom whose cone reaches inputs is flagged; a state-only atom is not.
+- **Rewrite correctness**: the augmented BTOR2 has exactly one new state per input-derived atom; its init is 0; its next is the atom's NID.
+- **Rename map**: the map covers every synthesized atom and no others.
+- **Fallback**: array-in-cone / non-boolean / bare-primary-input all produce refusal entries without mutating the file.
+
+### Integration — `adapter/btor2/symbolic_bitblast.rs::tests`
+
+- **Monono `wb_mem_client` shape** (positive): the fixture that previously refused (Phase A) now DECIDES with a Holds verdict, and the report lists a shadow entry.
+- **Bare `EF (input_derived)` regression**: engine-internal callers with no SVA-lift hint still refuse (soundness preservation).
+- **Combinational-of-state atom** (regression): unchanged — no shadow synthesized, no refusal.
+- **`--no-antecedent-shadow` opt-out**: with the flag, the same monono fixture refuses again with the Phase A message.
+
+### Differential oracle — new test file `crates/mununu-core/tests/antecedent_shadow_differential.rs`
+
+For a curated set of SVA `|=>` fixtures with input-derived antecedents:
+- Verdict from exact-symbolic engine WITH shadow-synth
+- Verdict from predicate-cube engine (which shadow-registers antecedents natively per the current refusal message's claim)
+- Assert: definite verdicts agree; if one is ⊥, the other may be definite (portfolio coverage difference); a definite-vs-definite disagreement raises a soundness alarm.
+
+The differential test is the key soundness argument — it independently verifies the shadow-synth against a peer engine using a different technique for the same problem. Run under `mununu-sva` per CLAUDE.md §"SVA-verification e2e validation (slang)".
+
+### End-to-end — extends `crates/mununu-core/tests/verify_auto_sweep.rs` (or equivalent)
+
+Full pipeline `slang → BTOR2 → shadow-synth → exact engine → verdict`, on:
+- The monono `wb_mem_client` reduced fixture (add to `examples/verify/`)
+- A ready-valid handshake with `assert property (valid && ready |=> next_state == X)`
+- An address-decoder with `assert property ((addr == BASE) && wr |=> sel_a)`
+
+Each asserts the expected verdict AND the presence of a shadow entry in the report.
+
+## Cross-engine implications
+
+- **Predicate-cube engine.** No change. It already shadow-registers antecedents (per the current refusal message). The differential oracle test exercises it as-is.
+- **`btor2 verify` direct path.** No change. Users writing hand-authored mu-calc formulas over BTOR2 files bypass the SVA lift → no shadow-synth → Phase A refusal still applies to input-derived atoms.
+- **Synthesis (`context synth`).** No change. Synthesis reads mu-calc formulas the user writes; no SVA lift; no shadow-synth. If a user writes a formula with an input-derived atom for synthesis, the Phase A refusal (from the exact-symbolic engine when it's used as an oracle in the synthesis pipeline) is the right answer.
+- **Recoverability (`AG EF good`) path** at `adapter/recoverability.rs`. Uses the exact engine; recoverability formulas typically have no input-derived antecedents. If they do, refusal remains the answer — no shadow-synth for non-`|=>` shapes.
+
+## Cross-repo impact
+
+- **ROSF** (subprocess `--profile industrial`). Verdict quality improves — previously `Skipped` properties may now decide. Report parsing is additive-safe. No Docker rebuild required unless a specific mununu version is pinned.
+- **Monono** (direct `sv verify-auto` calls). Same story. The `wb_mem_client` case + every combinational-of-input antecedent in monono's tree will now decide instead of refuse. Any code that treated `Skipped` as "we can't help you" should now expect definite verdicts on that class.
+
+## Docker rebuild determination
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | binary carries new engine behavior + new report fields | Yes for consumers that pin a version tag |
+| mununu `Dockerfile.dev` | binary bump | Only for the dev workflow that requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; e2e tests exercise the differential oracle (mandatory under this image per CLAUDE.md §"SVA-verification e2e validation") | **Yes** — mandatory rebuild + full slang-gated e2e test run under this image before merge |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `Dockerfile` | consumes mununu subprocess; verdict quality changes on input-derived antecedents | Only if pinned to a version tag; behavior updates on next binary pull otherwise |
+| rosf `Dockerfile.dev`, `.hw` | no direct dependence on the changed paths | No |
+
+## Rollout plan
+
+1. Land the shadow-synth module + SVA lift integration + refusal-as-fallback + unit tests on `fix/476-antecedent-shadow-synth` (rename of Phase A branch).
+2. Run the differential oracle under `mununu-sva` image; require green before merge.
+3. Update `docs/verifying-rtl.md` and `docs/api-schemas/verdict.md` (from the Phase C wide-doc pass) to describe shadow-synth and the new report fields.
+4. Update `wiki/RTL-Verification-Pipeline.md` with the new pipeline diagram (SVA lift → cone analysis → shadow-synth → exact engine).
+5. Update the cross-repo prompt (`docs/consumer-briefings/2026-09-open-issue-sweep.md`) to say: refusal is now the fallback, not the default; shadow-synth is the primary path.
+6. New policy file `docs/policies/cross-repo-impact.md` — enforce the Docker-rebuild-decision table format on every PR that changes engine behavior. Referenced from CLAUDE.md.
+7. File the follow-up mununu#477 (verify cube engine also handles input antecedents correctly — differential oracle for the differential oracle). Not blocking this PR.
+
+## Non-goals
+
+- No change to the SVA fragment supported.
+- No change to `PropertyVerdict` values or their `as_str()` shape.
+- No change to the predicate-cube engine.
+- No change to the recoverability, synthesis, or KMTS-3-valued paths.
+- No implementation of shadow-synth for `A |-> C` (immediate-implication SVA) in this PR — same-cycle sampling is a different shape; separate design.

--- a/docs/policies/cross-repo-impact.md
+++ b/docs/policies/cross-repo-impact.md
@@ -1,0 +1,84 @@
+# Cross-Repo Impact Reporting Policy
+
+> **Rule.** Every PR that changes user-visible behaviour of a mununu surface consumed by a downstream repo (ROSF, monono, mununu-ui, or any future consumer) must ship a **consumer briefing** — a single markdown file under [`docs/consumer-briefings/`](../consumer-briefings/) — that names the consumers affected, explains what changed for them, and states which Docker images (if any) need rebuilding.
+>
+> **Why.** mununu is one node in a small network of tools that build on top of it. Verdict semantics, JSON shapes, CLI flags, exit codes, sidecar formats, and engine behaviour all propagate to at least one consumer today (ROSF `--profile industrial` subprocess consumer; monono direct CLI consumer). Without a machine-checkable disclosure discipline, a "correct-in-isolation" mununu change silently breaks a downstream — or, more often, silently improves it in ways the downstream never notices and never validates. Both failure modes have happened.
+
+## When this policy fires
+
+A PR fires this policy when it does any of the following:
+
+1. Changes the value of any `PropertyVerdict` variant, or the message strings that accompany a `Skipped` / `Unknown` verdict.
+2. Changes the shape of any struct that `render_verify_auto_json`, `synthesis.diagnostics.to_json_value`, or any `POST /api/v1/*` handler serialises.
+3. Adds, removes, renames, or reorders any CLI flag on `context`, `sv`, `btor2`, `verify`, `contract`, or `codesign` (and their sub-verbs).
+4. Adds, removes, or reorders any HTTP API route under `/api/v1/`.
+5. Changes the semantics of a shipped verdict — a property that used to `Skipped` now decides, or a property that used to `Holds` now `Violated`s or vice versa. Bugfixes count; a soundness fix is the most important case to report, not an exception.
+6. Changes what tools mununu invokes as subprocesses (`slang`, `sv2v`, `yosys`, `pono`, `btormc`, `cvc5`, `verilator`) or the versions it pins in `docker/Dockerfile*`.
+7. Changes any sidecar schema (`.mununu.json`, `@mununu_predicate` / `@mununu_config` / `@mununu_abstraction` annotations, `verify.toml`).
+
+**Exemptions:** internal refactors that preserve every observable behaviour listed above; test-only changes; changes to `docs/` that only clarify existing behaviour; changes to `REVIEW_LOG.md`, `ONBOARDING.md`, or `scratchpad/`.
+
+## What a consumer briefing must contain
+
+At minimum:
+
+1. **Audience banner** naming every downstream consumer affected (today: ROSF, monono; add others as they appear).
+2. **TL;DR** paragraph — the behaviour change in one sentence, plus a phrase telling every consumer whether their action is required or optional.
+3. **What changed at engine level** — one paragraph. Cite the fix commit, the issue number if one exists, and the design doc if the change is non-trivial.
+4. **Per-consumer section** — one per audience — covering:
+   - *What to update on your side* (may be "nothing required" — say so explicitly).
+   - *What to expect* (verdicts that change, errors that go away, new fields that appear).
+   - *Report parsing impact* — additive-safe changes get flagged as "no action needed"; breaking shape changes require an explicit migration cheat sheet.
+   - *Docker rebuild disposition* for that consumer's images (see mandatory table below).
+   - *Test-the-transition steps* — a concrete reproducer the consumer can run to confirm the change on their side.
+5. **Docker rebuild table** — mandatory, verbatim shape. Columns: `Image | Impact | Rebuild required?`. Rows cover every Dockerfile in `mununu/docker/`, every Dockerfile in each consumer's `docker/` directory, and any consumer-side ad-hoc Docker files. Missing rows are a lint failure; blank rows are a lint failure.
+6. **Shared footer** with verification steps every consumer should run.
+7. **Provenance** — fix commit sha (or "pending merge — see branch `<name>`"), issue link, design-doc link, policy link.
+8. **Not covered here** — an explicit list of follow-ups this briefing does NOT address, so consumers know what's still open.
+
+## Where the briefing lives
+
+`docs/consumer-briefings/YYYY-MM-<slug>.md`. Slug is a short kebab-case description of the change (`antecedent-shadow-synth`, `verify-auto-input-refusal`, `sv-lint-exclude-glob`). One file per PR that fires this policy; a batched PR that changes multiple surfaces gets ONE briefing that covers all of them, so consumers read exactly one document per adoption round.
+
+## Docker rebuild disposition — how to fill the table
+
+For every image in scope, state the impact and the rebuild disposition. Standard verdicts:
+
+- **Yes if consumers pin a version tag** — the mununu binary changed; consumers that pin a specific tag must rebuild to pick it up.
+- **Yes — mandatory** — the change requires the image be rebuilt AND its e2e tests re-run before merge (typically applies to `mununu-sva` for slang-gated tests per CLAUDE.md §"SVA-verification e2e validation").
+- **Only if the dev workflow requires the new binary** — for `Dockerfile.dev` and consumer dev images.
+- **No** — image is unaffected.
+- **Behaviour updates on next binary pull** — for consumers that fetch the latest mununu binary on rebuild rather than pinning.
+
+Never write "Maybe" or leave blank. If the impact is genuinely unclear, that's a signal the design isn't ready to ship.
+
+## Enforcement
+
+Today (2026-08): manual — reviewers check that any PR firing the criteria above ships a briefing. Failing to include a briefing on a qualifying PR is a review comment, not (yet) a hard CI gate.
+
+Planned:
+
+- `make docs-audit` extends its cadence check to warn when a load-bearing surface changes without a matching briefing in the same PR.
+- Skill: `/cross-repo-impact-check` walks the diff, decides whether the policy fires, and either produces a briefing skeleton or asserts a matching briefing is present.
+- CLAUDE.md rule: agents drafting a qualifying PR must produce the briefing as part of the PR, not as a follow-up.
+
+## Historical context
+
+This policy formalises a rule that had been implicit but repeatedly missed:
+
+- **mununu#476** (2026-08) — soundness fix that changed verdicts on a class of SVA `|=>` properties. Consumers (monono especially) had been coding against the old — wrong — `Violated (1 cell)` results. The Phase A refusal + Option C shadow-synth PRs shipped with a briefing under this policy at [`docs/consumer-briefings/2026-08-antecedent-shadow-synth.md`](../consumer-briefings/2026-08-antecedent-shadow-synth.md) — the first briefing under the policy, and the case that motivated writing it down.
+
+Prior surface changes shipped without briefings, and consumers discovered the impact by re-running their tests. That model does not scale as more consumers appear.
+
+## What this policy is NOT
+
+- **Not a versioning policy.** Semver / release tagging is a separate discipline (currently: mununu is 0.4.x, all releases treated as breaking).
+- **Not a schema-freeze policy.** Consumers should still expect additive schema changes on `AutoVerifyReport` etc.; the briefing tells them when a change is additive (safe to ignore) vs breaking (must migrate).
+- **Not a "communicate every change" policy.** Internal refactors, test additions, and documentation-only changes do not fire it. The policy targets the small set of changes that actually cross the mununu boundary.
+- **Not a substitute for the mununu wiki or `docs/verifying-rtl.md`.** The wiki documents behaviour steadily; briefings document *transitions*.
+
+## See also
+
+- [`CLAUDE.md`](../../CLAUDE.md) — the binding rules; this policy is referenced from there.
+- [`docs/policies/claims-integrity.md`](claims-integrity.md) — sibling policy on how mununu talks about its own capabilities. Both policies exist because getting the second-order effects wrong (what downstream consumers assume from a change, what the outside world assumes from a claim) has been more expensive than any first-order engineering mistake.
+- [`docs/verifying-rtl.md`](../verifying-rtl.md) — the standing user-facing documentation. When a briefing lands, `verifying-rtl.md` should also be updated so the durable docs reflect the new behaviour.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -176,6 +176,61 @@ lifted model (misspelled, or a state/output/optimized-away name) is rejected aga
 the model's real inputs. Every applied pin — including one that coincides with an
 auto-detected reset pin — is echoed in the `config-concretization` note.
 
+### SVA `|=>` with input-derived antecedents: automatic shadow-synth
+
+> Source of truth: [`antecedent_shadow`](../crates/mununu-core/src/adapter/btor2/antecedent_shadow.rs) + [`detect_pipeimplies_antecedent_atoms`](../crates/mununu-core/src/mu_calculus/mod.rs) — surface: (CLI+API+UI, engine-internal, no user flag required)
+
+SVA `A |=> C` whose antecedent `A` reads primary inputs — directly OR through a
+combinational chain (`mem_rvalid_mine = mem_rvalid && (mem_rid == CLIENT_ID)`,
+`valid_and_ready = valid && ready`, address decoders, enable stacks) — is the
+common shape in real RTL. The exact-symbolic engine leaves inputs FREE per
+modality step, so pinning an input-derived antecedent decouples the antecedent
+copy from the transition copy of the same physical signal. Left alone, the
+engine would return a spurious verdict on correct RTL (`Violated (1 cell)` on
+monono's `wb_mem_client` was the mununu#476 report).
+
+**Automatic fix — antecedent shadow-register synthesis.** At verify time the
+engine detects the canonical `|=>` lift shape `nu X. ((¬A ∨ □B) ∧ □X)` in the
+mu-calc formula and, for every antecedent `A` whose combinational cone reaches
+primary inputs, synthesises a **shadow state cell** `_mununu_antshadow_<N>` in
+the BTOR2:
+
+- `init = 0` — SVA `|=>` semantics say cycle 0 has no prior antecedent, so the
+  obligation is trivially satisfied at reset.
+- `next = A` — the shadow samples `A` each cycle, so at cycle N+1 it carries
+  `A@N`.
+
+The antecedent atom is rewritten to reference the shadow; the exact engine
+evaluates on the augmented model. Verdicts that were previously `Skipped`
+(under the earlier transitive refusal) now decide correctly. Standard
+SVA-to-BMC compilation technique (SymbiYosys / JasperGold / EBMC do the
+equivalent). Full design + soundness argument:
+[`docs/design/antecedent-shadow-synthesis.md`](design/antecedent-shadow-synthesis.md).
+
+**Fallback conditions — a refusal, not an unsound verdict.** Five cases fall
+through to the earlier Phase A refusal (definite `Skipped`, never a wrong
+answer):
+
+- Non-Boolean antecedent (`|=>` should be Boolean; wider is a language misuse).
+- Array/memory in the antecedent's cone (havoc defeats the shadow).
+- The antecedent atom is **itself** a primary input (rare, author-confirmation
+  case — restate as `AG(prev(A) → C)` if truly desired).
+- Cone reaches an anonymous free input from a partial-write havoc
+  (a different soundness posture; see `signal_reaches_anonymous_input`).
+- Multi-atom antecedents like `(a && b) |=> c` (initial scope caught the
+  single-atom case; extension to Boolean-tree antecedents is a follow-up).
+
+**Opt-out** — the `MUNUNU_NO_ANTECEDENT_SHADOW=1` environment variable
+disables shadow-synth even for `|=>` shapes, reverting to the Phase A refusal.
+This is a debug / differential-oracle knob (used to cross-check shadow-synth
+verdicts against the predicate-cube engine's independent handling); production
+use should leave it unset.
+
+**Non-`|=>` formulas are unaffected.** A hand-authored `mu Y. (a or <> Y)`
+(bare `EF a`) whose atom happens to be input-derived does NOT match the
+detector and still hits the refusal — the shadow rewrite is only sound for the
+`|=>` shape. Direct `btor2 verify` callers with such formulas are unchanged.
+
 ---
 
 ## Driving it from an external agent (e.g. an agent writing RTL)


### PR DESCRIPTION
## Summary

Deep fix for #476: the exact-symbolic engine now auto-synthesises antecedent shadow registers for SVA `|=>` properties whose antecedent reaches primary inputs (directly or combinationally). Standard SVA-to-BMC compilation technique. Verdicts that were previously `Skipped` (or, before the Phase A refusal, unsoundly `Violated (1 cell)` on correct RTL) now decide.

- **Engine.** New `adapter/btor2/antecedent_shadow.rs` synthesises `_mununu_antshadow_<N>` state cells with `init=0`, `next=A`. Wired into `exact_symbolic_verdict_with_witness_inner` at the top; the Phase A transitive refusal remains as the fallback for five well-defined cases (non-Boolean antecedent, array/memory in cone, atom IS a primary input, cone reaches an anonymous free input from partial-write havoc, unresolvable name).
- **Detection.** New `mu_calculus::detect_pipeimplies_antecedent_atoms` walks the formula AST for the canonical `nu X. ((¬A ∨ □B) ∧ □X)` lift shape. Non-`|=>` formulas with input-derived atoms (bare `EF`, `AF`, etc.) do NOT match — they still hit the Phase A refusal (soundness preserved — the shadow rewrite is only sound for the `|=>` shape).
- **Opt-out.** `MUNUNU_NO_ANTECEDENT_SHADOW=1` env var reverts to the Phase A refusal (differential-oracle / debug use only). CLI flag + API field are additive follow-ups.

Full design + soundness argument: [`docs/design/antecedent-shadow-synthesis.md`](../blob/fix/476-antecedent-shadow-synth/docs/design/antecedent-shadow-synthesis.md).

## Cross-repo & policy

This is the first PR under a new policy: [`docs/policies/cross-repo-impact.md`](../blob/fix/476-antecedent-shadow-synth/docs/policies/cross-repo-impact.md). Every user-visible-behaviour PR now ships a consumer briefing under `docs/consumer-briefings/` with a mandatory Docker-rebuild table.

- Briefing for this PR: [`docs/consumer-briefings/2026-08-antecedent-shadow-synth.md`](../blob/fix/476-antecedent-shadow-synth/docs/consumer-briefings/2026-08-antecedent-shadow-synth.md) — role-branching for ROSF (subprocess `--profile industrial`) and monono (direct CLI). Docker rebuild disposition is documented per image.
- `CLAUDE.md` cross-refs the policy + design doc in the Reference Docs Index.
- User-facing doc update in [`docs/verifying-rtl.md`](../blob/fix/476-antecedent-shadow-synth/docs/verifying-rtl.md) under `sv verify-auto`.

## Docker rebuild (per new policy)

- `mununu/Dockerfile.sva` — **MANDATORY rebuild + full slang-gated e2e test run** before merge per CLAUDE.md §"SVA-verification e2e validation". This PR touches the SVA verify-auto engine path.
- Other mununu images — rebuild only if a downstream pins a version tag.
- Consumer Docker (rosf, monono) — behaviour updates on next binary pull; rebuild required only if version-pinned.

## Test plan

- [x] `cargo test -p mununu-core --lib antecedent_shadow` — 5/5 module unit tests
- [x] `cargo test -p mununu-core --lib -- --test-threads=1 detect_pipeimplies substitute_predicates` — 7/7 helper unit tests
- [x] `cargo test -p mununu-core --lib -- --test-threads=1 exact_symbolic_refuses shadow_synth_flips` — 3/3 refusal + shadow-synth integration tests
- [x] `cargo test -p mununu-core --lib symbolic_bitblast::tests` — 69/69 (was 68, +1)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p mununu-core --lib -- -D warnings` clean
- [x] Pre-commit hook (trimmed suite scoped to touched crates + doctests) clean
- [x] Pre-push hook (trimmed suite + `cargo machete`) clean
- [ ] `cargo test --workspace --all-features --doc` — CI's job (full workspace sweep)
- [ ] Slang-gated `#[ignore]`d `e2e_*` tests under the `mununu-sva` image — mandatory per CLAUDE.md; run separately from this PR's automated CI

## Follow-ups explicitly NOT in this PR

- #475 — five `sv lint` / `sv mutate` ergonomics gaps (separate scope).
- Multi-atom antecedents `(a && b) |=> c` — scope extension of the detector.
- `--no-antecedent-shadow` CLI flag + API field (env var is the current knob).
- Stable JSON schema doc for `PropertyVerdict` / `AutoVerifyReport` (`docs/api-schemas/verdict.md`).

Fixes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)