### PR TITLE
feat(sv): auto-apply `@mununu_assume GF <atom>` on sv verify-auto via the fair-cycle l2s bridge (closes #477)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1231,14 +1231,23 @@ struct AnnotationScan {
     /// `@mununu_guarantee <mu-calculus>` properties that parsed, as
     /// `TranslatedAssertion`s ready to merge into `extraction.translated`.
     guarantees: Vec<crate::adapter::slang::translate::TranslatedAssertion>,
-    /// `@mununu_assume <body>` bodies (verbatim) — recorded for provenance. A
+    /// `@mununu_assume <body>` bodies (verbatim) that were NOT recognised as
+    /// typed fairness / config assumes — recorded for provenance. A
     /// `<signal> = <value>` assume is applied by this path via config
-    /// concretization; a temporal `GF …` fairness assume is recorded rather
-    /// than auto-applied — the SV verify-auto lift does not yet route it to
-    /// the fairness-constrained engine. Fairness-constrained model checking
-    /// IS shipped (CTXDSL + GR(1); `btor2 game --objective recurrence`); see
-    /// mununu#477 for the bridge tracking.
+    /// concretization (typed elsewhere). A `GF <atom>` fairness assume is
+    /// parsed into [`Self::fairness_assumes`] and auto-applied via the
+    /// fair-cycle l2s (mununu#477 Option B PR 2); a body that fails to parse
+    /// as either falls through to this string bucket unchanged.
     assumes: Vec<String>,
+    /// `@mununu_assume GF <atom>` bodies parsed into typed
+    /// [`crate::adapter::liveness_rescue::Atom`]s. When non-empty, the SV
+    /// verify-auto dispatch routes response-shape guarantees (`AG(a → AF b)`)
+    /// through [`crate::adapter::liveness_rescue::response_liveness_rescue_under_fairness`]
+    /// (the Emerson–Lei fair-cycle l2s) instead of the plain
+    /// [`crate::adapter::liveness_rescue::response_liveness_rescue`]. Bodies
+    /// that name `GF` but whose atom fails to parse are surfaced in
+    /// [`Self::skipped`], never silently dropped.
+    fairness_assumes: Vec<crate::adapter::liveness_rescue::Atom>,
     /// `@mununu_guarantee` bodies that did NOT parse — surfaced, never silently
     /// dropped.
     skipped: Vec<String>,
@@ -1288,7 +1297,29 @@ fn scan_annotation_properties(sources: &[(String, String)]) -> AnnotationScan {
                         )),
                     }
                 }
