### PR TITLE
feat(sv): `--search-path <DIR>` for single-file cross-directory submodules (#475 item 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
  "mununu-core",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/mununu-cli/Cargo.toml
+++ b/crates/mununu-cli/Cargo.toml
@@ -25,6 +25,9 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 bitvec = "1.0"
 
+[dev-dependencies]
+tempfile = "3.24"
+
 [features]
 default = []
 # `smt` feature removed in Phase A.4 step 4.2 — Z3 is now mandatory in

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1849,6 +1849,24 @@ struct SvLiftArgs {
     /// upload).
     #[arg(long = "exclude", value_name = "NAME")]
     exclude: Vec<String>,
+    /// mununu#475 item 3 — additional module search directories for
+    /// single-file lifts: recursively scans DIR for `.v` / `.sv` sources
+    /// and adds them alongside the primary input, so a single-file input
+    /// that instantiates a submodule from a sibling directory
+    /// (`mem_sched.sv` → `slot_arbiter` from a peer dir, 53/109 unliftable
+    /// files in monono's tree) resolves without hand-listing every
+    /// `--source`. The same `--exclude` list filters the scan. Deduplicates
+    /// against the primary file and any explicit `--source` entries by
+    /// canonical path (a search-path that contains the primary file will
+    /// not double-add it). Repeatable. Also composable with `--design-dir`
+    /// — a primary design + sibling libraries.
+    ///
+    /// surface: CLI-only — like `--design-dir` / `--include-dir` /
+    /// `--exclude`, an on-disk directory scan has no analog on the
+    /// API/UI (their flat name-staging already lets the caller stage
+    /// whichever sources they want).
+    #[arg(long = "search-path", value_name = "DIR")]
+    search_paths: Vec<PathBuf>,
     /// Additional SV sources (packages, `include` targets), staged alongside the
     /// primary input. Repeatable.
     #[arg(long = "source", value_name = "FILE")]
@@ -5548,9 +5566,35 @@ fn read_sv_lift(args: &SvLiftArgs) -> Result<mununu_core::adapter::sv_verify::Sv
             .cloned()
             .chain(a.include_dirs)
             .collect();
+        // mununu#475 item 3 — --search-path composes with --design-dir: a
+        // primary block from design-dir + sibling libraries discovered
+        // under each search-path. Dedup against everything already staged.
+        let mut additional_sources = a.additional;
+        let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+        for dir in &args.search_paths {
+            let files = source_manifest::discover_sv_files(dir, &args.exclude)?;
+            for (p, content) in files {
+                if let Ok(c) = p.canonicalize()
+                    && !seen.insert(c)
+                {
+                    continue;
+                }
+                let name = p
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("source.sv")
+                    .to_string();
+                // Avoid a name collision with an already-staged source (rare;
+                // additive collisions have no lift value).
+                if additional_sources.iter().any(|(n, _)| n == &name) {
+                    continue;
+                }
+                additional_sources.push((name, content));
+            }
+        }
         return Ok(mununu_core::adapter::sv_verify::SvLift {
             source: a.primary.1,
-            additional_sources: a.additional,
+            additional_sources,
             top,
             use_sv2v: args.preprocess_sv2v,
             include_dirs,
@@ -5564,7 +5608,18 @@ fn read_sv_lift(args: &SvLiftArgs) -> Result<mununu_core::adapter::sv_verify::Sv
     let source = std::fs::read_to_string(file)
         .map_err(|e| format!("Failed to read SV '{}': {e}", file.display()))?;
     let mut additional_sources = Vec::new();
+    // Dedup by canonical path so a source listed via both --source and
+    // --search-path (or already the primary file) is not double-added.
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    if let Ok(c) = file.canonicalize() {
+        seen.insert(c);
+    }
     for p in &args.sources {
+        if let Ok(c) = p.canonicalize()
+            && !seen.insert(c)
+        {
+            continue;
+        }
         let content = std::fs::read_to_string(p)
             .map_err(|e| format!("Failed to read '{}': {e}", p.display()))?;
         let name = p
@@ -5573,6 +5628,44 @@ fn read_sv_lift(args: &SvLiftArgs) -> Result<mununu_core::adapter::sv_verify::Sv
             .unwrap_or("source.sv")
             .to_string();
         additional_sources.push((name, content));
+    }
+    // mununu#475 item 3 — --search-path: discover .sv/.v under each named
+    // directory (honouring --exclude, matching --design-dir's semantics)
+    // and add to additional_sources. Dedup TWICE: first by canonical path
+    // (the same file appearing via both --source and search-path), then
+    // by short filename (a search-path file that name-collides with the
+    // primary or an explicit source is a distinct file but would trip a
+    // "duplicate module" error under yosys — skip it, honest additive-only
+    // behaviour). The design-dir branch above applies the same filename
+    // check for the same reason.
+    for dir in &args.search_paths {
+        use mununu_core::adapter::yosys::source_manifest;
+        let files = source_manifest::discover_sv_files(dir, &args.exclude)?;
+        for (p, content) in files {
+            if let Ok(c) = p.canonicalize()
+                && !seen.insert(c)
+            {
+                continue;
+            }
+            let name = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("source.sv")
+                .to_string();
+            // Suppress name collisions with the primary (its file_name) or
+            // any already-staged additional source. A rare-but-possible case
+            // is a search-path directory that mirrors the primary's own
+            // filename — better to silently prefer the primary than emit two
+            // modules of the same name to yosys.
+            let primary_name = file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            if name == primary_name || additional_sources.iter().any(|(n, _)| n == &name) {
+                continue;
+            }
+            additional_sources.push((name, content));
+        }
     }
     Ok(mununu_core::adapter::sv_verify::SvLift {
         source,
@@ -8161,5 +8254,189 @@ mod controller_ctxdsl_tests {
         assert!(dsl.contains("transition "), "{dsl}");
         // The emitted controller CTXDSL is valid, re-loadable syntax.
         parse(&dsl).expect("emitted controller ctxdsl parses");
+    }
+}
+
+#[cfg(test)]
+mod sv_lift_search_path_tests {
+    //! mununu#475 item 3 — `--search-path <DIR>` discovers and stages every
+    //! `.v` / `.sv` under DIR alongside the primary file, so a single-file
+    //! lift with cross-directory submodule instantiations resolves without
+    //! the caller hand-listing every `--source`. Deduplicates against the
+    //! primary and explicit `--source` entries by canonical path.
+    use super::{SvFrontendArg, SvLiftArgs, read_sv_lift};
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn args(
+        file: Option<PathBuf>,
+        sources: Vec<PathBuf>,
+        search_paths: Vec<PathBuf>,
+        exclude: Vec<String>,
+    ) -> SvLiftArgs {
+        SvLiftArgs {
+            file,
+            design_dir: None,
+            exclude,
+            search_paths,
+            sources,
+            top: None,
+            preprocess_sv2v: false,
+            include_dirs: Vec::new(),
+            frontend: SvFrontendArg::Auto,
+        }
+    }
+
+    #[test]
+    fn search_path_discovers_cross_directory_submodules() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        // Reporter's shape: mem_sched.sv in one dir, slot_arbiter.sv in a peer dir.
+        for (rel, body) in [
+            ("mem_sched/mem_sched.sv", "module mem_sched; endmodule\n"),
+            ("lib/slot_arbiter.sv", "module slot_arbiter; endmodule\n"),
+            ("lib/util.sv", "module util; endmodule\n"),
+        ] {
+            let p = root.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, body).unwrap();
+        }
+        let a = args(
+            Some(root.join("mem_sched/mem_sched.sv")),
+            Vec::new(),
+            vec![root.join("lib")],
+            Vec::new(),
+        );
+        let lift = read_sv_lift(&a).expect("read_sv_lift with --search-path");
+        let names: Vec<&str> = lift
+            .additional_sources
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert!(
+            names.contains(&"slot_arbiter.sv"),
+            "search-path should stage cross-dir modules: {names:?}"
+        );
+        assert!(
+            names.contains(&"util.sv"),
+            "search-path scans DIR recursively: {names:?}"
+        );
+    }
+
+    #[test]
+    fn search_path_dedupes_against_primary_and_source_entries() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        for (rel, body) in [
+            ("primary.sv", "module top; endmodule\n"),
+            ("explicit.sv", "module explicit; endmodule\n"),
+            ("libdir/primary.sv", "module dup_top; endmodule\n"),
+            ("libdir/explicit.sv", "module dup_explicit; endmodule\n"),
+            ("libdir/unique.sv", "module unique; endmodule\n"),
+        ] {
+            let p = root.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, body).unwrap();
+        }
+        // Primary + one explicit --source; search-path libdir also contains
+        // a file named `primary.sv` and one named `explicit.sv` — those are
+        // DIFFERENT files on disk (different content), so canonical-path
+        // dedup keeps both because they have distinct paths. The dedup only
+        // fires if a search-path file IS the same file (same canonical path)
+        // as the primary or an explicit source.
+        let a = args(
+            Some(root.join("primary.sv")),
+            vec![root.join("explicit.sv")],
+            vec![root.join("libdir")],
+            Vec::new(),
+        );
+        let lift = read_sv_lift(&a).expect("read_sv_lift with --search-path + --source");
+        // Now the same test but with libdir ALSO listing the primary file as a symlink /
+        // duplicate. We use the primary itself via search-path to force a canonical-path
+        // collision.
+        let a2 = args(
+            Some(root.join("primary.sv")),
+            vec![root.join("explicit.sv")],
+            vec![root.to_path_buf()],
+            Vec::new(),
+        );
+        let lift2 = read_sv_lift(&a2).expect("read_sv_lift with root search-path");
+        // The primary `primary.sv` and the explicit `explicit.sv` must not appear
+        // twice — dedup by canonical path suppresses them from the search-path scan.
+        let primary_count = lift2
+            .additional_sources
+            .iter()
+            .filter(|(n, _)| n == "primary.sv")
+            .count();
+        let explicit_count = lift2
+            .additional_sources
+            .iter()
+            .filter(|(n, _)| n == "explicit.sv")
+            .count();
+        assert_eq!(
+            primary_count,
+            0,
+            "the primary file must NOT appear in additional_sources: {:?}",
+            lift2
+                .additional_sources
+                .iter()
+                .map(|(n, _)| n)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            explicit_count,
+            1,
+            "the explicit --source must appear exactly once: {:?}",
+            lift2
+                .additional_sources
+                .iter()
+                .map(|(n, _)| n)
+                .collect::<Vec<_>>()
+        );
+        // Sanity: the first lift found the libdir extras (different files).
+        let names: Vec<&str> = lift
+            .additional_sources
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert!(
+            names.contains(&"unique.sv"),
+            "libdir/unique.sv should be present: {names:?}"
+        );
+    }
+
+    #[test]
+    fn search_path_honours_exclude() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        for (rel, body) in [
+            ("primary.sv", "module top; endmodule\n"),
+            ("lib/util.sv", "module util; endmodule\n"),
+            ("lib/faulty/bad.sv", "module bad; endmodule\n"),
+        ] {
+            let p = root.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, body).unwrap();
+        }
+        let a = args(
+            Some(root.join("primary.sv")),
+            Vec::new(),
+            vec![root.join("lib")],
+            vec!["faulty".to_string()],
+        );
+        let lift = read_sv_lift(&a).expect("read_sv_lift with --search-path --exclude");
+        let names: Vec<&str> = lift
+            .additional_sources
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert!(
+            names.contains(&"util.sv"),
+            "util.sv should stage: {names:?}"
+        );
+        assert!(
+            !names.contains(&"bad.sv"),
+            "--exclude faulty must also filter search-path scans: {names:?}"
+        );
     }
 }

