### PR TITLE
docs(sva): rewrite `@mununu_assume GF` note to point at the shipped fairness routes (#477)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1232,9 +1232,12 @@ struct AnnotationScan {
     /// `TranslatedAssertion`s ready to merge into `extraction.translated`.
     guarantees: Vec<crate::adapter::slang::translate::TranslatedAssertion>,
     /// `@mununu_assume <body>` bodies (verbatim) — recorded for provenance. A
-    /// `<signal> = <value>` assume can be applied via the existing config
-    /// concretization; a temporal `GF ...` fairness assume is documented future
-    /// work (mununu has no native fairness-constrained model checking).
+    /// `<signal> = <value>` assume is applied by this path via config
+    /// concretization; a temporal `GF …` fairness assume is recorded rather
+    /// than auto-applied — the SV verify-auto lift does not yet route it to
+    /// the fairness-constrained engine. Fairness-constrained model checking
+    /// IS shipped (CTXDSL + GR(1); `btor2 game --objective recurrence`); see
+    /// mununu#477 for the bridge tracking.
     assumes: Vec<String>,
     /// `@mununu_guarantee` bodies that did NOT parse — surfaced, never silently
     /// dropped.
@@ -1336,21 +1339,32 @@ fn annotation_note(scan: &AnnotationScan) -> Option<VerificationNote> {
         summary: format!(
             "{} `@mununu_guarantee` propert{} verified alongside the design's SVA{}.",
             scan.guarantees.len(),
-            if scan.guarantees.len() == 1 { "y" } else { "ies" },
+            if scan.guarantees.len() == 1 {
+                "y"
+            } else {
+                "ies"
+            },
             if scan.skipped.is_empty() {
                 String::new()
             } else {
                 format!("; {} unparsable, skipped", scan.skipped.len())
             }
         ),
-        detail: "`@mununu_guarantee <mu-calculus>` / `@mununu_assume <body>` annotations carry the \
+        detail:
+            "`@mununu_guarantee <mu-calculus>` / `@mununu_assume <body>` annotations carry the \
                  mununu-exclusive properties an author adds beyond the design's own SVA (e.g. \
                  assume-guarantee liveness the SVA fragment cannot express). Guarantee bodies are \
                  mu-calculus formulas parsed by the same parser as the translated SVA and verified \
-                 through the same pipeline. `@mununu_assume` of the form `<signal> = <value>` can be \
-                 applied via config concretization; a temporal (`GF …`) fairness assume is not yet \
-                 checkable (no native fairness-constrained model checking) and is recorded here."
-            .into(),
+                 through the same pipeline. `@mununu_assume` of the form `<signal> = <value>` is \
+                 applied by this path via config concretization. A temporal (`GF …`) fairness \
+                 assume is recorded here rather than auto-applied — the SV verify-auto lift does \
+                 not yet route it to the fairness-constrained engine. Fairness-constrained model \
+                 checking IS shipped: `mununu sv emit-btor2` + `mununu btor2 game --objective \
+                 recurrence` (single-pair GR(1)) decides `(GF assume) → (GF guarantee)` on the \
+                 lifted design, and CTXDSL's GR(1) game engine `(⋀ GF envᵢ) → (⋀ GF sysⱼ)` \
+                 discharges multi-pair assume-guarantee liveness directly. See mununu#477 for \
+                 the SV-path auto-routing bridge."
+                .into(),
         items,
     })
 }

