### PR TITLE
docs(api): stable JSON schema for verdict + verify-auto response (#476 item 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,7 @@ Reference and how-to material — read when the task calls for it, not on every 
 - [`docs/adapters/tlsf-aiger.md`](docs/adapters/tlsf-aiger.md) — Turn-based compound-label encoding for TLSF and AIGER.
 - [`docs/policies/claims-integrity.md`](docs/policies/claims-integrity.md) — Full claims-integrity policy (10 rules + editorial framing).
 - [`docs/policies/cross-repo-impact.md`](docs/policies/cross-repo-impact.md) — Cross-repo impact reporting: when a PR must ship a consumer briefing under `docs/consumer-briefings/`, mandatory sections, and the Docker-rebuild-disposition table format.
+- [`docs/api-schemas/verdict.md`](docs/api-schemas/verdict.md) — Stable JSON schema for `PropertyVerdict` / `SvVerifyAutoResponse` / `PropertyVerdictView` / counterexample shapes; the wire-format contract downstream consumers (ROSF, monono) should code against.
 - [`docs/design/antecedent-shadow-synthesis.md`](docs/design/antecedent-shadow-synthesis.md) — Antecedent shadow-register synthesis for SVA `|=>` with input-derived antecedents (mununu#476 fix).
 - [`docs/design/black-box-modules.md`](docs/design/black-box-modules.md) — Document A (foundations of black-box contracts).
 - [`docs/design/rtl-frontend-unification.md`](docs/design/rtl-frontend-unification.md) — Document B (SV frontends).

--- a/docs/api-schemas/verdict.md
+++ b/docs/api-schemas/verdict.md
@@ -1,0 +1,206 @@
+# API schemas — verdict + verify-auto response
+
+> **Stability:** evolving — see the [stability contract](#stability-contract) at the end of this document. Additions arrive additively (new optional fields); breaking changes ship with a version bump and a consumer briefing under [`../consumer-briefings/`](../consumer-briefings/).
+>
+> **Source of truth:** [`crates/mununu-core/src/verdict.rs`](../../crates/mununu-core/src/verdict.rs) (types) + [`crates/mununu-core/src/api/models.rs`](../../crates/mununu-core/src/api/models.rs) (JSON views). This document mirrors those types; a divergence between this doc and the code is a `doc`-severity finding.
+>
+> **Audience:** downstream consumers that parse mununu's `POST /api/v1/sv/verify-auto` JSON responses — ROSF (subprocess `--profile industrial`), monono (direct CLI/API), any custom orchestrator.
+
+Mununu's verify surfaces (CLI, HTTP API, UI) all speak one verdict vocabulary. This document pins down the JSON wire format for the `sv verify-auto` response — the shape downstream tools should code against.
+
+## Contents
+
+1. [PropertyVerdict — the four canonical outcomes](#propertyverdict--the-four-canonical-outcomes)
+2. [SvVerifyAutoResponse — top-level shape](#svverifyautoresponse--top-level-shape)
+3. [PropertyVerdictView — per-property](#propertyverdictview--per-property)
+4. [Counterexample — CexCellView / CounterexampleView](#counterexample--cexcellview--counterexampleview)
+5. [Model diagnostics + notes](#model-diagnostics--notes)
+6. [Unsupported assertions](#unsupported-assertions)
+7. [DiscoveredAssumption — refinement-lane fields](#discoveredassumption--refinement-lane-fields)
+8. [Stability contract](#stability-contract)
+9. [Consumer guidance](#consumer-guidance)
+
+## PropertyVerdict — the four canonical outcomes
+
+Every verify surface reports one of four values as a lowercase string. Wire format:
+
+| Value | Semantics |
+|-------|-----------|
+| `"holds"` | The property holds on every reachable state / path — a sound proof. Definite. |
+| `"violated"` | The property is violated — a real counterexample exists. Definite. |
+| `"unknown"` | No engine decided within budget: abstention, over-cap, timeout, or a soundness alarm (contradiction between engines). Definite in intent — never a hidden `Holds`/`Violated`. |
+| `"skipped"` | The property was not evaluated: out of the supported fragment, refused by the engine's soundness guard (input-derived antecedent, partial-write havoc, etc.), or filtered pre-run. |
+
+Rust source: [`PropertyVerdict`](../../crates/mununu-core/src/verdict.rs#L22) — `as_str()` at line 155 is the canonical mapping.
+
+**Never treat `skipped` or `unknown` as `holds` in a CI gate.** The default `--fail-on violated` treats both as pass; `--fail-on none` treats both as fail. Choose the polarity your gate actually wants.
+
+## SvVerifyAutoResponse — top-level shape
+
+Rust source: [`SvVerifyAutoResponse`](../../crates/mununu-core/src/api/models.rs#L1691).
+
+```jsonc
+{
+  "properties": [ /* PropertyVerdictView[] — see below */ ],
+  "unsupported": [ /* UnsupportedAssertionView[] — SVA outside the fragment */ ],
+  "diagnostics": {
+    "state_register_count": 42,
+    "blackboxed_modules":   ["some_missing_module"],
+    "gated_resets":         ["rst_n=1"],
+    "auto_provided_stubs":  ["prim_sparse_fsm_flop"]
+  },
+  "notes": [ /* VerificationNoteView[] — provenance/scope/soundness notes */ ]
+}
+```
+
+## PropertyVerdictView — per-property
+
+Rust source: [`PropertyVerdictView`](../../crates/mununu-core/src/api/models.rs#L1743).
+
+```jsonc
+{
+  "name":               "my_assertion",
+  "kind":               "assert",              // "assert" | "assume" | "cover"
+  "formula":            "nu X. ((!req || [] grant) && [] X)",  // mu-calc lift of the SVA
+  "outcome":            "holds",               // canonical PropertyVerdict as-string
+  "detail":             "cube: 0 false / 12 unknown", // optional; skip reason, cell counts
+  "seeded_predicates":  ["req == 1", "grant == 1"],   // atoms auto-seeded for this property
+  "counterexample":     null                   // present only for exact-symbolic Violated on AF-shape
+}
+```
+
+**Field-by-field:**
+
+- `name` — SVA label from the source (`assert property (foo) …` → `"foo"` when labelled).
+- `kind` — `"assert"` / `"assume"` / `"cover"`.
+- `formula` — the mu-calc string the engine actually evaluated. Round-trip-parseable via `mu_calculus::parser::parse`.
+- `outcome` — one of the four canonical `PropertyVerdict` values. This is the field to gate on.
+- `detail` — human-facing extra: `"cube: <false> false / <unknown> unknown"` for cube verdicts; `"skip-<reason>"` for skips (see the skip-reason catalog below). Optional.
+- `seeded_predicates` — the abstraction-cube atom strings seeded for this property. Empty for engines that don't use a cube.
+- `counterexample` — see [Counterexample](#counterexample--cexcellview--counterexampleview) below. Only present for `Violated` on bare `AF p` / `AG EF p` / `AG AF p` decided by the exact-symbolic engine; `null`/absent otherwise.
+
+## Counterexample — CexCellView / CounterexampleView
+
+Rust source: [`CounterexampleView`](../../crates/mununu-core/src/api/models.rs#L1763) + [`CexCellView`](../../crates/mununu-core/src/api/models.rs#L1777).
+
+Two shapes co-exist in one field:
+
+**(1) Stall-lasso / trap-path** — for liveness/recoverability failures. Reset → `prefix` → repeating `cycle`; each state is an ordered list of register cells.
+
+```jsonc
+{
+  "prefix": [
+    [ { "register": "st_q",     "value": 0 }, { "register": "cnt_q", "value": 0 } ],
+    [ { "register": "st_q",     "value": 1 }, { "register": "cnt_q", "value": 1 } ]
+  ],
+  "cycle": [
+    [ { "register": "st_q",     "value": 3 }, { "register": "cnt_q", "value": 5 } ]
+  ]
+}
+```
+
+**(2) Unreachable-target witness** — for a `Violated` bare `EF p` (reachability). The target atoms are simply never reached from reset; no state trace.
+
+```jsonc
+{
+  "prefix": [],
+  "cycle":  [],
+  "unreachable_target": ["st_q == 7", "err_q == 1"]
+}
+```
+
+`unreachable_target` is omitted (or empty) for shape (1). `prefix`/`cycle` are empty for shape (2). Consumers should treat either `unreachable_target.length > 0` or `cycle.length > 0` as valid — never both non-empty.
+
+## Model diagnostics + notes
+
+**`diagnostics`** — one object per response:
+
+- `state_register_count` — total state register lines in the lifted BTOR2.
+- `blackboxed_modules` — modules instantiated with no body (cut to free inputs). A non-empty list often explains a `skipped` verdict.
+- `gated_resets` — reset inputs the run pinned inactive at model level (`"<signal>=<value>"`), with their `disable iff` guards dropped from the formulas.
+- `auto_provided_stubs` — cut flop primitives (e.g. `prim_sparse_fsm_flop`) for which a behavioural stub was auto-injected so the register survives the lift.
+
+**`notes`** — provenance / scope / soundness paragraph objects. Each has:
+
+- `kind` — kebab-case category, e.g. `"config-concretization"`, `"antecedent-shadow"`, `"parameter-override"`, `"control-slice"`, `"lift-frontend"`.
+- `level` — `"info"` | `"scope-caveat"` | `"soundness-caveat"`.
+- `summary` — one-line human line.
+- `detail` — longer explanation of the why + implication.
+- `items` — structured operands (e.g. `["cfg_detect_timer_i=7"]`).
+
+Every verdict-modifying decision (config pin, parameter override, cut point, reset gating, antecedent shadow, etc.) is echoed in `notes`, so verdict provenance is explicit.
+
+## Unsupported assertions
+
+Rust source: [`UnsupportedAssertionView`](../../crates/mununu-core/src/api/models.rs#L1551). One entry per SVA that could not be translated:
+
+```jsonc
+{ "name": "some_property", "kind": "assert", "reason": "unbounded ##[m:$] delay in sequence antecedent" }
+```
+
+Unsupported assertions are **surfaced honestly**, never silently dropped. Reasons are terse; the SVA fragment is documented at [`docs/verifying-rtl.md`](../verifying-rtl.md).
+
+## DiscoveredAssumption — refinement-lane fields
+
+`sv verify-auto` doesn't emit `holds_under` today — that field is populated by the recoverability verb's `--discover-assumptions` flow (see [`crates/mununu-core/src/verdict.rs`](../../crates/mununu-core/src/verdict.rs#L142)). Documented here for completeness because both fields share the `PropertyVerdict` vocabulary:
+
+```jsonc
+{
+  "phi":         "GF(en == 1)",             // human-readable predicate over named inputs
+  "kind":        "input_fairness",          // input_hold | input_conjunction | input_schedule
+                                            // reset_eventually | env_strategy
+                                            // input_fairness | input_fairness_conjunction
+  "non_vacuous": true,                      // gate: does `good` actually get reached under phi?
+  "engine":      "exact-symbolic per-cell"  // provenance
+}
+```
+
+**Critical semantic:** a discovered assumption is a **CONDITIONAL** result. The canonical `PropertyVerdict` remains `unknown` even when a non-vacuous `phi` is found. Consumers must not read `holds_under.length > 0` as "the property holds"; it means "the property would hold under `phi`, and we still don't know unconditionally."
+
+## Stability contract
+
+- **`PropertyVerdict` values** (`"holds"` / `"violated"` / `"unknown"` / `"skipped"`) are **stable**. Adding a new variant would be a breaking change and requires a policy-mandated consumer briefing.
+- **`SvVerifyAutoResponse` field shape** is **additive-evolving**: new optional fields land as `#[serde(default)]` (no consumer action required); renaming or removing a field requires a briefing.
+- **`PropertyVerdictView` field shape** is **additive-evolving**. Same additive rule.
+- **`kind` values on `VerificationNoteView`** are **evolving**: new categories land regularly (each landing carries a note-kind description in a briefing); consumers must treat unknown `kind` as informational (do not error on unknown kinds).
+- **`level` values on `VerificationNoteView`** are **stable**: `"info"` | `"scope-caveat"` | `"soundness-caveat"`.
+- **`AssumptionKind` values** are **evolving-adding** (each new variant lands with a briefing). Serialized as `snake_case`.
+- **Counterexample two-shape polymorphism** (stall-lasso vs unreachable-target) is **stable**: `prefix`/`cycle` for lasso, `unreachable_target` for reachability.
+
+Anything under `notes[].detail` or `notes[].summary` is human-facing prose — **do not string-match against it**. Use `notes[].kind` + `notes[].items` for structured signals.
+
+## Consumer guidance
+
+**For a CI gate**, the minimal parse is:
+
+```js
+const bad = report.properties.filter(p => p.outcome === "violated");
+process.exitCode = bad.length > 0 ? 2 : 0;
+```
+
+Or with the mununu-native semantic — treat both `violated` and `unknown` as failures unless you know you're OK with unknowns:
+
+```js
+const bad = report.properties.filter(p => p.outcome === "violated" || p.outcome === "unknown");
+```
+
+**For a differential oracle** across two mununu invocations (e.g. shadow-synth on/off): compare `properties[i].outcome` per property. Verdicts that flip between `holds` and `violated` are a soundness alarm; verdicts that gain a definite value from `unknown`/`skipped` are precision gains.
+
+**For a downstream that ingests a stream of verdicts:** always guard against unknown `kind`/`level`/enum values with a default branch. mununu's stability contract permits additive expansion; consumers that error on unknown enums will fail-open on the additive cases.
+
+**For version pinning:** the `Cargo.toml` version is not currently a semantic-version stability commitment. Every downstream that depends on the wire format should either:
+- Pin a specific mununu binary version and refresh on a schedule, OR
+- Subscribe to consumer briefings under [`../consumer-briefings/`](../consumer-briefings/) and adopt each briefing on its own cadence.
+
+**For error handling:** an HTTP 400 from the API means the request itself was rejected (malformed source, bad flag value); the response body is a `{ "error": string }` shape, not `SvVerifyAutoResponse`. An HTTP 500 means an unexpected engine failure; retry with the same input is usually safe.
+
+## Related
+
+- [`docs/verifying-rtl.md`](../verifying-rtl.md) — user-facing prose on the verify surfaces.
+- [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md) — when a wire-format change requires a consumer briefing.
+- [`docs/design/antecedent-shadow-synthesis.md`](../design/antecedent-shadow-synthesis.md) — how a `skipped` verdict can flip to a definite one after enabling shadow-synth (or vice versa on `--no-antecedent-shadow`).
+- Consumer briefings that touched this surface:
+  - [`../consumer-briefings/2026-08-antecedent-shadow-synth.md`](../consumer-briefings/2026-08-antecedent-shadow-synth.md)
+  - [`../consumer-briefings/2026-08-multi-atom-antecedent-shadow.md`](../consumer-briefings/2026-08-multi-atom-antecedent-shadow.md)
+  - [`../consumer-briefings/2026-08-no-antecedent-shadow-flag.md`](../consumer-briefings/2026-08-no-antecedent-shadow-flag.md)
+  - [`../consumer-briefings/2026-08-sv-mutate-param-api-parity.md`](../consumer-briefings/2026-08-sv-mutate-param-api-parity.md)

--- a/docs/policies/cross-repo-impact.md
+++ b/docs/policies/cross-repo-impact.md
@@ -73,7 +73,7 @@ Prior surface changes shipped without briefings, and consumers discovered the im
 ## What this policy is NOT
 
 - **Not a versioning policy.** Semver / release tagging is a separate discipline (currently: mununu is 0.4.x, all releases treated as breaking).
-- **Not a schema-freeze policy.** Consumers should still expect additive schema changes on `AutoVerifyReport` etc.; the briefing tells them when a change is additive (safe to ignore) vs breaking (must migrate).
+- **Not a schema-freeze policy.** Consumers should still expect additive schema changes on `SvVerifyAutoResponse` etc.; the briefing tells them when a change is additive (safe to ignore) vs breaking (must migrate). The pinned wire format lives at [`docs/api-schemas/verdict.md`](../api-schemas/verdict.md) — that is the durable reference; briefings document *transitions* against it.
 - **Not a "communicate every change" policy.** Internal refactors, test additions, and documentation-only changes do not fire it. The policy targets the small set of changes that actually cross the mununu boundary.
 - **Not a substitute for the mununu wiki or `docs/verifying-rtl.md`.** The wiki documents behaviour steadily; briefings document *transitions*.
 


### PR DESCRIPTION
## Summary

Closes the last of five follow-ups on the shadow-synth track. New [`docs/api-schemas/verdict.md`](../blob/docs/api-schemas-verdict/docs/api-schemas/verdict.md) — the stable JSON schema for `PropertyVerdict`, `SvVerifyAutoResponse`, `PropertyVerdictView`, counterexample shapes, model diagnostics, notes, unsupported assertions, and the refinement-lane `DiscoveredAssumption` (with the critical CONDITIONAL semantic explained).

Includes:
- **Stability contract** per field kind — `PropertyVerdict` values are stable; response fields are additive-evolving; note kinds are evolving-adding.
- **Consumer guidance** for CI gates, differential oracles, and stream ingestion. Explicit rule: unknown enum kinds must be treated as informational, not error.
- Explicit polymorphism doc for the counterexample two-shape (stall-lasso vs unreachable-target).

## Cross-refs added

- `CLAUDE.md` Reference Docs Index — new entry.
- `docs/policies/cross-repo-impact.md` — the "Not a schema-freeze policy" clause now names the schema doc as the durable reference (briefings document transitions against it).

## Consumer-briefing exemption

Docs-only change per `docs/policies/cross-repo-impact.md` "What is exempt": no code change, no wire-format change. The new doc documents behaviour that already exists.

## What did NOT change

- No Rust source.
- No wire format.
- No behaviour anywhere.

## Test plan

- [x] No compilation impact
- [x] `cargo fmt --check` clean
- [x] Pre-commit hook clean
- [x] Anchors resolve — verified against `crates/mununu-core/src/verdict.rs` and `crates/mununu-core/src/api/models.rs` at the cited line numbers
- [ ] `/docs-traceability` skill sweep — a natural follow-up

## Follow-ups NOT in this PR

- OpenAPI / JSON Schema formal generation from the Rust types.
- Schema docs for BTOR2-direct verbs (`sv verify`, `sv verify-liveness`, `sv verify-recoverability`, `sv check-fsm`, `sv cegar`) — share `PropertyVerdict` but each has its own response envelope.
- Schema docs for the synth surfaces (`context synthesize`, `/synth/gr1`).

Fixes: mununu#476 item 5 (the last of five follow-ups from the user's list). All five now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)