### PR TITLE
feat(engine): fair-cycle l2s + `btor2 verify-liveness-under-fairness` verb (#477 Option B, PR 1 of 2)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -268,6 +268,18 @@ enum Btor2Command {
     /// lasso), else `unknown` if any is, else `holds`. Surface peer of
     /// `POST /api/v1/btor2/verify-liveness-all`.
     VerifyLivenessAll(Btor2VerifyLivenessAllArgs),
+    /// Decide the response-liveness property `AG(request → AF grant)` UNDER a
+    /// conjunction of environment fairness assumptions `⋀ⱼ GF fairⱼ`
+    /// (mununu#477 Option B).
+    ///
+    /// The Emerson–Lei fair-cycle extension of `verify-liveness`: adds one
+    /// `fairⱼ_seen` latch per fairness atom and requires each on the closed
+    /// loop, so `bad` fires only on a lasso that satisfies EVERY fairness
+    /// constraint AND leaves a request forever ungranted. Empty `--fairness`
+    /// recovers `verify-liveness` exactly. `--request` / `--grant` / each
+    /// `--fairness` is a single register-comparison atom (`"grant_cpu == 1"`).
+    /// Surface peer of `POST /api/v1/btor2/verify-liveness-under-fairness`.
+    VerifyLivenessUnderFairness(Btor2VerifyLivenessUnderFairnessArgs),
     /// Decide recoverability `AG EF good` — the branching property SVA cannot state.
     ///
     /// "From every reachable state, can the design still get back to a `good`
@@ -721,6 +733,29 @@ struct Btor2VerifyLivenessAllArgs {
     /// `⋀ AG(ANTE → AF CONS)`. At least one required.
     #[arg(long = "response", value_name = "ANTE => CONS", required = true)]
     responses: Vec<String>,
+    #[command(flatten)]
+    ci: CiArgs,
+}
+
+/// Arguments for `mununu btor2 verify-liveness-under-fairness` — the fair-cycle
+/// l2s (Emerson–Lei) extension of `verify-liveness` (mununu#477 Option B).
+#[derive(Args, Debug)]
+struct Btor2VerifyLivenessUnderFairnessArgs {
+    /// Path to the BTOR2 input file.
+    #[arg(value_name = "BTOR2_FILE")]
+    file: PathBuf,
+    /// The request atom — a register comparison, e.g. `"req == 1"`.
+    #[arg(long, value_name = "ATOM")]
+    request: String,
+    /// The grant atom that must eventually follow on every path, e.g. `"ack == 1"`.
+    #[arg(long, value_name = "ATOM")]
+    grant: String,
+    /// A fairness atom `GF <atom>` — a single register-comparison atom whose
+    /// satisfaction is assumed to hold infinitely often on every path considered.
+    /// Repeatable; the verdict is the response under the conjunction
+    /// `⋀ⱼ GF fairⱼ`. Empty recovers `verify-liveness` exactly.
+    #[arg(long = "fairness", value_name = "ATOM")]
+    fairness: Vec<String>,
     #[command(flatten)]
     ci: CiArgs,
 }
@@ -2856,6 +2891,9 @@ fn handle_btor2(command: Btor2Command) -> Result<(), String> {
         Btor2Command::SpacerCheck(args) => btor2_spacer_check(args),
         Btor2Command::VerifyLiveness(args) => btor2_verify_liveness(args),
         Btor2Command::VerifyLivenessAll(args) => btor2_verify_liveness_all(args),
+        Btor2Command::VerifyLivenessUnderFairness(args) => {
+            btor2_verify_liveness_under_fairness(args)
+        }
         Btor2Command::VerifyRecoverability(args) => btor2_verify_recoverability(args),
         Btor2Command::VerifySafety(args) => btor2_verify_safety(args),
         Btor2Command::CheckFsm(args) => btor2_check_fsm(args),
@@ -3165,6 +3203,64 @@ fn btor2_verify_liveness_all(args: Btor2VerifyLivenessAllArgs) -> Result<(), Str
         "property": response_conjunction_property(&args.responses),
         "verdict": PropertyVerdict::from(verdict).as_str(),
         "responses": per_response_decided_by(&args.responses, &outcomes),
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&summary).map_err(|e| format!("serialize summary: {e}"))?
+    );
+    ci_gate_exit(PropertyVerdict::from(verdict).as_str(), args.ci.fail_on);
+    Ok(())
+}
+
+/// `mununu btor2 verify-liveness-under-fairness` (mununu#477 Option B) — decide
+/// `(⋀ GF fair) → AG(request → AF grant)` via the fair-cycle l2s (Emerson–Lei)
+/// plus the reachability portfolio, printing the verdict as JSON. Surface peer
+/// of `POST /api/v1/btor2/verify-liveness-under-fairness`.
+fn btor2_verify_liveness_under_fairness(
+    args: Btor2VerifyLivenessUnderFairnessArgs,
+) -> Result<(), String> {
+    use mununu_core::adapter::liveness_rescue::{
+        parse_fairness_atoms, parse_response_atom, response_liveness_rescue_under_fairness,
+    };
+    use mununu_core::verdict::PropertyVerdict;
+
+    let content = std::fs::read_to_string(&args.file)
+        .map_err(|e| format!("Failed to read BTOR2 '{}': {e}", args.file.display()))?;
+    let request = parse_response_atom(&args.request)?;
+    let grant = parse_response_atom(&args.grant)?;
+    let fairness = parse_fairness_atoms(&args.fairness)?;
+
+    let (verdict, outcome) =
+        response_liveness_rescue_under_fairness(&content, &request, &grant, &fairness, false)
+            .ok_or_else(|| {
+                format!(
+                    "could not build the fair-cycle liveness monitor for '{}' — an atom likely \
+                     binds no signal",
+                    args.file.display()
+                )
+            })?;
+
+    let property = if args.fairness.is_empty() {
+        format!("AG(({}) -> AF ({}))", args.request, args.grant)
+    } else {
+        let fair_and = args
+            .fairness
+            .iter()
+            .map(|f| format!("GF ({f})"))
+            .collect::<Vec<_>>()
+            .join(" && ");
+        format!(
+            "({fair_and}) -> AG(({}) -> AF ({}))",
+            args.request, args.grant
+        )
+    };
+    let summary = serde_json::json!({
+        "file": args.file.display().to_string(),
+        "property": property,
+        "verdict": PropertyVerdict::from(verdict).as_str(),
+        "fairness": args.fairness,
+        "decided_by": outcome.reachable_by.iter().chain(outcome.unreachable_by.iter())
+            .collect::<Vec<_>>(),
     });
     println!(
         "{}",

--- a/crates/mununu-core/src/adapter/btor2/l2s_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/l2s_monitor.rs
@@ -32,6 +32,39 @@
 //! `b`-free lasso through a pending request) and **complete** (a real violation has
 //! a suffix cycle on which `pending` stays 1 and `b` never holds, which the
 //! nondeterministic `save` can snapshot).
+//!
+//! # Fair-cycle extension (mununu#477 Option B)
+//!
+//! [`emit_response_l2s_monitor_under_fairness`] is the sibling that decides
+//! `(⋀_i GF fair_i) → AG(a → AF b)` — response-liveness UNDER a conjunctive
+//! justice assumption on primary-input (or combinational) atoms. It adds one
+//! `fair_i_seen` latch per fairness constraint (each mirroring `b_seen`'s
+//! definition exactly, with `fair_i` in `b`'s slot: was `fair_i` observed
+//! anywhere on the snapshotted cycle?) and conjuncts them into `bad`:
+//!
+//! ```text
+//! bad = looped ∧ ¬b_seen ∧ ⋀_i fair_i_seen
+//! ```
+//!
+//! **Soundness (bad reachable ⇒ genuine violation):** a reachable `bad` state
+//! has `looped` (snapshotted state repeats — a real cycle exists), `¬b_seen`
+//! (no `b` on the cycle segment), each `fair_i_seen` (each `fair_i` fires at
+//! least once on the cycle). The infinite unrolling `stem · cycle^ω` then
+//! satisfies each `GF fair_i` (fires once per cycle iteration ⇒ infinitely
+//! often) and violates `AG(a → AF b)` (the pending request stays outstanding
+//! forever since `b` never holds after the snapshot).
+//!
+//! **Completeness (violation ⇒ bad reachable):** if `π` violates
+//! `(⋀ GF fair_i) → AG(a → AF b)`, then `π` satisfies each `GF fair_i` and has
+//! a suffix cycle carrying pending-a with no b. The nondeterministic `save` can
+//! snapshot at the cycle-entry state; each `fair_i` fires somewhere on the
+//! subsequent cycle by `GF fair_i`; `b_seen` never latches by the pending-a
+//! assumption. Standard finite-state lasso closure gives `looped`. Hence `bad`
+//! is reachable. This is Emerson–Lei fair-cycle detection composed with the
+//! l2s save/snapshot argument (already trusted for the fairness-free case).
+//!
+//! Zero fairness atoms recovers the plain [`emit_response_l2s_monitor`]
+//! semantics exactly (the empty conjunction is `one`).
 
 use crate::adapter::btor2::ast::{Nid, Node};
 use crate::adapter::btor2::bad_monitor::{
@@ -98,11 +131,33 @@ fn emit_atom(
 /// Append the liveness-to-safety `bad` monitor for `AG(ante → AF cons)` to `content`.
 ///
 /// See the module docs for the construction. Returns an error when an atom does not
-/// resolve to a signal.
+/// resolve to a signal. Byte-for-byte equivalent to
+/// [`emit_response_l2s_monitor_under_fairness`] with an empty `fairness_atoms` slice.
 pub fn emit_response_l2s_monitor(
     content: &str,
     ante: (&str, CmpOp, u128),
     cons: (&str, CmpOp, u128),
+    reset_pinned: bool,
+) -> Result<String, AdapterError> {
+    emit_response_l2s_monitor_under_fairness(content, ante, cons, &[], reset_pinned)
+}
+
+/// mununu#477 Option B — append the fair-cycle l2s `bad` monitor for
+/// `(⋀_i GF fair_i) → AG(ante → AF cons)` to `content`.
+///
+/// See the module-level "Fair-cycle extension" section for the construction and the
+/// soundness / completeness argument. Adds one `fair_i_seen` latch per fairness atom
+/// (each mirroring `b_seen`'s definition exactly, with `fair_i` in `b`'s slot) and
+/// sets `bad = looped ∧ ¬b_seen ∧ ⋀_i fair_i_seen`. Empty `fairness_atoms` recovers
+/// [`emit_response_l2s_monitor`] byte-for-byte.
+///
+/// Returns an error when any atom (ante, cons, or a fairness atom) does not resolve
+/// to a signal.
+pub fn emit_response_l2s_monitor_under_fairness(
+    content: &str,
+    ante: (&str, CmpOp, u128),
+    cons: (&str, CmpOp, u128),
+    fairness_atoms: &[(&str, CmpOp, u128)],
     reset_pinned: bool,
 ) -> Result<String, AdapterError> {
     let file = parser::parse(content).map_err(|mut e| {
@@ -181,11 +236,50 @@ pub fn emit_response_l2s_monitor(
     let next_bseen = e.push(format!("ite {bool_sort} {save_en} {b} {inner}"));
     e.push(format!("next {bool_sort} {b_seen} {next_bseen}"));
 
-    // bad = looped && !b_seen — a b-free closed loop carrying a pending request.
+    // Fair-cycle extension: one fair_i_seen per fairness atom (mirrors b_seen).
+    // Skipped entirely when fairness_atoms is empty — keeps the plain
+    // `emit_response_l2s_monitor` emission byte-for-byte unchanged.
+    let mut fair_seen_terms: Vec<Nid> = Vec::with_capacity(fairness_atoms.len());
+    for (i, fair) in fairness_atoms.iter().enumerate() {
+        let f = emit_atom(
+            &file,
+            &mut e,
+            bool_sort,
+            *fair,
+            reset_pinned,
+            &format!("fairness_atom_{i}"),
+        )?;
+        let f_seen = e.push(format!("state {bool_sort} mununu_l2s_fair{i}_seen"));
+        e.push(format!("init {bool_sort} {f_seen} {zero1}"));
+        let f_seen_or_f = e.push(format!("or {bool_sort} {f_seen} {f}"));
+        let f_inner = e.push(format!("ite {bool_sort} {saved} {f_seen_or_f} {zero1}"));
+        let f_next = e.push(format!("ite {bool_sort} {save_en} {f} {f_inner}"));
+        e.push(format!("next {bool_sort} {f_seen} {f_next}"));
+        fair_seen_terms.push(f_seen);
+    }
+
+    // bad = looped && !b_seen (&& ⋀_i fair_i_seen when fairness_atoms non-empty).
+    // A b-free closed loop carrying a pending request AND — under fairness — each
+    // justice constraint observed at least once on the cycle. The FINAL `and`
+    // carries the BAD_COND_SYMBOL for provenance-stability with the plain monitor.
     let not_bseen = e.push(format!("not {bool_sort} {b_seen}"));
-    let bad_cond = e.push(format!(
-        "and {bool_sort} {looped} {not_bseen} {BAD_COND_SYMBOL}"
-    ));
+    let bad_cond = if fair_seen_terms.is_empty() {
+        // Byte-equivalent to the pre-extension emission: one two-way `and` with
+        // the symbol name.
+        e.push(format!(
+            "and {bool_sort} {looped} {not_bseen} {BAD_COND_SYMBOL}"
+        ))
+    } else {
+        let core_and = e.push(format!("and {bool_sort} {looped} {not_bseen}"));
+        let (last, rest) = fair_seen_terms
+            .split_last()
+            .expect("non-empty checked above");
+        let mut acc = core_and;
+        for &t in rest {
+            acc = e.push(format!("and {bool_sort} {acc} {t}"));
+        }
+        e.push(format!("and {bool_sort} {acc} {last} {BAD_COND_SYMBOL}"))
+    };
     e.push(format!("bad {bad_cond}"));
 
     Ok(format!("{}\n{}\n", content.trim_end(), e.lines.join("\n")))
@@ -260,6 +354,88 @@ mod tests {
 6 next 1 3 2
 7 output 3 grant
 ";
+
+    /// mununu#477 Option B — the empty-fairness path of the fair-cycle emitter is
+    /// byte-for-byte identical to the plain emitter. Guards against silent NID
+    /// drift on the existing `verify-liveness` verb.
+    #[test]
+    fn empty_fairness_matches_plain_emitter_byte_for_byte() {
+        let plain = emit_response_l2s_monitor(
+            RESPONDER,
+            ("req", CmpOp::Eq, 1),
+            ("st", CmpOp::Eq, 1),
+            false,
+        )
+        .expect("plain");
+        let fair_empty = emit_response_l2s_monitor_under_fairness(
+            RESPONDER,
+            ("req", CmpOp::Eq, 1),
+            ("st", CmpOp::Eq, 1),
+            &[],
+            false,
+        )
+        .expect("empty fair");
+        assert_eq!(
+            plain, fair_empty,
+            "empty-fairness path must be byte-for-byte identical to the plain emitter"
+        );
+    }
+
+    /// mununu#477 Option B — a non-empty fairness list adds `fair_i_seen` latches
+    /// and folds them into `bad`. Structural check on the emitted monitor.
+    #[test]
+    fn fairness_atoms_add_fair_seen_latches_and_extend_bad() {
+        let out = emit_response_l2s_monitor_under_fairness(
+            RESPONDER,
+            ("req", CmpOp::Eq, 1),
+            ("st", CmpOp::Eq, 1),
+            &[("req", CmpOp::Eq, 0)],
+            false,
+        )
+        .expect("emit");
+        assert!(
+            out.contains("mununu_l2s_fair0_seen"),
+            "fair0_seen latch present: {out}"
+        );
+        // The bad line still names the BAD_COND_SYMBOL on its final and.
+        let file = parser::parse(&out).expect("emitted BTOR2 re-parses");
+        assert!(
+            file.lines
+                .iter()
+                .any(|l| matches!(l.node, Node::Bad { .. })),
+            "a bad line is present"
+        );
+    }
+
+    /// mununu#477 Option B — multiple fairness atoms produce one latch per atom
+    /// and chain into `bad` via a left-associative `and` fold.
+    #[test]
+    fn multiple_fairness_atoms_produce_one_latch_each() {
+        let out = emit_response_l2s_monitor_under_fairness(
+            RESPONDER,
+            ("req", CmpOp::Eq, 1),
+            ("st", CmpOp::Eq, 1),
+            &[("req", CmpOp::Eq, 0), ("req", CmpOp::Eq, 1)],
+            false,
+        )
+        .expect("emit");
+        assert!(out.contains("mununu_l2s_fair0_seen"));
+        assert!(out.contains("mununu_l2s_fair1_seen"));
+    }
+
+    /// mununu#477 Option B — a fairness atom that binds no signal errors just like
+    /// an ante / cons atom that binds no signal.
+    #[test]
+    fn unresolvable_fairness_atom_errors() {
+        let e = emit_response_l2s_monitor_under_fairness(
+            RESPONDER,
+            ("req", CmpOp::Eq, 1),
+            ("st", CmpOp::Eq, 1),
+            &[("nonexistent_fair_signal", CmpOp::Eq, 1)],
+            false,
+        );
+        assert!(e.is_err(), "unbound fairness atom must error");
+    }
 
     #[test]
     fn binds_registered_output_grant() {

--- a/crates/mununu-core/src/adapter/liveness_rescue.rs
+++ b/crates/mununu-core/src/adapter/liveness_rescue.rs
@@ -65,7 +65,9 @@
 //! the mununu-sva toolchain, per the [`crate::adapter::reach_rescue`] no-target
 //! lesson).
 
-use crate::adapter::btor2::l2s_monitor::emit_response_l2s_monitor;
+use crate::adapter::btor2::l2s_monitor::{
+    emit_response_l2s_monitor, emit_response_l2s_monitor_under_fairness,
+};
 use crate::adapter::btor2::parser;
 use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr, parse_predicate_expr};
 use crate::adapter::reach_portfolio::{ReachOutcome, ReachVerdict, decide_reach_portfolio};
@@ -308,6 +310,57 @@ pub fn response_liveness_rescue_atoms(
         ReachVerdict::Unknown | ReachVerdict::Contradiction => LivenessVerdict::Inconclusive,
     };
     Some((verdict, outcome))
+}
+
+/// mununu#477 Option B — decide `(⋀_j GF fair_j) → AG(ante → AF cons)` via the
+/// fair-cycle l2s (Emerson–Lei extension of Biere–Artho–Schuppan). Same contract
+/// as [`response_liveness_rescue_atoms`] plus a slice of primary-input / state
+/// fairness atoms; an empty `fairness_atoms` slice recovers
+/// [`response_liveness_rescue_atoms`] exactly.
+///
+/// The construction — one `fair_j_seen` latch per fairness atom, mirroring the
+/// existing `b_seen`; `bad = looped ∧ ¬b_seen ∧ ⋀_j fair_j_seen` — is documented
+/// in [`emit_response_l2s_monitor_under_fairness`] with the soundness /
+/// completeness argument.
+///
+/// Returns `None` only when the l2s monitor cannot be built (an atom binds no
+/// signal). On `Some`, the second component is the raw [`ReachOutcome`] (which
+/// engines decided) for diagnostics / a witness note.
+pub fn response_liveness_rescue_under_fairness(
+    design_btor2: &str,
+    ante: &Atom,
+    cons: &Atom,
+    fairness_atoms: &[Atom],
+    reset_pinned: bool,
+) -> Option<(LivenessVerdict, ReachOutcome)> {
+    let fair_tuples: Vec<(&str, CmpOp, u128)> = fairness_atoms
+        .iter()
+        .map(|a| (a.signal.as_str(), a.op, a.value))
+        .collect();
+    let monitored = emit_response_l2s_monitor_under_fairness(
+        design_btor2,
+        (&ante.signal, ante.op, ante.value),
+        (&cons.signal, cons.op, cons.value),
+        &fair_tuples,
+        reset_pinned,
+    )
+    .ok()?;
+    let file = parser::parse(&monitored).ok()?;
+    let outcome = decide_reach_portfolio(&file);
+    let verdict = match outcome.verdict {
+        ReachVerdict::Unreachable => LivenessVerdict::Holds,
+        ReachVerdict::Reachable => LivenessVerdict::Violated,
+        ReachVerdict::Unknown | ReachVerdict::Contradiction => LivenessVerdict::Inconclusive,
+    };
+    Some((verdict, outcome))
+}
+
+/// Parse repeatable `"REG op VALUE"` fairness-atom strings (the
+/// `verify-liveness-under-fairness` surface) into [`Atom`]s. Reuses
+/// [`parse_response_atom`] so the grammar matches the request / grant atoms
+/// exactly; each entry must be a single register-comparison.
+pub fn parse_fairness_atoms(specs: &[String]) -> Result<Vec<Atom>, String> {
+    specs.iter().map(|s| parse_response_atom(s)).collect()
 }
 
 /// Decide a **conjunction** of response-liveness properties `⋀_i AG(a_i → AF b_i)`

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -842,6 +842,71 @@ fn btor2_verify_liveness_all_handler_impl(
     }))
 }
 
+/// mununu#477 Option B — decide `(⋀ⱼ GF fairⱼ) → AG(request → AF grant)`
+/// (`POST /api/v1/btor2/verify-liveness-under-fairness`) via the Emerson–Lei
+/// fair-cycle l2s + the reachability portfolio. Surface peer of the CLI
+/// `mununu btor2 verify-liveness-under-fairness`. A malformed atom is a
+/// `BadRequest`; empty `fairness` recovers `verify-liveness` exactly.
+pub async fn btor2_verify_liveness_under_fairness_handler(
+    Json(request): Json<Btor2VerifyLivenessUnderFairnessRequest>,
+) -> ApiResult<Json<Btor2VerifyLivenessResponse>> {
+    blocking(move || btor2_verify_liveness_under_fairness_handler_impl(request)).await
+}
+
+fn btor2_verify_liveness_under_fairness_handler_impl(
+    request: Btor2VerifyLivenessUnderFairnessRequest,
+) -> ApiResult<Json<Btor2VerifyLivenessResponse>> {
+    use crate::adapter::liveness_rescue::{
+        parse_fairness_atoms, parse_response_atom, response_liveness_rescue_under_fairness,
+    };
+
+    let bad_req = |message: String| ApiError::BadRequest {
+        message,
+        details: None,
+    };
+    let ante = parse_response_atom(&request.request).map_err(bad_req)?;
+    let cons = parse_response_atom(&request.grant).map_err(bad_req)?;
+    let fairness = parse_fairness_atoms(&request.fairness).map_err(bad_req)?;
+
+    let (verdict, outcome) =
+        response_liveness_rescue_under_fairness(&request.content, &ante, &cons, &fairness, false)
+            .ok_or_else(|| {
+            bad_req(
+            "could not build the fair-cycle liveness monitor — an atom likely binds no signal in \
+             the design"
+                .to_string(),
+        )
+        })?;
+
+    let property = if request.fairness.is_empty() {
+        format!("AG(({}) -> AF ({}))", request.request, request.grant)
+    } else {
+        let fair_and = request
+            .fairness
+            .iter()
+            .map(|f| format!("GF ({f})"))
+            .collect::<Vec<_>>()
+            .join(" && ");
+        format!(
+            "({fair_and}) -> AG(({}) -> AF ({}))",
+            request.request, request.grant
+        )
+    };
+
+    Ok(Json(Btor2VerifyLivenessResponse {
+        verdict: crate::verdict::PropertyVerdict::from(verdict)
+            .as_str()
+            .to_string(),
+        property,
+        decided_by: outcome
+            .reachable_by
+            .iter()
+            .chain(outcome.unreachable_by.iter())
+            .map(|s| s.to_string())
+            .collect(),
+    }))
+}
+
 /// Decide recoverability `AG EF target` (`POST /api/v1/btor2/verify-recoverability`)
 /// — "from every reachable state, can the design get back to `target`?", the
 /// branching property SVA cannot state. Surface peer of the CLI

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -992,6 +992,28 @@ pub struct Btor2VerifyLivenessAllRequest {
     pub responses: Vec<String>,
 }
 
+/// Request for the fair-cycle response-liveness endpoint
+/// (`POST /api/v1/btor2/verify-liveness-under-fairness`, mununu#477 Option B).
+/// Mirrors the CLI `mununu btor2 verify-liveness-under-fairness`: decides
+/// `(⋀ GF fair) → AG(request → AF grant)` via the Emerson–Lei fair-cycle l2s
+/// (see [`crate::adapter::btor2::l2s_monitor::emit_response_l2s_monitor_under_fairness`])
+/// plus the reachability portfolio. Empty `fairness` recovers
+/// [`Btor2VerifyLivenessRequest`] exactly. Reuses [`Btor2VerifyLivenessResponse`] for the reply.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct Btor2VerifyLivenessUnderFairnessRequest {
+    /// BTOR2 source content.
+    pub content: String,
+    /// The request atom (`"REG op VALUE"`).
+    pub request: String,
+    /// The grant atom that must eventually follow on every path.
+    pub grant: String,
+    /// Fairness atoms — each a `"REG op VALUE"` register-comparison atom whose
+    /// satisfaction is assumed to hold infinitely often on every path
+    /// considered. Empty recovers the plain `verify-liveness` semantics.
+    #[serde(default)]
+    pub fairness: Vec<String>,
+}
+
 /// Request for the recoverability endpoint
 /// (`POST /api/v1/btor2/verify-recoverability`). Mirrors the CLI
 /// `mununu btor2 verify-recoverability`: decides `AG EF target` — "from every

--- a/crates/mununu-core/src/api/schema.rs
+++ b/crates/mununu-core/src/api/schema.rs
@@ -29,7 +29,8 @@ use schemars::schema_for;
 
 use super::models::{
     Btor2CheckFsmRequest, Btor2CheckFsmResponse, Btor2VerifyLivenessAllRequest,
-    Btor2VerifyLivenessRequest, Btor2VerifyLivenessResponse, Btor2VerifyRecoverabilityRequest,
+    Btor2VerifyLivenessRequest, Btor2VerifyLivenessResponse,
+    Btor2VerifyLivenessUnderFairnessRequest, Btor2VerifyRecoverabilityRequest,
     Btor2VerifyRecoverabilityResponse, Btor2VerifyRequest, Btor2VerifyResponse, SvCheckFsmRequest,
     SvVerifyAutoRequest, SvVerifyAutoResponse, SvVerifyLivenessAllRequest, SvVerifyLivenessRequest,
     SvVerifyRecoverabilityRequest, SvVerifyRequest,
@@ -78,6 +79,14 @@ pub fn btor2_verify_liveness_response_schema() -> serde_json::Value {
 pub fn btor2_verify_liveness_all_request_schema() -> serde_json::Value {
     serde_json::to_value(schema_for!(Btor2VerifyLivenessAllRequest))
         .expect("Btor2VerifyLivenessAllRequest schema must serialise as JSON")
+}
+
+/// JSON Schema for `POST /api/v1/btor2/verify-liveness-under-fairness` request
+/// bodies (mununu#477 Option B). Response shape is the shared
+/// [`Btor2VerifyLivenessResponse`].
+pub fn btor2_verify_liveness_under_fairness_request_schema() -> serde_json::Value {
+    serde_json::to_value(schema_for!(Btor2VerifyLivenessUnderFairnessRequest))
+        .expect("Btor2VerifyLivenessUnderFairnessRequest schema must serialise as JSON")
 }
 
 /// JSON Schema for `POST /api/v1/btor2/verify-recoverability` request bodies.
@@ -291,6 +300,14 @@ mod tests {
         drift_check(
             "docs/api-schemas/btor2-verify-liveness-all-request.schema.json",
             &btor2_verify_liveness_all_request_schema(),
+        );
+    }
+
+    #[test]
+    fn api_schema_drift_btor2_verify_liveness_under_fairness_request() {
+        drift_check(
+            "docs/api-schemas/btor2-verify-liveness-under-fairness-request.schema.json",
+            &btor2_verify_liveness_under_fairness_request_schema(),
         );
     }
 

--- a/crates/mununu-core/src/api/server.rs
+++ b/crates/mununu-core/src/api/server.rs
@@ -126,6 +126,13 @@ fn create_router() -> Router {
             "/api/v1/btor2/verify-liveness-all",
             post(handlers::btor2_verify_liveness_all_handler),
         )
+        // mununu#477 Option B — response-liveness UNDER a conjunctive `GF` fairness
+        // assumption on primary-input (or state) atoms, via the Emerson–Lei fair-cycle
+        // l2s + the portfolio. Surface peer of `mununu btor2 verify-liveness-under-fairness`.
+        .route(
+            "/api/v1/btor2/verify-liveness-under-fairness",
+            post(handlers::btor2_verify_liveness_under_fairness_handler),
+        )
         // P2 recoverability — AG EF good ("can it always get back?"), the branching
         // property SVA cannot state. Surface peer of `mununu btor2 verify-recoverability`.
         .route(

--- a/crates/mununu-core/tests/fair_cycle_l2s.rs
+++ b/crates/mununu-core/tests/fair_cycle_l2s.rs
@@ -1,0 +1,265 @@
+//! mununu#477 Option B — soundness tests for the Emerson–Lei fair-cycle l2s
+//! `response_liveness_rescue_under_fairness`, over minimal hand-authored BTOR2
+//! fixtures with known-answer verdicts.
+//!
+//! The engine mechanics:
+//! - `AG(req → AF ack)` under `(⋀_j GF fair_j)` is decided by the fair-cycle l2s
+//!   `bad = looped ∧ ¬b_seen ∧ ⋀_j fair_j_seen` (see `adapter::btor2::l2s_monitor`).
+//! - Reachable `bad` ⇒ VIOLATED; unreachable ⇒ HOLDS; portfolio abstain ⇒ Inconclusive.
+//!
+//! The four load-bearing soundness checks:
+//! 1. **Positive rescue** — a design that starves the response without fairness but
+//!    HOLDS under a matching `GF fair` assumption.
+//! 2. **Regression** — a design that already HOLDS without fairness continues to HOLD
+//!    under any fairness assumption (an assumption can only remove violating paths,
+//!    never introduce them).
+//! 3. **Useless-fairness soundness control** — a `GF fair` assumption that is
+//!    trivially satisfied without constraining anything must NOT rescue a genuinely
+//!    starving design (analog of `exact_two_player_fairness.rs::buffer_recurrence_is_not_rescued_by_a_useless_assumption`).
+//! 4. **Zero-fairness equivalence** — the fair-cycle library entry with an empty
+//!    fairness slice returns the identical verdict as the plain
+//!    `response_liveness_rescue_atoms` (also confirmed at the byte level in the
+//!    l2s_monitor unit tests).
+//! 5. **Multi-conjunction TWOGATE analog** — a design where NEITHER `GF fair_1` NOR
+//!    `GF fair_2` alone rescues, but BOTH together do (analog of
+//!    `exact_two_player_fairness.rs::TWOGATE`).
+
+use mununu_core::adapter::btor2::predicate_expr::CmpOp;
+use mununu_core::adapter::liveness_rescue::{
+    Atom, LivenessVerdict, response_liveness_rescue_atoms, response_liveness_rescue_under_fairness,
+};
+
+fn atom(signal: &str, op: CmpOp, value: u128) -> Atom {
+    Atom {
+        signal: signal.to_string(),
+        op,
+        value,
+    }
+}
+
+// FAIR_GATED — ack fires only when `fair == 1` on a pending request; without a
+// fairness assumption an env can hold fair=0 forever and starve the response.
+// Also carries a `dead` primary input never read by the design — the useless-
+// fairness control keys on `GF(dead == 0)`, which env satisfies trivially by
+// holding dead=0 forever and thus adds no real constraint.
+//
+// next(pending) = (pending || req) && !ack
+// next(ack)     = fair && pending
+const FAIR_GATED: &str = "\
+1 sort bitvec 1
+2 input 1 req
+3 input 1 fair
+4 input 1 dead
+5 state 1 pending
+6 zero 1
+7 init 1 5 6
+8 state 1 ack
+9 init 1 8 6
+10 or 1 5 2
+11 not 1 8
+12 and 1 10 11
+13 next 1 5 12
+14 and 1 3 5
+15 next 1 8 14
+";
+
+/// (1) POSITIVE RESCUE — under `GF(fair == 1)` the response HOLDS. Without any
+/// assumption it VIOLATED (a plain-l2s baseline confirms).
+#[test]
+fn fair_gated_holds_under_gf_fair() {
+    // Baseline: no fairness ⇒ starving env exists ⇒ VIOLATED.
+    let (baseline, _) = response_liveness_rescue_atoms(
+        FAIR_GATED,
+        &atom("req", CmpOp::Eq, 1),
+        &atom("ack", CmpOp::Eq, 1),
+        false,
+    )
+    .expect("plain l2s baseline");
+    assert_eq!(
+        baseline,
+        LivenessVerdict::Violated,
+        "without fairness, env holds fair=0 forever and starves ack"
+    );
+
+    // Under GF(fair == 1) ⇒ every pending req eventually meets a fair cycle ⇒ HOLDS.
+    let fair = [atom("fair", CmpOp::Eq, 1)];
+    let (verdict, _) = response_liveness_rescue_under_fairness(
+        FAIR_GATED,
+        &atom("req", CmpOp::Eq, 1),
+        &atom("ack", CmpOp::Eq, 1),
+        &fair,
+        false,
+    )
+    .expect("fair-cycle l2s");
+    assert_eq!(
+        verdict,
+        LivenessVerdict::Holds,
+        "GF(fair == 1) rescues the response — fair-cycle l2s must say HOLDS"
+    );
+}
+
+/// (3) USELESS-FAIRNESS SOUNDNESS CONTROL — a fairness assumption `GF(dead == 0)`
+/// that env satisfies for free (by holding `dead = 0` on every cycle) must NOT
+/// rescue a genuinely starving design. Guards against the classic Emerson–Lei
+/// bug where a badly-placed `save_en` guard makes every fair_seen latch trivially
+/// true and the assumption becomes vacuous.
+#[test]
+fn fair_gated_is_not_rescued_by_useless_fairness() {
+    let useless = [atom("dead", CmpOp::Eq, 0)];
+    let (verdict, _) = response_liveness_rescue_under_fairness(
+        FAIR_GATED,
+        &atom("req", CmpOp::Eq, 1),
+        &atom("ack", CmpOp::Eq, 1),
+        &useless,
+        false,
+    )
+    .expect("fair-cycle l2s");
+    assert_eq!(
+        verdict,
+        LivenessVerdict::Violated,
+        "GF(dead == 0) is satisfied by env holding dead=0 forever — it adds no \
+         constraint, so a genuinely starving design must still VIOLATED"
+    );
+}
+
+// RESPONDER — the existing plain-l2s fixture (busy FSM). `AG(req → AF (st == 1))`
+// HOLDS without any fairness: pending req in idle is always granted next cycle.
+// Regression guard: adding a fairness assumption cannot make an already-holding
+// design fail (an assumption can only remove violating paths).
+const RESPONDER: &str = "\
+1 sort bitvec 1
+2 state 1 st
+3 zero 1
+4 init 1 2 3
+5 input 1 req
+6 one 1
+7 ite 1 2 3 5
+8 next 1 2 7
+";
+
+/// (2) REGRESSION — a design that HOLDS without fairness continues to HOLD under
+/// any fairness assumption.
+#[test]
+fn already_holds_stays_holds_under_arbitrary_fairness() {
+    let fair = [atom("req", CmpOp::Eq, 1)];
+    let (verdict, _) = response_liveness_rescue_under_fairness(
+        RESPONDER,
+        &atom("req", CmpOp::Eq, 1),
+        &atom("st", CmpOp::Eq, 1),
+        &fair,
+        false,
+    )
+    .expect("fair-cycle l2s");
+    assert_eq!(
+        verdict,
+        LivenessVerdict::Holds,
+        "an assumption never breaks an already-holding response — this must stay HOLDS"
+    );
+}
+
+/// (4) ZERO-FAIRNESS EQUIVALENCE — the fair-cycle library entry with `&[]` matches
+/// the plain `response_liveness_rescue_atoms` verdict. Complements the byte-level
+/// check in `l2s_monitor.rs::tests::empty_fairness_matches_plain_emitter_byte_for_byte`.
+#[test]
+fn zero_fairness_matches_plain_rescue_verdict() {
+    let ante = atom("req", CmpOp::Eq, 1);
+    let cons = atom("st", CmpOp::Eq, 1);
+    let (plain, _) = response_liveness_rescue_atoms(RESPONDER, &ante, &cons, false).expect("plain");
+    let (fair_empty, _) =
+        response_liveness_rescue_under_fairness(RESPONDER, &ante, &cons, &[], false)
+            .expect("fair &[]");
+    assert_eq!(
+        plain, fair_empty,
+        "empty-fairness verdict must match the plain-l2s verdict"
+    );
+}
+
+// TWOGATE — `ack` fires only when `fair_1 && saw_fair2` where `saw_fair2` latches
+// once `fair_2` has fired. Under `GF fair_1` alone the env picks fair_2=0 forever
+// ⇒ saw_fair2 stays 0 ⇒ ack never fires. Under `GF fair_2` alone the env picks
+// fair_1=0 forever ⇒ ack never fires. Under BOTH ⇒ fair_2 fires (latches
+// saw_fair2), then a later fair_1 fires ack. Direct analog of
+// `exact_two_player_fairness.rs::TWOGATE` for the fair-cycle l2s.
+//
+// next(pending)   = (pending || req) && !ack
+// next(saw_fair2) = saw_fair2 || fair_2
+// next(ack)       = fair_1 && saw_fair2 && pending
+const TWOGATE: &str = "\
+1 sort bitvec 1
+2 input 1 req
+3 input 1 fair_1
+4 input 1 fair_2
+5 state 1 pending
+6 zero 1
+7 init 1 5 6
+8 state 1 saw_fair2
+9 init 1 8 6
+10 state 1 ack
+11 init 1 10 6
+12 or 1 5 2
+13 not 1 10
+14 and 1 12 13
+15 next 1 5 14
+16 or 1 8 4
+17 next 1 8 16
+18 and 1 3 8
+19 and 1 18 5
+20 next 1 10 19
+";
+
+/// (5) MULTI-CONJUNCTION — `GF fair_1` alone does not rescue TWOGATE.
+#[test]
+fn twogate_not_rescued_by_gf_fair1_alone() {
+    let fair = [atom("fair_1", CmpOp::Eq, 1)];
+    let (verdict, _) = response_liveness_rescue_under_fairness(
+        TWOGATE,
+        &atom("req", CmpOp::Eq, 1),
+        &atom("ack", CmpOp::Eq, 1),
+        &fair,
+        false,
+    )
+    .expect("fair-cycle l2s");
+    assert_eq!(
+        verdict,
+        LivenessVerdict::Violated,
+        "GF fair_1 alone leaves fair_2 free to stay 0 ⇒ saw_fair2 never latches ⇒ ack never fires"
+    );
+}
+
+/// (5) MULTI-CONJUNCTION — `GF fair_2` alone does not rescue TWOGATE.
+#[test]
+fn twogate_not_rescued_by_gf_fair2_alone() {
+    let fair = [atom("fair_2", CmpOp::Eq, 1)];
+    let (verdict, _) = response_liveness_rescue_under_fairness(
+        TWOGATE,
+        &atom("req", CmpOp::Eq, 1),
+        &atom("ack", CmpOp::Eq, 1),
+        &fair,
+        false,
+    )
+    .expect("fair-cycle l2s");
+    assert_eq!(
+        verdict,
+        LivenessVerdict::Violated,
+        "GF fair_2 alone leaves fair_1 free to stay 0 ⇒ ack's fair_1 conjunct never fires"
+    );
+}
+
+/// (5) MULTI-CONJUNCTION — `GF fair_1 ∧ GF fair_2` rescues TWOGATE.
+#[test]
+fn twogate_holds_under_gf_fair1_and_gf_fair2() {
+    let fair = [atom("fair_1", CmpOp::Eq, 1), atom("fair_2", CmpOp::Eq, 1)];
+    let (verdict, _) = response_liveness_rescue_under_fairness(
+        TWOGATE,
+        &atom("req", CmpOp::Eq, 1),
+        &atom("ack", CmpOp::Eq, 1),
+        &fair,
+        false,
+    )
+    .expect("fair-cycle l2s");
+    assert_eq!(
+        verdict,
+        LivenessVerdict::Holds,
+        "GF fair_1 ∧ GF fair_2 lets fair_2 latch saw_fair2 and a later fair_1 fire ack"
+    );
+}

--- a/docs/api-schemas/README.md
+++ b/docs/api-schemas/README.md
@@ -22,6 +22,7 @@ Each `*.schema.json` file is a JSON Schema (Draft-07) derived directly from the 
 | [`btor2-verify-liveness-request.schema.json`](btor2-verify-liveness-request.schema.json) | `POST /api/v1/btor2/verify-liveness` | Request body |
 | [`btor2-verify-liveness-response.schema.json`](btor2-verify-liveness-response.schema.json) | `POST /api/v1/btor2/verify-liveness` (also `-all`) | Response body |
 | [`btor2-verify-liveness-all-request.schema.json`](btor2-verify-liveness-all-request.schema.json) | `POST /api/v1/btor2/verify-liveness-all` | Request body |
+| [`btor2-verify-liveness-under-fairness-request.schema.json`](btor2-verify-liveness-under-fairness-request.schema.json) | `POST /api/v1/btor2/verify-liveness-under-fairness` | Request body (response = `btor2-verify-liveness-response.schema.json`) |
 | [`btor2-verify-recoverability-request.schema.json`](btor2-verify-recoverability-request.schema.json) | `POST /api/v1/btor2/verify-recoverability` | Request body |
 | [`btor2-verify-recoverability-response.schema.json`](btor2-verify-recoverability-response.schema.json) | `POST /api/v1/btor2/verify-recoverability` | Response body |
 | [`btor2-check-fsm-request.schema.json`](btor2-check-fsm-request.schema.json) | `POST /api/v1/btor2/check-fsm` | Request body |

--- a/docs/api-schemas/btor2-verify-liveness-under-fairness-request.schema.json
+++ b/docs/api-schemas/btor2-verify-liveness-under-fairness-request.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Request for the fair-cycle response-liveness endpoint (`POST /api/v1/btor2/verify-liveness-under-fairness`, mununu#477 Option B). Mirrors the CLI `mununu btor2 verify-liveness-under-fairness`: decides `(⋀ⱼ GF fairⱼ) → AG(request → AF grant)` via the Emerson–Lei fair-cycle l2s (see [`crate::adapter::btor2::l2s_monitor::emit_response_l2s_monitor_under_fairness`]) + the reachability portfolio. Empty `fairness` recovers [`Btor2VerifyLivenessRequest`] exactly. Reuses [`Btor2VerifyLivenessResponse`] for the reply.",
+  "description": "Request for the fair-cycle response-liveness endpoint (`POST /api/v1/btor2/verify-liveness-under-fairness`, mununu#477 Option B). Mirrors the CLI `mununu btor2 verify-liveness-under-fairness`: decides `(⋀ GF fair) → AG(request → AF grant)` via the Emerson–Lei fair-cycle l2s (see [`crate::adapter::btor2::l2s_monitor::emit_response_l2s_monitor_under_fairness`]) plus the reachability portfolio. Empty `fairness` recovers [`Btor2VerifyLivenessRequest`] exactly. Reuses [`Btor2VerifyLivenessResponse`] for the reply.",
   "properties": {
     "content": {
       "description": "BTOR2 source content.",

--- a/docs/api-schemas/btor2-verify-liveness-under-fairness-request.schema.json
+++ b/docs/api-schemas/btor2-verify-liveness-under-fairness-request.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Request for the fair-cycle response-liveness endpoint (`POST /api/v1/btor2/verify-liveness-under-fairness`, mununu#477 Option B). Mirrors the CLI `mununu btor2 verify-liveness-under-fairness`: decides `(⋀ⱼ GF fairⱼ) → AG(request → AF grant)` via the Emerson–Lei fair-cycle l2s (see [`crate::adapter::btor2::l2s_monitor::emit_response_l2s_monitor_under_fairness`]) + the reachability portfolio. Empty `fairness` recovers [`Btor2VerifyLivenessRequest`] exactly. Reuses [`Btor2VerifyLivenessResponse`] for the reply.",
+  "properties": {
+    "content": {
+      "description": "BTOR2 source content.",
+      "type": "string"
+    },
+    "fairness": {
+      "default": [],
+      "description": "Fairness atoms — each a `\"REG op VALUE\"` register-comparison atom whose satisfaction is assumed to hold infinitely often on every path considered. Empty recovers the plain `verify-liveness` semantics.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "grant": {
+      "description": "The grant atom that must eventually follow on every path.",
+      "type": "string"
+    },
+    "request": {
+      "description": "The request atom (`\"REG op VALUE\"`).",
+      "type": "string"
+    }
+  },
+  "required": [
+    "content",
+    "grant",
+    "request"
+  ],
+  "title": "Btor2VerifyLivenessUnderFairnessRequest",
+  "type": "object"
+}

--- a/docs/api-schemas/verify-verbs.md
+++ b/docs/api-schemas/verify-verbs.md
@@ -11,6 +11,7 @@ The BTOR2-direct property verbs (`verify`, `verify-liveness`, `verify-liveness-a
 | `btor2 verify` / `sv verify` | Safety (`bad` unreachable) | `Btor2VerifyResponse` | Per-engine breakdown, soundness-alarm flag |
 | `btor2 verify-liveness` / `sv verify-liveness` | Response `AG(a → AF b)` | `Btor2VerifyLivenessResponse` | Reduced-property echo, deciding engines |
 | `btor2 verify-liveness-all` / `sv verify-liveness-all` | Conjunctive `⋀ᵢ AG(aᵢ → AF bᵢ)` | `Btor2VerifyLivenessResponse` | Same as `-liveness` — one merged verdict |
+| `btor2 verify-liveness-under-fairness` (mununu#477) | Response under fairness `(⋀ⱼ GF fairⱼ) → AG(a → AF b)` | `Btor2VerifyLivenessResponse` | Same shape as `-liveness`; empty `fairness` reduces to `-liveness` exactly |
 | `btor2 verify-recoverability` / `sv verify-recoverability` | Recoverability `AG EF good` | `Btor2VerifyRecoverabilityResponse` | Optional `VerdictRefinement` tree (vacuous / config-partition / holds-under / ⊥-hint) |
 | `btor2 check-fsm` / `sv check-fsm` | Auto-scan of illegal FSM encodings | `Btor2CheckFsmResponse` | Per-register findings + counts |
 
@@ -34,6 +35,36 @@ Runs every available sound reach-portfolio engine (native BMC / k-induction, McM
 - `verdict` — the merged canonical answer.
 - `reachable_by` / `unreachable_by` — the deciding engines. An `unreachable_by` list of length ≥ 1 is a sound safety proof; a `reachable_by` list of length ≥ 1 is a real counterexample.
 - `contradiction` — TRUE only when two sound engines disagree. **Treat this as a soundness alarm**, not a verdict-selection hint: raise it to a human and cross-check the input BTOR2 rather than picking a side.
+
+## `POST /btor2/verify-liveness-under-fairness` — response properties under a fairness assumption (mununu#477 Option B)
+
+Schema: [`btor2-verify-liveness-under-fairness-request.schema.json`](btor2-verify-liveness-under-fairness-request.schema.json) (response reuses `btor2-verify-liveness-response.schema.json`)
+
+Decides `(⋀ⱼ GF fairⱼ) → AG(request → AF grant)` via the Emerson–Lei fair-cycle extension of the plain l2s. The BTOR2 monitor gains one `fairⱼ_seen` latch per fairness atom (each mirroring the existing `b_seen`); `bad = looped ∧ ¬b_seen ∧ ⋀ⱼ fairⱼ_seen`. A reachable `bad` ⇒ a lasso exists that satisfies EVERY fairness constraint AND leaves a request forever ungranted ⇒ VIOLATED. An unreachable `bad` ⇒ HOLDS. Empty `fairness` recovers `verify-liveness` exactly.
+
+Request example:
+
+```json
+{
+  "content": "<btor2 source>",
+  "request": "req == 1",
+  "grant": "ack == 1",
+  "fairness": ["grant_cpu == 1"]
+}
+```
+
+Response:
+
+```json
+{
+  "verdict": "holds",
+  "property": "(GF (grant_cpu == 1)) -> AG((req == 1) -> AF (ack == 1))",
+  "decided_by": ["native_kind"]
+}
+```
+
+- `property` echoes the fully-quantified formula for provenance (empty fairness → the plain `AG(...) -> AF(...)` shape).
+- Soundness guarantee: the fair-cycle l2s is sound + complete for the response shape (see [`crates/mununu-core/src/adapter/btor2/l2s_monitor.rs`](../../crates/mununu-core/src/adapter/btor2/l2s_monitor.rs) module docs for the construction and Emerson–Lei argument). A useless fairness atom that env satisfies trivially (e.g. `GF (dead_input == 0)` where `dead_input` is not wired to anything) does NOT rescue a genuinely-starving design — validated by the `fair_gated_is_not_rescued_by_useless_fairness` soundness control.
 
 ## `POST /btor2/verify-liveness` and `-liveness-all` — response properties
 

--- a/docs/consumer-briefings/2026-09-fair-cycle-l2s.md
+++ b/docs/consumer-briefings/2026-09-fair-cycle-l2s.md
@@ -1,0 +1,98 @@
+# Consumer briefing — 2026-09 fair-cycle l2s primitive + `verify-liveness-under-fairness` verb (mununu#477 Option B, PR 1)
+
+> **Audience:** ROSF (API consumer via `--profile industrial`), monono (direct CLI + API consumer), any orchestrator that wants to decide `AG(request → AF grant)` under a `GF` environment fairness assumption.
+>
+> **Related:** [mununu#477](https://github.com/vscorza/mununu/issues/477) — the ticket asking for fairness-constrained MC on the SV path. This is **PR 1 of 2** for Option B: the standalone primitive + a `btor2`-direct verb. **PR 2** wires this into `sv verify-auto` so `// @mununu_assume GF x` is auto-applied on the SV path.
+>
+> **TL;DR:** new `mununu btor2 verify-liveness-under-fairness` verb + `POST /api/v1/btor2/verify-liveness-under-fairness` endpoint decide `(⋀ⱼ GF fairⱼ) → AG(request → AF grant)` via the Emerson–Lei fair-cycle extension of the plain l2s. **Purely additive** — existing `verify-liveness` behaviour is byte-for-byte unchanged (guarded by a regression test). Consumers who parse the plain `verify-liveness` response can consume the new verb with zero shape changes (same `Btor2VerifyLivenessResponse`).
+
+## What changed
+
+- **New engine primitive** — `emit_response_l2s_monitor_under_fairness` in [`crates/mununu-core/src/adapter/btor2/l2s_monitor.rs`](../../crates/mununu-core/src/adapter/btor2/l2s_monitor.rs). Additive sibling of `emit_response_l2s_monitor`; empty `fairness_atoms` slice recovers the plain emitter byte-for-byte (guarded by `empty_fairness_matches_plain_emitter_byte_for_byte`).
+- **New library entry** — `response_liveness_rescue_under_fairness` in [`crates/mununu-core/src/adapter/liveness_rescue.rs`](../../crates/mununu-core/src/adapter/liveness_rescue.rs), plus a `parse_fairness_atoms` helper.
+- **New CLI verb** — `mununu btor2 verify-liveness-under-fairness --request R --grant G --fairness F1 --fairness F2 <btor2>`. Repeatable `--fairness`; empty recovers `verify-liveness` semantics.
+- **New API endpoint** — `POST /api/v1/btor2/verify-liveness-under-fairness`. Request type `Btor2VerifyLivenessUnderFairnessRequest` (new); response type is the existing shared `Btor2VerifyLivenessResponse` (no new response type — verdict / property / decided_by).
+- **New UI client** — `runBtor2VerifyLivenessUnderFairness` in `mununu-ui/src/api/endpoints.ts` (sibling repo). Uses the extended (`aiApiClient`, 120s) client since the primitive is Z3/subprocess-heavy on nontrivial designs.
+- **New JSON schema file** — `docs/api-schemas/btor2-verify-liveness-under-fairness-request.schema.json`. Drift-detector row + schema-derivation function added.
+- **Documentation** — `docs/verifying-rtl.md` gains the verb section; `docs/api-schemas/verify-verbs.md` gains the endpoint row; `docs/api-schemas/README.md` lists the new schema file.
+- **Soundness tests** (7 pass in [`crates/mununu-core/tests/fair_cycle_l2s.rs`](../../crates/mununu-core/tests/fair_cycle_l2s.rs) + 4 unit tests in the l2s_monitor module):
+  1. Positive rescue — `GF fair` rescues a starving design.
+  2. Regression — an already-holding design stays holding under any fairness.
+  3. **Useless-fairness soundness control** — `GF(dead_input == 0)` does NOT rescue a genuinely starving design (guards against the Emerson–Lei bug where a bad guard makes every `fair_seen` trivially true).
+  4. Zero-fairness equivalence — the fair-cycle entry with `&[]` matches the plain entry.
+  5-7. Multi-conjunction TWOGATE analog — neither `GF fair_1` nor `GF fair_2` alone rescues, both together do.
+
+## What did NOT change
+
+- **Wire format** — every existing endpoint and response shape unchanged.
+- **`verify-liveness` behaviour** — byte-for-byte identical on the emitted l2s monitor (guarded by a byte-equivalence test).
+- **`PropertyVerdict` values** — same canonical vocabulary.
+- **Existing schema files** — no diff on any existing `docs/api-schemas/*.schema.json`.
+
+## For ROSF and monono
+
+**What to update:** nothing forced. To adopt the new verb:
+
+```sh
+# CLI:
+mununu btor2 verify-liveness-under-fairness design.btor2 \
+    --request "req == 1" --grant "ack == 1" \
+    --fairness "grant_cpu == 1"
+
+# HTTP API:
+curl -X POST http://localhost:3000/api/v1/btor2/verify-liveness-under-fairness \
+    -H "Content-Type: application/json" \
+    -d '{
+      "content": "<btor2 source>",
+      "request": "req == 1",
+      "grant": "ack == 1",
+      "fairness": ["grant_cpu == 1"]
+    }'
+```
+
+The response reuses `Btor2VerifyLivenessResponse` — same `verdict` / `property` / `decided_by` shape. Empty `fairness` reduces to `verify-liveness` exactly, so a consumer can safely default to the fair-cycle verb everywhere and pass `fairness: []` on the non-fairness path.
+
+**Soundness contract:**
+
+- A `holds` verdict under `⋀ⱼ GF fairⱼ` means the response property holds against every environment schedule that satisfies each fairness constraint infinitely often.
+- A `violated` verdict means there exists a reachable lasso satisfying every fairness constraint AND leaving a request forever ungranted.
+- A useless fairness atom (one env satisfies trivially — e.g., a dead input the design never reads set to 0) does NOT change the verdict. The soundness control test validates this.
+- The atoms follow the same shape as `verify-liveness`: `REG op VALUE` single-register comparisons, resolved via the same `state_nid_and_sort` / `input_nid_and_sort` / `output_nid_and_sort` lookup as the ante / cons atoms.
+
+**Docker rebuild:** binary bump only; no subprocess tool changes.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | binary picks up new verb + endpoint + engine entry | Yes if consumers pin a version tag |
+| mununu `Dockerfile.dev` | binary bump + 7 new soundness tests + 4 new unit tests | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; no e2e slang-gated behaviour change | No — the ignored SVA e2e set is unaffected |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `Dockerfile` / `Dockerfile.dev` / `.hw` | consumes mununu CLI/API; opt-in feature only | No — behaviour updates on next binary pull; adoption is optional |
+| monono Docker (if any) | primary beneficiary — `wb_mem_client`-shaped cases become decidable | No — pull the new binary and start passing `--fairness` |
+| mununu-ui deployment | new client function available; existing UI unaffected | No — deploy the new bundle if a UI component consumes it |
+
+## Verification steps
+
+- `cargo test -p mununu-core --test fair_cycle_l2s` — 7 soundness tests pass.
+- `cargo test -p mununu-core --lib l2s_monitor` — 7 unit tests pass (byte-equivalence + structural).
+- `MUNUNU_UPDATE_API_SCHEMAS=1 cargo test -p mununu-core --lib --features api api_schema_drift_ -- --test-threads=1` — regenerates all schemas idempotently; the new drift-detector row (`api_schema_drift_btor2_verify_liveness_under_fairness_request`) passes.
+- `mununu btor2 verify-liveness-under-fairness --help` prints the new verb; `--fairness` accepts repeatable atoms.
+- End-to-end on a hand-authored BTOR2 with a rescue-shape design: expect `holds` under a matching `GF fair`; expect `violated` with an empty or useless fairness list.
+
+## Provenance
+
+- Fix commit: (pending merge — branch `feat/477-b-fair-cycle-l2s-primitive`).
+- Ticket: [mununu#477](https://github.com/vscorza/mununu/issues/477).
+- Prior briefing on this track: [`2026-09-fairness-note-honesty.md`](2026-09-fairness-note-honesty.md) — Option A note honesty fix.
+- Follow-up: PR 2 will wire `// @mununu_assume GF x` on `sv verify-auto` to auto-dispatch to this primitive.
+- Design record: agent-side plan doc `.claude/plans/477-b-fair-cycle-l2s.md`.
+- Policy: [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here (follow-ups)
+
+- **PR 2 — the SV verify-auto bridge.** Detect `GF <atom>` in `@mununu_assume` annotations; for guarantees with response shape, auto-dispatch to `response_liveness_rescue_under_fairness`; fold the verdict into the property row via `holds_under` with `AssumptionKind::InputFairness`. Closes #477.
+- **Full Streett shape `⋀_i AG(a_i → AF b_i)` under coupled fairness.** The current primitive handles a single response under conjunctive justice; the multi-response coupled shape (where fairness constraints couple the guarantees) is a further follow-up.
+- **General LTL assumptions.** The ticket explicitly narrows to `GF <signal>` conjunctions; broader LTL is out of scope.
+- **`sv verify-liveness-under-fairness`** SV-wrapped verb. Not shipped in this PR since the SV auto-routing bridge in PR 2 supersedes it for the main use case; can be added additively if a consumer needs it directly.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -62,6 +62,25 @@ Cross-checked against the exact engine.
 mununu btor2 verify-liveness design.btor2 --request "st == 1" --grant "st == 2"
 ```
 
+### `btor2 verify-liveness-under-fairness` — response liveness under a `GF` fairness assumption (mununu#477)
+
+> Source of truth: [`response_liveness_rescue_under_fairness`](../crates/mununu-core/src/adapter/liveness_rescue.rs#L313) — surface: (CLI+API+UI)
+
+Decides `(⋀ⱼ GF fairⱼ) → AG(request → AF grant)` via the Emerson–Lei extension of the plain l2s: one `fairⱼ_seen` latch per fairness atom (each mirroring the existing `b_seen`), conjuncted into `bad = looped ∧ ¬b_seen ∧ ⋀ⱼ fairⱼ_seen`. A reachable `bad` ⇒ a lasso exists that satisfies every fairness constraint AND leaves a request forever ungranted ⇒ VIOLATED. Empty `--fairness` recovers `verify-liveness` exactly, byte-for-byte on the emitted monitor. Sound + complete for the response shape (a useless fairness atom env satisfies trivially does NOT rescue a genuinely starving design — the `fair_gated_is_not_rescued_by_useless_fairness` soundness control validates this).
+
+Use when a block cannot own its liveness on its own — its grant comes from an arbiter it does not control — and you can express the arbiter's obligation as a `GF <signal>` on a primary input. See [`design/emerson-lei-fair-cycle.md`](design/emerson-lei-fair-cycle.md) for the construction and soundness argument (module-level docs in [`crates/mununu-core/src/adapter/btor2/l2s_monitor.rs`](../crates/mununu-core/src/adapter/btor2/l2s_monitor.rs)).
+
+```bash
+mununu btor2 verify-liveness-under-fairness design.btor2 \
+    --request "req == 1" --grant "ack == 1" \
+    --fairness "grant_cpu == 1"
+
+# Multiple fairness constraints — conjunctive `GF fair_1 ∧ GF fair_2` — repeat --fairness.
+mununu btor2 verify-liveness-under-fairness design.btor2 \
+    --request "req == 1" --grant "ack == 1" \
+    --fairness "fair_1 == 1" --fairness "fair_2 == 1"
+```
+
 ### `btor2 verify-recoverability` — recoverability `AG EF good`
 
 > Source of truth: [`verify_recoverability`](../crates/mununu-core/src/adapter/recoverability.rs#L46) — surface: (CLI+API+UI)


### PR DESCRIPTION
Advances #477 Option B (the follow-up to #487's note honesty fix). This PR ships the standalone primitive + a `btor2`-direct verb. **PR 2** wires this into `sv verify-auto` so `// @mununu_assume GF x` is auto-applied on the SV path, closing #477.

## Summary

The Emerson–Lei fair-cycle extension of `response_liveness_rescue`, explicitly named as an unshipped follow-up at [liveness_rescue.rs:330-332](crates/mununu-core/src/adapter/liveness_rescue.rs#L330) (*"the open-system Streett shape … is a separate follow-up (the Emerson–Lei fair-cycle l2s)"*). Decides `(⋀ⱼ GF fairⱼ) → AG(request → AF grant)` on a BTOR2 design via a minimal, additive extension of the existing l2s monitor: one `fairⱼ_seen` latch per fairness atom (each mirroring the existing `b_seen` next-state exactly, with `fairⱼ` in `b`'s slot), conjuncted into `bad = looped ∧ ¬b_seen ∧ ⋀ⱼ fairⱼ_seen`. **Empty fairness slice recovers the plain monitor byte-for-byte** (guarded).

## What ships

- **Engine primitive:** [`emit_response_l2s_monitor_under_fairness`](crates/mununu-core/src/adapter/btor2/l2s_monitor.rs) — additive sibling; the plain emitter now delegates to it with `&[]`. Module-level docstring carries the Emerson–Lei soundness + completeness argument composed with the existing l2s save/snapshot argument.
- **Library entry:** [`response_liveness_rescue_under_fairness`](crates/mununu-core/src/adapter/liveness_rescue.rs) + `parse_fairness_atoms` helper.
- **CLI verb:** `mununu btor2 verify-liveness-under-fairness --request R --grant G --fairness F1 --fairness F2 <btor2>`. Repeatable `--fairness`; empty recovers `verify-liveness` semantics.
- **API endpoint:** `POST /api/v1/btor2/verify-liveness-under-fairness`. New `Btor2VerifyLivenessUnderFairnessRequest`; response reuses the shared `Btor2VerifyLivenessResponse` — no new response type.
- **JSON schema:** [`btor2-verify-liveness-under-fairness-request.schema.json`](docs/api-schemas/btor2-verify-liveness-under-fairness-request.schema.json), regenerated via the standard `MUNUNU_UPDATE_API_SCHEMAS=1` flow; new drift-detector row.
- **UI client** (companion PR): `runBtor2VerifyLivenessUnderFairness` in mununu-ui.
- **Docs:** [`docs/verifying-rtl.md`](docs/verifying-rtl.md) verb section, [`docs/api-schemas/verify-verbs.md`](docs/api-schemas/verify-verbs.md) endpoint row, [`README.md`](docs/api-schemas/README.md) schema index entry.
- **Consumer briefing:** [`2026-09-fair-cycle-l2s.md`](docs/consumer-briefings/2026-09-fair-cycle-l2s.md).

## Soundness

11 tests pass across the module + integration suite:

**Unit tests** (l2s_monitor, 4):
- Byte-for-byte equivalence with the plain emitter on empty fairness (`empty_fairness_matches_plain_emitter_byte_for_byte`).
- `fair_seen` latch presence + structural shape.
- Multi-atom emit.
- Unresolvable-fairness-atom error path.

**Integration soundness tests** (7) in [`tests/fair_cycle_l2s.rs`](crates/mununu-core/tests/fair_cycle_l2s.rs):
1. **Positive rescue** — `GF fair` rescues a starving design (`fair_gated_holds_under_gf_fair`).
2. **Regression** — an already-holding design stays holding under any fairness (`already_holds_stays_holds_under_arbitrary_fairness`).
3. **Useless-fairness soundness control** — `GF(dead == 0)` does NOT rescue a genuinely starving design (`fair_gated_is_not_rescued_by_useless_fairness`). Guards against the Emerson–Lei bug where a bad guard makes every `fair_seen` trivially true.
4. **Zero-fairness verdict equivalence** — the fair-cycle library entry with `&[]` matches the plain rescue (`zero_fairness_matches_plain_rescue_verdict`).
5-7. **Multi-conjunction TWOGATE analog** — neither `GF fair_1` alone nor `GF fair_2` alone rescues; both together do (`twogate_not_rescued_by_gf_fair1_alone`, `twogate_not_rescued_by_gf_fair2_alone`, `twogate_holds_under_gf_fair1_and_gf_fair2`).

## What did NOT change

- Wire format for every existing endpoint — unchanged.
- `verify-liveness` behaviour — **byte-for-byte identical** on the emitted l2s monitor (guarded).
- `PropertyVerdict` values — same canonical vocabulary.
- Existing `docs/api-schemas/*.schema.json` files — no diff.

## Follow-up

**PR 2** — the SV verify-auto bridge — detects `GF <atom>` in `@mununu_assume` annotations and auto-dispatches guarantees with response shape to this primitive; folds verdict into `holds_under` with the existing `AssumptionKind::InputFairness` variant. Closes #477.

Companion PR in mununu-ui adds `runBtor2VerifyLivenessUnderFairness` typed client.

Design record: `.claude/plans/477-b-fair-cycle-l2s.md`.

## Test plan

- [x] `cargo test -p mununu-core --test fair_cycle_l2s` — 7/7 pass.
- [x] `cargo test -p mununu-core --lib l2s_monitor` — 7/7 pass (4 new + 3 pre-existing).
- [x] `MUNUNU_UPDATE_API_SCHEMAS=1 cargo test -p mununu-core --lib --features api api_schema_drift_ -- --test-threads=1` — 17/17 pass; new schema file generated idempotently.
- [x] `cargo check --workspace --features mununu-core/api --tests` clean.
- [x] Pre-commit hook green (fmt, machete, workspace check, clippy, tests).
- [ ] GitHub Actions CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)