### PR TITLE
feat(sva): `--no-antecedent-shadow` CLI + API for per-request opt-out (#476 item 4)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -1756,6 +1756,18 @@ struct SvVerifyAutoArgs {
     /// this to report the cube's ⊥ verdict unchanged for both.
     #[arg(long = "no-rescue")]
     no_rescue: bool,
+    /// mununu#476 item 4 — disable antecedent shadow-register synthesis for
+    /// the exact-symbolic engine. By default (shipped as of mununu#478), an
+    /// SVA `|=>` property whose antecedent combinationally reaches primary
+    /// inputs gets an automatic shadow-register rewrite and DECIDES; pass
+    /// this to force the Phase A refusal instead (properties `Skipped` with
+    /// the "combinationally driven by primary input" message). Differential-
+    /// oracle / debug use — production runs should leave this unset. Mirrored
+    /// on the API as `no_antecedent_shadow: true` and via the process-global
+    /// `MUNUNU_NO_ANTECEDENT_SHADOW=1` env var (per-request opt-out here is
+    /// thread-safe; the env var is not).
+    #[arg(long = "no-antecedent-shadow")]
+    no_antecedent_shadow: bool,
     /// H.J.b — config concretization: pin a wide config input to a constant so
     /// comparisons against it become decidable (e.g. a timer threshold).
     /// Repeatable; format `SIGNAL=VALUE` (e.g. `--config-value
@@ -3687,6 +3699,8 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         rescue_bottom_recoverability: !args.no_rescue,
         // `sv verify-auto` verifies the design as-lifted; mutation is the `sv mutate` verb's job.
         mutation: None,
+        // mununu#476 item 4 — --no-antecedent-shadow reverts to the Phase A refusal.
+        antecedent_shadow: !args.no_antecedent_shadow,
     };
 
     let report = verify_auto(&sources, &yopts, &opts)

--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2905,7 +2905,66 @@ pub fn exact_symbolic_verdict_with_witness(
     btor2_content: &str,
     formula: &Formula,
 ) -> Result<(ExactVerdict, Option<StallLasso>), String> {
-    verdict_with_witness_catching(btor2_content, formula, &std::collections::HashSet::new())
+    verdict_with_witness_catching(
+        btor2_content,
+        formula,
+        &std::collections::HashSet::new(),
+        &ExactSymbolicOptions::default(),
+    )
+}
+
+/// Options for the exact-symbolic engine — thread-safe per-invocation overrides
+/// for behaviours that were previously env-var-only. Introduced 2026-08 to
+/// support `--no-antecedent-shadow` (CLI) / `no_antecedent_shadow` (API) as
+/// proper per-request opt-outs; the env-var `MUNUNU_NO_ANTECEDENT_SHADOW=1`
+/// remains as a process-global escape hatch (differential-oracle / debug),
+/// and either channel disabling shadow-synth wins (`false && env-var`).
+#[derive(Debug, Clone, Copy)]
+pub struct ExactSymbolicOptions {
+    /// Whether antecedent shadow-register synthesis (mununu#476 fix) is
+    /// enabled. Defaults to `true`; set to `false` to force the Phase A
+    /// refusal for SVA `|=>` properties with input-derived antecedents, so a
+    /// caller can differentially verify the shadow-synth verdict against the
+    /// refusal path or reproduce pre-mununu#476 behaviour.
+    pub antecedent_shadow_enabled: bool,
+}
+
+impl Default for ExactSymbolicOptions {
+    fn default() -> Self {
+        Self {
+            antecedent_shadow_enabled: true,
+        }
+    }
+}
+
+/// Opts-accepting variant of [`exact_symbolic_verdict`]. Same semantics; the
+/// only per-call knob today is [`ExactSymbolicOptions::antecedent_shadow_enabled`].
+pub fn exact_symbolic_verdict_with_options(
+    btor2_content: &str,
+    formula: &Formula,
+    opts: &ExactSymbolicOptions,
+) -> Result<ExactVerdict, String> {
+    verdict_with_witness_catching(
+        btor2_content,
+        formula,
+        &std::collections::HashSet::new(),
+        opts,
+    )
+    .map(|(v, _)| v)
+}
+
+/// Opts-accepting variant of [`exact_symbolic_verdict_with_witness`].
+pub fn exact_symbolic_verdict_with_witness_and_options(
+    btor2_content: &str,
+    formula: &Formula,
+    opts: &ExactSymbolicOptions,
+) -> Result<(ExactVerdict, Option<StallLasso>), String> {
+    verdict_with_witness_catching(
+        btor2_content,
+        formula,
+        &std::collections::HashSet::new(),
+        opts,
+    )
 }
 
 /// P2.5-F — the SOUND-POSTURE two-player game model: exclude the CLOCK and RESET from the adversary.