--- a/docs/consumer-briefings/2026-08-sv-search-path.md
+++ b/docs/consumer-briefings/2026-08-sv-search-path.md
@@ -1,0 +1,73 @@
+# Consumer briefing — 2026-08 `sv lint` / verify verbs `--search-path <DIR>` (mununu#475 item 3)
+
+> **Audience:** primarily **monono** (the adoption reporter for the cross-directory submodule gap), secondarily **ROSF** (no direct impact; touches CLI-only surface).
+>
+> **Fix:** mununu#475 item 3, closing the fifth of five ergonomics gaps in the original report. The prior four items shipped in the previous briefing at [`2026-08-sv-lint-mutate-ergonomics.md`](2026-08-sv-lint-mutate-ergonomics.md).
+>
+> **User-facing docs:** [`docs/verifying-rtl.md`](../verifying-rtl.md) §`sv lint` — the new "Recent additions" callout on `--search-path`.
+>
+> **TL;DR:** one new CLI flag `--search-path <DIR>` on the shared SV-lift args (so every `sv` verb inherits it) unblocks the last piece of monono's whole-tree workflow — single-file lifts with cross-directory submodule instantiations. No verdict semantics change; the plumbing is additive-only.
+
+## What changed
+
+- **`--search-path <DIR>`** on `SvLiftArgs` — inherited by `sv verify`, `sv verify-auto`, `sv verify-liveness`, `sv verify-liveness-all`, `sv verify-recoverability`, `sv check-fsm`, `sv cegar`, `sv lint`, `sv mutate`, `sv extract-sva`. Recursively scans DIR for `.v` / `.sv` files (using `discover_sv_files`, same walker `--design-dir` uses) and stages them alongside the primary input. Honours `--exclude` — the same directory-component skip list applies to the scan.
+- **Dedup discipline** — the scanner suppresses two collision classes: canonical-path collisions (the same file listed via both `--source` and `--search-path`) and short-name collisions (a search-path file with the same filename as the primary or a staged source — yosys would error on duplicate module names). Silently additive.
+- **Composable with `--design-dir`** — a primary block from `--design-dir` plus sibling libraries from one or more `--search-path <DIR>` invocations, for a design + peer-utility layout.
+
+## What did NOT change
+
+- `PropertyVerdict` — unchanged.
+- `AutoVerifyReport` — unchanged.
+- Existing CLI flags — unchanged shape and semantics.
+- HTTP API routes — unchanged. `--search-path` is CLI-only (like `--design-dir` / `--include-dir` / `--exclude` — an on-disk directory scan has no analog on the API/UI, whose flat name-staging already lets the caller stage whichever sources they want).
+- Engine behaviour on any previously-decided property — unchanged.
+
+## For monono-agents (direct CLI consumer)
+
+**What to update on your side:** at minimum, nothing — old commands still work. To adopt the new flag on the previously-blocked 53/109 files:
+
+- Replace hand-listed `--source` chains with `mununu sv lint <primary.sv> --search-path <peer_lib_dir>`. `--search-path` is repeatable if peers live in more than one directory.
+- Combine with `--exclude` if your tree has directories the search-path scan should skip: `mununu sv lint <primary.sv> --search-path <peers> --exclude faulty`.
+- If you were previously working around the gap by pointing `--design-dir` at a parent directory, that still works and remains the right choice when you want the whole tree treated as one design; `--search-path` is the answer when you want ONE primary file with a set of module-dependency directories staged.
+
+**What to expect:** the reporter's `mem_sched.sv` → `slot_arbiter` case should now lift cleanly under `sv lint mem_sched.sv --search-path <lib_dir>`. The 53/109-unliftable count in the reporter's tree should drop toward zero for any file whose only lift blocker was cross-directory module resolution.
+
+**Docker rebuild:** monono's Docker (if any) needs rebuild only if it pins a specific mununu binary version. No sidecar or config change required.
+
+## For ROSF-agents (subprocess `--profile industrial`)
+
+**What to update on your side:** nothing required. This PR doesn't touch the `--profile industrial` verify-auto engine path, and `--search-path` is CLI-only (the API stages sources by name, so directory-scan flags have no analog there).
+
+**What to expect:** if ROSF ever shells out to the mununu CLI directly (as opposed to via the industrial-profile API path) and hits a cross-directory submodule case, `--search-path` is available.
+
+**Docker rebuild:** `rosf/docker/Dockerfile` needs rebuild only if it pins a specific mununu binary version.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod CLI) | binary carries one new CLI flag `--search-path` | Yes if consumers pin a version tag |
+| mununu `Dockerfile.dev` | binary bump | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; no e2e-test behaviour change | Only if a downstream requires the new binary |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `docker/Dockerfile` | consumes mununu subprocess; no engine-behaviour change in this PR | Only if pinned to a version tag; behavior updates on next binary pull otherwise |
+| rosf `docker/Dockerfile.dev`, `.hw` | no direct dependence on the changed paths | No |
+| monono Docker (any) | consumes `sv lint` and `sv verify-auto` CLI | Only if pinned to a version tag |
+
+## Shared footer — verification you should run after adopting
+
+1. **Confirm the cross-directory unblock**: run `mununu sv lint <primary.sv> --search-path <peer_dir>` on a case that previously errored with `unknown module`. It should lift cleanly.
+2. **Confirm `--exclude` composition**: `mununu sv lint <primary.sv> --search-path <peer_dir> --exclude <bad_subdir>` should skip the excluded subtree just as `--design-dir --exclude` does.
+3. **Confirm the composability with `--design-dir`**: `mununu sv verify-auto --design-dir <block> --search-path <peer_libs>` should stage BOTH the block's own files AND the peer-lib scans, deduped.
+
+## Provenance
+
+- Fix commit: (pending merge — see branch `fix/475-search-path-single-file` in the mununu repo)
+- Issue: mununu#475 item 3 — <https://github.com/vscorza/mununu/issues/475>
+- Policy this briefing was written to satisfy: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md)
+- Sibling briefing (items 1, 2, 4, 5): [`2026-08-sv-lint-mutate-ergonomics.md`](2026-08-sv-lint-mutate-ergonomics.md)
+
+## Not covered here (follow-ups)
+
+- **API/UI parity** for `--search-path`. The design deliberately keeps this CLI-only (matches `--design-dir`, `--include-dir`, `--exclude` — an on-disk directory scan has no meaningful API analog).
+- **`--filelist <PATH>`** — the alternative to `--search-path`, accepting a filelist.f-style file listing sources. Not needed for the reporter's case; a future add if a filelist-driven workflow emerges.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -450,6 +450,20 @@ case demands it). The reporter's whole-tree workflow —
 `mununu sv lint --design-dir <root> --exclude faulty` — is now reachable
 without adding to the hardcoded list.
 
