### PR TITLE
fix(sv): four `sv lint` / `sv mutate` ergonomics gaps (#475)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1479,6 +1479,13 @@ enum SvCommand {
     /// predicate would be *refused* on (skipped, never mis-decided) by the formal
     /// gate — surfaced in ~0.1 s before the minutes-long verify. Read-only, changes
     /// no verdict. Surface peer of `POST /api/v1/sv/lint`.
+    ///
+    /// Exit codes (per the `--fail-on` gate default): 0 = no findings; 2 = at
+    /// least one finding (a gate-friendly default so `sv lint` fits directly into
+    /// CI). A LIFT FAILURE (front-end error, missing file, etc.) exits 1 —
+    /// distinct from "found something". A batch scanner that wants to distinguish
+    /// "found a bad register" from "could not lift" should pass `--fail-on none`
+    /// and inspect the JSON/text output for findings (mununu#475 item 5).
     Lint(SvLintArgs),
     /// Apply a NAMED structural mutation to the design and re-verify, checking that
     /// the property verdicts FLIP (property adequacy). A flip confirms a property
@@ -1827,6 +1834,21 @@ struct SvLiftArgs {
     /// back a future API auto-top enhancement.
     #[arg(long = "design-dir", value_name = "DIR", conflicts_with = "file")]
     design_dir: Option<PathBuf>,
+    /// mununu#475 item 2 — additional path-component names to exclude from
+    /// `--design-dir` scans, on top of the hardcoded skip set
+    /// (`mutations` / `buggy` / `buggy_artifacts` / `tb` / `testbench` /
+    /// `sim` / `figures`). Match is case-insensitive against a single path
+    /// component (`--exclude faulty` skips every `.../faulty/...` subtree
+    /// but leaves `.../faulty_variant/...` alone). Repeatable. No-op without
+    /// `--design-dir`. Not a full glob syntax — a richer form is a future
+    /// extension when a case demands it.
+    ///
+    /// surface: CLI-only — like `--design-dir` and `--include-dir`, an
+    /// on-disk directory-scan filter has no analog on the API/UI (their
+    /// flat name-staging already lets the caller choose which sources to
+    /// upload).
+    #[arg(long = "exclude", value_name = "NAME")]
+    exclude: Vec<String>,
     /// Additional SV sources (packages, `include` targets), staged alongside the
     /// primary input. Repeatable.
     #[arg(long = "source", value_name = "FILE")]
@@ -1975,6 +1997,17 @@ struct SvMutateArgs {
     /// recoverability property to flip under `drop-reset`). Default `off`.
     #[arg(long, value_enum, default_value_t = MustEdgeInferenceArg::Off)]
     must_edge_inference: MustEdgeInferenceArg,
+    /// mununu#475 item 4 — override a module parameter BEFORE elaboration
+    /// (parity with `sv verify-auto`'s `--param`). Format `NAME=VALUE`
+    /// (top-module scope) or `MODULE.NAME=VALUE` (submodule scope; slang
+    /// applies it top-level by bare name). Repeatable. Shrinks a
+    /// parameterised design so its counters fit the bit-blast cap during
+    /// the baseline + mutant re-verify; blocks that need `--param` to
+    /// verify at all could not previously be mutated. A malformed `--param`
+    /// is a HARD error; yosys errors downstream on a parameter it cannot
+    /// apply — never a silent drop.
+    #[arg(long = "param", value_name = "NAME=VALUE")]
+    params: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -5489,7 +5522,7 @@ fn read_sv_lift(args: &SvLiftArgs) -> Result<mununu_core::adapter::sv_verify::Sv
     // E6 — `--design-dir`: discover + auto-assemble a multi-file design.
     if let Some(dir) = &args.design_dir {
         use mununu_core::adapter::yosys::source_manifest;
-        let files = source_manifest::discover_sv_files(dir)?;
+        let files = source_manifest::discover_sv_files(dir, &args.exclude)?;
         let design_name = dir.file_name().and_then(|s| s.to_str());
         let a = source_manifest::assemble_sv_design(&files, design_name);
         // explicit --top overrides the detected top; --include-dir adds to detected dirs.
@@ -5768,12 +5801,33 @@ fn sv_mutate(args: SvMutateArgs) -> Result<(), String> {
         .unwrap_or_else(|| "top.sv".to_string());
     let mut sources: Vec<(String, String)> = vec![(primary_name, lift.source.clone())];
     sources.extend(lift.additional_sources.iter().cloned());
+    // mununu#475 item 4 — --param parity with `sv verify-auto`. Matches the parsing
+    // shape at the verify-auto handler (`NAME=VALUE` or `MODULE.NAME=VALUE`, both
+    // sides non-empty). A malformed --param is a HARD error here; yosys errors
+    // downstream on a parameter it cannot apply.
+    let params: Vec<(String, String)> = args
+        .params
+        .iter()
+        .map(|e| {
+            let (lhs, val) = e.split_once('=').ok_or_else(|| {
+                format!("malformed --param '{e}': expected NAME=VALUE or MODULE.NAME=VALUE")
+            })?;
+            let (lhs, val) = (lhs.trim(), val.trim());
+            if lhs.is_empty() || val.is_empty() {
+                return Err(format!(
+                    "malformed --param '{e}': NAME and VALUE must both be non-empty"
+                ));
+            }
+            Ok((lhs.to_string(), val.to_string()))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
     let yopts = YosysOptions {
         top: lift.top.clone(),
         additional_sources: lift.additional_sources.clone(),
         use_sv2v: lift.use_sv2v,
         extra_include_dirs: lift.include_dirs.clone(),
         frontend: lift.frontend,
+        params,
         ..Default::default()
     };
 

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -244,16 +244,32 @@ fn lint_undriven_partial_writes(btor2: &str) -> Result<Vec<SvLintFinding>, Strin
     // can match on: State + Op(symbol) → a register (the partsel alias `a_q` is a
     // `uext`/`concat` Op carrying the register's name), Output(symbol) → a
     // combinational output. `Register` wins when a name appears as both.
+    //
+    // mununu#475 item 1 — SKIP Op-node symbols containing `.`. Yosys/slang
+    // mangle **function-argument** names as `<function>.<arg>` (e.g.
+    // `ctrl_code.c`, `ones8.v` in monono's `tmds_encoder.sv`). These emit as
+    // Op nodes with a dotted symbol whose cone happens to reach an anonymous
+    // input (the function-scope input placeholder), so the raw filter below
+    // false-positives them as partial-write registers. Register aliases the
+    // lint IS supposed to catch (`a_q` from `q[hi:lo] <= d`) never carry
+    // dotted names, so the heuristic is targeted. State-node names may
+    // contain dots (hierarchical `top.sub.reg_q`) and are not filtered here —
+    // real registers should still be reported.
     let mut kinds: std::collections::BTreeMap<String, SvLintSignalKind> =
         std::collections::BTreeMap::new();
     for line in &file.lines {
         let (name, kind) = match &line.node {
             Node::State {
                 symbol: Some(s), ..
-            }
-            | Node::Op {
-                symbol: Some(s), ..
             } => (s, SvLintSignalKind::Register),
+            Node::Op {
+                symbol: Some(s), ..
+            } => {
+                if s.contains('.') {
+                    continue;
+                }
+                (s, SvLintSignalKind::Register)
+            }
             Node::Output {
                 symbol: Some(s), ..
             } => (s, SvLintSignalKind::Output),
@@ -421,6 +437,40 @@ mod tests {
         assert!(
             lint_undriven_partial_writes("not btor2 at all").is_err(),
             "a malformed BTOR2 body must surface a parse error, not an empty pass"
+        );
+    }
+
+    /// mununu#475 item 1 — a function argument's `<function>.<arg>` mangled
+    /// name (e.g. monono's `ctrl_code.c`, `ones8.v` in `tmds_encoder.sv`)
+    /// emits as an `Op` node whose cone reaches a function-scope anonymous
+    /// input; the raw `signal_reaches_anonymous_input` check would
+    /// false-positive it as a partial-write register. The `.` heuristic
+    /// filters these out. Fixture: two Op-symbol nodes — one dotted (a
+    /// function-arg alias, must NOT be flagged) and one plain (a legitimate
+    /// partsel alias, MUST be flagged).
+    #[test]
+    fn lint_skips_function_arg_dotted_op_symbols() {
+        // - Anonymous input (nid 2) — the "havoc" that both Op signals read.
+        // - `a_q` (nid 3, Op with plain symbol, reads the anonymous input via
+        //   nid 4) — a legitimate partsel-alias shape → MUST be flagged.
+        // - `ones8.v` (nid 5, Op with dotted symbol, same shape) — the
+        //   function-arg case that used to false-positive → MUST NOT be flagged.
+        const FN_ARG_LIFT: &str = r#"1 sort bitvec 1
+2 input 1
+3 and 1 2 2 a_q
+4 output 3 a_q_out
+5 and 1 2 2 ones8.v
+6 output 5 ones8_out
+"#;
+        let findings = lint_undriven_partial_writes(FN_ARG_LIFT).expect("lint parses the BTOR2");
+        let names: Vec<&str> = findings.iter().map(|f| f.signal.as_str()).collect();
+        assert!(
+            names.contains(&"a_q"),
+            "the plain partsel-alias `a_q` must still be flagged: {findings:?}"
+        );
+        assert!(
+            !names.contains(&"ones8.v"),
+            "the function-arg `ones8.v` must NOT be flagged (mununu#475 item 1): {findings:?}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/yosys/source_manifest.rs
+++ b/crates/mununu-core/src/adapter/yosys/source_manifest.rs
@@ -433,16 +433,34 @@ pub fn assemble_sv_design(
 /// Discover SV/Verilog files under `dir` (recursively), excluding common
 /// non-RTL subtrees (mutations, buggy artifacts, testbenches). CLI helper for
 /// `--design-dir`; the API assembles from provided source *contents* instead.
-pub fn discover_sv_files(dir: &Path) -> Result<Vec<(PathBuf, String)>, String> {
-    fn excluded(p: &Path) -> bool {
+pub fn discover_sv_files(
+    dir: &Path,
+    extra_excludes: &[String],
+) -> Result<Vec<(PathBuf, String)>, String> {
+    // Base skip set — directories that never carry a compilable design under
+    // the reproducible-lift contract (deliberately-broken twins, testbenches,
+    // simulation waveforms, etc.). Extended per-invocation by
+    // `extra_excludes` (mununu#475 item 2 — the `--exclude` CLI flag).
+    //
+    // Match semantics: case-insensitive equality against a single path
+    // component. `--exclude faulty` therefore matches `.../faulty/x.sv` and
+    // `.../a/faulty/y.sv` but NOT `.../faulty_variant/x.sv`. This is not a
+    // full glob (there is no glob dep yet) but it exactly matches the
+    // reporter's `faulty/` use case + the existing hardcoded semantics; a
+    // richer glob syntax is a future extension when a case demands it.
+    let extra_lower: Vec<String> = extra_excludes
+        .iter()
+        .map(|s| s.trim_matches('/').to_ascii_lowercase())
+        .collect();
+    let excluded = |p: &Path| -> bool {
         p.components().any(|c| {
             let s = c.as_os_str().to_string_lossy().to_ascii_lowercase();
             matches!(
                 s.as_str(),
                 "mutations" | "buggy_artifacts" | "buggy" | "tb" | "testbench" | "sim" | "figures"
-            )
+            ) || extra_lower.contains(&s.to_string())
         })
-    }
+    };
     let mut out = Vec::new();
     let mut stack = vec![dir.to_path_buf()];
     while let Some(d) = stack.pop() {
@@ -478,6 +496,91 @@ mod tests {
 
     fn f(name: &str, content: &str) -> (PathBuf, String) {
         (PathBuf::from(name), content.to_string())
+    }
+
+    /// mununu#475 item 2 — `discover_sv_files`'s `extra_excludes` skips a
+    /// named path component on top of the hardcoded skip set. Reporter's
+    /// case: a `faulty/` sibling directory of deliberately-invalid twins
+    /// breaks `--design-dir <parent>` because slang rejects the twins on
+    /// elaboration; `--exclude faulty` restores the whole-tree scan.
+    #[test]
+    fn discover_honours_extra_excludes() {
+        use tempfile::tempdir;
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        // Layout:
+        //   root/keep/a.sv       (should appear)
+        //   root/faulty/bad.sv   (excluded by --exclude faulty)
+        //   root/mutations/m.sv  (excluded by the hardcoded skip set)
+        //   root/nested/faulty/deep.sv   (excluded — component match anywhere in the path)
+        //   root/faulty_variant/ok.sv    (should appear — component match is EQUALITY, not prefix)
+        for (rel, body) in [
+            ("keep/a.sv", "module a; endmodule\n"),
+            ("faulty/bad.sv", "module bad; endmodule\n"),
+            ("mutations/m.sv", "module m; endmodule\n"),
+            ("nested/faulty/deep.sv", "module deep; endmodule\n"),
+            ("faulty_variant/ok.sv", "module ok; endmodule\n"),
+        ] {
+            let p = root.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, body).unwrap();
+        }
+        let files = discover_sv_files(root, &["faulty".to_string()])
+            .expect("discovery with the exclude should succeed");
+        let names: Vec<String> = files
+            .iter()
+            .map(|(p, _)| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.contains(&"a.sv".to_string()),
+            "keep/a.sv should be present: {names:?}"
+        );
+        assert!(
+            !names.contains(&"bad.sv".to_string()),
+            "faulty/bad.sv should be excluded by --exclude faulty: {names:?}"
+        );
+        assert!(
+            !names.contains(&"m.sv".to_string()),
+            "mutations/ should still be excluded by the hardcoded skip set: {names:?}"
+        );
+        assert!(
+            !names.contains(&"deep.sv".to_string()),
+            "nested/faulty/deep.sv should be excluded (component match anywhere in path): {names:?}"
+        );
+        assert!(
+            names.contains(&"ok.sv".to_string()),
+            "faulty_variant/ok.sv should be present (exclude is equality, not prefix): {names:?}"
+        );
+    }
+
+    /// The `extra_excludes` are case-insensitive and tolerate leading/trailing
+    /// slashes — `--exclude Faulty/` and `--exclude faulty` behave identically.
+    #[test]
+    fn discover_exclude_is_case_insensitive_and_trims_slashes() {
+        use tempfile::tempdir;
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        for (rel, body) in [
+            ("keep/a.sv", "module a; endmodule\n"),
+            ("FAULTY/x.sv", "module x; endmodule\n"),
+        ] {
+            let p = root.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, body).unwrap();
+        }
+        // Same lowercase-normalised excludes, given in three forms.
+        for exclude in ["faulty", "Faulty", "/faulty/"] {
+            let files = discover_sv_files(root, &[exclude.to_string()])
+                .expect("discovery with the exclude should succeed");
+            let names: Vec<String> = files
+                .iter()
+                .map(|(p, _)| p.file_name().unwrap().to_string_lossy().into_owned())
+                .collect();
+            assert!(
+                !names.iter().any(|n| n == "x.sv"),
+                "FAULTY/x.sv excluded via '{exclude}': {names:?}"
+            );
+        }
     }
 
     #[test]

--- a/docs/consumer-briefings/2026-08-sv-lint-mutate-ergonomics.md
+++ b/docs/consumer-briefings/2026-08-sv-lint-mutate-ergonomics.md
@@ -1,0 +1,77 @@
+# Consumer briefing — 2026-08 `sv lint` / `sv mutate` ergonomics (mununu#475)
+
+> **Audience:** primarily **monono** (the adoption reporter for `sv lint` / `sv mutate`), secondarily **ROSF** (touches CLI/API surface parity but no verdict semantics).
+>
+> **Fix:** mununu#475. **User-facing docs:** [`docs/verifying-rtl.md`](../verifying-rtl.md) §§`sv lint`, `sv mutate` — the "Recent additions" callouts.
+>
+> **TL;DR:** four ergonomics gaps in `sv lint` / `sv mutate` closed; one docstring clarified. Item 3 (single-file cross-directory module resolution) deferred to a follow-up. No verdict semantics change; parser surface adds two new CLI flags. Consumer action is opt-in — new flags let previously-blocked workflows land.
+
+## What changed
+
+- **Item 1 — `sv lint` false-positive on `function automatic` args.** `ctrl_code.c`, `ones8.v` and similar function-arg-mangled names in yosys/slang output no longer show up as partial-write register findings. Filter is the `.` heuristic on Op-node symbols (register aliases + hierarchical State names never carry dots; function args always do). One new regression test in `sv_verify.rs`.
+- **Item 2 — `--exclude <NAME>` on `--design-dir`.** Case-insensitive path-component match; skips a named directory anywhere in the scan tree on top of the hardcoded `mutations`/`buggy`/`buggy_artifacts`/`tb`/`testbench`/`sim`/`figures` list. `--exclude faulty` was the reporter's use case. Repeatable. Not a full glob (a richer syntax is a future extension). Two new tests in `source_manifest.rs`.
+- **Item 4 — `--param NAME=VALUE` on `sv mutate`.** Parity with `sv verify-auto`'s `--param`. Same parser, same yosys `chparam` / slang `-G` plumbing. Blocks whose adequacy measurement had to shrink a parameterised timing interval can now be mutated end-to-end.
+- **Item 5 — `sv lint --help` exit-code doc.** New docstring on the `Lint` command variant explains: exit `0` = clean, exit `2` = at least one finding, exit `1` = lift failure. Batch scanners that want to distinguish "found something" from "could not lift" should pass `--fail-on none` and inspect the JSON/text output.
+
+**Item 3 (single-file `sv lint` cannot resolve cross-directory submodules)** — deferred to a follow-up PR. It needs deeper design thought around yosys/slang module search-path semantics (`--search-path <DIR>` vs `--filelist <PATH>`). In the meantime, the item 2 `--exclude` closes the reporter's whole-tree workflow via `--design-dir <parent> --exclude faulty`, which was the operative unblock.
+
+## What did NOT change
+
+- **`PropertyVerdict`** — unchanged.
+- **`AutoVerifyReport`** — unchanged.
+- **Existing CLI flags** — unchanged shape and semantics.
+- **HTTP API routes** — unchanged. `--exclude` and `--param` on `sv mutate` are CLI-only additions in this PR (no API/UI parity yet — additive follow-up).
+- **Engine behaviour on any previously-decided property** — unchanged.
+
+## For monono-agents (direct CLI consumer)
+
+**What to update on your side:** at minimum, nothing — old commands still work. To adopt the new flags:
+
+- **Whole-tree lint over a `faulty/` sibling tree**: `mununu sv lint --design-dir <root> --exclude faulty`. Previously blocked because slang rejects the deliberately-invalid twins; now unblocked without touching the hardcoded skip list.
+- **`function automatic` false-positive purge**: no action needed — the fix is automatic. Any allowlist entry your CI carried for `<fn>.<arg>` findings can be dropped (and *should* be dropped, because an allowlist entry for a false positive is the thing most likely to later hide a true one — reporter's exact phrasing).
+- **Mutate parameterised blocks**: `mununu sv mutate <file> --mutation stick:<reg> --param ROW_BITS=2` and similar. The blocks that most need adequacy measurement — the ones sized by parameters — are now reachable.
+- **Exit-code discipline**: your batch scanner should either accept the new gate default (exit 2 = finding, exit 1 = lift failure) or pass `--fail-on none` and read JSON. Documented in `sv lint --help`.
+
+**What to expect:** the reporter's `tmds_encoder.sv` case should now report zero findings on `ctrl_code.c` / `ones8.v`. The whole-tree `--design-dir <root> --exclude faulty` scan should complete without slang rejecting the twins. Any mutation on a parameterised block that previously couldn't lift under the mutate path should now lift with `--param`.
+
+**Docker rebuild:** monono's Docker (if any) needs rebuild only if it pins a specific mununu binary version. Otherwise the ergonomics fixes pick up on the next binary pull. No sidecar or config change required.
+
+## For ROSF-agents (subprocess `--profile industrial`)
+
+**What to update on your side:** nothing required. This PR doesn't touch the `--profile industrial` verify-auto path.
+
+**What to expect:** if your industrial profile ever invoked `sv lint` or `sv mutate` (e.g. as a preflight before verify), the new flags are available. Otherwise, no observable change.
+
+**Docker rebuild:** `rosf/docker/Dockerfile` needs rebuild only if it pins a specific mununu binary version. Otherwise no action.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod CLI) | binary carries two new CLI flags + a lint-filter fix | Yes if consumers pin a version tag |
+| mununu `Dockerfile.dev` | binary bump | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; no e2e-test behaviour change (the shipped `#[ignore]`d e2e tests do not exercise `sv lint` / `sv mutate` cross-directory paths) | Only if a downstream requires the new binary |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `docker/Dockerfile` | consumes mununu subprocess; no verify-auto or verdict-semantics change in this PR | Only if pinned to a version tag; behavior updates on next binary pull otherwise |
+| rosf `docker/Dockerfile.dev`, `.hw` | no direct dependence on the changed paths | No |
+| monono Docker (any) | consumes `sv lint` / `sv mutate` CLI | Only if pinned to a version tag |
+
+## Shared footer — verification you should run after adopting
+
+1. **Confirm the false-positive purge**: `mununu sv lint tmds_encoder.sv --frontend slang` on any module with `function automatic` should report zero function-arg findings.
+2. **Confirm the whole-tree unblock**: `mununu sv lint --design-dir <root> --exclude faulty` runs to completion where `--design-dir <root>` alone previously errored on the twins.
+3. **Confirm `sv mutate --param` parity**: `mununu sv mutate <file> --mutation stick:<reg> --param KEY=VAL` accepts the parameter and the mutant re-verifies. A malformed `--param` should be a hard error, not a silent drop.
+4. **Read the `--help`**: `mununu sv lint --help` documents the exit-code semantics explicitly; batch scanners that were using the old default without knowing exit-2 was "finding" should sanity-check they handle it as intended.
+
+## Provenance
+
+- Fix commit: (pending merge — see branch `fix/475-sv-lint-mutate-ergonomics` in the mununu repo)
+- Issue: mununu#475 — <https://github.com/vscorza/mununu/issues/475>
+- Policy this briefing was written to satisfy: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md)
+- Sibling briefing (mununu#476 antecedent shadow-synth): [`2026-08-antecedent-shadow-synth.md`](2026-08-antecedent-shadow-synth.md)
+
+## Not covered here (follow-ups)
+
+- **Item 3** — single-file `sv lint` cannot resolve cross-directory submodules (53/109 files in monono's tree lift standalone). Needs `--search-path <DIR>` (or `--filelist <PATH>`) design work; separate PR.
+- API/UI parity for `--exclude` and `--param` (currently CLI-only additive).
+- Full glob syntax on `--exclude` (currently path-component equality; suffices for `faulty/`).

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -424,6 +424,32 @@ the same reason). A finding maps to the shared CI gate's `violated` verdict, so 
 default `--fail-on violated` fails the build; `--fail-on none` makes it advisory. A
 clean design reports zero findings and exits `0`.
 
+**Exit codes** (2026-08, mununu#475 item 5). `sv lint --fail-on violated` (the
+default) exits `0` on a clean design, `2` when a bad register is found — a
+gate-friendly default that plugs directly into CI. A LIFT FAILURE (front-end
+error, missing file, etc.) exits `1` — distinct from "found something". A batch
+scanner that wants to distinguish "found a bad register" from "could not lift"
+should pass `--fail-on none` and inspect the JSON/text output for findings.
+
+**`function automatic` arguments are no longer false-positives** (2026-08,
+mununu#475 item 1). Yosys/slang mangle SV function arguments as
+`<function>.<arg>` (e.g. monono's `ctrl_code.c`, `ones8.v` in
+`tmds_encoder.sv`). Their combinational cone reaches a function-scope anonymous
+input, so the raw filter used to flag them as partial-write registers.
+`sv lint` now skips any Op-node symbol containing a `.` — a targeted filter
+that leaves the intended catches (register aliases like `a_q` from
+`q[hi:lo] <= d`, hierarchical State names, etc.) reported as before.
+
+**`--exclude <NAME>` on `--design-dir`** (2026-08, mununu#475 item 2). The
+hardcoded skip set (`mutations` / `buggy` / `buggy_artifacts` / `tb` /
+`testbench` / `sim` / `figures`) is now extensible per-invocation. Match is
+case-insensitive against a single path component — `--exclude faulty` skips
+every `.../faulty/...` subtree but leaves `.../faulty_variant/...` alone.
+Repeatable. Not a full glob syntax (a richer form is a future extension when a
+case demands it). The reporter's whole-tree workflow —
+`mununu sv lint --design-dir <root> --exclude faulty` — is now reachable
+without adding to the hardcoded list.
+
 ## Are the properties adequate? `sv mutate`
 
 > Source of truth: [`mutate_and_compare`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L1824) — surface: (CLI+API+UI)
@@ -475,6 +501,14 @@ so default `--fail-on violated` fails the build; `--fail-on none` is advisory. `
 always exits `0`. A mutation that names a missing register — or does not apply (e.g.
 `drop-reset` on a register with no reset mux) — is a hard **error**, never a silent
 no-op (which would masquerade as an unflipped/adequacy finding).
+
+**`--param NAME=VALUE` parity with `sv verify-auto`** (2026-08, mununu#475 item 4).
+`sv mutate` now accepts `--param`, plumbed through to the same yosys `chparam` /
+slang `-G` path `verify-auto` uses. Blocks whose adequacy measurement had to shrink
+a parameterised timing interval (`--param ROW_BITS=2` and similar are load-bearing
+in monono's tree) can now be mutated end-to-end without a wrapper module. Same
+semantics as `verify-auto`'s `--param`: a malformed value is a HARD error; yosys
+errors downstream on a parameter it cannot apply — never a silent drop.
 
 ## Using mununu in CI (GitHub Actions and friends)
 


### PR DESCRIPTION
## Summary

Adoption-report fixes from monono's #475: four of the five ergonomics gaps closed in one PR. Item 3 (single-file cross-directory module resolution) deferred to a follow-up — items 1 + 2 already unblock the reporter's whole-tree workflow via \`sv lint --design-dir <root> --exclude faulty\`.

**Item 1 — `sv lint` false-positive on `function automatic` args**. `<function>.<arg>` mangled names (`ctrl_code.c`, `ones8.v` in monono's `tmds_encoder.sv`) no longer show up as partial-write findings. The filter is the `.` heuristic on Op-node symbols: register aliases and hierarchical State names never carry dots.

**Item 2 — `--exclude <NAME>`** on `sv lint --design-dir` (and every SvLift verb). Case-insensitive path-component match on top of the hardcoded `mutations`/`buggy`/`buggy_artifacts`/`tb`/`testbench`/`sim`/`figures` skip list. `--exclude faulty` skips `.../faulty/...` but leaves `.../faulty_variant/...` alone. Repeatable. Not a full glob syntax (no glob dep; equality suffices for the reporter's case).

**Item 4 — `--param NAME=VALUE`** on `sv mutate` (parity with `sv verify-auto`). Blocks whose adequacy measurement had to shrink a parameterised timing interval — `--param ROW_BITS=2` and similar — can now be mutated end-to-end.

**Item 5 — `sv lint --help`** now documents exit-code semantics: exit 0 = clean, exit 2 = at least one finding (gate-friendly default), exit 1 = lift failure. Batch scanners that want to distinguish "found something" from "could not lift" should pass `--fail-on none`.

## Cross-repo & policy

- Consumer briefing (per [`docs/policies/cross-repo-impact.md`](../blob/fix/475-sv-lint-mutate-ergonomics/docs/policies/cross-repo-impact.md)): [`docs/consumer-briefings/2026-08-sv-lint-mutate-ergonomics.md`](../blob/fix/475-sv-lint-mutate-ergonomics/docs/consumer-briefings/2026-08-sv-lint-mutate-ergonomics.md) — role-branching for monono (primary reporter) + ROSF (no direct impact); Docker-rebuild table included.
- User-facing docs: [`docs/verifying-rtl.md`](../blob/fix/475-sv-lint-mutate-ergonomics/docs/verifying-rtl.md) — three "Recent additions" callouts under `sv lint` and `sv mutate`.

## What did NOT change

- `PropertyVerdict` semantics — unchanged.
- `AutoVerifyReport` shape — unchanged.
- Existing CLI flags — unchanged shape and semantics.
- HTTP API routes — unchanged. `--exclude` and `--param` on `sv mutate` are CLI-only additions (additive follow-up for API/UI parity).
- Engine behaviour on any previously-decided property — unchanged.

## Docker rebuild disposition (per new policy)

| Image | Impact | Rebuild required? |
|-------|--------|-------------------|
| mununu `Dockerfile` (prod CLI) | binary carries two new CLI flags + a lint-filter fix | Yes if consumers pin a version tag |
| mununu `Dockerfile.dev` | binary bump | Only if the dev workflow requires the new binary |
| mununu `Dockerfile.sva` | binary bump; no e2e-test behaviour change | Only if a downstream requires the new binary |
| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
| rosf/monono Docker | consumes mununu CLI | Only if version-pinned; behavior updates on next binary pull otherwise |

## Test plan

- [x] `cargo test -p mununu-core --lib -- lint_ discover_` — 25/25 (incl. 3 new regressions)
  - `lint_skips_function_arg_dotted_op_symbols` (item 1)
  - `discover_honours_extra_excludes` (item 2)
  - `discover_exclude_is_case_insensitive_and_trims_slashes` (item 2)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p mununu-core --lib -- -D warnings` clean
- [x] `cargo clippy -p mununu-cli -- -D warnings` clean
- [x] Pre-commit hook (fmt + clippy + tests on touched crates + doctests) clean
- [x] Pre-push hook (trimmed suite + `cargo machete`) clean
- [ ] `cargo test --workspace` — CI's job

## Follow-ups explicitly NOT in this PR

- **Item 3** — single-file `sv lint` cannot resolve cross-directory submodules (53/109 files in monono's tree lift standalone). Needs `--search-path <DIR>` (or `--filelist <PATH>`) design work; separate PR.
- API/UI parity for `--exclude` and `--param` (currently CLI-only additive).
- Full glob syntax on `--exclude` (currently path-component equality; suffices for `faulty/`).

Fixes #475 (items 1, 2, 4, 5; item 3 tracked as a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)