@@ -2972,7 +3031,13 @@ pub fn exact_two_player_verdict(
 ) -> Result<ExactVerdict, String> {
     let set: std::collections::HashSet<String> =
         controllable.iter().map(|s| s.to_string()).collect();
-    verdict_with_witness_catching(btor2_content, formula, &set).map(|(v, _)| v)
+    verdict_with_witness_catching(
+        btor2_content,
+        formula,
+        &set,
+        &ExactSymbolicOptions::default(),
+    )
+    .map(|(v, _)| v)
 }
 
 /// P2.5-F — is the controllable-reachability game to `good` REALIZABLE? Builds the reachability formula
@@ -3242,9 +3307,10 @@ fn verdict_with_witness_catching(
     btor2_content: &str,
     formula: &Formula,
     controllable: &std::collections::HashSet<String>,
+    opts: &ExactSymbolicOptions,
 ) -> Result<(ExactVerdict, Option<StallLasso>), String> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        exact_symbolic_verdict_with_witness_inner(btor2_content, formula, controllable)
+        exact_symbolic_verdict_with_witness_inner(btor2_content, formula, controllable, opts)
     }))
     .unwrap_or_else(|_| {
         Err(
@@ -3260,6 +3326,7 @@ fn exact_symbolic_verdict_with_witness_inner(
     btor2_content: &str,
     formula: &Formula,
     controllable: &std::collections::HashSet<String>,
+    opts: &ExactSymbolicOptions,
 ) -> Result<(ExactVerdict, Option<StallLasso>), String> {
     let file = crate::adapter::btor2::parser::parse(btor2_content)
         .map_err(|e| format!("adapter/btor2/exact MC: {}", e.message))?;
@@ -3271,10 +3338,17 @@ fn exact_symbolic_verdict_with_witness_inner(
     // rewritten formula are then handed to the rest of this fn. Atoms that
     // cannot be shadowed (see `RefusalReason`) fall through to the Phase A
     // refusal below. See `docs/design/antecedent-shadow-synthesis.md` for the
-    // full design + soundness argument. `MUNUNU_NO_ANTECEDENT_SHADOW=1` opts out
-    // (differential-oracle / debug use).
+    // full design + soundness argument.
+    //
+    // Two orthogonal opt-out channels; EITHER disabling wins:
+    //   1. `opts.antecedent_shadow_enabled = false` — per-invocation opt-out
+    //      threaded from CLI (`--no-antecedent-shadow`) / API
+    //      (`no_antecedent_shadow: true`). Thread-safe, per-request.
+    //   2. `MUNUNU_NO_ANTECEDENT_SHADOW=1` env var — process-global escape
+    //      hatch for differential-oracle / debug use.
     let (file, rewritten_formula) = {
-        let opt_out = std::env::var("MUNUNU_NO_ANTECEDENT_SHADOW").is_ok();
+        let opt_out =
+            !opts.antecedent_shadow_enabled || std::env::var("MUNUNU_NO_ANTECEDENT_SHADOW").is_ok();
         let antecedents = crate::mu_calculus::detect_pipeimplies_antecedent_atoms(formula);
         if !opt_out && !antecedents.is_empty() {
             let synth = crate::adapter::btor2::antecedent_shadow::synthesize_shadows(
@@ -7772,17 +7846,19 @@ mod tests {
             "with shadow-synth, `mem_rvalid_mine |=> (q == 0)` where q'=0 always Holds",
         );
 
-        // Opt-out (MUNUNU_NO_ANTECEDENT_SHADOW=1) restores the Phase A refusal
-        // even for `|=>` shapes — the differential-oracle / debug knob.
-        // SAFETY: single-threaded test; env-var mutation is scoped to this call.
-        unsafe {
-            std::env::set_var("MUNUNU_NO_ANTECEDENT_SHADOW", "1");
-        }
-        let err = exact_symbolic_verdict(BTOR2, &formula)
-            .expect_err("opt-out must revert to the Phase A transitive-fan-in refusal");
-        unsafe {
-            std::env::remove_var("MUNUNU_NO_ANTECEDENT_SHADOW");
-        }
+        // Opt-out via the thread-safe options channel (`--no-antecedent-shadow`
+        // CLI / `no_antecedent_shadow: true` API — mununu#476 item 4). Restores
+        // the Phase A refusal even for `|=>` shapes. Env-var opt-out
+        // (`MUNUNU_NO_ANTECEDENT_SHADOW=1`) is the equivalent process-global
+        // channel; either channel disabling shadow-synth wins.
+        let err = exact_symbolic_verdict_with_options(
+            BTOR2,
+            &formula,
+            &ExactSymbolicOptions {
+                antecedent_shadow_enabled: false,
+            },
+        )
+        .expect_err("opt-out must revert to the Phase A transitive-fan-in refusal");
         assert!(
             err.contains("combinationally driven by primary input"),
             "opt-out refusal should still be the Phase A message: {err}"

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -809,6 +809,18 @@ pub struct VerifyAutoOptions {
     /// `verify-auto` surfaces never populate it. See
     /// [`crate::adapter::btor2::mutate`].
     pub mutation: Option<crate::adapter::btor2::mutate::Mutation>,
+    /// mununu#476 item 4 — whether antecedent shadow-register synthesis is
+    /// enabled for the exact-symbolic engine. `true` (default) matches the
+    /// shipped shadow-synth behaviour: SVA `|=>` properties whose antecedent
+    /// combinationally reaches primary inputs get an automatic shadow-register
+    /// rewrite and DECIDE. `false` reverts to the Phase A transitive-fan-in
+    /// refusal (properties `Skipped` with the "combinationally driven by
+    /// primary input" message) — the differential-oracle / debug knob, mirrored
+    /// on the CLI as `--no-antecedent-shadow` and on the API as
+    /// `no_antecedent_shadow: true`. The process-global
+    /// `MUNUNU_NO_ANTECEDENT_SHADOW=1` env var is the third channel; either
+    /// channel disabling shadow-synth wins.
+    pub antecedent_shadow: bool,
 }
 
 /// PORTFOLIO scheduling mode — the budget knob for the multi-engine default.
@@ -867,6 +879,7 @@ impl Default for VerifyAutoOptions {
             rescue_bottom_liveness: true,
             rescue_bottom_recoverability: true,
             mutation: None,
+            antecedent_shadow: true,
         }
     }
 }
@@ -2600,41 +2613,47 @@ pub(crate) fn verify_auto_impl(
         // (build errors above the bit cap ⇒ Skipped).
         if opts.exact_symbolic {
             use crate::adapter::btor2::symbolic_bitblast::{
-                ExactVerdict, exact_symbolic_verdict_with_witness,
+                ExactSymbolicOptions, ExactVerdict, exact_symbolic_verdict_with_witness_and_options,
             };
-            let (outcome, counterexample) =
-                match exact_symbolic_verdict_with_witness(&btor2, &formula) {
-                    Ok((ExactVerdict::Holds, _)) => (VerifyOutcome::Holds, None),
-                    Ok((ExactVerdict::Violated, witness)) => {
-                        // A definite full-state counterexample (not a cube tally). For a
-                        // liveness/recoverability failure (`AF p` / `AG AF p` / `AG EF p`)
-                        // the witness carries the concrete path (stall lasso / trap path).
-                        // Failing that, a bare `EF p` (reachability) violation carries the
-                        // A.4 unreachable-target witness — no trace, because the target is
-                        // simply never reached (sound under the over-approximating cut).
-                        (
-                            VerifyOutcome::Violated { false_cells: 1 },
-                            witness
-                                .map(exact_counterexample_from_lasso)
-                                .or_else(|| ef_unreachable_counterexample(&formula)),
-                        )
+            let exact_opts = ExactSymbolicOptions {
+                antecedent_shadow_enabled: opts.antecedent_shadow,
+            };
+            let (outcome, counterexample) = match exact_symbolic_verdict_with_witness_and_options(
+                &btor2,
+                &formula,
+                &exact_opts,
+            ) {
+                Ok((ExactVerdict::Holds, _)) => (VerifyOutcome::Holds, None),
+                Ok((ExactVerdict::Violated, witness)) => {
+                    // A definite full-state counterexample (not a cube tally). For a
+                    // liveness/recoverability failure (`AF p` / `AG AF p` / `AG EF p`)
+                    // the witness carries the concrete path (stall lasso / trap path).
+                    // Failing that, a bare `EF p` (reachability) violation carries the
+                    // A.4 unreachable-target witness — no trace, because the target is
+                    // simply never reached (sound under the over-approximating cut).
+                    (
+                        VerifyOutcome::Violated { false_cells: 1 },
+                        witness
+                            .map(exact_counterexample_from_lasso)
+                            .or_else(|| ef_unreachable_counterexample(&formula)),
+                    )
+                }
+                Err(e) => {
+                    // RANKING RESCUE — the bit-blaster is over-cap (a wide counter);
+                    // a recoverability `AG EF <cnt == N>` may still HOLD by a
+                    // well-founded datapath descent the exact engine can't fit. Route
+                    // it to the scalable ranking/recoverability engine before abstaining.
+                    match try_ranking_recoverability(&btor2, &formula) {
+                        Some(outcome) => (outcome, None),
+                        None => (
+                            VerifyOutcome::Skipped {
+                                reason: format!("exact symbolic MC: {e}"),
+                            },
+                            None,
+                        ),
                     }
-                    Err(e) => {
-                        // RANKING RESCUE — the bit-blaster is over-cap (a wide counter);
-                        // a recoverability `AG EF <cnt == N>` may still HOLD by a
-                        // well-founded datapath descent the exact engine can't fit. Route
-                        // it to the scalable ranking/recoverability engine before abstaining.
-                        match try_ranking_recoverability(&btor2, &formula) {
-                            Some(outcome) => (outcome, None),
-                            None => (
-                                VerifyOutcome::Skipped {
-                                    reason: format!("exact symbolic MC: {e}"),
-                                },
-                                None,
-                            ),
-                        }
-                    }
-                };
+                }
+            };
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
                 kind: t.kind,
@@ -3139,7 +3158,7 @@ pub(crate) fn rescue_skipped_via_exact(
     opts: &VerifyAutoOptions,
 ) -> Vec<VerificationNote> {
     use crate::adapter::btor2::symbolic_bitblast::{
-        ExactVerdict, exact_symbolic_verdict_with_witness,
+        ExactSymbolicOptions, ExactVerdict, exact_symbolic_verdict_with_witness_and_options,
     };
     use crate::mu_calculus::parser as mu_parser;
 
@@ -3149,6 +3168,9 @@ pub(crate) fn rescue_skipped_via_exact(
     if !opts.gate_reset || opts.exact_symbolic {
         return notes;
     }
+    let exact_opts = ExactSymbolicOptions {
+        antecedent_shadow_enabled: opts.antecedent_shadow,
+    };
     for prop in report.properties.iter_mut() {
         if !matches!(prop.outcome, VerifyOutcome::Skipped { .. }) {
             continue;
@@ -3156,7 +3178,7 @@ pub(crate) fn rescue_skipped_via_exact(
         let Ok(formula) = mu_parser::parse(&prop.formula) else {
             continue;
         };
-        match exact_symbolic_verdict_with_witness(design_btor2, &formula) {
+        match exact_symbolic_verdict_with_witness_and_options(design_btor2, &formula, &exact_opts) {
             Ok((ExactVerdict::Holds, _)) => {
                 prop.outcome = VerifyOutcome::Holds;
                 prop.counterexample = None;

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1796,6 +1796,10 @@ fn sv_verify_auto_handler_impl(
         rescue_bottom_recoverability: request.rescue_bottom_recoverability.unwrap_or(true),
         // `verify-auto` verifies the design as-lifted; mutation is the `sv mutate` verb's job.
         mutation: None,
+        // mununu#476 item 4 — per-request antecedent shadow-synth opt-out.
+        // `no_antecedent_shadow: true` reverts to the Phase A refusal; default
+        // (unspecified / false) keeps the shipped shadow-synth behaviour.
+        antecedent_shadow: !request.no_antecedent_shadow.unwrap_or(false),
     };
 
     let report = verify_auto(&sources, &yopts, &opts).map_err(|e| ApiError::BadRequest {

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1674,6 +1674,16 @@ pub struct SvVerifyAutoRequest {
     /// shape.
     #[serde(default)]
     pub rescue_bottom_recoverability: Option<bool>,
+    /// mununu#476 item 4 — disable antecedent shadow-register synthesis for
+    /// the exact-symbolic engine (default `false` ⇒ shadow-synth enabled, the
+    /// shipped behaviour). Set `true` to force the Phase A refusal for SVA
+    /// `|=>` properties whose antecedent combinationally reaches primary
+    /// inputs — the differential-oracle / debug knob mirrored on the CLI as
+    /// `--no-antecedent-shadow` and via the process-global
+    /// `MUNUNU_NO_ANTECEDENT_SHADOW=1` env var. Per-request opt-out is
+    /// thread-safe (unlike the env var, which is process-global).
+    #[serde(default)]
+    pub no_antecedent_shadow: Option<bool>,
 }
 
 /// Response for `/api/v1/sv/verify-auto`.

--- a/docs/consumer-briefings/2026-08-no-antecedent-shadow-flag.md
+++ b/docs/consumer-briefings/2026-08-no-antecedent-shadow-flag.md
@@ -1,0 +1,68 @@
+# Consumer briefing — 2026-08 `--no-antecedent-shadow` CLI + API (mununu#476 item 4)
+
+> **Audience:** ROSF (industrial-profile API consumer), monono (CLI consumer), plus any downstream that runs differential-oracle checks against the exact-symbolic engine.
+>
+> **Related:** the antecedent shadow-synth landed in PR mununu#478; the design doc [`docs/design/antecedent-shadow-synthesis.md`](../design/antecedent-shadow-synthesis.md) explicitly listed this CLI/API opt-out as follow-up.
+>
+> **TL;DR:** shadow-synth now has three opt-out channels — CLI flag, per-request API field, and the pre-existing process-global env var. Per-request opt-out is thread-safe (the env var isn't). Default behaviour unchanged: shadow-synth stays enabled, verdicts on SVA `|=>` properties with input-derived antecedents continue to decide.
+
+## What changed
+
+- **`ExactSymbolicOptions` struct** in `crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs` — new per-invocation options with `antecedent_shadow_enabled: bool` (default `true`). Enables thread-safe per-call control of the shadow-synth path.
+- **New public engine entries** `exact_symbolic_verdict_with_options` + `exact_symbolic_verdict_with_witness_and_options` — opts-accepting variants of the existing public entries. Existing entries wrap with `Default::default()` for backward compat.
+- **`VerifyAutoOptions.antecedent_shadow: bool`** (default `true`) — plumbed through the two engine callsites in `verify_auto.rs` (`exact_symbolic` path + `rescue_skipped_via_exact` fallback). Both now pass through `ExactSymbolicOptions { antecedent_shadow_enabled: opts.antecedent_shadow }`.
+- **CLI** — `--no-antecedent-shadow` on `SvVerifyAutoArgs`. `sv verify-auto` handler threads it into `VerifyAutoOptions.antecedent_shadow`.
+- **API** — `no_antecedent_shadow: Option<bool>` on `SvVerifyAutoRequest` (defaults to `false` when absent). `sv_verify_auto_handler` threads it into `VerifyAutoOptions.antecedent_shadow`.
+- **UI** — `no_antecedent_shadow?: boolean` on the mununu-ui `SvVerifyAutoRequest` TypeScript interface.
+- **Env-var check refactored** — the check in `exact_symbolic_verdict_with_witness_inner` is now `!opts.antecedent_shadow_enabled || env::var(...).is_ok()`. Either channel disabling shadow-synth wins.
+
+## What did NOT change
+
+- Default behaviour — shadow-synth stays enabled; all previously-decided properties still decide.
+- `PropertyVerdict` — unchanged.
+- `AutoVerifyReport` — unchanged.
+- Existing CLI flags / API fields — unchanged shape and semantics.
+- The env-var opt-out (`MUNUNU_NO_ANTECEDENT_SHADOW=1`) — still works, kept for scripts and CI shells.
+- Engine behaviour on any previously-decided property — unchanged.
+
+## Thread-safety note
+
+The env-var channel is **process-global** and races when a multi-tenant server has concurrent verify-auto calls with different `antecedent_shadow` intents. The new per-request API field is the correct choice for such consumers. Single-threaded CLI / test scripts can continue to use whichever channel is more ergonomic.
+
+## For ROSF-agents (subprocess `--profile industrial`)
+
+**What to update:** nothing forced — defaults preserve the shipped shadow-synth behaviour. If ROSF wants a differential-oracle mode where the industrial profile flips between shadow-synth-on/off per request, add `"no_antecedent_shadow": true` to specific requests. Thread-safe under concurrent invocation.
+
+**Docker rebuild:** required only if ROSF pins a specific mununu binary version.
+
+## For monono-agents (direct CLI consumer)
+
+**What to update:** nothing forced. If monono runs a differential-oracle sweep that needs to compare shadow-synth verdicts against the Phase A refusal, replace `MUNUNU_NO_ANTECEDENT_SHADOW=1 mununu sv verify-auto …` with `mununu sv verify-auto --no-antecedent-shadow …`. Cleaner (no shell env-var management) and matches the API shape.
+
+**Docker rebuild:** required only if monono pins a specific mununu binary version.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod CLI + API) | new CLI flag + new optional API field + engine opts refactor (backward-compat public entries) | Yes if consumers pin a version tag |
+| mununu `Dockerfile.dev` | binary bump | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; test refactor uses the new opts channel (no env-var mutation) | Only if a downstream requires the new binary |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `docker/Dockerfile` | consumes mununu subprocess/API | Only if pinned to a version tag; behavior updates on next binary pull otherwise |
+| rosf `docker/Dockerfile.dev`, `.hw` | no direct dependence | No |
+| monono Docker (any) | consumes CLI or API | Only if pinned to a version tag |
+| mununu-ui deployment | new typed field on `SvVerifyAutoRequest` | Rebuild + redeploy on the ui-side change |
+
+## Provenance
+
+- Fix commit (mununu-side): (pending merge — branch `fix/no-antecedent-shadow-flag`).
+- Fix commit (mununu-ui-side): matching `no_antecedent_shadow?: boolean` on TS `SvVerifyAutoRequest`, lands independently.
+- Issue: mununu#476 item 4 (design-doc follow-up).
+- Design: [`docs/design/antecedent-shadow-synthesis.md`](../design/antecedent-shadow-synthesis.md).
+- Policy this briefing satisfies: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+- Sibling briefings: [`2026-08-antecedent-shadow-synth.md`](2026-08-antecedent-shadow-synth.md) (initial landing), [`2026-08-multi-atom-antecedent-shadow.md`](2026-08-multi-atom-antecedent-shadow.md) (multi-atom extension).
+
+## Not covered here (follow-ups from the user's list)
+
+- `docs/api-schemas/verdict.md` — stable JSON schema doc for `PropertyVerdict` / `AutoVerifyReport`. Next item.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -230,11 +230,22 @@ shadow target. Independent shadows compose correctly:
 `shadow(A) ∧ shadow(B) = A@N ∧ B@N`, `shadow(A) ∨ shadow(B) = A@N ∨ B@N`,
 `!shadow(A) = !A@N`.
 
-**Opt-out** — the `MUNUNU_NO_ANTECEDENT_SHADOW=1` environment variable
-disables shadow-synth even for `|=>` shapes, reverting to the Phase A refusal.
-This is a debug / differential-oracle knob (used to cross-check shadow-synth
-verdicts against the predicate-cube engine's independent handling); production
-use should leave it unset.
+**Opt-out** — three channels, thread-safe per-request first, then process-global:
+
+1. **CLI flag** `--no-antecedent-shadow` on `sv verify-auto` (mununu#476 item 4,
+   added 2026-08). Per-invocation, thread-safe.
+2. **API field** `no_antecedent_shadow: true` on `POST /api/v1/sv/verify-auto`
+   (mununu#476 item 4). Per-request, thread-safe — the correct opt-out for a
+   multi-tenant server.
+3. **Env var** `MUNUNU_NO_ANTECEDENT_SHADOW=1`. Process-global; races across
+   concurrent verify-auto calls with different intents. Kept as an
+   ergonomic escape hatch for scripts and CI shells that never spawn
+   concurrent verify-auto calls.
+
+Either channel disabling shadow-synth wins. All three are debug /
+differential-oracle knobs (used to cross-check shadow-synth verdicts against
+the predicate-cube engine's independent handling); production use should
+leave all three unset.
 
 **Non-`|=>` formulas are unaffected.** A hand-authored `mu Y. (a or <> Y)`
 (bare `EF a`) whose atom happens to be input-derived does NOT match the


### PR DESCRIPTION
## Summary

Closes the fourth of five follow-ups on the antecedent shadow-synth track from #476. The env-var opt-out (`MUNUNU_NO_ANTECEDENT_SHADOW=1`) shipped with the initial landing, but it is process-global and races when a multi-tenant API server has concurrent verify-auto calls with different intents. This PR adds two thread-safe per-invocation channels:

- **CLI flag** `--no-antecedent-shadow` on `sv verify-auto`.
- **API field** `no_antecedent_shadow: Option<bool>` on `SvVerifyAutoRequest`.

Either channel disabling shadow-synth wins; both compose with the pre-existing env var.

## Engine refactor (backward-compat)

- `ExactSymbolicOptions { antecedent_shadow_enabled: bool }` — new pub struct, default `true`.
- New public entries `exact_symbolic_verdict_with_options` + `exact_symbolic_verdict_with_witness_and_options` accept opts. Existing public entries wrap with `Default::default()` — zero breaking change to shipped API.
- Internal chain (`verdict_with_witness_catching`, `exact_symbolic_verdict_with_witness_inner`) takes `opts` as parameter. Env-var check becomes `!opts.antecedent_shadow_enabled || env::var(...).is_ok()`.

## Verify-auto wiring

- `VerifyAutoOptions.antecedent_shadow: bool` (default `true`).
- Both engine callsites in `verify_auto.rs` (main exact-symbolic path + `rescue_skipped_via_exact` fallback) switched to opts-accepting variants.

## What did NOT change

- Default behaviour — shadow-synth stays enabled.
- `PropertyVerdict` — unchanged.
- `AutoVerifyReport` — unchanged.
- Existing CLI flags / API fields — unchanged shape and semantics.
- Env-var opt-out — still works.

## Cross-repo & policy

- Consumer briefing (per [`docs/policies/cross-repo-impact.md`](../blob/fix/no-antecedent-shadow-flag/docs/policies/cross-repo-impact.md)): [`docs/consumer-briefings/2026-08-no-antecedent-shadow-flag.md`](../blob/fix/no-antecedent-shadow-flag/docs/consumer-briefings/2026-08-no-antecedent-shadow-flag.md).
- mununu-ui matching field lands independently in `vscorza/mununu-ui#fix/no-antecedent-shadow-flag`.
- `docs/verifying-rtl.md` opt-out paragraph now enumerates all three channels with thread-safety properties.

## Docker rebuild disposition

| Image | Impact | Rebuild required? |
|-------|--------|-------------------|
| mununu `Dockerfile` (prod) | new CLI flag + new API field + engine opts refactor | Yes if consumers pin a version tag |
| mununu `Dockerfile.dev` / `.sva` | binary bump; test refactor uses new opts channel (no env-var mutation) | Only if the workflow requires the new binary |
| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
| rosf/monono Docker | consumes CLI/API | Only if version-pinned |
| mununu-ui deployment | new typed field | Rebuild + redeploy on the ui-side change |

## Test plan

- [x] `cargo test -p mununu-core --lib -- shadow_synth` — 2/2 (opts channel used; env-var mutation removed from test)
- [x] `cargo test -p mununu-core --lib -- detect_pipeimplies` — 12/12
- [x] `cargo check -p mununu-core --lib --features api` clean
- [x] `cargo check -p mununu-cli` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p mununu-core --lib --features api -- -D warnings` clean
- [x] `cargo clippy -p mununu-cli -- -D warnings` clean
- [x] `npm run type-check` in mununu-ui clean
- [ ] `cargo test --workspace` — CI's job

## Follow-ups NOT in this PR (last item from user's list)

- `docs/api-schemas/verdict.md` — stable JSON schema doc for `PropertyVerdict` / `AutoVerifyReport`. Next PR.

Fixes: mununu#476 item 4 (design-doc follow-up). ui matching PR: `vscorza/mununu-ui#fix/no-antecedent-shadow-flag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)