### PR TITLE
docs(api): JSON schemas for the BTOR2 + SV property-verb endpoints

### DIFF
--- a/crates/mununu-core/src/adapter/recoverability.rs
+++ b/crates/mununu-core/src/adapter/recoverability.rs
@@ -2200,6 +2200,7 @@ fn verify_recoverability_counter_abstracted(
 /// Purely a diagnostic: it NEVER produces or changes a verdict. Localizes the structural obstacles in
 /// the good's recovery cone that the predicate abstraction cannot cross.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "api", derive(schemars::JsonSchema))]
 pub struct RecoverabilityBotDiagnosis {
     /// Down-counters that GATE the recovery (in the good's cone, not read by the good) whose descent
     /// is NOT ranking-certified — a fairness-gated reload or a non-affine descent: `(name, width)`.

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -926,7 +926,7 @@ pub struct Btor2CegarRequest {
 /// Request for the multi-engine safety portfolio endpoint
 /// (`POST /api/v1/btor2/verify`). Mirrors the CLI `mununu btor2 verify`: decides
 /// `bad`-reachability of a BTOR2 design across every available sound engine.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct Btor2VerifyRequest {
     /// BTOR2 source content.
     pub content: String,
@@ -935,7 +935,7 @@ pub struct Btor2VerifyRequest {
 /// Response for `POST /api/v1/btor2/verify` — the merged portfolio verdict plus
 /// which engines reached each definite conclusion. Mirrors
 /// [`crate::adapter::reach_portfolio::ReachOutcome`].
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct Btor2VerifyResponse {
     /// Canonical property verdict — `"holds"` (`bad` unreachable) | `"violated"`
     /// (reachable) | `"unknown"` (undecided / contradiction), via
@@ -955,7 +955,7 @@ pub struct Btor2VerifyResponse {
 /// `mununu btor2 verify-liveness`: decides `AG(request → AF grant)` via the l2s
 /// reduction + the portfolio. `request` / `grant` are register-comparison atom
 /// strings (`"st == 1"`).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct Btor2VerifyLivenessRequest {
     /// BTOR2 source content.
     pub content: String,
@@ -967,7 +967,7 @@ pub struct Btor2VerifyLivenessRequest {
 
 /// Response for `POST /api/v1/btor2/verify-liveness`. Mirrors
 /// [`crate::adapter::liveness_rescue::LivenessVerdict`].
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct Btor2VerifyLivenessResponse {
     /// Canonical property verdict — `"holds"` | `"violated"` | `"unknown"`, via
     /// [`crate::verdict::PropertyVerdict`].
@@ -984,7 +984,7 @@ pub struct Btor2VerifyLivenessResponse {
 /// `mununu btor2 verify-liveness-all`: decides `⋀ᵢ AG(aᵢ → AF bᵢ)`. Each `responses`
 /// entry is a `"ANTE => CONS"` pair of register-comparison atoms. At least one
 /// required. Reuses [`Btor2VerifyLivenessResponse`] for the reply.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct Btor2VerifyLivenessAllRequest {
     /// BTOR2 source content.
     pub content: String,
@@ -997,7 +997,7 @@ pub struct Btor2VerifyLivenessAllRequest {
 /// `mununu btor2 verify-recoverability`: decides `AG EF target` — "from every
 /// reachable state, can the design get back to `target`?". `target` is a single
 /// register-comparison atom string (`"state_q == 3"`).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct Btor2VerifyRecoverabilityRequest {
     /// BTOR2 source content.
     pub content: String,
@@ -1028,7 +1028,7 @@ pub struct Btor2VerifyRecoverabilityRequest {
 }
 
 /// Response for `POST /api/v1/btor2/verify-recoverability`.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct Btor2VerifyRecoverabilityResponse {
     /// Canonical property verdict — `"holds"` (every reachable state can reach
     /// `target`) | `"violated"` (a reachable trap cannot) | `"unknown"` (over the
@@ -1048,7 +1048,7 @@ pub struct Btor2VerifyRecoverabilityResponse {
 /// auto-discovers the FSM-like state registers and checks, from the reset state,
 /// whether any illegal encoding (a value outside the register's legal set) is
 /// reachable — with **no user input** (the legal set is derived from the design).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct Btor2CheckFsmRequest {
     /// BTOR2 source content.
     pub content: String,
@@ -1062,7 +1062,7 @@ fn default_fsm_max_width() -> u32 {
 }
 
 /// One state register's illegal-encoding result in a [`Btor2CheckFsmResponse`].
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct FsmRegisterFinding {
     /// The state register's symbol.
     pub register: String,
@@ -1076,7 +1076,7 @@ pub struct FsmRegisterFinding {
 }
 
 /// Response for `POST /api/v1/btor2/check-fsm`.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct Btor2CheckFsmResponse {
     /// Number of FSM-like state registers scanned.
     pub fsm_registers_checked: usize,
@@ -1171,7 +1171,7 @@ pub struct Btor2GameResponse {
 /// (`/api/v1/sv/verify`, `/sv/verify-liveness`, `/sv/verify-recoverability`). These
 /// lift the module (sv2v + Yosys) and then decide the corresponding BTOR2 property,
 /// returning the same `Btor2Verify*Response` shapes — one call, no `emit-btor2` step.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SvVerifyRequest {
     /// SystemVerilog primary source content.
     pub source: String,
@@ -1193,7 +1193,7 @@ pub struct SvVerifyRequest {
 
 /// Request for `POST /api/v1/sv/verify-liveness` — the SV lift fields plus the
 /// response-liveness atoms.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SvVerifyLivenessRequest {
     /// SystemVerilog primary source content.
     pub source: String,
@@ -1219,7 +1219,7 @@ pub struct SvVerifyLivenessRequest {
 /// Request for `POST /api/v1/sv/verify-liveness-all` — the SV lift fields plus the
 /// conjunction's `"ANTE => CONS"` response pairs. Mirrors the CLI
 /// `mununu sv verify-liveness-all`; reuses [`Btor2VerifyLivenessResponse`].
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SvVerifyLivenessAllRequest {
     /// SystemVerilog primary source content.
     pub source: String,
@@ -1242,7 +1242,7 @@ pub struct SvVerifyLivenessAllRequest {
 
 /// Request for `POST /api/v1/sv/verify-recoverability` — the SV lift fields plus the
 /// recoverability target atom.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SvVerifyRecoverabilityRequest {
     /// SystemVerilog primary source content.
     pub source: String,
@@ -1281,7 +1281,7 @@ pub struct SvVerifyRecoverabilityRequest {
 /// Request for `POST /api/v1/sv/check-fsm` — the SV lift fields plus the FSM width
 /// bound. Lifts the module and auto-scans every FSM register for a reachable illegal
 /// encoding (no property to name). Returns a [`Btor2CheckFsmResponse`].
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SvCheckFsmRequest {
     /// SystemVerilog primary source content.
     pub source: String,

--- a/crates/mununu-core/src/api/schema.rs
+++ b/crates/mununu-core/src/api/schema.rs
@@ -27,7 +27,13 @@
 
 use schemars::schema_for;
 
-use super::models::{SvVerifyAutoRequest, SvVerifyAutoResponse};
+use super::models::{
+    Btor2CheckFsmRequest, Btor2CheckFsmResponse, Btor2VerifyLivenessAllRequest,
+    Btor2VerifyLivenessRequest, Btor2VerifyLivenessResponse, Btor2VerifyRecoverabilityRequest,
+    Btor2VerifyRecoverabilityResponse, Btor2VerifyRequest, Btor2VerifyResponse, SvCheckFsmRequest,
+    SvVerifyAutoRequest, SvVerifyAutoResponse, SvVerifyLivenessAllRequest, SvVerifyLivenessRequest,
+    SvVerifyRecoverabilityRequest, SvVerifyRequest,
+};
 
 /// JSON Schema (Draft 2019-09) for `POST /api/v1/sv/verify-auto` request bodies.
 pub fn sv_verify_auto_request_schema() -> serde_json::Value {
@@ -39,6 +45,96 @@ pub fn sv_verify_auto_request_schema() -> serde_json::Value {
 pub fn sv_verify_auto_response_schema() -> serde_json::Value {
     serde_json::to_value(schema_for!(SvVerifyAutoResponse))
         .expect("SvVerifyAutoResponse schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/verify` request bodies.
+pub fn btor2_verify_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2VerifyRequest))
+        .expect("Btor2VerifyRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/verify` responses. Also the response shape
+/// for `POST /api/v1/sv/verify` (SV → BTOR2 lift then decide).
+pub fn btor2_verify_response_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2VerifyResponse))
+        .expect("Btor2VerifyResponse schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/verify-liveness` request bodies.
+pub fn btor2_verify_liveness_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2VerifyLivenessRequest))
+        .expect("Btor2VerifyLivenessRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/verify-liveness` responses. Also the response
+/// shape for `/btor2/verify-liveness-all`, `/sv/verify-liveness`, and
+/// `/sv/verify-liveness-all`.
+pub fn btor2_verify_liveness_response_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2VerifyLivenessResponse))
+        .expect("Btor2VerifyLivenessResponse schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/verify-liveness-all` request bodies.
+pub fn btor2_verify_liveness_all_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2VerifyLivenessAllRequest))
+        .expect("Btor2VerifyLivenessAllRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/verify-recoverability` request bodies.
+pub fn btor2_verify_recoverability_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2VerifyRecoverabilityRequest))
+        .expect("Btor2VerifyRecoverabilityRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/verify-recoverability` responses. Also the
+/// response shape for `POST /api/v1/sv/verify-recoverability`. Includes the
+/// optional structured [`crate::verdict::VerdictRefinement`] tree.
+pub fn btor2_verify_recoverability_response_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2VerifyRecoverabilityResponse))
+        .expect("Btor2VerifyRecoverabilityResponse schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/check-fsm` request bodies.
+pub fn btor2_check_fsm_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2CheckFsmRequest))
+        .expect("Btor2CheckFsmRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/check-fsm` responses. Also the response
+/// shape for `POST /api/v1/sv/check-fsm`.
+pub fn btor2_check_fsm_response_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2CheckFsmResponse))
+        .expect("Btor2CheckFsmResponse schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/sv/verify` request bodies (SV lift + BTOR2 verify).
+pub fn sv_verify_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(SvVerifyRequest))
+        .expect("SvVerifyRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/sv/verify-liveness` request bodies.
+pub fn sv_verify_liveness_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(SvVerifyLivenessRequest))
+        .expect("SvVerifyLivenessRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/sv/verify-liveness-all` request bodies.
+pub fn sv_verify_liveness_all_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(SvVerifyLivenessAllRequest))
+        .expect("SvVerifyLivenessAllRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/sv/verify-recoverability` request bodies.
+pub fn sv_verify_recoverability_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(SvVerifyRecoverabilityRequest))
+        .expect("SvVerifyRecoverabilityRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/sv/check-fsm` request bodies.
+pub fn sv_check_fsm_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(SvCheckFsmRequest))
+        .expect("SvCheckFsmRequest schema must serialise as JSON")
 }
 
 #[cfg(test)]
@@ -155,6 +251,118 @@ mod tests {
         drift_check(
             "docs/api-schemas/sv-verify-auto-response.schema.json",
             &sv_verify_auto_response_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_verify_request() {
+        drift_check(
+            "docs/api-schemas/btor2-verify-request.schema.json",
+            &btor2_verify_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_verify_response() {
+        drift_check(
+            "docs/api-schemas/btor2-verify-response.schema.json",
+            &btor2_verify_response_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_verify_liveness_request() {
+        drift_check(
+            "docs/api-schemas/btor2-verify-liveness-request.schema.json",
+            &btor2_verify_liveness_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_verify_liveness_response() {
+        drift_check(
+            "docs/api-schemas/btor2-verify-liveness-response.schema.json",
+            &btor2_verify_liveness_response_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_verify_liveness_all_request() {
+        drift_check(
+            "docs/api-schemas/btor2-verify-liveness-all-request.schema.json",
+            &btor2_verify_liveness_all_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_verify_recoverability_request() {
+        drift_check(
+            "docs/api-schemas/btor2-verify-recoverability-request.schema.json",
+            &btor2_verify_recoverability_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_verify_recoverability_response() {
+        drift_check(
+            "docs/api-schemas/btor2-verify-recoverability-response.schema.json",
+            &btor2_verify_recoverability_response_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_check_fsm_request() {
+        drift_check(
+            "docs/api-schemas/btor2-check-fsm-request.schema.json",
+            &btor2_check_fsm_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_check_fsm_response() {
+        drift_check(
+            "docs/api-schemas/btor2-check-fsm-response.schema.json",
+            &btor2_check_fsm_response_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_sv_verify_request() {
+        drift_check(
+            "docs/api-schemas/sv-verify-request.schema.json",
+            &sv_verify_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_sv_verify_liveness_request() {
+        drift_check(
+            "docs/api-schemas/sv-verify-liveness-request.schema.json",
+            &sv_verify_liveness_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_sv_verify_liveness_all_request() {
+        drift_check(
+            "docs/api-schemas/sv-verify-liveness-all-request.schema.json",
+            &sv_verify_liveness_all_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_sv_verify_recoverability_request() {
+        drift_check(
+            "docs/api-schemas/sv-verify-recoverability-request.schema.json",
+            &sv_verify_recoverability_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_sv_check_fsm_request() {
+        drift_check(
+            "docs/api-schemas/sv-check-fsm-request.schema.json",
+            &sv_check_fsm_request_schema(),
         );
     }
 }

--- a/crates/mununu-core/src/verdict.rs
+++ b/crates/mununu-core/src/verdict.rs
@@ -19,6 +19,7 @@ use crate::adapter::reach_portfolio::ReachVerdict;
 
 /// The canonical answer to "did the property hold?", shared by every verify surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "api", derive(schemars::JsonSchema))]
 pub enum PropertyVerdict {
     /// The property holds on every reachable state / path — a sound proof.
     Holds,
@@ -44,6 +45,7 @@ pub enum PropertyVerdict {
 /// [`Self::vacuous`] + [`Self::bot_diagnosis`]; Phase 1 populates [`Self::config_partition`]; Phase 2
 /// populates [`Self::holds_under`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "api", derive(schemars::JsonSchema))]
 pub struct VerdictRefinement {
     /// The recovery target is never reachable from the initial state — `AG EF(good)` is degenerate
     /// (the target is never entered), so the plain verdict is misleading. A SOUND witness (the
@@ -76,6 +78,7 @@ impl VerdictRefinement {
 
 /// See [`VerdictRefinement::vacuous`]. The recovery target is never reached.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "api", derive(schemars::JsonSchema))]
 pub struct VacuityWitness {
     /// `good` is unreachable from the initial state (a sound reachability-portfolio `Unreachable`).
     pub good_unreachable: bool,
@@ -91,6 +94,7 @@ pub type ConfigValuation = Vec<(String, u64)>;
 /// exact-symbolic); `exhaustive` is true ONLY when the enumerated config set is the complete reachable
 /// set. (Populated in Phase 1.)
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "api", derive(schemars::JsonSchema))]
 pub struct ConfigPartition {
     /// The config leaves case-split on: `(name, width)`.
     pub config_atoms: Vec<(String, u32)>,
@@ -111,6 +115,7 @@ pub struct ConfigPartition {
 
 /// The shape of a discovered environment assumption.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "api", derive(schemars::JsonSchema))]
 pub enum AssumptionKind {
     /// An input held at a constant value (`en = 1`).
     InputHold,
@@ -139,6 +144,7 @@ pub enum AssumptionKind {
 /// See [`VerdictRefinement::holds_under`]. A CONDITIONAL result: the property holds under `phi`.
 /// (Populated in Phase 2.)
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "api", derive(schemars::JsonSchema))]
 pub struct DiscoveredAssumption {
     /// A human-readable predicate over named inputs (Phase 2b may carry a typed schedule/strategy).
     pub phi: String,

--- a/docs/api-schemas/README.md
+++ b/docs/api-schemas/README.md
@@ -6,12 +6,40 @@ Each `*.schema.json` file is a JSON Schema (Draft-07) derived directly from the 
 
 ## Files
 
+### The flagship (BTOR2-free SV entry)
+
 | File | Endpoint | Direction |
 |------|----------|-----------|
 | [`sv-verify-auto-request.schema.json`](sv-verify-auto-request.schema.json) | `POST /api/v1/sv/verify-auto` | Request body |
 | [`sv-verify-auto-response.schema.json`](sv-verify-auto-response.schema.json) | `POST /api/v1/sv/verify-auto` | Response body |
 
-More endpoints will land in additive PRs (BTOR2-direct verbs, synth endpoints) — see the roadmap in `docs/consumer-briefings/`.
+### BTOR2-direct property verbs
+
+| File | Endpoint | Direction |
+|------|----------|-----------|
+| [`btor2-verify-request.schema.json`](btor2-verify-request.schema.json) | `POST /api/v1/btor2/verify` | Request body |
+| [`btor2-verify-response.schema.json`](btor2-verify-response.schema.json) | `POST /api/v1/btor2/verify` | Response body |
+| [`btor2-verify-liveness-request.schema.json`](btor2-verify-liveness-request.schema.json) | `POST /api/v1/btor2/verify-liveness` | Request body |
+| [`btor2-verify-liveness-response.schema.json`](btor2-verify-liveness-response.schema.json) | `POST /api/v1/btor2/verify-liveness` (also `-all`) | Response body |
+| [`btor2-verify-liveness-all-request.schema.json`](btor2-verify-liveness-all-request.schema.json) | `POST /api/v1/btor2/verify-liveness-all` | Request body |
+| [`btor2-verify-recoverability-request.schema.json`](btor2-verify-recoverability-request.schema.json) | `POST /api/v1/btor2/verify-recoverability` | Request body |
+| [`btor2-verify-recoverability-response.schema.json`](btor2-verify-recoverability-response.schema.json) | `POST /api/v1/btor2/verify-recoverability` | Response body |
+| [`btor2-check-fsm-request.schema.json`](btor2-check-fsm-request.schema.json) | `POST /api/v1/btor2/check-fsm` | Request body |
+| [`btor2-check-fsm-response.schema.json`](btor2-check-fsm-response.schema.json) | `POST /api/v1/btor2/check-fsm` | Response body |
+
+### SV-wrapped verbs (lift SV → BTOR2, then decide — response shape is the BTOR2 sibling)
+
+| File | Endpoint | Direction | Response schema |
+|------|----------|-----------|-----------------|
+| [`sv-verify-request.schema.json`](sv-verify-request.schema.json) | `POST /api/v1/sv/verify` | Request body | `btor2-verify-response.schema.json` |
+| [`sv-verify-liveness-request.schema.json`](sv-verify-liveness-request.schema.json) | `POST /api/v1/sv/verify-liveness` | Request body | `btor2-verify-liveness-response.schema.json` |
+| [`sv-verify-liveness-all-request.schema.json`](sv-verify-liveness-all-request.schema.json) | `POST /api/v1/sv/verify-liveness-all` | Request body | `btor2-verify-liveness-response.schema.json` |
+| [`sv-verify-recoverability-request.schema.json`](sv-verify-recoverability-request.schema.json) | `POST /api/v1/sv/verify-recoverability` | Request body | `btor2-verify-recoverability-response.schema.json` |
+| [`sv-check-fsm-request.schema.json`](sv-check-fsm-request.schema.json) | `POST /api/v1/sv/check-fsm` | Request body | `btor2-check-fsm-response.schema.json` |
+
+More endpoints will land in additive PRs (CEGAR + synth) — see the roadmap in `docs/consumer-briefings/`.
+
+Narrative companion: [`verify-verbs.md`](verify-verbs.md) walks the BTOR2 + SV verb responses field-by-field and explains where each verb sits on the safety / liveness / recoverability / FSM axes.
 
 ## Consumer flow
 

--- a/docs/api-schemas/btor2-check-fsm-request.schema.json
+++ b/docs/api-schemas/btor2-check-fsm-request.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Request for the auto FSM illegal-encoding scan (`POST /api/v1/btor2/check-fsm`). Mirrors the CLI `mununu btor2 check-fsm`: auto-discovers the FSM-like state registers and checks, from the reset state, whether any illegal encoding (a value outside the register's legal set) is reachable — with **no user input** (the legal set is derived from the design).",
+  "properties": {
+    "content": {
+      "description": "BTOR2 source content.",
+      "type": "string"
+    },
+    "max_width": {
+      "default": 8,
+      "description": "Max state-register width treated as an FSM (wider = datapath/counter, skipped).",
+      "format": "uint32",
+      "minimum": 0.0,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "content"
+  ],
+  "title": "Btor2CheckFsmRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/btor2-check-fsm-response.schema.json
+++ b/docs/api-schemas/btor2-check-fsm-response.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FsmRegisterFinding": {
+      "description": "One state register's illegal-encoding result in a [`Btor2CheckFsmResponse`].",
+      "properties": {
+        "illegal_encoding_reachable": {
+          "description": "`true` when an illegal encoding is reachable (a finding).",
+          "type": "boolean"
+        },
+        "legal_encodings": {
+          "description": "The legal encodings the register's own logic recognizes (sorted).",
+          "items": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "register": {
+          "description": "The state register's symbol.",
+          "type": "string"
+        },
+        "verdict": {
+          "description": "Canonical verdict — `\"holds\"` (stays within its encoding) | `\"violated\"` (an illegal encoding is reachable) | `\"unknown\"` (the portfolio could not decide).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "illegal_encoding_reachable",
+        "legal_encodings",
+        "register",
+        "verdict"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Response for `POST /api/v1/btor2/check-fsm`.",
+  "properties": {
+    "fsm_registers_checked": {
+      "description": "Number of FSM-like state registers scanned.",
+      "format": "uint",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "illegal_encodings_found": {
+      "description": "Number of registers with a reachable illegal encoding (`verdict == \"violated\"`).",
+      "format": "uint",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "registers": {
+      "description": "Per-register results.",
+      "items": {
+        "$ref": "#/definitions/FsmRegisterFinding"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "fsm_registers_checked",
+    "illegal_encodings_found",
+    "registers"
+  ],
+  "title": "Btor2CheckFsmResponse",
+  "type": "object"
+}

--- a/docs/api-schemas/btor2-verify-liveness-all-request.schema.json
+++ b/docs/api-schemas/btor2-verify-liveness-all-request.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Request for the conjunctive response-liveness endpoint (`POST /api/v1/btor2/verify-liveness-all`). Mirrors the CLI `mununu btor2 verify-liveness-all`: decides `⋀ᵢ AG(aᵢ → AF bᵢ)`. Each `responses` entry is a `\"ANTE => CONS\"` pair of register-comparison atoms. At least one required. Reuses [`Btor2VerifyLivenessResponse`] for the reply.",
+  "properties": {
+    "content": {
+      "description": "BTOR2 source content.",
+      "type": "string"
+    },
+    "responses": {
+      "description": "The response pairs, each `\"ANTE => CONS\"`.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "content",
+    "responses"
+  ],
+  "title": "Btor2VerifyLivenessAllRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/btor2-verify-liveness-request.schema.json
+++ b/docs/api-schemas/btor2-verify-liveness-request.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Request for the response-liveness endpoint (`POST /api/v1/btor2/verify-liveness`). Mirrors the CLI `mununu btor2 verify-liveness`: decides `AG(request → AF grant)` via the l2s reduction + the portfolio. `request` / `grant` are register-comparison atom strings (`\"st == 1\"`).",
+  "properties": {
+    "content": {
+      "description": "BTOR2 source content.",
+      "type": "string"
+    },
+    "grant": {
+      "description": "The grant atom that must eventually follow on every path.",
+      "type": "string"
+    },
+    "request": {
+      "description": "The request atom (`\"REG op VALUE\"`).",
+      "type": "string"
+    }
+  },
+  "required": [
+    "content",
+    "grant",
+    "request"
+  ],
+  "title": "Btor2VerifyLivenessRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/btor2-verify-liveness-response.schema.json
+++ b/docs/api-schemas/btor2-verify-liveness-response.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Response for `POST /api/v1/btor2/verify-liveness`. Mirrors [`crate::adapter::liveness_rescue::LivenessVerdict`].",
+  "properties": {
+    "decided_by": {
+      "description": "Portfolio engines that decided the reduced `bad`-reachability query.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "property": {
+      "description": "The reduced property, echoed for provenance: `AG((<request>) -> AF (<grant>))`.",
+      "type": "string"
+    },
+    "verdict": {
+      "description": "Canonical property verdict — `\"holds\"` | `\"violated\"` | `\"unknown\"`, via [`crate::verdict::PropertyVerdict`].",
+      "type": "string"
+    }
+  },
+  "required": [
+    "decided_by",
+    "property",
+    "verdict"
+  ],
+  "title": "Btor2VerifyLivenessResponse",
+  "type": "object"
+}

--- a/docs/api-schemas/btor2-verify-recoverability-request.schema.json
+++ b/docs/api-schemas/btor2-verify-recoverability-request.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Request for the recoverability endpoint (`POST /api/v1/btor2/verify-recoverability`). Mirrors the CLI `mununu btor2 verify-recoverability`: decides `AG EF target` — \"from every reachable state, can the design get back to `target`?\". `target` is a single register-comparison atom string (`\"state_q == 3\"`).",
+  "properties": {
+    "config_values": {
+      "default": [],
+      "description": "Config-partition (capability A): config inputs to split the verdict over, each `\"NAME=v1,v2,...\"`. The refinement then carries a `config_partition` decided exactly per config. Implies the refined output. Mirrors the CLI `--config-values`.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "content": {
+      "description": "BTOR2 source content.",
+      "type": "string"
+    },
+    "discover_assumptions": {
+      "default": false,
+      "description": "Assumption discovery (capability B): when the property does NOT hold, search for an environment assumption φ under which it becomes a non-vacuous HOLDS → the refinement carries `holds_under`. CONDITIONAL-only (never changes the canonical verdict). Implies the refined output. Mirrors the CLI `--discover-assumptions`.",
+      "type": "boolean"
+    },
+    "predicates": {
+      "default": [],
+      "description": "Extra abstraction predicate(s) for the cube-path escalation, each `\"NAME:REGISTER=VALUE\"` (P2 Slice 1). Used only when the exact engine abstains (over the ~40-bit cone cap); the escalation is automatic even with none.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "refine": {
+      "default": false,
+      "description": "Also compute a structured [`crate::verdict::VerdictRefinement`] alongside the verdict — a `vacuous` witness when the target is never reachable, an auto `config_partition` over the design's detected reset when recovery depends on it, and a \"why ⊥\" hint. Diagnostic-only: it never changes the canonical verdict. (Mirrors the CLI `--refine`.)",
+      "type": "boolean"
+    },
+    "target": {
+      "description": "The `good` atom to recover to (`\"REG op VALUE\"`).",
+      "type": "string"
+    }
+  },
+  "required": [
+    "content",
+    "target"
+  ],
+  "title": "Btor2VerifyRecoverabilityRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/btor2-verify-recoverability-response.schema.json
+++ b/docs/api-schemas/btor2-verify-recoverability-response.schema.json
@@ -1,0 +1,361 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "AssumptionKind": {
+      "description": "The shape of a discovered environment assumption.",
+      "oneOf": [
+        {
+          "description": "An input held at a constant value (`en = 1`).",
+          "enum": [
+            "InputHold"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A CONJUNCTION of environment-input holds (`ack == 1 && escalate == 0`) — the minimal set of environment inputs that must be constrained for a two-player game to become realizable, when no single hold suffices (the design has multiple independent adversarial blockers).",
+          "enum": [
+            "InputConjunction"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A finite input schedule (a command sequence).",
+          "enum": [
+            "InputSchedule"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "\"Reset is eventually asserted.\"",
+          "enum": [
+            "ResetEventually"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A synthesized positional environment strategy (1-player: the environment owns all inputs).",
+          "enum": [
+            "EnvStrategy"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A LIVENESS / fairness environment assumption `GF(in == v)` — the environment input holds `v` INFINITELY OFTEN — under which an unrealizable RECURRENCE (Büchi) game `GF good` becomes realizable (`GF a → GF good`, the GR(1) 1-pair objective). Distinct from `InputHold` (a SAFETY hold `G(a)`): fairness is strictly weaker (the environment may violate `a` finitely often).",
+          "enum": [
+            "InputFairness"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A CONJUNCTION of fairness assumptions `GF(e_1 == v_1) ∧ … ∧ GF(e_k == v_k)` — the minimal set of environment liveness assumptions under which an unrealizable RECURRENCE game becomes realizable (`(⋀_i GF a_i) → GF good`, the MULTI-pair GR(1) objective), when no SINGLE fairness assumption suffices (multiple independent liveness blockers). The fairness analog of `InputConjunction`.",
+          "enum": [
+            "InputFairnessConjunction"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "ConfigPartition": {
+      "description": "See [`VerdictRefinement::config_partition`]. The property's verdict partitioned over the config leaves the recovery rides on. Sound per cell (each is a concrete pinned model decided by exact-symbolic); `exhaustive` is true ONLY when the enumerated config set is the complete reachable set. (Populated in Phase 1.)",
+      "properties": {
+        "config_atoms": {
+          "description": "The config leaves case-split on: `(name, width)`.",
+          "items": {
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "engine": {
+          "description": "The deciding engine, for provenance (e.g. `\"exact-symbolic per-config pin\"`).",
+          "type": "string"
+        },
+        "exhaustive": {
+          "description": "True iff the enumerated config set is the COMPLETE reachable config set (else the partition is over the enumerated/reachable subset only).",
+          "type": "boolean"
+        },
+        "holds": {
+          "description": "Config valuations for which the property HOLDS.",
+          "items": {
+            "items": {
+              "items": [
+                {
+                  "type": "string"
+                },
+                {
+                  "format": "uint64",
+                  "minimum": 0.0,
+                  "type": "integer"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "unknown": {
+          "description": "… for which it stayed ⊥ even pinned.",
+          "items": {
+            "items": {
+              "items": [
+                {
+                  "type": "string"
+                },
+                {
+                  "format": "uint64",
+                  "minimum": 0.0,
+                  "type": "integer"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "vacuous": {
+          "description": "… for which the target is vacuous (never reached under that config).",
+          "items": {
+            "items": {
+              "items": [
+                {
+                  "type": "string"
+                },
+                {
+                  "format": "uint64",
+                  "minimum": 0.0,
+                  "type": "integer"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "violated": {
+          "description": "… for which it is VIOLATED.",
+          "items": {
+            "items": {
+              "items": [
+                {
+                  "type": "string"
+                },
+                {
+                  "format": "uint64",
+                  "minimum": 0.0,
+                  "type": "integer"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "config_atoms",
+        "engine",
+        "exhaustive",
+        "holds",
+        "unknown",
+        "vacuous",
+        "violated"
+      ],
+      "type": "object"
+    },
+    "DiscoveredAssumption": {
+      "description": "See [`VerdictRefinement::holds_under`]. A CONDITIONAL result: the property holds under `phi`. (Populated in Phase 2.)",
+      "properties": {
+        "engine": {
+          "description": "The engine that discovered it, for provenance.",
+          "type": "string"
+        },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/AssumptionKind"
+            }
+          ],
+          "description": "The assumption's shape."
+        },
+        "non_vacuous": {
+          "description": "True iff `good` is genuinely reached under `phi` (the non-vacuity gate passed).",
+          "type": "boolean"
+        },
+        "phi": {
+          "description": "A human-readable predicate over named inputs (Phase 2b may carry a typed schedule/strategy).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "engine",
+        "kind",
+        "non_vacuous",
+        "phi"
+      ],
+      "type": "object"
+    },
+    "RecoverabilityBotDiagnosis": {
+      "description": "A best-effort, SOUND-hint explanation of WHY an `AG EF good` recoverability property stayed ⊥ — so a ⊥ becomes ACTIONABLE (\"what would it take to decide this?\") instead of a bare \"don't know\". Purely a diagnostic: it NEVER produces or changes a verdict. Localizes the structural obstacles in the good's recovery cone that the predicate abstraction cannot cross.",
+      "properties": {
+        "uncertified_counters": {
+          "description": "Down-counters that GATE the recovery (in the good's cone, not read by the good) whose descent is NOT ranking-certified — a fairness-gated reload or a non-affine descent: `(name, width)`. Deciding needs a ranking certificate or a fairness assumption.",
+          "items": {
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "wide_influences": {
+          "description": "Wide state / inputs (NOT a small FSM, NOT a certified counter) whose value flows into the recovery target: `(name, width)`. The recovery value rides that wide state, so the verdict is data/config-scoped (a specific config may HOLD, another VIOLATE) — the predicate cube cannot enumerate it. Constrain those inputs, or the ⊥ is the honest config-independent answer.",
+          "items": {
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "uncertified_counters",
+        "wide_influences"
+      ],
+      "type": "object"
+    },
+    "VacuityWitness": {
+      "description": "See [`VerdictRefinement::vacuous`]. The recovery target is never reached.",
+      "properties": {
+        "good_unreachable": {
+          "description": "`good` is unreachable from the initial state (a sound reachability-portfolio `Unreachable`).",
+          "type": "boolean"
+        },
+        "note": {
+          "description": "A one-line, user-facing explanation.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "good_unreachable",
+        "note"
+      ],
+      "type": "object"
+    },
+    "VerdictRefinement": {
+      "description": "A structured elaboration of a [`PropertyVerdict`], carried ALONGSIDE the canonical verdict — never replacing it. `None`/empty on the common path. This is how a bare `⊥`/`violated` becomes an *actionable* result: which configs hold, under what assumption it would hold, or that the target is simply never reachable. It follows the same contract as the cube-cell / countertrace detail Track I already carries: **a refinement is a diagnostic and NEVER changes the canonical verdict** — a config-scoped or assumption-scoped result keeps the canonical verdict `Unknown` (the honest unconditional answer; an assumption is not monotone for `AG EF`, so it cannot soundly transfer).\n\nPhases (see `.claude/plans/refined-verdicts-assumption-discovery.md`): Phase 0 populates [`Self::vacuous`] + [`Self::bot_diagnosis`]; Phase 1 populates [`Self::config_partition`]; Phase 2 populates [`Self::holds_under`].",
+      "properties": {
+        "bot_diagnosis": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RecoverabilityBotDiagnosis"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The best-effort structural \"why ⊥ / what would decide it\" hint (promoted from the standalone [`crate::adapter::recoverability::diagnose_recoverability_bot`])."
+        },
+        "config_partition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConfigPartition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A config-scoped partition: the property depends on config values (Phase 1 / capability A)."
+        },
+        "holds_under": {
+          "description": "Environment assumption(s) under which the property holds (Phase 2 / capability B). Each is a CONDITIONAL result (`HoldsUnder(φ)`) — the canonical verdict stays `Unknown`.",
+          "items": {
+            "$ref": "#/definitions/DiscoveredAssumption"
+          },
+          "type": "array"
+        },
+        "vacuous": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VacuityWitness"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The recovery target is never reachable from the initial state — `AG EF(good)` is degenerate (the target is never entered), so the plain verdict is misleading. A SOUND witness (the reachability portfolio proved `good` unreachable; only emitted when that proof is sound — i.e. not on free-init state, per `ReachVerdict::Unreachable`)."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "description": "Response for `POST /api/v1/btor2/verify-recoverability`.",
+  "properties": {
+    "property": {
+      "description": "The decided property, echoed for provenance: `AG EF (<target>)`.",
+      "type": "string"
+    },
+    "refinement": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/VerdictRefinement"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The structured refinement, when `refine` was requested and it produced one. `None` otherwise. Diagnostic detail carried ALONGSIDE the verdict — never changes it."
+    },
+    "verdict": {
+      "description": "Canonical property verdict — `\"holds\"` (every reachable state can reach `target`) | `\"violated\"` (a reachable trap cannot) | `\"unknown\"` (over the exact engine's cap; try the cube + `smt-hyper-must` path), via [`crate::verdict::PropertyVerdict`].",
+      "type": "string"
+    }
+  },
+  "required": [
+    "property",
+    "verdict"
+  ],
+  "title": "Btor2VerifyRecoverabilityResponse",
+  "type": "object"
+}

--- a/docs/api-schemas/btor2-verify-request.schema.json
+++ b/docs/api-schemas/btor2-verify-request.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Request for the multi-engine safety portfolio endpoint (`POST /api/v1/btor2/verify`). Mirrors the CLI `mununu btor2 verify`: decides `bad`-reachability of a BTOR2 design across every available sound engine.",
+  "properties": {
+    "content": {
+      "description": "BTOR2 source content.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "content"
+  ],
+  "title": "Btor2VerifyRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/btor2-verify-response.schema.json
+++ b/docs/api-schemas/btor2-verify-response.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Response for `POST /api/v1/btor2/verify` — the merged portfolio verdict plus which engines reached each definite conclusion. Mirrors [`crate::adapter::reach_portfolio::ReachOutcome`].",
+  "properties": {
+    "contradiction": {
+      "description": "`true` when two sound engines disagree — a soundness alarm, not a guess.",
+      "type": "boolean"
+    },
+    "reachable_by": {
+      "description": "Engines that found `bad` reachable (a real counterexample).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "unreachable_by": {
+      "description": "Engines that proved `bad` unreachable (a real safety proof).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "verdict": {
+      "description": "Canonical property verdict — `\"holds\"` (`bad` unreachable) | `\"violated\"` (reachable) | `\"unknown\"` (undecided / contradiction), via [`crate::verdict::PropertyVerdict`]. The reachability *detail* is in the `reachable_by` / `unreachable_by` lists + the `contradiction` alarm.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "contradiction",
+    "reachable_by",
+    "unreachable_by",
+    "verdict"
+  ],
+  "title": "Btor2VerifyResponse",
+  "type": "object"
+}

--- a/docs/api-schemas/sv-check-fsm-request.schema.json
+++ b/docs/api-schemas/sv-check-fsm-request.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FileContent": {
+      "description": "File content with optional name",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Request for `POST /api/v1/sv/check-fsm` — the SV lift fields plus the FSM width bound. Lifts the module and auto-scans every FSM register for a reachable illegal encoding (no property to name). Returns a [`Btor2CheckFsmResponse`].",
+  "properties": {
+    "additional_sources": {
+      "default": [],
+      "description": "Additional SV sources (packages / includes).",
+      "items": {
+        "$ref": "#/definitions/FileContent"
+      },
+      "type": "array"
+    },
+    "max_width": {
+      "default": 8,
+      "description": "Max state-register width treated as an FSM (wider = datapath/counter, skipped).",
+      "format": "uint32",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "source": {
+      "description": "SystemVerilog primary source content.",
+      "type": "string"
+    },
+    "top": {
+      "default": null,
+      "description": "Top module for the lift (auto-detect when omitted).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "use_slang": {
+      "default": false,
+      "description": "Force the slang RTL front-end (`read_slang`). Requires the yosys-slang plugin. Default `false`.",
+      "type": "boolean"
+    },
+    "use_sv2v": {
+      "default": false,
+      "description": "Run sv2v before Yosys. Default `false`.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "source"
+  ],
+  "title": "SvCheckFsmRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/sv-verify-liveness-all-request.schema.json
+++ b/docs/api-schemas/sv-verify-liveness-all-request.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FileContent": {
+      "description": "File content with optional name",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Request for `POST /api/v1/sv/verify-liveness-all` — the SV lift fields plus the conjunction's `\"ANTE => CONS\"` response pairs. Mirrors the CLI `mununu sv verify-liveness-all`; reuses [`Btor2VerifyLivenessResponse`].",
+  "properties": {
+    "additional_sources": {
+      "default": [],
+      "description": "Additional SV sources (packages / includes).",
+      "items": {
+        "$ref": "#/definitions/FileContent"
+      },
+      "type": "array"
+    },
+    "responses": {
+      "description": "The response pairs, each `\"ANTE => CONS\"`. At least one required.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "source": {
+      "description": "SystemVerilog primary source content.",
+      "type": "string"
+    },
+    "top": {
+      "default": null,
+      "description": "Top module for the lift (auto-detect when omitted).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "use_slang": {
+      "default": false,
+      "description": "Force the slang RTL front-end (`read_slang`). Requires the yosys-slang plugin. Default `false`.",
+      "type": "boolean"
+    },
+    "use_sv2v": {
+      "default": false,
+      "description": "Run sv2v before Yosys. Default `false`.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "responses",
+    "source"
+  ],
+  "title": "SvVerifyLivenessAllRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/sv-verify-liveness-request.schema.json
+++ b/docs/api-schemas/sv-verify-liveness-request.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FileContent": {
+      "description": "File content with optional name",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Request for `POST /api/v1/sv/verify-liveness` — the SV lift fields plus the response-liveness atoms.",
+  "properties": {
+    "additional_sources": {
+      "default": [],
+      "description": "Additional SV sources (packages / includes).",
+      "items": {
+        "$ref": "#/definitions/FileContent"
+      },
+      "type": "array"
+    },
+    "grant": {
+      "description": "The grant atom that must eventually follow on every path.",
+      "type": "string"
+    },
+    "request": {
+      "description": "The request atom (`\"REG op VALUE\"`).",
+      "type": "string"
+    },
+    "source": {
+      "description": "SystemVerilog primary source content.",
+      "type": "string"
+    },
+    "top": {
+      "default": null,
+      "description": "Top module for the lift (auto-detect when omitted).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "use_slang": {
+      "default": false,
+      "description": "Force the slang RTL front-end (`read_slang`). Requires the yosys-slang plugin. Default `false`.",
+      "type": "boolean"
+    },
+    "use_sv2v": {
+      "default": false,
+      "description": "Run sv2v before Yosys. Default `false`.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "grant",
+    "request",
+    "source"
+  ],
+  "title": "SvVerifyLivenessRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/sv-verify-recoverability-request.schema.json
+++ b/docs/api-schemas/sv-verify-recoverability-request.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FileContent": {
+      "description": "File content with optional name",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Request for `POST /api/v1/sv/verify-recoverability` — the SV lift fields plus the recoverability target atom.",
+  "properties": {
+    "additional_sources": {
+      "default": [],
+      "description": "Additional SV sources (packages / includes).",
+      "items": {
+        "$ref": "#/definitions/FileContent"
+      },
+      "type": "array"
+    },
+    "config_values": {
+      "default": [],
+      "description": "Config-partition config inputs, each `\"NAME=v1,v2,...\"` (mirrors the CLI `--config-values`).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "discover_assumptions": {
+      "default": false,
+      "description": "Assumption discovery (capability B): search for an enabling φ when the property does not hold → `holds_under` (conditional-only). Mirrors the CLI `--discover-assumptions`.",
+      "type": "boolean"
+    },
+    "predicates": {
+      "default": [],
+      "description": "Extra abstraction predicate(s) for the cube-path escalation, each `\"NAME:REGISTER=VALUE\"` (P2 Slice 1). Used only when the exact engine abstains.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "refine": {
+      "default": false,
+      "description": "Also compute a structured `refinement` alongside the verdict (mirrors the CLI `--refine`). Diagnostic-only — never changes the canonical verdict.",
+      "type": "boolean"
+    },
+    "source": {
+      "description": "SystemVerilog primary source content.",
+      "type": "string"
+    },
+    "target": {
+      "description": "The `good` atom to recover to (`\"REG op VALUE\"`).",
+      "type": "string"
+    },
+    "top": {
+      "default": null,
+      "description": "Top module for the lift (auto-detect when omitted).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "use_slang": {
+      "default": false,
+      "description": "Force the slang RTL front-end (`read_slang`). Requires the yosys-slang plugin. Default `false`.",
+      "type": "boolean"
+    },
+    "use_sv2v": {
+      "default": false,
+      "description": "Run sv2v before Yosys. Default `false`.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "source",
+    "target"
+  ],
+  "title": "SvVerifyRecoverabilityRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/sv-verify-request.schema.json
+++ b/docs/api-schemas/sv-verify-request.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FileContent": {
+      "description": "File content with optional name",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "The SV → BTOR2 lift inputs shared by the SV-direct verb endpoints (`/api/v1/sv/verify`, `/sv/verify-liveness`, `/sv/verify-recoverability`). These lift the module (sv2v + Yosys) and then decide the corresponding BTOR2 property, returning the same `Btor2Verify*Response` shapes — one call, no `emit-btor2` step.",
+  "properties": {
+    "additional_sources": {
+      "default": [],
+      "description": "Additional SV sources (packages / includes).",
+      "items": {
+        "$ref": "#/definitions/FileContent"
+      },
+      "type": "array"
+    },
+    "source": {
+      "description": "SystemVerilog primary source content.",
+      "type": "string"
+    },
+    "top": {
+      "default": null,
+      "description": "Top module for the lift (auto-detect when omitted).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "use_slang": {
+      "default": false,
+      "description": "Force the slang RTL front-end (`read_slang`) for modern-SV constructs yosys/sv2v reject (`while` loops, `import pkg::*;`). Requires the yosys-slang plugin. Default `false`.",
+      "type": "boolean"
+    },
+    "use_sv2v": {
+      "default": false,
+      "description": "Run sv2v before Yosys (modern SV). Default `false`.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "source"
+  ],
+  "title": "SvVerifyRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/verify-verbs.md
+++ b/docs/api-schemas/verify-verbs.md
@@ -1,0 +1,152 @@
+# BTOR2 + SV verb responses — narrative
+
+> Source of truth: [`crates/mununu-core/src/api/models.rs`](../../crates/mununu-core/src/api/models.rs) — surface: API. Machine-readable schemas live alongside as [`*.schema.json`](.) files; this document is the prose you read *before* wiring a consumer to them.
+
+The BTOR2-direct property verbs (`verify`, `verify-liveness`, `verify-liveness-all`, `verify-recoverability`, `check-fsm`) and their SV-wrapped siblings (`sv/verify`, `sv/verify-liveness`, `sv/verify-liveness-all`, `sv/verify-recoverability`, `sv/check-fsm`) all end in the same canonical `PropertyVerdict` vocabulary — `holds` / `violated` / `unknown` / `skipped`. What differs across verbs is *which structured detail* accompanies that verdict.
+
+## The axis map
+
+| Verb pair | Property class | Response type | Detail axis |
+|-----------|---------------|---------------|-------------|
+| `btor2 verify` / `sv verify` | Safety (`bad` unreachable) | `Btor2VerifyResponse` | Per-engine breakdown, soundness-alarm flag |
+| `btor2 verify-liveness` / `sv verify-liveness` | Response `AG(a → AF b)` | `Btor2VerifyLivenessResponse` | Reduced-property echo, deciding engines |
+| `btor2 verify-liveness-all` / `sv verify-liveness-all` | Conjunctive `⋀ᵢ AG(aᵢ → AF bᵢ)` | `Btor2VerifyLivenessResponse` | Same as `-liveness` — one merged verdict |
+| `btor2 verify-recoverability` / `sv verify-recoverability` | Recoverability `AG EF good` | `Btor2VerifyRecoverabilityResponse` | Optional `VerdictRefinement` tree (vacuous / config-partition / holds-under / ⊥-hint) |
+| `btor2 check-fsm` / `sv check-fsm` | Auto-scan of illegal FSM encodings | `Btor2CheckFsmResponse` | Per-register findings + counts |
+
+The SV wrappers exist so downstream consumers do not need the intermediate `sv emit-btor2` step. They accept SystemVerilog on the wire, lift it via `sv2v` + Yosys (or `read_slang` when `use_slang` is set — the reliable path for modern SV per `docs/verifying-rtl.md`), and return the sibling BTOR2 response shape.
+
+## `POST /btor2/verify` (and `POST /sv/verify`) — safety portfolio
+
+Schema: [`btor2-verify-response.schema.json`](btor2-verify-response.schema.json)
+
+Runs every available sound reach-portfolio engine (native BMC / k-induction, McMillan interpolation, in-process Boolector when the feature is on, and any external members the binary can locate) against the design's `bad` signal.
+
+```json
+{
+  "verdict": "holds",
+  "reachable_by": [],
+  "unreachable_by": ["native_kind", "mcmillan_interp"],
+  "contradiction": false
+}
+```
+
+- `verdict` — the merged canonical answer.
+- `reachable_by` / `unreachable_by` — the deciding engines. An `unreachable_by` list of length ≥ 1 is a sound safety proof; a `reachable_by` list of length ≥ 1 is a real counterexample.
+- `contradiction` — TRUE only when two sound engines disagree. **Treat this as a soundness alarm**, not a verdict-selection hint: raise it to a human and cross-check the input BTOR2 rather than picking a side.
+
+## `POST /btor2/verify-liveness` and `-liveness-all` — response properties
+
+Schema: [`btor2-verify-liveness-response.schema.json`](btor2-verify-liveness-response.schema.json) (shared)
+
+Decides `AG(request → AF grant)` via the standard l2s (liveness-to-safety) reduction, then hands the reduced safety query to the reach portfolio. The `-all` variant does the same for a conjunction `⋀ᵢ AG(aᵢ → AF bᵢ)`.
+
+```json
+{
+  "verdict": "unknown",
+  "property": "AG((st == 1) -> AF (st == 3))",
+  "decided_by": []
+}
+```
+
+- `property` — the reduced formula, echoed for provenance. On the `-all` verb this is the AND of every response's reduction.
+- `decided_by` — engines that decided the reduced `bad`-reachability query.
+
+`unknown` here typically means the l2s reduction pushed the bit-width past the portfolio's cap; try `--engine` overrides on the CLI or narrow the atoms.
+
+## `POST /btor2/verify-recoverability` (and `POST /sv/verify-recoverability`) — the deepest response
+
+Schema: [`btor2-verify-recoverability-response.schema.json`](btor2-verify-recoverability-response.schema.json)
+
+Decides `AG EF good` — "from every reachable state, can the design get back to `good`?". This is the recoverability property SVA cannot express, and the one where mununu's structured refinement earns its keep.
+
+```json
+{
+  "verdict": "unknown",
+  "property": "AG EF (state_q == 3)",
+  "refinement": {
+    "vacuous": null,
+    "config_partition": {
+      "config_atoms": [["mode", 2]],
+      "holds": [[["mode", 0]], [["mode", 1]]],
+      "violated": [],
+      "unknown": [[["mode", 2]]],
+      "vacuous": [],
+      "exhaustive": true,
+      "engine": "exact-symbolic per-config pin"
+    },
+    "holds_under": [],
+    "bot_diagnosis": {
+      "uncertified_counters": [["retry_ctr", 8]],
+      "wide_influences": []
+    }
+  }
+}
+```
+
+- `verdict` — the CANONICAL (unconditional) answer. A `config_partition` or a non-empty `holds_under` never changes this — a refinement is a diagnostic, not a verdict.
+- `property` — the checked formula echoed for provenance.
+- `refinement` — present only when the request set `refine`, `config_values`, or `discover_assumptions`. Structured detail:
+  - `vacuous` — the recovery target `good` was never reachable from the initial state. Bare `AG EF good` is degenerate then; the plain verdict is misleading.
+  - `config_partition` — per-config decided verdicts when `config_values` was requested. Each row is `[(name, u64)]`. `exhaustive: true` means the enumerated cells cover the entire reachable config space.
+  - `holds_under` — CONDITIONAL results: the property holds under environment assumption `φ`. `kind` names the shape (`InputHold`, `InputConjunction`, `InputFairness`, …). `non_vacuous: true` means the non-vacuity gate passed — `good` is actually reached under `φ`, not just trivially satisfied.
+  - `bot_diagnosis` — best-effort structural "why ⊥" hint. `uncertified_counters` names counters gating recovery without a ranking certificate; `wide_influences` names wide state/inputs the predicate cube cannot enumerate.
+
+The full refinement tree includes `AssumptionKind`, `VerdictRefinement`, `VacuityWitness`, `ConfigPartition`, `DiscoveredAssumption`, and `RecoverabilityBotDiagnosis`; consult the JSON schema for their exact shape.
+
+## `POST /btor2/check-fsm` (and `POST /sv/check-fsm`) — auto FSM scan
+
+Schema: [`btor2-check-fsm-response.schema.json`](btor2-check-fsm-response.schema.json)
+
+Auto-discovers the design's FSM-like state registers (state registers narrower than `max_width`, default 6 bits), computes each one's legal encoding set from the design's own next-state logic, and reports whether any illegal encoding is reachable — **without the caller naming any property**.
+
+```json
+{
+  "fsm_registers_checked": 3,
+  "illegal_encodings_found": 1,
+  "registers": [
+    {
+      "register": "ctrl_state",
+      "legal_encodings": [0, 1, 2, 3],
+      "verdict": "violated",
+      "illegal_encoding_reachable": true
+    }
+  ]
+}
+```
+
+- `verdict` per register is the same canonical vocabulary. `illegal_encoding_reachable` is a convenience alias for `verdict == "violated"`.
+- Wider registers are treated as datapath / counters and skipped (see `default_fsm_max_width` in the source).
+
+## The SV request shapes
+
+All five SV wrappers share the same lift-input core:
+
+- `source` — the primary SystemVerilog module content.
+- `additional_sources` — extra packages / includes as `FileContent` records.
+- `top` — top module for the lift (auto-detected when omitted).
+- `use_sv2v` — run `sv2v` before Yosys (needed for modern SV constructs Yosys refuses).
+- `use_slang` — force the `read_slang` frontend (needed for `while` loops, `import pkg::*;`, and other constructs `sv2v` silently drops — see the CLAUDE.md "slang-gated" note under `SVA-verification e2e validation`).
+
+Verb-specific fields (`request` / `grant` / `target` / `responses` / `max_width` / `predicates` / `refine` / `config_values` / `discover_assumptions`) match the BTOR2 sibling's non-`content` fields one-for-one. A downstream consumer that already parses the BTOR2 verbs adds the SV wrappers cheaply.
+
+## Consumer guidance
+
+Same as [`verdict.md`](verdict.md):
+
+- Treat `verdict` as the source of truth; parse structured detail only when the verb ships it.
+- Tolerate unknown enum-shaped strings (`AssumptionKind`, `verdict`, `terminated_with`). mununu's stability contract allows additive expansion.
+- A `contradiction: true` on `/btor2/verify` is a soundness alarm, not a hint; escalate rather than picking a side.
+- `refinement` on `/btor2/verify-recoverability` is optional. Only ask for it (`refine: true`, `config_values: […]`, or `discover_assumptions: true`) when the consumer knows what to do with it — the default path stays minimal.
+
+## Not covered here
+
+- **`POST /btor2/cegar`** and **`POST /sv/cegar`** — the CEGAR refinement-trace endpoint (viewer-shaped). Follows in a subsequent PR alongside `/context/synthesize` and `/synth/gr1`.
+- **`POST /sv/verify-auto`** — the flagship BTOR2-free entry with its own richer response tree. Covered in [`verdict.md`](verdict.md).
+
+## See also
+
+- [`README.md`](README.md) — index of every shipped schema file plus the update procedure.
+- [`verdict.md`](verdict.md) — narrative for the flagship `sv verify-auto` response.
+- [`../verifying-rtl.md`](../verifying-rtl.md) — user-facing walkthrough of each verb from the CLI side.
+- [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md) — when a wire-format change must ship a briefing.

--- a/docs/consumer-briefings/2026-09-btor2-and-sv-verb-schemas.md
+++ b/docs/consumer-briefings/2026-09-btor2-and-sv-verb-schemas.md
@@ -1,0 +1,101 @@
+# Consumer briefing — 2026-09 JSON schemas for the BTOR2 + SV verb endpoints
+
+> **Audience:** ROSF (API consumer via `--profile industrial`), monono (direct API + CLI), any orchestrator or codegen consumer that hits `/btor2/*` or `/sv/*` property-verb endpoints.
+>
+> **Related:** the machine-readable JSON Schema mechanism landed in mununu#485 ([`docs/api-schemas/`](../api-schemas/)) with only the flagship `sv verify-auto` derived. This PR extends the coverage across the BTOR2-direct verbs and their SV wrappers.
+>
+> **TL;DR:** 14 additional `*.schema.json` files landed under [`docs/api-schemas/`](../api-schemas/) covering `POST /btor2/verify`, `verify-liveness`, `verify-liveness-all`, `verify-recoverability`, `check-fsm` and their `sv/*` siblings. **No wire-format change.** Consumers who point `quicktype` / `openapi-typescript` / `datamodel-code-generator` at the new files get typed clients for the full verify-verb surface. Consumers that continue to hand-parse are unaffected.
+
+## What changed
+
+- **`JsonSchema` derives** on 12 wire types in `crates/mununu-core/src/api/models.rs`:
+  - Requests: `Btor2VerifyRequest`, `Btor2VerifyLivenessRequest`, `Btor2VerifyLivenessAllRequest`, `Btor2VerifyRecoverabilityRequest`, `Btor2CheckFsmRequest`, `SvVerifyRequest`, `SvVerifyLivenessRequest`, `SvVerifyLivenessAllRequest`, `SvVerifyRecoverabilityRequest`, `SvCheckFsmRequest`.
+  - Responses: `Btor2VerifyResponse`, `Btor2VerifyLivenessResponse`, `Btor2VerifyRecoverabilityResponse`, `Btor2CheckFsmResponse` (nested `FsmRegisterFinding`). The SV wrappers reuse the BTOR2 responses one-for-one.
+- **Cfg-attr `JsonSchema` derives** on 6 external types that the recoverability response transitively references (unchanged behaviour; the derive is `#[cfg_attr(feature = "api", …)]` so default builds are unaffected):
+  - `crate::verdict::PropertyVerdict`, `VerdictRefinement`, `VacuityWitness`, `ConfigPartition`, `AssumptionKind`, `DiscoveredAssumption`.
+  - `crate::adapter::recoverability::RecoverabilityBotDiagnosis`.
+- **`crates/mununu-core/src/api/schema.rs`** — 14 new generator functions + 14 new drift-detector tests.
+- **Shipped schema files** under `docs/api-schemas/`:
+  - `btor2-verify-request.schema.json`, `btor2-verify-response.schema.json`
+  - `btor2-verify-liveness-request.schema.json`, `btor2-verify-liveness-response.schema.json`
+  - `btor2-verify-liveness-all-request.schema.json`
+  - `btor2-verify-recoverability-request.schema.json`, `btor2-verify-recoverability-response.schema.json`
+  - `btor2-check-fsm-request.schema.json`, `btor2-check-fsm-response.schema.json`
+  - `sv-verify-request.schema.json`, `sv-verify-liveness-request.schema.json`, `sv-verify-liveness-all-request.schema.json`, `sv-verify-recoverability-request.schema.json`, `sv-check-fsm-request.schema.json`
+- **`docs/api-schemas/README.md`** — extended with sectioned tables covering BTOR2-direct verbs, SV-wrapped verbs, and the SV → BTOR2 response-reuse mapping.
+- **`docs/api-schemas/verify-verbs.md`** — new — narrative companion walking each response field-by-field and mapping every verb onto safety / liveness / recoverability / FSM.
+
+## What did NOT change
+
+- Wire format — unchanged.
+- `PropertyVerdict` values — unchanged.
+- Handler code, engine behaviour, and route table — unchanged.
+- The `sv verify-auto` schema from mununu#485 — unchanged.
+
+## For ROSF and monono
+
+**What to update:** nothing forced. To adopt machine-readable typing on your side for the BTOR2 + SV verb surface:
+
+```sh
+# Point codegen at the response schemas your consumer parses. Example — TypeScript:
+for f in docs/api-schemas/btor2-*-response.schema.json docs/api-schemas/sv-verify-auto-response.schema.json; do
+  base=$(basename "$f" .schema.json)
+  npx openapi-typescript "$f" --output "types/${base}.d.ts"
+done
+
+# For request bodies your consumer posts:
+for f in docs/api-schemas/btor2-*-request.schema.json docs/api-schemas/sv-*-request.schema.json; do
+  base=$(basename "$f" .schema.json)
+  npx openapi-typescript "$f" --output "types/${base}.d.ts"
+done
+```
+
+The SV → BTOR2 response reuse means a consumer only needs the BTOR2 response types plus the SV request types. See [`docs/api-schemas/verify-verbs.md`](../api-schemas/verify-verbs.md) for the mapping.
+
+Pin a specific mununu binary release + the corresponding schema files. On a version bump, either accept the drift (the new release's schema is the new contract) or pin the previous release while you migrate. A briefing accompanies any wire-format change.
+
+**Docker rebuild:** none required. The schema files are docs; the mununu binary itself does not carry the schemas at runtime.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | binary picks up new JsonSchema derives + generator functions. No behavioural change. | No — unless you consume the derived schemas out of the binary via a helper endpoint (there isn't one shipped) |
+| mununu `Dockerfile.dev` | binary bump; drift-detector test now covers 16 schemas total | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; no e2e-test behaviour change | No — the slang-gated e2e set is unaffected by pure derive additions |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `Dockerfile` / `Dockerfile.dev` / `.hw` | consumes mununu CLI/API; no wire-format change | No — new schema files land as docs, not as binary contract |
+| monono Docker (if any) | consumes CLI; no CLI change | No |
+| mununu-ui deployment | no impact | No |
+
+## Regenerate flow (when the wire format changes)
+
+Unchanged from mununu#485 — one command covers every derived schema:
+
+```sh
+MUNUNU_UPDATE_API_SCHEMAS=1 \
+  cargo test -p mununu-core --lib --features api api_schema_drift_ -- --test-threads=1
+git add docs/api-schemas/
+```
+
+Then ship a consumer briefing per [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md) explaining the transition.
+
+## Verification
+
+- `make ci` green with the new derives in place.
+- `MUNUNU_UPDATE_API_SCHEMAS=1 cargo test -p mununu-core --lib --features api api_schema_drift_` regenerates all 16 shipped schemas idempotently (unset the env var and the drift-detector confirms zero diff).
+- `docs/api-schemas/verify-verbs.md` walks every response and every SV request; the `README.md` table lists every file.
+
+## Provenance
+
+- Fix commit: (pending merge — branch `docs/api-schemas-btor2-and-synth`).
+- Related: mununu#485 (machine-readable schema mechanism + flagship `sv verify-auto`).
+- Policy: [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+- Prior briefing on this track: [`2026-08-json-schema-derivation.md`](2026-08-json-schema-derivation.md).
+
+## Not covered here (follow-ups)
+
+- **CEGAR schemas** — `POST /btor2/cegar` and `POST /sv/cegar`. Response has a large view-type tree (`CegarIterationView`, `PredicateView`, `WitnessCellView`, `CounterTraceView`, `CegarVerdictSummary`, `PredicateSpecRequest`) that adds ~10 more derives; lands separately to keep this PR focused.
+- **Synth schemas** — `POST /context/synthesize` and `POST /synth/gr1`. Responses reference `SynthesisDiagnostics`, `CounterstrategyResult`, and `TemplateRef` outside the `api::` module; adds a small non-api-module derive set. Lands in the CEGAR follow-up or a synth-specific one.
+- **Enum-typing for `verdict` / `AssumptionKind` in the schemas.** `verdict` is `String` in the Rust source for backward-compat; `AssumptionKind` is already a proper Rust enum and DOES appear as a JSON-Schema `oneOf` in `btor2-verify-recoverability-response.schema.json`. Migrating `verdict` to a serde-enum is a wire-format shape change with a mandatory briefing — not scoped here.
+- **OpenAPI / `utoipa` integration.** Not needed today; the per-response schema files serve every codegen. Can be added additively later.


### PR DESCRIPTION
## Summary

Extends the machine-readable schema mechanism from #485 (which covered only `POST /sv/verify-auto`) across every BTOR2-direct property verb and its SV wrapper. Consumers who point `quicktype` / `openapi-typescript` / `datamodel-code-generator` at the new files get typed clients for the full verify-verb surface; consumers that continue to hand-parse are unaffected.

## What ships

**Derives on 12 wire types** in [`crates/mununu-core/src/api/models.rs`](crates/mununu-core/src/api/models.rs):

- Requests: `Btor2VerifyRequest`, `Btor2VerifyLivenessRequest`, `Btor2VerifyLivenessAllRequest`, `Btor2VerifyRecoverabilityRequest`, `Btor2CheckFsmRequest`, `SvVerifyRequest`, `SvVerifyLivenessRequest`, `SvVerifyLivenessAllRequest`, `SvVerifyRecoverabilityRequest`, `SvCheckFsmRequest`.
- Responses: `Btor2VerifyResponse`, `Btor2VerifyLivenessResponse`, `Btor2VerifyRecoverabilityResponse`, `Btor2CheckFsmResponse` (nested `FsmRegisterFinding`). The SV wrappers reuse the BTOR2 responses one-for-one.

**Cfg-attr derives on 6 external types** the recoverability response transitively references — `verdict::{PropertyVerdict, VerdictRefinement, VacuityWitness, ConfigPartition, AssumptionKind, DiscoveredAssumption}` and `adapter::recoverability::RecoverabilityBotDiagnosis`. `#[cfg_attr(feature = \"api\", derive(schemars::JsonSchema))]` so default builds stay unaffected.

**Generator + drift** — 14 new generator functions and 14 new drift-detector tests in [`crates/mununu-core/src/api/schema.rs`](crates/mununu-core/src/api/schema.rs). Regeneration is the same one-command flow as #485:

```sh
MUNUNU_UPDATE_API_SCHEMAS=1 \
  cargo test -p mununu-core --lib --features api api_schema_drift_ -- --test-threads=1
```

**14 new schema files** under [`docs/api-schemas/`](docs/api-schemas/) (10 BTOR2-direct request/response + 4 SV wrapper requests + 1 SV `check-fsm` request). Existing `sv-verify-auto-*` files unchanged.

**Narrative + index** — new [`docs/api-schemas/verify-verbs.md`](docs/api-schemas/verify-verbs.md) walks each response field-by-field and maps every verb onto safety / liveness / recoverability / FSM. [`README.md`](docs/api-schemas/README.md) extended with sectioned tables covering BTOR2-direct verbs, SV-wrapped verbs, and the SV → BTOR2 response-reuse mapping.

**Consumer briefing** at [`docs/consumer-briefings/2026-09-btor2-and-sv-verb-schemas.md`](docs/consumer-briefings/2026-09-btor2-and-sv-verb-schemas.md) per the cross-repo-impact policy — no wire-format change, additive-safe for ROSF and monono, docker rebuild table filled.

## What did NOT change

- Wire format — unchanged.
- `PropertyVerdict` values — unchanged.
- Handler code, engine behaviour, route table — unchanged.
- The `sv verify-auto` schema from #485 — unchanged.

## Deferred (called out in the briefing)

- **CEGAR** — `POST /btor2/cegar`, `POST /sv/cegar`. Larger view-type tree (`CegarIterationView`, `PredicateView`, `WitnessCellView`, `CounterTraceView`, `CegarVerdictSummary`, `PredicateSpecRequest`); lands separately.
- **Synth** — `POST /context/synthesize`, `POST /synth/gr1`. Responses reference `SynthesisDiagnostics`, `CounterstrategyResult`, `TemplateRef` outside `api::`; adds a small non-api-module derive set. Lands in the CEGAR follow-up or a synth-specific PR.

## Test plan

- [x] `MUNUNU_UPDATE_API_SCHEMAS=1 cargo test -p mununu-core --lib --features api api_schema_drift_` regenerates all 16 shipped schemas idempotently.
- [x] Same tests with the env var UNSET → 16/16 pass (drift-detector confirms zero diff).
- [x] `cargo check --workspace` clean on default features (external cfg-attr derives don't leak).
- [x] `cargo check --workspace --features mununu-core/api` clean.
- [x] Pre-commit hook green (fmt, machete, workspace check, clippy, test).
- [ ] GitHub Actions CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)