-                MununuTag::Assume => scan.assumes.push(ann.value.trim().to_string()),
+                MununuTag::Assume => {
+                    let body = ann.value.trim();
+                    // mununu#477 Option B — parse `GF <atom>` into a typed fairness assume.
+                    // The atom must be a single register-comparison (`REG op VALUE`),
+                    // matching the fair-cycle primitive's atom shape exactly. Anything
+                    // else falls through to the untyped string bucket unchanged (the
+                    // config-concretization path already picks up `<sig> = <val>`).
+                    if let Some(atom_str) = body
+                        .strip_prefix("GF ")
+                        .or_else(|| body.strip_prefix("GF\t"))
+                    {
+                        let atom_str = atom_str.trim();
+                        match crate::adapter::liveness_rescue::parse_response_atom(atom_str) {
+                            Ok(atom) => scan.fairness_assumes.push(atom),
+                            Err(e) => scan.skipped.push(format!(
+                                "@mununu_assume GF `{atom_str}` did not parse as a \
+                                 register-comparison atom: {e}"
+                            )),
+                        }
+                    } else {
+                        scan.assumes.push(body.to_string());
+                    }
+                }
                 MununuTag::Predicate => {
                     let body = ann.value.trim();
                     // A bare identifier (`sig` ≡ `sig == 1`) is admitted like a bare
@@ -1316,7 +1347,11 @@ fn scan_annotation_properties(sources: &[(String, String)]) -> AnnotationScan {
 /// seen, and any guarantee bodies that failed to parse (surfaced, never dropped).
 /// `None` when the source carried no `@mununu` property annotations.
 fn annotation_note(scan: &AnnotationScan) -> Option<VerificationNote> {
-    if scan.guarantees.is_empty() && scan.assumes.is_empty() && scan.skipped.is_empty() {
+    if scan.guarantees.is_empty()
+        && scan.assumes.is_empty()
+        && scan.fairness_assumes.is_empty()
+        && scan.skipped.is_empty()
+    {
         return None;
     }
     let mut items = Vec::new();
@@ -1325,6 +1360,21 @@ fn annotation_note(scan: &AnnotationScan) -> Option<VerificationNote> {
     }
     for a in &scan.assumes {
         items.push(format!("assume: {a}"));
+    }
+    for a in &scan.fairness_assumes {
+        items.push(format!(
+            "assume: GF ({} {} {}) — auto-applied via fair-cycle l2s (mununu#477)",
+            a.signal,
+            match a.op {
+                crate::adapter::btor2::predicate_expr::CmpOp::Eq => "==",
+                crate::adapter::btor2::predicate_expr::CmpOp::Ne => "!=",
+                crate::adapter::btor2::predicate_expr::CmpOp::Lt => "<",
+                crate::adapter::btor2::predicate_expr::CmpOp::Le => "<=",
+                crate::adapter::btor2::predicate_expr::CmpOp::Gt => ">",
+                crate::adapter::btor2::predicate_expr::CmpOp::Ge => ">=",
+            },
+            a.value,
+        ));
     }
     for s in &scan.skipped {
         items.push(format!("skipped: {s}"));
@@ -1353,17 +1403,21 @@ fn annotation_note(scan: &AnnotationScan) -> Option<VerificationNote> {
         detail:
             "`@mununu_guarantee <mu-calculus>` / `@mununu_assume <body>` annotations carry the \
                  mununu-exclusive properties an author adds beyond the design's own SVA (e.g. \
-                 assume-guarantee liveness the SVA fragment cannot express). Guarantee bodies are \
-                 mu-calculus formulas parsed by the same parser as the translated SVA and verified \
-                 through the same pipeline. `@mununu_assume` of the form `<signal> = <value>` is \
-                 applied by this path via config concretization. A temporal (`GF …`) fairness \
-                 assume is recorded here rather than auto-applied — the SV verify-auto lift does \
-                 not yet route it to the fairness-constrained engine. Fairness-constrained model \
-                 checking IS shipped: `mununu sv emit-btor2` + `mununu btor2 game --objective \
-                 recurrence` (single-pair GR(1)) decides `(GF assume) → (GF guarantee)` on the \
-                 lifted design, and CTXDSL's GR(1) game engine `(⋀ GF envᵢ) → (⋀ GF sysⱼ)` \
-                 discharges multi-pair assume-guarantee liveness directly. See mununu#477 for \
-                 the SV-path auto-routing bridge."
+                 assume-guarantee liveness the SVA fragment cannot express). Guarantee bodies \
+                 are mu-calculus formulas parsed by the same parser as the translated SVA and \
+                 verified through the same pipeline. `@mununu_assume` of the form \
+                 `<signal> = <value>` is applied by this path via config concretization. A \
+                 temporal `GF <REG op VALUE>` fairness assume is auto-applied for \
+                 response-shape guarantees (`AG(a → AF b)`) via the Emerson–Lei fair-cycle l2s \
+                 (mununu#477 Option B) — each `GF` assume adds a `fair_seen` monitor latch, \
+                 and a `holds` verdict under fairness means the guarantee holds against every \
+                 environment schedule satisfying the assumption infinitely often. For \
+                 assumptions that do not fit `GF <REG op VALUE>` — a state predicate, a \
+                 non-response guarantee shape, or a multi-guarantee-coupled fairness — the \
+                 assume is recorded here; use `mununu btor2 verify-liveness-under-fairness` \
+                 on the emitted BTOR2 or model in CTXDSL where the GR(1) game engine \
+                 `(⋀ GF envᵢ) → (⋀ GF sysⱼ)` discharges multi-pair assume-guarantee liveness \
+                 directly."
                 .into(),
         items,
     })
@@ -2946,7 +3000,13 @@ pub(crate) fn verify_auto_impl(
     // `rescue_bottom_*` opt and only fires on its recognized shape. (P2.1b routes the
     // re-plan entry through the planner, delegating the edge-application to the existing
     // rescue subsystem — verdict-equivalent; P2.1c adds the soundness plan-invariants.)
-    let rescue_notes = crate::planner::replan(&mut report, &btor2, reset_pinned, opts);
+    let rescue_notes = crate::planner::replan(
+        &mut report,
+        &btor2,
+        reset_pinned,
+        opts,
+        &ann_scan.fairness_assumes,
+    );
 
     // Lever (b) — exact-symbolic rescue for cube-SKIPPED properties. The predicate cube
     // cannot seed an ATOM-LESS modal formula (no-deadlock `nu X.(<> true && [] X)`, a pure
@@ -3011,10 +3071,12 @@ pub(crate) fn escalate_bottom(
     design_btor2: &str,
     reset_pinned: bool,
     opts: &VerifyAutoOptions,
+    fairness_atoms: &[crate::adapter::liveness_rescue::Atom],
 ) -> Vec<VerificationNote> {
     use crate::adapter::btor2::predicate_expr::CmpOp;
     use crate::adapter::liveness_rescue::{
-        LivenessVerdict, reduce_ag_ef_target, response_liveness_rescue,
+        LivenessVerdict, reduce_ag_ef_target, reduce_response_af, response_liveness_rescue,
+        response_liveness_rescue_under_fairness,
     };
     use crate::adapter::reach_rescue::{RescueVerdict, reach_portfolio_rescue};
     use crate::adapter::recoverability::{verify_recoverability, verify_recoverability_scalable};
@@ -3067,7 +3129,47 @@ pub(crate) fn escalate_bottom(
             }
             PropertyClass::Liveness => {
                 let mut handled = false;
+                // mununu#477 Option B — if `GF <atom>` fairness assumes are present AND
+                // this guarantee reduces to response shape, route through the fair-cycle
+                // l2s primitive `(⋀ⱼ GF fairⱼ) → AG(a → AF b)` (Emerson–Lei). Empty
+                // fairness ⇒ falls through to the plain rescue below, unchanged.
                 if opts.rescue_bottom_liveness
+                    && !fairness_atoms.is_empty()
+                    && let Some(r) = reduce_response_af(&formula)
+                    && let Some((verdict, reach)) = response_liveness_rescue_under_fairness(
+                        design_btor2,
+                        &r.ante,
+                        &r.cons,
+                        fairness_atoms,
+                        reset_pinned,
+                    )
+                {
+                    handled = true;
+                    let engines = engines_of(&reach);
+                    match verdict {
+                        LivenessVerdict::Holds => {
+                            prop.outcome = VerifyOutcome::Holds;
+                            notes.push(fair_cycle_rescue_note(
+                                &prop.name,
+                                "HOLDS",
+                                &engines,
+                                fairness_atoms,
+                            ));
+                        }
+                        LivenessVerdict::Violated => {
+                            prop.outcome = VerifyOutcome::Violated { false_cells: 0 };
+                            notes.push(fair_cycle_rescue_note(
+                                &prop.name,
+                                "VIOLATED",
+                                &engines,
+                                fairness_atoms,
+                            ));
+                        }
+                        LivenessVerdict::Inconclusive => {}
+                    }
+                }
+                if !handled
+                    && opts.rescue_bottom_liveness
                     && let Some((verdict, reach)) =
                         response_liveness_rescue(design_btor2, &formula, reset_pinned)
                 {
@@ -3322,6 +3424,56 @@ fn recoverability_bot_reason_note(
     }
 }
 
+/// mununu#477 Option B — provenance note for a box-AF liveness property the
+/// fair-cycle l2s (Emerson–Lei extension) decided under a conjunctive `GF` fairness
+/// assumption on primary-input atoms. Names the assumption(s) applied.
+fn fair_cycle_rescue_note(
+    name: &str,
+    verdict: &str,
+    engines: &[&str],
+    fairness_atoms: &[crate::adapter::liveness_rescue::Atom],
+) -> VerificationNote {
+    use crate::adapter::btor2::predicate_expr::CmpOp;
+    let fair_render: Vec<String> = fairness_atoms
+        .iter()
+        .map(|a| {
+            let op = match a.op {
+                CmpOp::Eq => "==",
+                CmpOp::Ne => "!=",
+                CmpOp::Lt => "<",
+                CmpOp::Le => "<=",
+                CmpOp::Gt => ">",
+                CmpOp::Ge => ">=",
+            };
+            format!("GF ({} {} {})", a.signal, op, a.value)
+        })
+        .collect();
+    let fair_conj = fair_render.join(" && ");
+    VerificationNote {
+        kind: "fair-cycle-rescue".into(),
+        level: NoteLevel::Info,
+        summary: format!(
+            "`{name}`: the cube abstraction left ⊥; the fair-cycle l2s (Emerson–Lei) \
+             decided it {verdict} under {fair_conj} (engine(s): {})",
+            if engines.is_empty() {
+                "—".to_string()
+            } else {
+                engines.join(", ")
+            }
+        ),
+        detail: "The box-response liveness ⊥ (`AG(a → AF b)`) was decided under the \
+                 conjunctive fairness assumption (mununu#477 Option B) via the Emerson–Lei \
+                 fair-cycle l2s: the standard l2s pending / snapshot construction plus one \
+                 `fair_seen` monitor latch per `GF` atom, all conjuncted into `bad`. A `holds` \
+                 verdict means the guarantee holds against every environment schedule \
+                 satisfying every fairness assume infinitely often; a `violated` verdict is \
+                 a reachable lasso satisfying every fairness constraint that leaves the \
+                 request forever ungranted."
+            .into(),
+        items: Vec::new(),
+    }
+}
+
 /// A provenance note for a box-AF liveness property the l2s reduction + reachability
 /// portfolio rescued from `⊥`.
 fn liveness_rescue_note(name: &str, verdict: &str, engines: &[&str]) -> VerificationNote {
@@ -3567,7 +3719,13 @@ mod tests {
             ..Default::default()
         };
 
-        let notes = escalate_bottom(&mut report, DESIGN, false, &VerifyAutoOptions::default());
+        let notes = escalate_bottom(
+            &mut report,
+            DESIGN,
+            false,
+            &VerifyAutoOptions::default(),
+            &[],
+        );
         assert!(
             matches!(report.properties[0].outcome, VerifyOutcome::Holds),
             "the ⊥ safety property should be rescued to HOLDS, got {:?}",
@@ -3599,7 +3757,13 @@ mod tests {
             }],
             ..Default::default()
         };
-        let notes = escalate_bottom(&mut report, COUNTER, false, &VerifyAutoOptions::default());
+        let notes = escalate_bottom(
+            &mut report,
+            COUNTER,
+            false,
+            &VerifyAutoOptions::default(),
+            &[],
+        );
         assert!(
             matches!(report.properties[0].outcome, VerifyOutcome::Violated { .. }),
             "the ⊥ safety property should be rescued to VIOLATED, got {:?}",
@@ -3737,7 +3901,7 @@ mod tests {
             rescue_bottom_recoverability: false,
             ..VerifyAutoOptions::default()
         };
-        let notes = escalate_bottom(&mut report, DESIGN, false, &opts);
+        let notes = escalate_bottom(&mut report, DESIGN, false, &opts, &[]);
         assert!(
             matches!(report.properties[0].outcome, VerifyOutcome::Unknown { .. }),
             "a νμ ⊥ must be left untouched by the safety arm (2-valued reachability can't \
@@ -3788,6 +3952,7 @@ mod tests {
             RESPONDER_LIVE,
             false,
             &VerifyAutoOptions::default(),
+            &[],
         );
         assert!(
             matches!(report.properties[0].outcome, VerifyOutcome::Holds),
@@ -3797,6 +3962,145 @@ mod tests {
         assert!(
             notes.iter().any(|n| n.kind == "liveness-rescue"),
             "a liveness-rescue provenance note should be recorded"
+        );
+    }
+
+    // mununu#477 Option B — a fair-cycle rescue fixture. `next(pending) = (pending || req) && !ack`
+    // and `next(ack) = fair && pending`: without a `GF fair` assumption env holds fair=0 forever
+    // and starves ack; under `GF(fair == 1)` every pending req eventually meets a fair cycle.
+    const FAIR_GATED: &str = "\
+1 sort bitvec 1
+2 input 1 req
+3 input 1 fair
+4 state 1 pending
+5 zero 1
+6 init 1 4 5
+7 state 1 ack
+8 init 1 7 5
+9 or 1 4 2
+10 not 1 7
+11 and 1 9 10
+12 next 1 4 11
+13 and 1 3 4
+14 next 1 7 13
+";
+
+    /// mununu#477 Option B — `AG(req → AF ack)` on FAIR_GATED is VIOLATED without any
+    /// fairness (env starves fair forever). Baseline for the fair-cycle test below.
+    #[test]
+    fn escalate_bottom_fair_cycle_baseline_violated_without_fairness() {
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "req_ack".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                formula: "nu Z. ((!(req == 1) || mu Y. ((ack == 1) || [] Y)) && [] Z)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let _notes = escalate_bottom(
+            &mut report,
+            FAIR_GATED,
+            false,
+            &VerifyAutoOptions::default(),
+            &[],
+        );
+        assert!(
+            matches!(report.properties[0].outcome, VerifyOutcome::Violated { .. }),
+            "without a fairness assumption env can starve fair=0 forever, so the response is \
+             VIOLATED; got {:?}",
+            report.properties[0].outcome
+        );
+    }
+
+    /// mununu#477 Option B — the same property on the same design HOLDS under
+    /// `GF(fair == 1)`: the fair-cycle bridge routes to
+    /// `response_liveness_rescue_under_fairness` when the annotation scanner has
+    /// a typed `fairness_assumes` list. This is the load-bearing test for the SV
+    /// verify-auto bridge — the ticket's `wb_mem_client`-shape case reduced to
+    /// the BTOR2 layer this escalation runs on.
+    #[test]
+    fn escalate_bottom_fair_cycle_rescues_response_under_gf_fair() {
+        use crate::adapter::btor2::predicate_expr::CmpOp;
+        use crate::adapter::liveness_rescue::Atom;
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "req_ack".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                formula: "nu Z. ((!(req == 1) || mu Y. ((ack == 1) || [] Y)) && [] Z)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let fair = [Atom {
+            signal: "fair".to_string(),
+            op: CmpOp::Eq,
+            value: 1,
+        }];
+        let notes = escalate_bottom(
+            &mut report,
+            FAIR_GATED,
+            false,
+            &VerifyAutoOptions::default(),
+            &fair,
+        );
+        assert!(
+            matches!(report.properties[0].outcome, VerifyOutcome::Holds),
+            "under GF(fair == 1), the fair-cycle bridge must decide the response HOLDS; \
+             got {:?}",
+            report.properties[0].outcome
+        );
+        assert!(
+            notes.iter().any(|n| n.kind == "fair-cycle-rescue"),
+            "a fair-cycle-rescue provenance note should be recorded (found: {:?})",
+            notes.iter().map(|n| &n.kind).collect::<Vec<_>>()
+        );
+        assert!(
+            notes.iter().any(|n| n.summary.contains("GF (fair == 1)")),
+            "the note must name the fairness assumption applied"
+        );
+    }
+
+    /// mununu#477 Option B — a `GF <atom>` assume paired with a non-response guarantee
+    /// (a νμ recoverability) does NOT go through the fair-cycle bridge (the primitive is
+    /// response-specific). The escalation must leave the non-response verdict untouched
+    /// rather than mis-route it — soundness guard.
+    #[test]
+    fn escalate_bottom_fair_cycle_does_not_route_non_response_guarantees() {
+        use crate::adapter::btor2::predicate_expr::CmpOp;
+        use crate::adapter::liveness_rescue::Atom;
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "recover".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                // A νμ recoverability (`AG(a → EF b)`), NOT the box-AF shape the primitive expects.
+                formula: "nu Z. ((!(req == 1) || mu Y. ((ack == 1) || <> Y)) && [] Z)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let fair = [Atom {
+            signal: "fair".to_string(),
+            op: CmpOp::Eq,
+            value: 1,
+        }];
+        let notes = escalate_bottom(
+            &mut report,
+            FAIR_GATED,
+            false,
+            &VerifyAutoOptions::default(),
+            &fair,
+        );
+        assert!(
+            !notes.iter().any(|n| n.kind == "fair-cycle-rescue"),
+            "the fair-cycle bridge must not fire on a non-response guarantee shape; found: {:?}",
+            notes.iter().map(|n| &n.kind).collect::<Vec<_>>()
         );
     }
 
@@ -3821,6 +4125,7 @@ mod tests {
             RESPONDER_LIVE,
             false,
             &VerifyAutoOptions::default(),
+            &[],
         );
         assert!(
             matches!(report.properties[0].outcome, VerifyOutcome::Unknown { .. }),
@@ -3851,6 +4156,7 @@ mod tests {
             RESPONDER_LIVE,
             false,
             &VerifyAutoOptions::default(),
+            &[],
         );
         // The router dispatches the νμ ⊥ to the cube + smt-hyper-must path, which now DECIDES it
         // `Holds`: the N1-first-increment property-directed seeding (good register's other control
@@ -3889,7 +4195,13 @@ mod tests {
             ..Default::default()
         };
         // reset_pinned = true → the ③a exact-first routing is enabled (A.6 sound).
-        let notes = escalate_bottom(&mut report, COUNTER, true, &VerifyAutoOptions::default());
+        let notes = escalate_bottom(
+            &mut report,
+            COUNTER,
+            true,
+            &VerifyAutoOptions::default(),
+            &[],
+        );
         assert!(
             matches!(report.properties[0].outcome, VerifyOutcome::Holds),
             "reset-pinned recoverability ⊥ must be rescued to Holds via exact+COI, got {:?}",
@@ -4194,10 +4506,70 @@ module uart_tx(); endmodule"#;
         let scan = scan_annotation_properties(&src(sv));
         assert!(scan.guarantees.is_empty());
         assert_eq!(scan.assumes, vec!["tick_baud_x16 = 1".to_string()]);
+        assert!(scan.fairness_assumes.is_empty());
         assert!(annotation_note(&scan).is_some());
 
         let plain = scan_annotation_properties(&src("module m(); endmodule"));
         assert!(annotation_note(&plain).is_none());
+    }
+
+    /// mununu#477 Option B — `// @mununu_assume GF <REG op VALUE>` bodies are parsed
+    /// into typed [`crate::adapter::liveness_rescue::Atom`]s on [`AnnotationScan::fairness_assumes`],
+    /// NOT into the untyped `assumes` string bucket. The scanner is the entry point
+    /// for the fair-cycle bridge.
+    #[test]
+    fn h5_gr1_fairness_assume_parses_into_typed_atom() {
+        use crate::adapter::btor2::predicate_expr::CmpOp;
+        let sv = "// @mununu_assume GF grant_cpu == 1\nmodule m(); endmodule";
+        let scan = scan_annotation_properties(&src(sv));
+        assert!(
+            scan.assumes.is_empty(),
+            "typed fairness must not spill into `assumes`"
+        );
+        assert_eq!(scan.fairness_assumes.len(), 1);
+        assert_eq!(scan.fairness_assumes[0].signal, "grant_cpu");
+        assert_eq!(scan.fairness_assumes[0].op, CmpOp::Eq);
+        assert_eq!(scan.fairness_assumes[0].value, 1);
+    }
+
+    /// mununu#477 Option B — multiple `GF` assumes accumulate; the fair-cycle
+    /// bridge treats them as a conjunction `⋀ GF fairⱼ`.
+    #[test]
+    fn h5_gr1_fairness_assume_multiple_accumulate() {
+        let sv = "// @mununu_assume GF fair_1 == 1\n\
+                  // @mununu_assume GF fair_2 != 0\n\
+                  module m(); endmodule";
+        let scan = scan_annotation_properties(&src(sv));
+        assert!(scan.assumes.is_empty());
+        assert_eq!(scan.fairness_assumes.len(), 2);
+        assert_eq!(scan.fairness_assumes[0].signal, "fair_1");
+        assert_eq!(scan.fairness_assumes[1].signal, "fair_2");
+    }
+
+    /// mununu#477 Option B — a `GF` body whose atom does not parse as a
+    /// register-comparison is surfaced in `skipped`, never silently dropped.
+    /// Sound-by-refusal: unrecognized fairness never affects a verdict.
+    #[test]
+    fn h5_gr1_fairness_assume_malformed_atom_is_skipped() {
+        let sv = "// @mununu_assume GF not_a_valid_atom_shape !!! bogus\nmodule m(); endmodule";
+        let scan = scan_annotation_properties(&src(sv));
+        assert!(scan.fairness_assumes.is_empty());
+        assert!(
+            scan.skipped.iter().any(|s| s.contains("GF")),
+            "malformed GF body must surface in `skipped`: {:?}",
+            scan.skipped
+        );
+    }
+
+    /// mununu#477 Option B — a plain `@mununu_assume <signal> = <value>` (no `GF`
+    /// prefix) still routes to the untyped `assumes` bucket for the existing
+    /// config-concretization path. Regression guard.
+    #[test]
+    fn h5_gr1_non_fairness_assume_stays_in_string_bucket() {
+        let sv = "// @mununu_assume clk_en = 1\nmodule m(); endmodule";
+        let scan = scan_annotation_properties(&src(sv));
+        assert!(scan.fairness_assumes.is_empty());
+        assert_eq!(scan.assumes, vec!["clk_en = 1".to_string()]);
     }
 
     #[test]

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -254,8 +254,9 @@ pub fn replan(
     design_btor2: &str,
     reset_pinned: bool,
     opts: &VerifyAutoOptions,
+    fairness_atoms: &[crate::adapter::liveness_rescue::Atom],
 ) -> Vec<VerificationNote> {
-    escalate_bottom(report, design_btor2, reset_pinned, opts)
+    escalate_bottom(report, design_btor2, reset_pinned, opts, fairness_atoms)
 }
 
 /// A **composed** recoverability plan — the point of a *planner*: mechanisms combine. It runs the

--- a/docs/consumer-briefings/2026-09-sv-fairness-bridge.md
+++ b/docs/consumer-briefings/2026-09-sv-fairness-bridge.md
@@ -1,0 +1,97 @@
+# Consumer briefing — 2026-09 SV verify-auto ← fair-cycle l2s bridge (mununu#477 Option B, PR 2 — closes the ticket)
+
+> **Audience:** ROSF (API consumer via `--profile industrial`), monono (direct CLI + API consumer, primary beneficiary), any orchestrator that runs `sv verify-auto` on SystemVerilog with `@mununu_assume` annotations.
+>
+> **Related:** [mununu#477](https://github.com/vscorza/mununu/issues/477) — the ticket. Prior briefings on this track: [`2026-09-fairness-note-honesty.md`](2026-09-fairness-note-honesty.md) (Option A note honesty fix, mununu#487) and [`2026-09-fair-cycle-l2s.md`](2026-09-fair-cycle-l2s.md) (Option B PR 1 — the standalone `btor2 verify-liveness-under-fairness` verb, mununu#488). **This is Option B PR 2 and closes the ticket.**
+>
+> **TL;DR:** `// @mununu_assume GF <REG op VALUE>` in a SystemVerilog source is now **auto-applied** by `sv verify-auto` to any response-shape guarantee (`AG(a → AF b)`) in the same source. **No new verdict values; no new response fields; wire format unchanged.** The change is a runtime-dispatch upgrade: response-shape guarantees under fairness assumes now flow through PR 1's fair-cycle primitive instead of the plain response-liveness rescue, producing definite `holds` verdicts on cases that previously stayed `unknown`. Consumers observe the change as a new note kind (`fair-cycle-rescue`) accompanying properties the fair-cycle path decided.
+
+## What changed
+
+- **Typed fairness detection in the annotation scanner** — `crates/mununu-core/src/adapter/slang/verify_auto.rs`:
+  - `AnnotationScan` gains `fairness_assumes: Vec<Atom>` alongside the existing `assumes: Vec<String>` bucket.
+  - `// @mununu_assume GF <REG op VALUE>` bodies parse into typed `Atom` values (single register-comparison atoms). A body that fails to parse surfaces in `skipped` — never silently dropped.
+  - Non-`GF` assumes (`// @mununu_assume clk_en = 1`) continue to flow through the untyped `assumes` bucket for the existing config-concretization path — unchanged.
+- **Fair-cycle dispatch in `escalate_bottom`** — when the ⊥-escalation router hits a Liveness-class property AND `fairness_assumes` is non-empty AND the guarantee reduces to response shape, dispatch through `response_liveness_rescue_under_fairness` (mununu#488's primitive) instead of the plain `response_liveness_rescue`. Non-response guarantees fall through to the existing rescue path unchanged (soundness guard tested).
+- **New `fair-cycle-rescue` verification-note kind** — accompanies any property the bridge decided; names the assumption(s) applied (`GF (grant_cpu == 1) && GF (fair_2 == 1)`).
+- **`annotation-properties` note text upgraded** — the "recorded here" language becomes "auto-applied for response-shape guarantees"; the CTXDSL/btor2-verb pointer stays for cases the bridge doesn't cover.
+- **Docs** — [`docs/verifying-rtl.md`](../verifying-rtl.md) gains a "fair-cycle bridge" section walking the `@mununu_assume GF` semantics; [`wiki/Property-Templates.md`](../../wiki/Property-Templates.md) soundness callout updated.
+
+## What did NOT change
+
+- **Wire format** — response shape unchanged; `SvVerifyAutoResponse` JSON schema unchanged (validated by the drift-detector — 17/17 pass with no regeneration needed).
+- **`PropertyVerdict` values** — same canonical vocabulary.
+- **CLI surface** — no new flags on `sv verify-auto`.
+- **Existing rescue behaviour on properties without fairness assumes** — byte-for-byte unchanged.
+- **PR 1's `btor2 verify-liveness-under-fairness` verb** — unchanged (the bridge calls the same library entry).
+
+## For ROSF and monono
+
+**What to update:** nothing forced. To use the bridge:
+
+```systemverilog
+// @mununu_assume GF grant_cpu == 1
+// @mununu_guarantee nu Z. ((!(req == 1) || mu Y. ((ack == 1) || [] Y)) && [] Z)
+module wb_mem_client(...);
+    // ... your existing RTL ...
+endmodule
+```
+
+```sh
+# The guarantee decides under GF(grant_cpu == 1) automatically:
+mununu sv verify-auto wb_mem_client.sv
+# expected: verdict "holds" (previously "unknown" without the bridge)
+```
+
+Multiple `@mununu_assume GF <atom>` accumulate as a conjunction `(⋀ⱼ GF fairⱼ)` — the SV translator collects every `GF` assume in the source and applies them together to each response-shape guarantee.
+
+**Report parsing impact:** additive-safe. A consumer that inspects `verification_notes[i].kind` may now see `"fair-cycle-rescue"` on properties the bridge decided. The verification-note SHAPE is unchanged.
+
+**Soundness contract** — the same as PR 1:
+
+- A `holds` verdict under `⋀ⱼ GF fairⱼ` means the response holds against every environment schedule satisfying each fairness constraint infinitely often.
+- A `violated` verdict is a reachable lasso satisfying every constraint that still leaves the request forever ungranted.
+- A useless fairness atom (env satisfies trivially) does NOT rescue a genuinely starving design — validated by mununu#488's soundness controls, which apply here transitively.
+
+**Assumes not covered by the bridge:**
+
+- State predicates as fairness atoms (`GF (fsm_state == IDLE)`) — the primitive accepts state atoms too, but the SV bridge currently only parses register-comparison shapes; use `btor2 verify-liveness-under-fairness` on the emitted BTOR2 for state-predicate fairness.
+- Non-response guarantees (`AG p` safety, `AG EF good` recoverability) — fairness has well-defined semantics on them, but the fair-cycle primitive is response-specific.
+- Coupled multi-guarantee fairness (`⋀ᵢ AG(aᵢ → AF bᵢ)` under one `⋀ⱼ GF fairⱼ`) — each guarantee's fair-cycle rescue runs independently; the coupled Streett shape is a further follow-up.
+- Any of the above: use `mununu btor2 verify-liveness-under-fairness` on the emitted BTOR2 directly, or model in CTXDSL where the GR(1) game engine handles multi-pair coupled fairness.
+
+**Docker rebuild:** binary bump only; no subprocess tool changes.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | binary picks up the SV verify-auto bridge; user-observable on any SV source with `@mununu_assume GF <atom>` | Yes if consumers pin a version tag |
+| mununu `Dockerfile.dev` | binary bump + 3 new bridge tests + 4 new scanner tests | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; the ignored slang-gated e2e set is unaffected | No — no e2e coverage in this PR |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `Dockerfile` / `Dockerfile.dev` / `.hw` | consumes mununu CLI/API; verdicts on SV sources with `@mununu_assume GF` may flip from `unknown` to `holds` | No — behaviour updates on next binary pull; a monitoring gate that expected `unknown` should be revalidated |
+| monono Docker (if any) | primary beneficiary — the `wb_mem_client`-shape case becomes decidable via annotation | No — pull the new binary and add `// @mununu_assume GF grant_cpu == 1` to the module |
+| mununu-ui deployment | no impact | No |
+
+## Verification
+
+- `cargo test -p mununu-core --lib --features api escalate_bottom_fair_cycle` — 3 bridge tests pass (baseline VIOLATED, positive rescue HOLDS, soundness guard against non-response misroute).
+- `cargo test -p mununu-core --lib --features api h5_gr1_` — 8 scanner tests pass (4 new: typed fairness parse, multi-accumulation, malformed skip, non-fairness stays in string bucket).
+- `cargo test -p mununu-core --lib --features api api_schema_drift_ -- --test-threads=1` — 17/17 schema drift tests pass (no regen needed; wire shape unchanged).
+- End-to-end (post-merge): a SystemVerilog module with `// @mununu_assume GF grant_cpu == 1` + a response-shape `@mununu_guarantee` returns `holds` on `sv verify-auto` — no CLI flags needed.
+
+## Provenance
+
+- Fix commit: (pending merge — branch `feat/477-b-sv-verify-auto-fairness-bridge`).
+- Ticket: [mununu#477](https://github.com/vscorza/mununu/issues/477) — **closes on merge**.
+- Prior briefings on this track: [`2026-09-fairness-note-honesty.md`](2026-09-fairness-note-honesty.md), [`2026-09-fair-cycle-l2s.md`](2026-09-fair-cycle-l2s.md).
+- Design record: `.claude/plans/477-b-fair-cycle-l2s.md` — plan doc; this PR completes its Phase 4-6.
+- Policy: [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here (documented non-goals)
+
+- **State-predicate fairness on the SV bridge.** The primitive supports state atoms; the SV scanner currently accepts register-comparison shapes. Trivial follow-up if a consumer asks.
+- **Coupled multi-guarantee Streett shape.** Each guarantee's fair-cycle rescue runs independently in this PR.
+- **General LTL assumptions.** The ticket explicitly narrows to `GF <signal>` conjunctions.
+- **`sv verify-liveness-under-fairness` SV-wrapped verb.** Not shipped since the SV auto-routing bridge here supersedes the main use case; can be added additively if a consumer needs it directly.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -104,6 +104,29 @@ path (validated on real OpenTitan `csrng` RTL — see `recoverability-vs-sva.md`
 
 ---
 
+### `sv verify-auto` fair-cycle bridge — `// @mununu_assume GF <atom>` (mununu#477)
+
+> Source of truth: [`escalate_bottom`](../crates/mununu-core/src/adapter/slang/verify_auto.rs) — surface: (CLI+API+UI)
+
+A `// @mununu_assume GF <REG op VALUE>` inline annotation is **auto-applied to any response-shape guarantee** (`AG(a → AF b)`) in the same source. The SV verify-auto orchestration parses the `GF <atom>` into a typed fairness atom during annotation scanning; when a response-shape guarantee's cube-abstraction verdict is ⊥, the ⊥-escalation router dispatches through [`response_liveness_rescue_under_fairness`](../crates/mununu-core/src/adapter/liveness_rescue.rs) (the fair-cycle l2s primitive described above) instead of the plain `response_liveness_rescue`. A definite `holds` under fairness means the guarantee holds against every environment schedule satisfying the assumption infinitely often; a definite `violated` is a reachable lasso satisfying the assumption that still leaves the request forever ungranted.
+
+Multiple `// @mununu_assume GF <atom>` in one source accumulate as a conjunction `(⋀ⱼ GF fairⱼ)`. The scanner records the applied assume in the `annotation-properties` verification note; each fair-cycle rescue emits a `fair-cycle-rescue` note naming the assumption(s) applied.
+
+Assumes that don't fit `GF <REG op VALUE>` — a state predicate, a non-response guarantee shape, or coupled multi-guarantee fairness — remain recorded rather than auto-applied. Route those through `mununu btor2 verify-liveness-under-fairness` on the emitted BTOR2, or model in CTXDSL where the GR(1) game engine handles multi-pair coupled fairness directly.
+
+```systemverilog
+// @mununu_assume GF grant_cpu == 1
+// @mununu_guarantee nu Z. ((!(req == 1) || mu Y. ((ack == 1) || [] Y)) && [] Z)
+module wb_mem_client(...);
+    // ...
+endmodule
+```
+
+```bash
+# The guarantee is decided under GF(grant_cpu == 1) automatically:
+mununu sv verify-auto wb_mem_client.sv
+```
+
 ## No-sidecar SystemVerilog verification: `sv verify-auto`
 
 > Source of truth: [`verify_auto`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L1537) — surface: (CLI+API+UI)

--- a/wiki/Property-Templates.md
+++ b/wiki/Property-Templates.md
@@ -50,11 +50,14 @@ Shorthand → mu-calculus is the [Mu-Calculus Reference](Mu-Calculus-Reference.m
 
 **Soundness default — use `EF` (reachable), not `AF` (inevitable).** `AF`/box-`AF` is sound only where no free
 input (a kick, a clock-stretch, a competing request, a bus-cycle drop) can stall the antecedent path forever.
-On the `sv verify-auto` flagship path, a `GF` fairness assumption is currently *recorded* rather than
-auto-applied — the SV lift does not yet route it to the fairness-constrained engine. Fairness IS supported
-today via `mununu btor2 game --objective recurrence` (single-pair GR(1) on the emitted BTOR2) and via
-CTXDSL's GR(1) game engine `(⋀ GF envᵢ) → (⋀ GF sysⱼ)`; see mununu#477 for the SV-path bridge tracking.
-When unsure and staying on `sv verify-auto`, prefer `EF`.
+On the `sv verify-auto` flagship path, a `// @mununu_assume GF <REG op VALUE>` assumption is **auto-applied
+to any response-shape guarantee** (`AG(a → AF b)`) via the Emerson–Lei fair-cycle l2s (mununu#477 Option B):
+each `GF` assume adds a `fair_seen` monitor latch, and a `holds` verdict under fairness means the guarantee
+holds against every environment schedule satisfying the assumption infinitely often. For assumptions that
+don't fit `GF <REG op VALUE>` — a state predicate, a non-response guarantee, or coupled multi-guarantee
+fairness — use `mununu btor2 verify-liveness-under-fairness` on the emitted BTOR2, or model in CTXDSL where
+the GR(1) game engine `(⋀ GF envᵢ) → (⋀ GF sysⱼ)` discharges multi-pair assume-guarantee liveness directly.
+When unsure and staying on `sv verify-auto` without a matching `@mununu_assume GF`, prefer `EF`.
 
 | class | trigger | patterns (shorthand, `<slots>` = observable signals) |
 |---|---|---|


### PR DESCRIPTION
Closes #477.

The SV-path bridge of Option B — PR 2 of 2. When `sv verify-auto` sees `// @mununu_assume GF <REG op VALUE>` alongside a response-shape guarantee (`AG(a → AF b)`), the ⊥-escalation router now dispatches through `response_liveness_rescue_under_fairness` (the fair-cycle l2s primitive shipped in #488) instead of the plain `response_liveness_rescue`. A `holds` verdict under the assume means the guarantee holds against every environment schedule satisfying the assumption infinitely often; the load-bearing case from the ticket (`wb_mem_client` decomposed against an arbiter it does not control) becomes decidable via annotation alone.

## What ships

- **Typed fairness detection** in [`AnnotationScan`](crates/mununu-core/src/adapter/slang/verify_auto.rs): new `fairness_assumes: Vec<Atom>` field; scanner parses `GF <REG op VALUE>` bodies into typed atoms. Malformed bodies surface in `skipped` (never silently dropped); non-`GF` assumes continue to flow through the untyped `assumes` string bucket for the existing config-concretization path.
- **Fair-cycle dispatch** in `escalate_bottom`: trailing `fairness_atoms: &[Atom]` parameter. Liveness arm: when non-empty AND the guarantee reduces to response shape, call the fair-cycle rescue instead of the plain one; otherwise fall through unchanged. Non-response guarantees with fairness assumes stay on their existing paths (soundness guard tested).
- **New `fair-cycle-rescue` verification-note kind** naming the assumption(s) applied.
- **`annotation-properties` note text** upgraded from "recorded here" (#487) to "auto-applied for response-shape guarantees"; the CTXDSL / `btor2 verify-liveness-under-fairness` pointer stays for cases the bridge doesn't cover.
- **Docs**: [`docs/verifying-rtl.md`](docs/verifying-rtl.md) gains a "fair-cycle bridge" section with the worked wb_mem_client example; [`wiki/Property-Templates.md`](wiki/Property-Templates.md) soundness callout upgraded.
- **Consumer briefing**: [`2026-09-sv-fairness-bridge.md`](docs/consumer-briefings/2026-09-sv-fairness-bridge.md).

## Tests

- **Bridge (3):** baseline VIOLATED without fairness on the FAIR_GATED starving-design fixture, positive rescue HOLDS under `GF(fair == 1)`, soundness guard that non-response guarantees do NOT go through the fair-cycle bridge.
- **Scanner (4 new + 4 existing = 8):** typed fairness parse into `Atom`, multi-accumulation as conjunction, malformed atom surfaces in `skipped`, non-fairness assume stays in string bucket; all pre-existing scanner tests continue to pass.
- **Schema drift** (17/17): zero regeneration needed — wire format unchanged.

## What did NOT change

- Wire format — `SvVerifyAutoResponse` schema unchanged (drift-detector confirms).
- `PropertyVerdict` values — same canonical vocabulary.
- CLI surface — no new flags on `sv verify-auto`.
- Existing rescue behaviour on properties without fairness assumes — byte-for-byte unchanged.
- The #488 `btor2 verify-liveness-under-fairness` verb — unchanged (the bridge calls the same library entry).

## Non-goals (documented in the briefing)

- **State-predicate fairness on the SV bridge.** The primitive supports state atoms; the SV scanner accepts register-comparison today. Trivial follow-up.
- **Coupled multi-guarantee Streett shape.** Each guarantee's fair-cycle rescue runs independently.
- **General LTL assumptions.** The ticket explicitly narrows to `GF <signal>` conjunctions.

For any of those, use `btor2 verify-liveness-under-fairness` on the emitted BTOR2 or model in CTXDSL.

## Test plan

- [x] `cargo test -p mununu-core --lib --features api escalate_bottom_fair_cycle` — 3/3 bridge tests pass.
- [x] `cargo test -p mununu-core --lib --features api h5_gr1_` — 8/8 scanner tests pass.
- [x] `cargo test -p mununu-core --lib --features api api_schema_drift_ -- --test-threads=1` — 17/17 pass (zero diff).
- [x] `cargo check --workspace --features mununu-core/api --tests` clean.
- [x] `cargo clippy -p mununu-core --features api --lib -- -D warnings` clean.
- [x] Pre-commit hook green.
- [ ] GitHub Actions CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)