### PR TITLE
feat(api): `sv/mutate` accepts `params` for API/UI parity with the CLI (#475 item 4 follow-up)

### DIFF
--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1418,6 +1418,32 @@ fn sv_mutate_handler_impl(request: SvMutateRequest) -> ApiResult<Json<SvMutateRe
     for f in &request.additional_sources {
         sources.push((f.name.clone(), f.content.clone()));
     }
+    // mununu#475 item 4 — --param API parity. Same parse shape as the CLI
+    // + as `sv verify-auto`'s params: `NAME=VALUE` or `MODULE.NAME=VALUE`,
+    // both sides non-empty. A malformed entry is a HARD BadRequest here;
+    // yosys errors downstream on a parameter it cannot apply.
+    let params: Vec<(String, String)> = request
+        .params
+        .iter()
+        .map(|e| {
+            let (lhs, val) = e.split_once('=').ok_or_else(|| ApiError::BadRequest {
+                message: format!(
+                    "malformed `params` entry '{e}': expected NAME=VALUE or MODULE.NAME=VALUE"
+                ),
+                details: None,
+            })?;
+            let (lhs, val) = (lhs.trim(), val.trim());
+            if lhs.is_empty() || val.is_empty() {
+                return Err(ApiError::BadRequest {
+                    message: format!(
+                        "malformed `params` entry '{e}': NAME and VALUE must both be non-empty"
+                    ),
+                    details: None,
+                });
+            }
+            Ok((lhs.to_string(), val.to_string()))
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
     let yopts = YosysOptions {
         top: request.top.clone(),
         additional_sources: request
@@ -1431,6 +1457,7 @@ fn sv_mutate_handler_impl(request: SvMutateRequest) -> ApiResult<Json<SvMutateRe
         } else {
             SvFrontend::Auto
         },
+        params,
         ..Default::default()
     };
 

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1389,6 +1389,17 @@ pub struct SvMutateRequest {
     /// recoverability property under `drop-reset`). Default off.
     #[serde(default)]
     pub must_edge_inference: Option<String>,
+    /// mununu#475 item 4 — parity with `POST /api/v1/sv/verify-auto`'s
+    /// `params`. Override module parameters BEFORE elaboration. Each entry
+    /// is `"NAME=VALUE"` (top-module scope) or `"MODULE.NAME=VALUE"`
+    /// (submodule scope; slang applies it top-level by bare name).
+    /// Shrinks a parameterised design so its counters fit the bit-blast
+    /// cap during the baseline + mutant re-verify; blocks that need
+    /// `params` to verify at all could not previously be mutated via the
+    /// API. A malformed entry is a HARD `BadRequest`; yosys errors
+    /// downstream on a parameter it cannot apply — never a silent drop.
+    #[serde(default)]
+    pub params: Vec<String>,
 }
 
 /// The mutation targets available in a design (the `list` response payload).

--- a/docs/consumer-briefings/2026-08-sv-mutate-param-api-parity.md
+++ b/docs/consumer-briefings/2026-08-sv-mutate-param-api-parity.md
@@ -1,0 +1,52 @@
+# Consumer briefing — 2026-08 `sv mutate` `params` API/UI parity (mununu#475 item 4 follow-up)
+
+> **Audience:** primarily **ROSF** and **monono** if either drives `POST /api/v1/sv/mutate` (rather than the CLI directly), plus the mununu-ui typed client.
+>
+> **Related:** the CLI-side landing of `--param` for `sv mutate` shipped in PR mununu#479. The prior briefing [`2026-08-sv-lint-mutate-ergonomics.md`](2026-08-sv-lint-mutate-ergonomics.md) explicitly listed API/UI parity as a follow-up. This closes it.
+>
+> **TL;DR:** `SvMutateRequest.params: string[]` is now accepted by the API and typed on the UI client. Same parse shape as the sibling `sv/verify-auto` endpoint: each entry is `"NAME=VALUE"` (top-module) or `"MODULE.NAME=VALUE"` (submodule scope). Backward-compatible; consumers that don't send `params` see zero behavioural change.
+
+## What changed
+
+- **`crates/mununu-core/src/api/models.rs`** — added `params: Vec<String>` (with `#[serde(default)]`) to `SvMutateRequest`.
+- **`crates/mununu-core/src/api/handlers.rs`** — `sv_mutate_handler_impl` parses each entry the same way `sv verify-auto`'s CLI + API do (both sides non-empty; hard `BadRequest` on malformed) and threads into `YosysOptions::params`.
+- **`mununu-ui/src/api/endpoints.ts`** — added `params?: string[]` to the `SvMutateRequest` interface.
+
+## What did NOT change
+
+- `PropertyVerdict` — unchanged.
+- `SvMutateResponse` — unchanged (params are input-side only).
+- Route `POST /api/v1/sv/mutate` — unchanged.
+- Existing request fields on `SvMutateRequest` — unchanged shape and semantics.
+- Engine behaviour on any previously-decided property — unchanged.
+
+## For ROSF and monono
+
+**What to update:** nothing forced. To adopt: send `"params": ["ROW_BITS=2", "COL_BITS=3"]` (or similar) alongside your existing mutate request when the block needs parameter shrinkage to lift under the bit-blast cap. Malformed values (missing `=`, empty NAME or VALUE) return HTTP 400 with a descriptive message — never a silent drop.
+
+**Docker rebuild:** required only if a consumer pins a specific mununu binary version. Otherwise the field appears on the next binary pull; existing requests continue to work with an empty `params`.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod CLI + API server) | one new optional request field | Yes if consumers pin a version tag |
+| mununu `Dockerfile.dev` | binary bump | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; no e2e-test behaviour change | Only if a downstream requires the new binary |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `docker/Dockerfile` | consumes mununu subprocess and/or API | Only if pinned to a version tag |
+| rosf `docker/Dockerfile.dev`, `.hw` | no direct dependence | No |
+| monono Docker (any) | consumes CLI + potentially API | Only if pinned to a version tag |
+| mununu-ui deployment | new typed field on `SvMutateRequest` | Rebuild + redeploy on the ui-side change |
+
+## Provenance
+
+- Fix commit (mununu-side): (pending merge — branch `fix/api-ui-parity-sv-mutate-param`).
+- Fix commit (mununu-ui-side): landed independently — matching `params?: string[]` field.
+- Issue: mununu#475 item 4 — API/UI parity follow-up.
+- Policy this briefing satisfies: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+- Sibling briefing (CLI-side landing): [`2026-08-sv-lint-mutate-ergonomics.md`](2026-08-sv-lint-mutate-ergonomics.md).
+
+## Not covered here
+
+- `--exclude` and `--search-path` API/UI parity — deliberately CLI-only. On-disk directory scans have no API analog (the API stages sources by name). The docstrings on those flags carry the `surface: CLI-only` exemption per CLAUDE.md's Surface Parity rule.


### PR DESCRIPTION
## Summary

Closes the API/UI parity follow-up flagged in [`docs/consumer-briefings/2026-08-sv-lint-mutate-ergonomics.md`](../blob/fix/api-ui-parity-sv-mutate-param/docs/consumer-briefings/2026-08-sv-lint-mutate-ergonomics.md). The CLI-side `--param` landed in #479; this PR mirrors it on the API + UI.

- `SvMutateRequest.params: Vec<String>` (`#[serde(default)]` — additive, no breaking change).
- `sv_mutate_handler_impl` parses each entry the same way `sv verify-auto` does (both sides non-empty; hard `BadRequest` on malformed) and threads into `YosysOptions::params`.
- Matching `params?: string[]` field lands in mununu-ui at `fix/sv-mutate-params-api-parity` (independent PR).

## What did NOT change

- `PropertyVerdict` — unchanged.
- `SvMutateResponse` — unchanged (params are input-only).
- Route `POST /api/v1/sv/mutate` — unchanged.
- Existing `SvMutateRequest` fields — unchanged shape and semantics.
- Engine behaviour on any previously-decided property — unchanged.

## Docker rebuild disposition

| Image | Impact | Rebuild required? |
|-------|--------|-------------------|
| mununu `Dockerfile` (prod CLI + API) | one new optional request field | Yes if consumers pin a version tag |
| mununu `Dockerfile.dev` / `.sva` | binary bump | Only if the workflow requires the new binary |
| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
| rosf/monono Docker | consumes mununu subprocess/API | Only if version-pinned; behavior updates on next binary pull otherwise |
| mununu-ui deployment | new typed field on `SvMutateRequest` | Rebuild + redeploy on the ui-side change |

## Cross-repo & policy

- Consumer briefing (per [`docs/policies/cross-repo-impact.md`](../blob/fix/api-ui-parity-sv-mutate-param/docs/policies/cross-repo-impact.md)): [`docs/consumer-briefings/2026-08-sv-mutate-param-api-parity.md`](../blob/fix/api-ui-parity-sv-mutate-param/docs/consumer-briefings/2026-08-sv-mutate-param-api-parity.md).
- `--exclude` and `--search-path` are DELIBERATELY CLI-only (marked `surface: CLI-only` in their docstrings per CLAUDE.md's Surface Parity rule). On-disk directory scans have no API analog.

## Test plan

- [x] `cargo check -p mununu-core --lib --features api` clean
- [x] `cargo clippy -p mununu-core --lib --features api -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Pre-commit hook (fmt + clippy + tests on touched crates + doctests) clean
- [ ] `cargo test --workspace` — CI's job
- [ ] Live API smoke test against a small parameterised mutate case (post-merge)

Fixes: mununu#475 item 4 API parity (CLI landed in #479; ui matching PR is `vscorza/mununu-ui#fix/sv-mutate-params-api-parity`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)