--- a/docs/consumer-briefings/2026-09-fairness-note-honesty.md
+++ b/docs/consumer-briefings/2026-09-fairness-note-honesty.md
@@ -1,0 +1,61 @@
+# Consumer briefing — 2026-09 `@mununu_assume GF` note text now points at the supported route
+
+> **Audience:** ROSF (API consumer via `--profile industrial`), monono (direct CLI + API consumer), any orchestrator that parses the `sv verify-auto` `annotation-properties` verification note.
+>
+> **Related:** [mununu#477](https://github.com/vscorza/mununu/issues/477) — the ticket that surfaced the misleading framing.
+>
+> **TL;DR:** the `annotation-properties` note text on the `sv verify-auto` response has been rewritten. It no longer reads as "the tool cannot do fairness-constrained model checking"; it points users at the routes that ARE shipped (`mununu btor2 game --objective recurrence` and CTXDSL's GR(1) engine). Same note kind, same level, same items list — **only the `detail` string changed.** No wire-format shape change; a consumer that only inspects `verdict` / `kind` / `level` is unaffected. Two doc pages were also updated (`Composition.md` gains a composition footgun gotcha; `Property-Templates.md` clarifies where fairness IS supported).
+
+## What changed
+
+- **`crates/mununu-core/src/adapter/slang/verify_auto.rs`** — the `annotation_note` detail string at line ~1346 rewritten. Old text ended "and is recorded here" after saying "no native fairness-constrained model checking"; new text says fairness IS shipped via `mununu btor2 game --objective recurrence` (single-pair GR(1) on the emitted BTOR2) and via CTXDSL's GR(1) game engine, with a `mununu#477` reference for the SV-path auto-routing bridge.
+- **Struct doc comment** at `AnnotationScan::assumes` (line ~1234) mirrors the same correction.
+- **`wiki/Composition.md`** — new "Key Gotchas" bullet: *a shared label the component cannot take is a label the environment cannot emit — silently.* Filed against a real monono debug per the ticket comment.
+- **`wiki/Property-Templates.md`** — the "Soundness default" callout about `AF` / `GF` fairness updated to name where fairness IS supported today (`btor2 game --objective recurrence` and CTXDSL GR(1)), rather than the flat "not assumable" statement.
+- **Plan doc** `/.claude/plans/477-fairness-assumption-sv-bridge.md` (agent-side, not in-repo) — the Option B follow-up bridging `sv verify-auto` to the game engine, scoped as a future track.
+
+## What did NOT change
+
+- Wire format — unchanged. The `annotation-properties` note's `kind`, `level`, and `items` array are byte-identical.
+- Response shape / route table / engine behaviour — unchanged.
+- The `sv verify-auto` schema shipped in mununu#485 — unchanged.
+- CLI / API surface — no new flags, no new endpoints.
+
+## For ROSF and monono
+
+**What to update:** nothing forced. A consumer that surfaces the annotation-properties note to a user or log will see the new text; verify any regex/keyword matches on the old string content ("no native fairness-constrained model checking", "recorded here") and remove or update them.
+
+**What to expect on already-affected properties:** the `wb_mem_client` case from the ticket comment — `AG(req → AF ack)` under `@mununu_assume GF grant_cpu` — still returns `Unknown` on the `sv verify-auto` path (Option B is what fixes that). This PR does NOT change the verdict; it changes the **note text** that told users the tool couldn't do fairness at all. The actual capability IS shipped, just via a different verb — walk it through `mununu sv emit-btor2 && mununu btor2 game --objective recurrence` (or model in CTXDSL).
+
+**Docker rebuild:** none required.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | binary picks up the rewritten note detail; no behavioural change | No — unless you pin a tag and want the new text |
+| mununu `Dockerfile.dev` | binary bump | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; no e2e behaviour change | No |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `Dockerfile` / `Dockerfile.dev` / `.hw` | consumes mununu CLI/API; note-text change is user-visible if surfaced | No — behaviour updates on next binary pull |
+| monono Docker (if any) | primary beneficiary of the corrected framing | No — pull the new binary when adopting |
+| mununu-ui deployment | no impact | No |
+
+## Verification steps
+
+- `mununu sv verify-auto <sv-with-@mununu_assume>` returns the note; inspect `verification_notes[i].detail` for the new text.
+- `cargo test -p mununu-core --lib h5_gr1_assume_recorded_and_empty_source_has_no_note` passes.
+- `docs/api-schemas/sv-verify-auto-response.schema.json` unchanged (no derive touched).
+
+## Provenance
+
+- Fix commit: (pending merge — branch `fix/477-annotation-note-fairness-honesty`).
+- Ticket: [mununu#477](https://github.com/vscorza/mununu/issues/477).
+- Follow-up track: agent-side plan `477-fairness-assumption-sv-bridge.md` — the Option B full bridge; not scoped for this PR.
+- Policy: [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here (follow-ups)
+
+- **The SV verify-auto → game-engine bridge.** Detecting `GF <atom>` bodies in the annotation scanner, dispatching to the recurrence game engine automatically, and folding the definite verdict back into the property row. Planned as Option B on the same ticket; agent-side plan doc names the phases + effort estimate.
+- **Multi-pair GR(1) on the SV path.** The CTXDSL path supports it; the SV bridge starts single-pair per the ticket's narrowed ask.
+- **General LTL assumptions.** The ticket explicitly narrows to `GF <signal>` conjunctions on primary inputs.

--- a/wiki/Composition.md
+++ b/wiki/Composition.md
@@ -209,6 +209,7 @@ The full example is in `tutorial/examples/04_cross_domain.ctxdsl`.
 - **Skip labels are only needed for synchronous composition.** In asynchronous mode, members are not required to step, so self-loop skip labels are unnecessary.
 - **Hierarchical composition is order-sensitive.** Inner compositions must be declared before the outer composition that references them.
 - **Formulas can target any level.** You can write mu-calculus properties over individual automata, inner compositions, or the outermost system -- just set the `over` field accordingly.
+- **A shared label the component cannot take is a label the environment cannot emit — silently.** In synchronous composition, if only one side declares a transition on a shared label, the composed system can only fire it when *both* sides are ready. From the component's point of view this makes an unmodelled state look like "the environment does not act here" — but in the real system the environment *does* act; the event just gets dropped by the component. That is a common protocol-modelling footgun: an omitted transition constrains the environment rather than the component, and a liveness property that should have failed will hold vacuously. If the environment can act anyway and you lose the event, model the loss explicitly — a self-loop or a discard transition on the receiving side is the difference between *cannot happen* (a spec claim) and *happens and is lost* (a real bug). Filed against a real monono debug in mununu#477.
 
 ## KMTS Composition — Modality Merge (post-R.1)
 

--- a/wiki/Property-Templates.md
+++ b/wiki/Property-Templates.md
@@ -49,8 +49,12 @@ Shorthand → mu-calculus is the [Mu-Calculus Reference](Mu-Calculus-Reference.m
 `AG EF p = nu Y.((mu X.(p || <> X)) && [] Y)`, `AG(a → EF b) = nu Z.((!(a) || mu Y.(b || <> Y)) && [] Z)`.
 
 **Soundness default — use `EF` (reachable), not `AF` (inevitable).** `AF`/box-`AF` is sound only where no free
-input (a kick, a clock-stretch, a competing request, a bus-cycle drop) can stall the antecedent path forever;
-`GF` fairness is not assumable. When unsure, `EF`.
+input (a kick, a clock-stretch, a competing request, a bus-cycle drop) can stall the antecedent path forever.
+On the `sv verify-auto` flagship path, a `GF` fairness assumption is currently *recorded* rather than
+auto-applied — the SV lift does not yet route it to the fairness-constrained engine. Fairness IS supported
+today via `mununu btor2 game --objective recurrence` (single-pair GR(1) on the emitted BTOR2) and via
+CTXDSL's GR(1) game engine `(⋀ GF envᵢ) → (⋀ GF sysⱼ)`; see mununu#477 for the SV-path bridge tracking.
+When unsure and staying on `sv verify-auto`, prefer `EF`.
 
 | class | trigger | patterns (shorthand, `<slots>` = observable signals) |
 |---|---|---|


### PR DESCRIPTION
Fixes #477 (Option A — the note-text honesty fix).

## Summary

The `annotation-properties` verification note that `sv verify-auto` emitted said *"a temporal (`GF …`) fairness assume is not yet checkable (no native fairness-constrained model checking) and is recorded here"*, which reads as "the tool cannot do this." That was wrong: mununu ships fairness-constrained model checking today via `mununu btor2 game --objective recurrence` (single-pair GR(1) on the emitted BTOR2) and via CTXDSL's GR(1) game engine `(⋀ GF envᵢ) → (⋀ GF sysⱼ)` for multi-pair.

The gap is that the SV verify-auto path does not yet auto-route into either — the ticket's Option B is that follow-up bridge, scoped separately.

## What ships

- **[verify_auto.rs](crates/mununu-core/src/adapter/slang/verify_auto.rs)** — `annotation_note` detail rewritten to name both supported routes explicitly and reference #477 for the SV-path auto-routing bridge. `AnnotationScan::assumes` struct doc mirrors the same correction.
- **[wiki/Composition.md](wiki/Composition.md)** — new "Key Gotchas" bullet on the composition footgun the ticket comment surfaced from a real monono debug: *a shared label the component cannot take is a label the environment cannot emit, silently.* Model the loss explicitly rather than omitting the transition.
- **[wiki/Property-Templates.md](wiki/Property-Templates.md)** — the "Soundness default" callout no longer flatly says `GF` fairness is unassumable; it names the verbs where it IS supported today (`btor2 game --objective recurrence`, CTXDSL GR(1)) and the SV-path caveat.
- **[docs/consumer-briefings/2026-09-fairness-note-honesty.md](docs/consumer-briefings/2026-09-fairness-note-honesty.md)** — briefing per the cross-repo-impact policy. **No wire-format shape change**; the `annotation-properties` note's `kind`, `level`, and `items` are byte-identical; only the `detail` string moved.

## What did NOT change

- Wire format — unchanged.
- Engine behaviour — unchanged.
- Verdicts on existing properties — unchanged. (The `wb_mem_client` ticket case still returns `Unknown` on `sv verify-auto` — Option B is what fixes that. This PR corrects the framing that said the tool couldn't do fairness at all.)
- CLI / API surface — no new flags, no new endpoints.
- The `sv verify-auto` schema shipped in #485 — unchanged.

## Follow-up

**Option B** — the SV verify-auto → game-engine bridge — is scoped as an agent-side plan doc at `.claude/plans/477-fairness-assumption-sv-bridge.md` (not in-repo, not blocking this PR). Estimated 3 sessions across 2 PRs. Detects `GF <atom>` bodies in the annotation scanner, dispatches to the recurrence game engine automatically, folds the definite verdict back into the property row via the existing `holds_under` refinement mechanism with `AssumptionKind::InputFairness`.

## Test plan

- [x] All 4 `h5_gr1_*` annotation tests pass with the rewritten detail.
- [x] `cargo check -p mununu-core --features api --lib` clean.
- [x] `cargo fmt --check` clean.
- [x] Pre-commit hook green.
- [ ] GitHub Actions CI on this PR.

Consumers that grep on the old text ("no native fairness-constrained model checking", "recorded here") need to update; every other consumer is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)