+**`--search-path <DIR>` for single-file cross-directory submodules** (2026-08,
+mununu#475 item 3). A single-file input that instantiates a submodule from a
+sibling directory (`mem_sched.sv` → `slot_arbiter` from a peer dir — 53/109
+unliftable files in monono's tree) previously errored with `unknown module`.
+`--search-path <DIR>` recursively discovers every `.v` / `.sv` under DIR and
+stages them alongside the primary input, so cross-directory instantiations
+resolve without hand-listing every `--source`. Deduplicates against the
+primary file and any explicit `--source` entries by canonical path, and
+suppresses short-name collisions (a search-path file with the same filename
+as the primary or a staged source is silently skipped rather than emit two
+modules of the same name to yosys). The same `--exclude` list filters the
+scan. Repeatable. Composable with `--design-dir` — a primary block plus
+sibling libraries — for a design + peer-utility layout.
+
 ## Are the properties adequate? `sv mutate`
 
 > Source of truth: [`mutate_and_compare`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L1824) — surface: (CLI+API+UI)


### PR DESCRIPTION
## Summary

Closes the fifth of five ergonomics gaps in monono's #475 adoption report (items 1, 2, 4, 5 shipped in #479). New `--search-path <DIR>` flag on the shared `SvLiftArgs`, inherited by every SV verb (verify, verify-auto, verify-liveness[-all], verify-recoverability, check-fsm, cegar, lint, mutate, extract-sva).

- Recursively scans DIR for `.v`/`.sv` sources via the same `discover_sv_files` walker `--design-dir` uses. Honours `--exclude`. Repeatable.
- Two dedup passes: canonical-path (same file via `--source` + `--search-path`) and short-filename (a search-path file whose filename collides with the primary or a staged source — yosys would otherwise error on duplicate module names).
- Composable with `--design-dir`: a primary block + peer libraries.
- Surface parity: CLI-only, matching `--design-dir` / `--include-dir` / `--exclude` (on-disk directory scan has no meaningful API analog).

## Reporter's use case

monono's tree has 53/109 files that don't lift standalone because `mem_sched.sv` instantiates `slot_arbiter` from a sibling directory, and slang errors with `unknown module 'slot_arbiter'`. After this PR: `mununu sv lint mem_sched.sv --search-path <lib_dir>` resolves cleanly.

## Cross-repo & policy

- Consumer briefing (per [`docs/policies/cross-repo-impact.md`](../blob/fix/475-search-path-single-file/docs/policies/cross-repo-impact.md)): [`docs/consumer-briefings/2026-08-sv-search-path.md`](../blob/fix/475-search-path-single-file/docs/consumer-briefings/2026-08-sv-search-path.md) — role-branching for monono (primary reporter) + ROSF (no direct impact).
- User-facing doc: [`docs/verifying-rtl.md`](../blob/fix/475-search-path-single-file/docs/verifying-rtl.md) — new "Recent additions" callout on `--search-path` under `sv lint`.

## Docker rebuild disposition

| Image | Impact | Rebuild required? |
|-------|--------|-------------------|
| mununu `Dockerfile` (prod CLI) | binary carries one new CLI flag | Yes if consumers pin a version tag |
| mununu `Dockerfile.dev` | binary bump | Only if the dev workflow requires the new binary |
| mununu `Dockerfile.sva` | binary bump; no e2e-test behaviour change | Only if a downstream requires the new binary |
| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
| rosf/monono Docker | consumes mununu CLI | Only if version-pinned; behavior updates on next binary pull otherwise |

## What did NOT change

- `PropertyVerdict` semantics — unchanged.
- `AutoVerifyReport` shape — unchanged.
- Existing CLI flags — unchanged shape and semantics.
- HTTP API routes — unchanged. `--search-path` is CLI-only.
- Engine behaviour on any previously-decided property — unchanged.

## Test plan

- [x] `cargo test -p mununu-cli --bin mununu -- sv_lift_search_path` — 3/3 new regressions:
  - `search_path_discovers_cross_directory_submodules` (reporter's case)
  - `search_path_dedupes_against_primary_and_source_entries` (canonical + short-name dedup)
  - `search_path_honours_exclude` (composition with item 2's flag)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p mununu-cli -- -D warnings` clean
- [x] Pre-commit hook (fmt + clippy + tests on touched crates + doctests) clean
- [x] Pre-push hook (trimmed suite + `cargo machete`) clean
- [ ] `cargo test --workspace` — CI's job

## Follow-ups explicitly NOT in this PR

- **API/UI parity** for `--search-path` — deliberately CLI-only.
- **`--filelist <PATH>`** — alternative filelist.f-style workflow; not needed for the reporter's case.

Fixes #475 (item 3 — final of five)

🤖 Generated with [Claude Code](https://claude.com/claude-code)