### PR TITLE
feat(verify-auto): compound-atom safety rescue + `bottom-reason` diagnostic (closes #492)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -539,23 +539,63 @@ pub fn emit_ag_boolean_invariant_monitor(
                 Ok(n)
             }
             MuNode::Not(inner) => {
-                let a = compile(formula, *inner, file, reset_pinned, bool_sort, next_nid, appended)?;
+                let a = compile(
+                    formula,
+                    *inner,
+                    file,
+                    reset_pinned,
+                    bool_sort,
+                    next_nid,
+                    appended,
+                )?;
                 let n = *next_nid;
                 *next_nid += 1;
                 appended.push(format!("{n} not {bool_sort} {a}"));
                 Ok(n)
             }
             MuNode::And(l, r) => {
-                let a = compile(formula, *l, file, reset_pinned, bool_sort, next_nid, appended)?;
-                let b = compile(formula, *r, file, reset_pinned, bool_sort, next_nid, appended)?;
+                let a = compile(
+                    formula,
+                    *l,
+                    file,
+                    reset_pinned,
+                    bool_sort,
+                    next_nid,
+                    appended,
+                )?;
+                let b = compile(
+                    formula,
+                    *r,
+                    file,
+                    reset_pinned,
+                    bool_sort,
+                    next_nid,
+                    appended,
+                )?;
                 let n = *next_nid;
                 *next_nid += 1;
                 appended.push(format!("{n} and {bool_sort} {a} {b}"));
                 Ok(n)
             }
             MuNode::Or(l, r) => {
-                let a = compile(formula, *l, file, reset_pinned, bool_sort, next_nid, appended)?;
-                let b = compile(formula, *r, file, reset_pinned, bool_sort, next_nid, appended)?;
+                let a = compile(
+                    formula,
+                    *l,
+                    file,
+                    reset_pinned,
+                    bool_sort,
+                    next_nid,
+                    appended,
+                )?;
+                let b = compile(
+                    formula,
+                    *r,
+                    file,
+                    reset_pinned,
+                    bool_sort,
+                    next_nid,
+                    appended,
+                )?;
                 let n = *next_nid;
                 *next_nid += 1;
                 appended.push(format!("{n} or {bool_sort} {a} {b}"));
@@ -601,8 +641,15 @@ pub fn emit_ag_boolean_invariant_monitor(
         }
     }
 
-    let inv_expr =
-        compile(formula, root, &file, reset_pinned, bool_sort, &mut next_nid, &mut appended)?;
+    let inv_expr = compile(
+        formula,
+        root,
+        &file,
+        reset_pinned,
+        bool_sort,
+        &mut next_nid,
+        &mut appended,
+    )?;
 
     // bad = !(compound); the final NOT carries BAD_COND_SYMBOL.
     let bad_cond = next_nid;

--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -481,6 +481,141 @@ pub fn emit_latched_predicate_state_named(
     Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
 }
 
+/// mununu#492 — append a `bad` monitor for `AG (COMPOUND)` where `COMPOUND` is a
+/// boolean expression tree over `And`/`Or`/`Not`/`True`/`False`/`Predicate` mu-calc
+/// nodes; each `Predicate` leaf resolves via state cell → output net → primary input.
+///
+/// Widens [`emit_ag_state_atom_monitor`] to (a) compound boolean invariants, and
+/// (b) atoms bound to primary inputs (essential for zero-state models where every
+/// atom is input-only). The bad line is `bad = !(compound_expr)`; the final NOT
+/// node carries [`BAD_COND_SYMBOL`].
+///
+/// Signal-resolution fallback is state → output → **input**: the primary-input
+/// fallback is what zero-state models need. Under safety-monitor semantics this
+/// is sound — a `bad` reachable under some input assignment IS a real
+/// counterexample (the SVA property is `AG(compound)` universally-quantified over
+/// inputs), no different from a witness on a stateful design where the counterexample
+/// is `(state_trajectory, input_schedule)`.
+pub fn emit_ag_boolean_invariant_monitor(
+    content: &str,
+    formula: &crate::mu_calculus::Formula,
+    root: crate::mu_calculus::NodeId,
+    reset_pinned: bool,
+) -> Result<String, AdapterError> {
+    use crate::adapter::btor2::predicate_expr::{PredicateExpr, parse_predicate_expr};
+    use crate::mu_calculus::Node as MuNode;
+
+    let file = parser::parse(content).map_err(|mut e| {
+        e.message = format!("adapter/btor2/bad_monitor: {}", e.message);
+        e
+    })?;
+
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut appended: Vec<String> = Vec::new();
+    let bool_sort = find_or_make_bool_sort(&file, &mut next_nid, &mut appended);
+
+    // Walk the mu-calc subtree rooted at `id`; emit BTOR2 nodes; return the
+    // NID of the compiled boolean expression (1-bit).
+    fn compile(
+        formula: &crate::mu_calculus::Formula,
+        id: crate::mu_calculus::NodeId,
+        file: &crate::adapter::btor2::ast::Btor2File,
+        reset_pinned: bool,
+        bool_sort: Nid,
+        next_nid: &mut Nid,
+        appended: &mut Vec<String>,
+    ) -> Result<Nid, AdapterError> {
+        match formula.node(id) {
+            MuNode::True => {
+                let n = *next_nid;
+                *next_nid += 1;
+                appended.push(format!("{n} constd {bool_sort} 1"));
+                Ok(n)
+            }
+            MuNode::False => {
+                let n = *next_nid;
+                *next_nid += 1;
+                appended.push(format!("{n} constd {bool_sort} 0"));
+                Ok(n)
+            }
+            MuNode::Not(inner) => {
+                let a = compile(formula, *inner, file, reset_pinned, bool_sort, next_nid, appended)?;
+                let n = *next_nid;
+                *next_nid += 1;
+                appended.push(format!("{n} not {bool_sort} {a}"));
+                Ok(n)
+            }
+            MuNode::And(l, r) => {
+                let a = compile(formula, *l, file, reset_pinned, bool_sort, next_nid, appended)?;
+                let b = compile(formula, *r, file, reset_pinned, bool_sort, next_nid, appended)?;
+                let n = *next_nid;
+                *next_nid += 1;
+                appended.push(format!("{n} and {bool_sort} {a} {b}"));
+                Ok(n)
+            }
+            MuNode::Or(l, r) => {
+                let a = compile(formula, *l, file, reset_pinned, bool_sort, next_nid, appended)?;
+                let b = compile(formula, *r, file, reset_pinned, bool_sort, next_nid, appended)?;
+                let n = *next_nid;
+                *next_nid += 1;
+                appended.push(format!("{n} or {bool_sort} {a} {b}"));
+                Ok(n)
+            }
+            MuNode::Predicate(atom) => match parse_predicate_expr(atom) {
+                Ok(PredicateExpr::Cmp {
+                    register,
+                    op,
+                    value,
+                }) => {
+                    let (sig_nid, sig_sort) = state_nid_and_sort(file, &register, reset_pinned)
+                        .or_else(|| output_nid_and_sort(file, &register))
+                        .or_else(|| input_nid_and_sort(file, &register))
+                        .ok_or_else(|| {
+                            err(format!(
+                                "adapter/btor2/bad_monitor: leaf atom `{register}` does not \
+                                 resolve to a state cell, output port, or primary input"
+                            ))
+                        })?;
+                    let const_nid = *next_nid;
+                    *next_nid += 1;
+                    appended.push(format!("{const_nid} constd {sig_sort} {value}"));
+                    let cmp_kw = btor2_cmp_keyword(op);
+                    let n = *next_nid;
+                    *next_nid += 1;
+                    appended.push(format!("{n} {cmp_kw} {bool_sort} {sig_nid} {const_nid}"));
+                    Ok(n)
+                }
+                Ok(_) => Err(err(format!(
+                    "adapter/btor2/bad_monitor: leaf atom `{atom}` uses a relational / addend / \
+                     select shape not supported by the compound monitor"
+                ))),
+                Err(e) => Err(err(format!(
+                    "adapter/btor2/bad_monitor: leaf atom `{atom}` did not parse as a predicate \
+                     expression: {e:?}"
+                ))),
+            },
+            other => Err(err(format!(
+                "adapter/btor2/bad_monitor: compound safety monitor accepts \
+                 And/Or/Not/True/False/Predicate only; found {other:?}"
+            ))),
+        }
+    }
+
+    let inv_expr =
+        compile(formula, root, &file, reset_pinned, bool_sort, &mut next_nid, &mut appended)?;
+
+    // bad = !(compound); the final NOT carries BAD_COND_SYMBOL.
+    let bad_cond = next_nid;
+    next_nid += 1;
+    appended.push(format!(
+        "{bad_cond} not {bool_sort} {inv_expr} {BAD_COND_SYMBOL}"
+    ));
+    let bad_line = next_nid;
+    appended.push(format!("{bad_line} bad {bad_cond}"));
+
+    Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -54,7 +54,9 @@
 //! validated end-to-end by the `#[ignore]`d `e2e_rescue_*` tests below (both verdict
 //! directions + the beyond-40-bit-cap case, with live btormc/Pono).
 
-use crate::adapter::btor2::bad_monitor::emit_ag_state_atom_monitor;
+use crate::adapter::btor2::bad_monitor::{
+    emit_ag_boolean_invariant_monitor, emit_ag_state_atom_monitor,
+};
 use crate::adapter::btor2::parser;
 use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr, parse_predicate_expr};
 use crate::adapter::reach_portfolio::{ReachOutcome, ReachVerdict, decide_reach_portfolio};
@@ -139,6 +141,70 @@ pub fn reduce_ag_invariant(formula: &Formula) -> Option<AgInvariant> {
     }
 }
 
+/// mununu#492 — reduce `nu X. (COMPOUND && [] X)` to the [`NodeId`] of `COMPOUND`
+/// when `COMPOUND` is a boolean tree over `And`/`Or`/`Not`/`True`/`False`/`Predicate`
+/// nodes, with each `Predicate` leaf parseable as a single register-comparison
+/// (`PredicateExpr::Cmp`) — widening [`reduce_ag_invariant`] which accepts only a
+/// single atomic body. Non-boolean leaves (`CmpReg`, `CmpRegAddend`, `Select`) are
+/// rejected here so the compound emitter never receives a leaf it cannot compile;
+/// modal / fixpoint nodes inside `COMPOUND` are rejected — the outer `AG` is the only
+/// modality allowed.
+///
+/// **Soundness rationale.** The compound body compiles to a pure boolean expression
+/// over the (state × input) universe; the emitted `bad` is its negation, so a
+/// reachable `bad` is a genuine reachable state × input assignment falsifying the
+/// invariant. `AG(COMPOUND)` is universally-quantified over ALL trajectories AND
+/// input schedules, so the counterexample transfers unchanged. Same soundness
+/// argument as [`emit_ag_state_atom_monitor`], generalised from a single leaf.
+pub fn reduce_ag_boolean_body(formula: &Formula) -> Option<NodeId> {
+    // Outer shape must be `nu X. (BODY && [] X)` — same as reduce_ag_invariant.
+    let Node::Nu { var, body } = formula.node(formula.root()) else {
+        return None;
+    };
+    let Node::And(l, r) = formula.node(*body) else {
+        return None;
+    };
+    let (compound_id, modal_id) = classify_and(formula, *l, *r, *var)?;
+    let Node::Modal {
+        kind: ModalKind::Box,
+        guard,
+        target,
+    } = formula.node(modal_id)
+    else {
+        return None;
+    };
+    if *guard != Guard::default() {
+        return None;
+    }
+    match formula.node(*target) {
+        Node::Variable(v) if *v == *var => {}
+        _ => return None,
+    }
+    // The compound subtree must be pure boolean-of-single-atom-leaves — no
+    // modals / fixpoints / variables, and every Predicate leaf parses as Cmp.
+    if !is_compilable_boolean_body(formula, compound_id) {
+        return None;
+    }
+    Some(compound_id)
+}
+
+/// Walk the subtree; verify it is only And/Or/Not/True/False/Predicate and every
+/// Predicate leaf parses as `PredicateExpr::Cmp`. A single modal / fixpoint /
+/// variable / CmpReg / CmpRegAddend / Select rejects the whole tree.
+fn is_compilable_boolean_body(formula: &Formula, id: NodeId) -> bool {
+    match formula.node(id) {
+        Node::True | Node::False => true,
+        Node::Not(inner) => is_compilable_boolean_body(formula, *inner),
+        Node::And(l, r) | Node::Or(l, r) => {
+            is_compilable_boolean_body(formula, *l) && is_compilable_boolean_body(formula, *r)
+        }
+        Node::Predicate(atom) => {
+            matches!(parse_predicate_expr(atom), Ok(PredicateExpr::Cmp { .. }))
+        }
+        _ => false,
+    }
+}
+
 /// Return `(atom_node, modal_node)` iff exactly one of `l` / `r` is a box-to-`var`
 /// and the other is not. `None` if neither or both look like the box recursion,
 /// keeping the shape match unambiguous.
@@ -186,12 +252,30 @@ pub fn reach_portfolio_rescue(
     formula: &Formula,
     reset_pinned: bool,
 ) -> Option<(RescueVerdict, ReachOutcome)> {
-    let inv = reduce_ag_invariant(formula)?;
-    // bad = !(signal ⋈ value); the emitter validates `signal` resolves to a state
-    // cell (a non-state signal ⇒ Err ⇒ abstain).
-    let monitored =
-        emit_ag_state_atom_monitor(design_btor2, &inv.signal, inv.op, inv.value, reset_pinned)
-            .ok()?;
+    // Try the existing single-atom reducer first — preserves byte-for-byte
+    // emission on the shipped case. Fall back to the compound-atom reducer
+    // (mununu#492) for `AG(compound_boolean_expression)` and for atoms bound
+    // to primary inputs (essential for zero-state models).
+    let monitored = if let Some(inv) = reduce_ag_invariant(formula) {
+        // bad = !(signal ⋈ value); the emitter validates `signal` resolves to a
+        // state cell / output net (a non-state / non-output signal ⇒ Err ⇒
+        // fall through to the compound path below).
+        match emit_ag_state_atom_monitor(design_btor2, &inv.signal, inv.op, inv.value, reset_pinned)
+        {
+            Ok(s) => s,
+            Err(_) => {
+                // The single-atom emitter refused the signal (zero-state atom
+                // on a primary input, say). Try the compound path — its leaf
+                // resolution includes primary inputs.
+                let root = reduce_ag_boolean_body(formula)?;
+                emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned).ok()?
+            }
+        }
+    } else {
+        // Non-single-atom shape — try compound.
+        let root = reduce_ag_boolean_body(formula)?;
+        emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned).ok()?
+    };
     let file = parser::parse(&monitored).ok()?;
     let outcome = decide_reach_portfolio(&file);
     let verdict = match outcome.verdict {
@@ -311,6 +395,133 @@ mod tests {
         // not reducible — the design text is never even parsed.
         let f = parse("mu X. ((b != 0) || <> X)");
         assert!(reach_portfolio_rescue("1 sort bitvec 1\n", &f, false).is_none());
+    }
+
+    // ---- mununu#492 Part A: compound-atom safety reducer + integration ----
+
+    #[test]
+    fn compound_reducer_accepts_exclusion_shape() {
+        // `AG(!a || !b)` — the exclusion safety `!(a && b)`, a compound Or-of-Nots.
+        let f = parse("nu X. (((!(a == 1)) || (!(b == 1))) && [] X)");
+        assert!(
+            reduce_ag_boolean_body(&f).is_some(),
+            "the exclusion safety must reduce under the compound reducer"
+        );
+        // And the single-atom reducer must still reject it — the widening is
+        // strictly additive on the single-atom lane.
+        assert!(
+            reduce_ag_invariant(&f).is_none(),
+            "the single-atom reducer must stay strict on compound shapes"
+        );
+    }
+
+    #[test]
+    fn compound_reducer_accepts_implication_shape() {
+        // `AG(!a || b)` — the classical implication safety `AG(a -> b)`.
+        let f = parse("nu X. (((!(a == 1)) || (b == 1)) && [] X)");
+        assert!(reduce_ag_boolean_body(&f).is_some());
+    }
+
+    #[test]
+    fn compound_reducer_accepts_conjunctive_body() {
+        // `AG(a && b)` — a conjunctive safety.
+        let f = parse("nu X. (((a == 1) && (b == 1)) && [] X)");
+        assert!(reduce_ag_boolean_body(&f).is_some());
+    }
+
+    #[test]
+    fn compound_reducer_rejects_modal_inside_body() {
+        // A modal (box / diamond) inside the compound is rejected — the compound
+        // emitter compiles a pure boolean expression, not a modal one.
+        let f = parse("nu X. (((a == 1) && [] (b == 1)) && [] X)");
+        assert!(
+            reduce_ag_boolean_body(&f).is_none(),
+            "a compound with an embedded modal must not reduce"
+        );
+    }
+
+    #[test]
+    fn compound_reducer_rejects_relational_leaf() {
+        // A `CmpReg` leaf (register-vs-register) is out of the compilable set;
+        // the compound emitter would reject it, so the reducer must too.
+        let f = parse("nu X. (((a == 1) && (b == c)) && [] X)");
+        assert!(reduce_ag_boolean_body(&f).is_none());
+    }
+
+    #[test]
+    fn compound_reducer_rejects_guarded_box() {
+        // Same guard-box refusal as reduce_ag_invariant.
+        let f = parse("nu X. (((a == 1) && (b == 1)) && [(labels = {step})] X)");
+        assert!(reduce_ag_boolean_body(&f).is_none());
+    }
+
+    // A zero-state model — 3 primary inputs, no registers. `AG(!a || !b)` is
+    // violated when a=b=1; `AG(!a || b)` is violated when a=1,b=0; `AG(a || !a)`
+    // is trivially true. These are exactly the ticket-#492 shapes on the
+    // stateless `mem_router` contrast pair.
+    const ZERO_STATE_MODEL: &str = "\
+1 sort bitvec 1
+2 input 1 a
+3 input 1 b
+4 input 1 c
+";
+
+    #[test]
+    fn zero_state_exclusion_safety_gets_violated_via_compound_rescue() {
+        // `AG(!(a == 1) || !(b == 1))` — a=1,b=1 falsifies. Expected: VIOLATED.
+        let f = parse("nu X. (((!(a == 1)) || (!(b == 1))) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(ZERO_STATE_MODEL, &f, false)
+            .expect("rescue must fire on the compound path");
+        assert_eq!(
+            verdict,
+            RescueVerdict::Violated,
+            "a=1 && b=1 falsifies AG(!a || !b); expected VIOLATED, got {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn zero_state_implication_safety_gets_violated_via_compound_rescue() {
+        // `AG(!(a == 1) || (b == 1))` — a=1,b=0 falsifies. Expected: VIOLATED.
+        let f = parse("nu X. (((!(a == 1)) || (b == 1)) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(ZERO_STATE_MODEL, &f, false)
+            .expect("rescue must fire on the compound path");
+        assert_eq!(verdict, RescueVerdict::Violated);
+    }
+
+    #[test]
+    fn zero_state_tautology_gets_holds_via_compound_rescue() {
+        // `AG((a == 1) || (a != 1))` — trivially true. Expected: HOLDS.
+        let f = parse("nu X. (((a == 1) || (a != 1)) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(ZERO_STATE_MODEL, &f, false)
+            .expect("rescue must fire on the compound path");
+        assert_eq!(
+            verdict,
+            RescueVerdict::Holds,
+            "AG(a || !a) is trivially true; expected HOLDS, got {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn zero_state_conjunctive_safety_gets_violated_via_compound_rescue() {
+        // `AG(a==1 && b==1)` — a=0 falsifies. Expected: VIOLATED.
+        let f = parse("nu X. (((a == 1) && (b == 1)) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(ZERO_STATE_MODEL, &f, false)
+            .expect("rescue must fire on the compound path");
+        assert_eq!(verdict, RescueVerdict::Violated);
+    }
+
+    // The single-atom regression: the widened `reach_portfolio_rescue` must still
+    // route a `AG(cnt != 3)` on the WIDE_INPUT_FSM through the existing
+    // single-atom emitter (byte-equivalent). We can't assert on emitted bytes
+    // here (the file text isn't returned), but we can assert the verdict is the
+    // same as it was before the widening — VIOLATED on `AG(cnt != 3)` at k=2.
+    #[test]
+    fn single_atom_regression_still_decides_via_the_original_lane() {
+        let f = parse("nu X. ((cnt == 0) && [] X)");
+        // cnt starts at 0, then transitions to 1 → clearly violated at k=1.
+        let (verdict, _) = reach_portfolio_rescue(WIDE_INPUT_FSM, &f, false)
+            .expect("single-atom lane must still rescue");
+        assert_eq!(verdict, RescueVerdict::Violated);
     }
 
     // ---- docker-validated (`mununu-sva`): full rescue path with live btormc/Pono ----

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -3310,7 +3310,142 @@ pub(crate) fn escalate_bottom(
             _ => {}
         }
     }
+    // mununu#492 Part B — classify residual ⊥s so a downstream gate can distinguish
+    // "resource-abstain" (the engine gave up) from "shape-not-reducible-here" (the
+    // rescue couldn't reduce this shape) from "no-state-model" (the property class
+    // is degenerate on a stateless model). Prevents ⊥ from a fundamental modelling
+    // issue (which calls for a fix) from being confused with ⊥ from a resource cap
+    // (which calls for a raise).
+    let stateless_model = design_stateless(design_btor2);
+    for prop in report.properties.iter() {
+        if !matches!(prop.outcome, VerifyOutcome::Unknown { .. }) {
+            continue;
+        }
+        let reason = classify_bottom_reason(prop, stateless_model);
+        notes.push(bottom_reason_note(&prop.name, reason));
+    }
     notes
+}
+
+/// mununu#492 Part B — reason a residual ⊥ can be classified as, distinguishing
+/// the three mechanically-detectable cases from "unknown (no signal)".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BottomReason {
+    /// The property is Safety-class but neither the single-atom nor the compound
+    /// reducer could reduce it — its shape is out of what the rescue lane
+    /// currently supports (e.g. a compound with a `CmpReg` register-vs-register
+    /// leaf, or a non-standard AG outer shape).
+    SafetyShapeNotReducible,
+    /// A recoverability (`AG EF good`) or liveness (`AG(a → AF b)`) property on
+    /// a design with zero state registers. Recoverability is vacuously true on
+    /// a stateless model; response-liveness's l2s reduction needs state to
+    /// lasso. Either case is a modelling issue, not an engine cap.
+    NoStateModelNonSafety,
+    /// None of the above — the ⊥ is unexplained by this classifier (probably a
+    /// resource abstain on the cube / exact engine, or a shape the residual
+    /// doesn't cover here). A downstream gate should NOT treat this as
+    /// distinct-from-abstain without more evidence.
+    UnclassifiedBottom,
+}
+
+/// True when the design has no state registers (`state ...` lines).
+fn design_stateless(design_btor2: &str) -> bool {
+    match crate::adapter::btor2::parser::parse(design_btor2) {
+        Ok(file) => !file
+            .lines
+            .iter()
+            .any(|l| matches!(l.node, crate::adapter::btor2::ast::Node::State { .. })),
+        Err(_) => false,
+    }
+}
+
+/// Classify a residual ⊥ property. Called ONLY on properties whose outcome is
+/// still `Unknown` after the escalation pass.
+fn classify_bottom_reason(prop: &PropertyVerdict, stateless_model: bool) -> BottomReason {
+    use crate::mu_calculus::{PropertyClass, parser as mu_parser};
+    let Ok(formula) = mu_parser::parse(&prop.formula) else {
+        return BottomReason::UnclassifiedBottom;
+    };
+    match formula.property_class() {
+        PropertyClass::Safety => {
+            let single_atom = crate::adapter::reach_rescue::reduce_ag_invariant(&formula).is_some();
+            let compound = crate::adapter::reach_rescue::reduce_ag_boolean_body(&formula).is_some();
+            if !single_atom && !compound {
+                BottomReason::SafetyShapeNotReducible
+            } else {
+                BottomReason::UnclassifiedBottom
+            }
+        }
+        PropertyClass::Liveness | PropertyClass::Reachability | PropertyClass::Mixed => {
+            if stateless_model {
+                BottomReason::NoStateModelNonSafety
+            } else {
+                BottomReason::UnclassifiedBottom
+            }
+        }
+        PropertyClass::Propositional => BottomReason::UnclassifiedBottom,
+    }
+}
+
+/// mununu#492 Part B — the per-property provenance note that names a residual
+/// ⊥'s classification so a consumer's gate can act on the distinction.
+fn bottom_reason_note(name: &str, reason: BottomReason) -> VerificationNote {
+    let (summary, detail) = match reason {
+        BottomReason::SafetyShapeNotReducible => (
+            format!(
+                "`{name}`: residual ⊥ classified as `safety-shape-not-reducible` — the \
+                 rescue lane could not reduce this AG-safety shape (compound-of-relational, \
+                 non-standard AG outer shape, or a leaf the compiler rejects). NOT the same \
+                 as an engine resource abstain — this is a modelling / property-shape gap."
+            ),
+            "The safety-rescue lane (mununu#492) accepts `AG(single_atom)` and \
+             `AG(compound_boolean_of_single_atoms)` where each leaf is a `REG op VALUE` \
+             comparison. Shapes outside that — a compound-of-relational (`AG(reg_a == reg_b \
+             && …)`), a `CmpRegAddend` leaf, an `AG(a → AX b)` implication-with-next, or a \
+             non-standard AG outer shape — are rejected here. A downstream gate should NOT \
+             treat this ⊥ as interchangeable with an engine's resource abstain: this needs \
+             a property reshape or a new rescue reducer, not a bigger budget."
+                .into(),
+        ),
+        BottomReason::NoStateModelNonSafety => (
+            format!(
+                "`{name}`: residual ⊥ classified as `no-state-model-non-safety` — the design \
+                 has zero state registers AND this property is non-Safety (liveness / \
+                 recoverability). On a stateless model, `AG EF good` is vacuously true (rule \
+                 4) and `AG(a → AF b)` has no lasso to reduce; the ⊥ is a modelling issue, \
+                 not an engine cap."
+            ),
+            "A purely combinational block has no reachable state trajectory beyond the \
+             initial (empty-state) point, so non-Safety property classes are either \
+             vacuously true (recoverability) or unfulfillable-by-shape (response-liveness's \
+             l2s needs state to close a lasso). Either compose the block with an enclosing \
+             stateful context (its scheduler / driver), or restrict the property set to \
+             tier-1 safety invariants — which the compound-safety rescue (mununu#492) does \
+             decide on stateless models."
+                .into(),
+        ),
+        BottomReason::UnclassifiedBottom => (
+            format!(
+                "`{name}`: residual ⊥ was not classified by the mununu#492 diagnostic. Most \
+                 commonly this is a resource abstain (bit-cap / node-budget / iteration / \
+                 wall-clock) on the exact-symbolic or cube engine — check for a sibling \
+                 `bit-cap` / `abstained on the …` note on the same property."
+            ),
+            "The bottom-reason classifier recognises three shapes (safety-shape-not-reducible, \
+             no-state-model-non-safety, unclassified). Anything outside those falls back to \
+             this note. It is NOT a claim about resource vs shape — just an honest 'this \
+             classifier did not narrow it further', so the consumer looks at the engine-side \
+             notes for the actionable answer."
+                .into(),
+        ),
+    };
+    VerificationNote {
+        kind: "bottom-reason".into(),
+        level: NoteLevel::ScopeCaveat,
+        summary,
+        detail,
+        items: Vec::new(),
+    }
 }
 
 /// Lever (b) — exact-symbolic rescue for cube-SKIPPED properties.
@@ -3975,9 +4110,18 @@ mod tests {
             "a νμ ⊥ must be left untouched by the safety arm (2-valued reachability can't \
              soundly decide it)"
         );
+        // No rescue note fires, but the mununu#492 Part B classifier attaches a
+        // `bottom-reason` note explaining WHY the ⊥ stands.
         assert!(
-            notes.is_empty(),
-            "no rescue note for an un-reducible property"
+            !notes.iter().any(|n| n.kind == "safety-rescue"
+                || n.kind == "liveness-rescue"
+                || n.kind == "recoverability-rescue"),
+            "no rescue note fires for a non-safety-reducible ⊥"
+        );
+        assert!(
+            notes.iter().any(|n| n.kind == "bottom-reason"),
+            "the Part B classifier must attach a bottom-reason note; got kinds: {:?}",
+            notes.iter().map(|n| &n.kind).collect::<Vec<_>>()
         );
     }
 
@@ -4199,7 +4343,17 @@ mod tests {
             matches!(report.properties[0].outcome, VerifyOutcome::Unknown { .. }),
             "a diamond-EF νμ ⊥ must be left untouched (l2s does not decide it)"
         );
-        assert!(notes.is_empty(), "no rescue note for a non-box-AF property");
+        // mununu#492 Part B — the residual ⊥ gets a `bottom-reason` note, but no
+        // rescue-arm note fires.
+        assert!(
+            !notes.iter().any(|n| n.kind == "liveness-rescue"),
+            "no liveness-rescue note for a non-box-AF property"
+        );
+        assert!(
+            notes.iter().any(|n| n.kind == "bottom-reason"),
+            "the Part B classifier must attach a bottom-reason note; got kinds: {:?}",
+            notes.iter().map(|n| &n.kind).collect::<Vec<_>>()
+        );
     }
 
     // A νμ recoverability property `AG EF (st == 0)` the cube left ⊥ is routed by
@@ -4278,6 +4432,132 @@ mod tests {
         assert!(
             notes.iter().any(|n| n.kind == "recoverability-rescue"),
             "a recoverability-rescue provenance note should be recorded"
+        );
+    }
+
+    // ---- mununu#492 Part B: bottom-reason classifier tests ----
+
+    // A zero-state design — 3 primary inputs, no state cells.
+    const BOTTOM_REASON_ZERO_STATE: &str = "\
+1 sort bitvec 1
+2 input 1 a
+3 input 1 b
+4 input 1 c
+";
+
+    /// mununu#492 — on the zero-state exclusion property, escalate_bottom's Safety
+    /// arm now DECIDES it VIOLATED via the compound-atom rescue (Part A). No
+    /// bottom-reason note is attached because the outcome is no longer Unknown.
+    #[test]
+    fn bottom_reason_zero_state_compound_safety_gets_decided_no_bottom_reason() {
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "mem_router_exclusion".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                formula: "nu X. (((!(a == 1)) || (!(b == 1))) && [] X)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 2 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let notes = escalate_bottom(
+            &mut report,
+            BOTTOM_REASON_ZERO_STATE,
+            false,
+            &VerifyAutoOptions::default(),
+            &[],
+        );
+        assert!(
+            matches!(report.properties[0].outcome, VerifyOutcome::Violated { .. }),
+            "the compound-atom rescue decides the exclusion VIOLATED on the zero-state model; \
+             got {:?}",
+            report.properties[0].outcome
+        );
+        // No bottom-reason note — the outcome is definite.
+        assert!(
+            !notes.iter().any(|n| n.kind == "bottom-reason"),
+            "no bottom-reason note when the outcome is decided"
+        );
+    }
+
+    /// mununu#492 — a safety property whose shape the rescue lane cannot reduce
+    /// (a compound with a `CmpReg` register-vs-register leaf) stays ⊥ and gets
+    /// a `bottom-reason` note classifying it as `safety-shape-not-reducible`.
+    #[test]
+    fn bottom_reason_safety_shape_not_reducible_gets_classified() {
+        // `AG(a == 1 && b == c)` — the b==c leaf is CmpReg, out of the compilable
+        // set for the compound emitter.
+        let design = "\
+1 sort bitvec 1
+2 input 1 a
+3 input 1 b
+4 input 1 c
+";
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "compound_with_relational_leaf".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                formula: "nu X. (((a == 1) && (b == c)) && [] X)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let notes = escalate_bottom(
+            &mut report,
+            design,
+            false,
+            &VerifyAutoOptions::default(),
+            &[],
+        );
+        assert!(
+            matches!(report.properties[0].outcome, VerifyOutcome::Unknown { .. }),
+            "the CmpReg leaf must stay ⊥ (out of the compilable set)"
+        );
+        let br = notes
+            .iter()
+            .find(|n| n.kind == "bottom-reason")
+            .expect("bottom-reason note must be attached to a residual ⊥");
+        assert!(
+            br.summary.contains("safety-shape-not-reducible"),
+            "classifier must name `safety-shape-not-reducible`; got summary: {}",
+            br.summary
+        );
+    }
+
+    /// mununu#492 — a non-Safety property (νμ recoverability) on a stateless
+    /// model is classified `no-state-model-non-safety`.
+    #[test]
+    fn bottom_reason_no_state_model_non_safety_gets_classified() {
+        let mut report = AutoVerifyReport {
+            properties: vec![PropertyVerdict {
+                name: "vacuous_recoverability".to_string(),
+                kind: crate::adapter::slang::translate::SvaKind::Assert,
+                // AG EF (a == 1) — recoverability on a stateless model.
+                formula: "nu Y. ((mu X. ((a == 1) || <> X)) && [] Y)".to_string(),
+                outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
+                seeded_predicates: Vec::new(),
+                counterexample: None,
+            }],
+            ..Default::default()
+        };
+        let opts = VerifyAutoOptions {
+            // Isolate the classifier from the recoverability rescue path so the
+            // residual ⊥ is what the classifier sees.
+            rescue_bottom_recoverability: false,
+            ..VerifyAutoOptions::default()
+        };
+        let notes = escalate_bottom(&mut report, BOTTOM_REASON_ZERO_STATE, false, &opts, &[]);
+        let br = notes
+            .iter()
+            .find(|n| n.kind == "bottom-reason")
+            .expect("bottom-reason note must be attached to a residual ⊥");
+        assert!(
+            br.summary.contains("no-state-model-non-safety"),
+            "classifier must name `no-state-model-non-safety`; got summary: {}",
+            br.summary
         );
     }
 

--- a/docs/consumer-briefings/2026-09-compound-safety-and-bottom-diagnostic.md
+++ b/docs/consumer-briefings/2026-09-compound-safety-and-bottom-diagnostic.md
@@ -1,0 +1,89 @@
+# Consumer briefing — 2026-09 compound-safety rescue + `bottom-reason` diagnostic (closes mununu#492)
+
+> **Audience:** monono (primary reporter — their `mem_router` contrast pair depends on this), ROSF (API consumer via `--profile industrial`), any orchestrator gating on `sv verify-auto` verdicts and needing to distinguish `unknown` variants.
+>
+> **Related:** [mununu#492](https://github.com/vscorza/mununu/issues/492) — the ticket. Complements mununu#490 (process-memory ceiling; distinguishes "ran out of memory" from "engine did not decide") by adding the third distinction: "the property shape doesn't fit the rescue lane" vs "the engine gave up."
+>
+> **TL;DR:** two changes to the `sv verify-auto` ⊥-escalation. **(A)** The safety-rescue lane now decides `AG(compound_boolean_of_single_atoms)` — exclusion (`!a || !b`), implication (`!a || b`), conjunctive (`a && b`) — with leaves resolved through state cells / output nets / **primary inputs** (the last is essential for zero-state / stateless models). The ticket's `mem_router_faulty` case now returns `VIOLATED` instead of `UNKNOWN`. **(B)** For any property that stays ⊥ after escalation, a new `bottom-reason` verification note classifies why — `safety-shape-not-reducible`, `no-state-model-non-safety`, or `unclassified`. Purely additive; wire format unchanged; consumers observe a new note kind on residual-⊥ properties.
+
+## What changed
+
+### Part A — compound-atom safety escalation
+
+- **New reducer** in [`crates/mununu-core/src/adapter/reach_rescue.rs`](../../crates/mununu-core/src/adapter/reach_rescue.rs): `reduce_ag_boolean_body(formula) -> Option<NodeId>` — accepts `nu X. (COMPOUND && [] X)` where `COMPOUND` is `And`/`Or`/`Not`/`True`/`False`/`Predicate`, and each `Predicate` leaf parses as `PredicateExpr::Cmp` (single register-comparison). Rejects `CmpReg` / `CmpRegAddend` / `Select` leaves and any modal / fixpoint / variable inside `COMPOUND`.
+- **New emitter** in [`crates/mununu-core/src/adapter/btor2/bad_monitor.rs`](../../crates/mununu-core/src/adapter/btor2/bad_monitor.rs): `emit_ag_boolean_invariant_monitor` — walks the mu-calc subtree, compiles each leaf `Cmp` to a BTOR2 comparison node, combinators to `and`/`or`/`not` BTOR2 nodes, and emits `bad = !compound_expr`. Signal-resolution fallback is state → output → **input** (the input fallback is new — it's what makes zero-state models decidable without a state cone).
+- **Wiring** in `reach_portfolio_rescue`: try the existing single-atom reducer + emitter first (preserves byte-for-byte behavior on the shipped case); fall back to the compound path when the single-atom lane returns None or the single-atom emitter refuses the signal.
+
+### Part B — `bottom-reason` diagnostic
+
+- **New classifier** in `crates/mununu-core/src/adapter/slang/verify_auto.rs`: `classify_bottom_reason` recognizes three shapes:
+  - `SafetyShapeNotReducible` — Safety-class property that neither reducer accepts.
+  - `NoStateModelNonSafety` — non-Safety (liveness / recoverability / mixed / reachability) property on a design with zero state registers.
+  - `UnclassifiedBottom` — none of the above; the ⊥ is unexplained by this classifier (most commonly a resource abstain the engine already flagged).
+- **New `bottom-reason` verification note** — one per residual-⊥ property, kind `"bottom-reason"`, `ScopeCaveat` level, `summary` and `detail` naming the classification + actionable guidance.
+- Attached at the tail of `escalate_bottom` so any consumer of `sv verify-auto` sees it in the response `verification_notes` array.
+
+## What did NOT change
+
+- **Wire format** — 17/17 schema drift tests pass with zero regeneration; `SvVerifyAutoResponse` unchanged; verification-note SHAPE unchanged (a new `kind` string appears on residual-⊥ properties).
+- **`PropertyVerdict` values** — same canonical vocabulary. Verdicts that were `unknown` under Part A's addressable shapes are now `violated` or `holds` — a soundness upgrade, not a wire change.
+- **CLI surface** — no new flags.
+- **Existing rescue paths** — single-atom safety, liveness l2s, fair-cycle l2s, recoverability all unchanged in behavior. Two pre-existing tests updated (they asserted `notes.is_empty()` after a Liveness-class ⊥ escalation; they now assert the presence of a `bottom-reason` note instead).
+
+## For monono, ROSF, and any lane consumer
+
+**What to expect on adoption:**
+
+- **Verdict upgrades**: any `sv verify-auto` invocation on a design with compound-atom safety properties (especially on stateless / zero-state models) may see previously-`unknown` verdicts flip to `holds` / `violated`. For monono's `mem_router` contrast pair: the faulty twin's `sva_20` now returns `violated` instead of `unknown/⊥`. **This is a soundness upgrade** — the property was always violable; the escalation just didn't reach it.
+- **New note kind**: `verification_notes[i].kind == "bottom-reason"` appears on any property that stays ⊥. To distinguish resource-abstain from shape-mismatch, parse the summary:
+  - `"safety-shape-not-reducible"` — property reshape needed (or a new reducer).
+  - `"no-state-model-non-safety"` — modelling issue (compose with a stateful context or restrict to tier-1 safety).
+  - `"unclassified"` — look at sibling engine notes (`bit-cap`, `abstained on the …`) for the actionable answer.
+
+**A downstream gate that treated all ⊥ interchangeably** (rejecting everything as "not decided here") continues to work unchanged — a `bottom-reason` note is additive information, not a verdict override. **A downstream gate that wants to act on the distinction** now can: e.g., `safety-shape-not-reducible` should NOT be retried with a bigger budget (it will still fail); `unclassified` MAY be worth retrying with a raised bit-cap / node-budget.
+
+**Soundness contract:**
+
+- The compound-atom rescue is sound. `AG(compound)` is universally quantified over all trajectories AND input schedules; the emitted `bad = !compound` is reachable iff there exists a reachable state × input assignment falsifying the invariant — a genuine counterexample transferring unchanged to the design.
+- Zero-state models work at k=0: with no state cone to walk, the reachability portfolio decides in one SAT query.
+- The `bottom-reason` note is diagnostic-only; it never overrides a verdict.
+- Non-goals (still ⊥ after this PR):
+  - Compound with `CmpReg` register-vs-register leaves (`AG(a == 1 && b == c)`) — classified `safety-shape-not-reducible`.
+  - Non-Safety on zero-state models — classified `no-state-model-non-safety`; compose to add state or restrict to tier-1 safety.
+  - `AG(a → AX b)` implication-with-next shape — separate reducer, out of scope.
+
+**Docker rebuild:** binary bump only; no subprocess tool changes.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | binary picks up the widened safety rescue + `bottom-reason` classifier; verdicts on compound-atom safety on stateless models may flip from `unknown` to `violated`/`holds` | Yes if consumers pin a version tag; the flip is a soundness upgrade |
+| mununu `Dockerfile.dev` | binary bump + 11 new reducer/e2e tests + 3 classifier tests | Only if the dev workflow requires the new binary |
+| mununu `Dockerfile.sva` | binary bump; no e2e slang-gated behaviour change (existing `#[ignore]`d `e2e_rescue_*` tests still #[ignore]d) | No — the SVA e2e set is unaffected |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact | No |
+| rosf `Dockerfile` / `Dockerfile.dev` / `.hw` | consumes mununu CLI/API; may see verdict upgrades on stateless blocks — this is what the industrial-profile lane WANTS | No — behaviour updates on next binary pull |
+| monono Docker (if any) | primary beneficiary — `mem_router` faulty twin flips to `violated`, contrast pair becomes real | No — pull the new binary and re-run the contrast lane |
+| mununu-ui deployment | no impact — note kinds are string data | No |
+
+## Verification steps
+
+- `cargo test -p mununu-core --lib adapter::reach_rescue::` — 20/20 (11 new + 9 preserved), including 4 end-to-end verdict tests on a hand-crafted zero-state fixture (`ZERO_STATE_MODEL`) covering exclusion, implication, tautology, and conjunction shapes.
+- `cargo test -p mununu-core --lib --features api escalate_bottom` — 10/10 (2 updated to assert `bottom-reason` presence).
+- `cargo test -p mununu-core --lib --features api bottom_reason` — 3/3 classifier tests (compound-safety gets decided rather than classified; safety-shape-not-reducible classified correctly; no-state-model-non-safety classified correctly).
+- `cargo test -p mununu-core --lib --features api api_schema_drift_ -- --test-threads=1` — 17/17 schema tests pass, zero regeneration.
+
+## Provenance
+
+- Fix commit: (pending merge — branch `fix/492-compound-safety-and-bottom-diagnostic`).
+- Ticket: [mununu#492](https://github.com/vscorza/mununu/issues/492).
+- Design record: `.claude/plans/492-compound-safety-and-bottom-diagnostic.md`.
+- Policy: [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+- Related shipped work: mununu#490 (process-memory ceiling — distinguishes "ran out of memory" from "engine did not decide"; this PR adds the third distinction "shape doesn't fit the rescue lane").
+
+## Not covered here (documented non-goals)
+
+- **Compound-with-CmpReg leaves** (`AG(a == 1 && b == c)`). Requires a broader compilable-leaf set on the emitter; classified `safety-shape-not-reducible` today.
+- **Non-Safety on zero-state models.** Response-liveness's l2s and recoverability's cube both need state to reason over; the diagnostic classifies these as `no-state-model-non-safety` with a modelling recommendation.
+- **`AG(a → AX b)` implication-with-next shape.** A separate reducer; not the ticket.
+- **A stateless-model fast path** that compiles the entire formula into a boolean-of-inputs SAT query. Part A + the existing portfolio handle it via k=0 reachability without a special path — simpler.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -204,6 +204,20 @@ trial-and-error.
 
 > Source of truth: [`bitblast_oom_skip_note`](../crates/mununu-core/src/planner/mod.rs) — surface: (CLI+API+UI)
 
+### Compound-atom safety escalation + `bottom-reason` diagnostic (mununu#492)
+
+> Source of truth: [`reduce_ag_boolean_body`](../crates/mununu-core/src/adapter/reach_rescue.rs) + [`emit_ag_boolean_invariant_monitor`](../crates/mununu-core/src/adapter/btor2/bad_monitor.rs) — surface: (CLI+API+UI)
+
+**Compound-safety rescue.** A residual ⊥ on a safety property of the shape `AG(compound)` — where `compound` is a boolean tree over `And`/`Or`/`Not`/`True`/`False`/`Predicate` nodes and each `Predicate` leaf is a single `REG op VALUE` comparison — is now decided by the reachability portfolio. Widens the existing single-atom escalation to accept exclusion (`!a || !b`), implication (`!a || b`), and conjunctive (`a && b`) shapes, and — critically — resolves each leaf via state cell → output net → **primary input**, so a zero-state model (a purely combinational block like `mem_router`) can have its properties decided at k=0 without a state cone to walk. Preserves byte-for-byte behavior on the shipped single-atom path (single-atom shapes route through the original emitter; the compound emitter is a fallback).
+
+**`bottom-reason` note.** For any property that stays ⊥ after the escalation pass, a new `bottom-reason` verification note classifies WHY the ⊥ stands:
+
+- **`safety-shape-not-reducible`** — the property is Safety-class but neither reducer accepts its shape (a compound with a register-vs-register `CmpReg` leaf, a non-standard AG outer shape, etc.). NOT the same as a resource abstain — this needs a property reshape or a new rescue reducer, not a bigger budget.
+- **`no-state-model-non-safety`** — the design has zero state registers AND this property is non-Safety (liveness / recoverability). On a stateless model, `AG EF good` is vacuously true and `AG(a → AF b)`'s l2s reduction has no lasso to close. The ⊥ is a modelling issue (compose with a stateful context or restrict to tier-1 safety), not an engine cap.
+- **`unclassified`** — the classifier did not narrow further; most commonly a resource abstain the engine already flagged with a `bit-cap` / `abstained on the …` sibling note.
+
+Consumers keying on `verification_notes[i].kind` can distinguish "the engine gave up" from "the property shape doesn't fit this rescue lane," and act accordingly. Prior to mununu#492, the two cases were indistinguishable — a critical distinction for contrast pairs where a stateless block's supposed-to-fail twin was returning ⊥ instead of VIOLATED (the ticket's `mem_router_faulty` case).
+
 ### Process-wide memory ceiling: `MUNUNU_MAX_PROCESS_MEMORY_BYTES` (mununu#490)
 
 > Source of truth: [`adapter::memory_budget::check_process_memory_budget`](../crates/mununu-core/src/adapter/memory_budget.rs) — surface: (CLI+API+UI, env var — process-global)


### PR DESCRIPTION
Closes #492.

`sv verify-auto` returned `UNKNOWN/⊥` on the ticket's zero-state `mem_router_faulty` twin whenever a compound safety property was falsifiable by a one-cycle free-input assignment. Two independent narrowings dropped the case:

- `reduce_ag_invariant` accepted only single register-comparison atoms, rejecting compounds like `!a || !b`, `!a || b`, `a && b`.
- `emit_ag_state_atom_monitor` required the signal to resolve to a state cell or output net, so an atom over a primary input on a zero-state model errored.

A property that can only ever return HOLDS or ⊥ can't be shown to be capable of failing — breaking the contrast-pair discipline (monono's rule 8 says `unknown` means "not decided here", never "safe"). This PR closes both narrowings + adds a diagnostic classifying residual ⊥s.

## Part A — compound-atom safety escalation

- **New reducer** [`reduce_ag_boolean_body`](crates/mununu-core/src/adapter/reach_rescue.rs) — accepts `nu X. (COMPOUND && [] X)` where `COMPOUND` is a boolean tree of `And`/`Or`/`Not`/`True`/`False`/`Predicate`, each `Predicate` leaf parseable as `PredicateExpr::Cmp` (single register-comparison). Rejects `CmpReg` / `CmpRegAddend` / `Select` leaves and any modal / fixpoint / variable inside `COMPOUND`.
- **New emitter** [`emit_ag_boolean_invariant_monitor`](crates/mununu-core/src/adapter/btor2/bad_monitor.rs) — walks the mu-calc subtree, compiles leaves + combinators to BTOR2, emits `bad = !compound_expr`. Signal-resolution fallback is **state → output → primary input** (the input fallback is new; essential for zero-state models).
- **Wiring** in `reach_portfolio_rescue`: try shipped single-atom lane first (preserves byte-for-byte behavior); fall back to compound path when single-atom returns None or refuses the signal.

**Soundness.** `AG(COMPOUND)` is universally-quantified over ALL trajectories AND input schedules; the emitted `bad` is a pure boolean expression over (state × input); a reachable `bad` is a genuine counterexample transferring unchanged to the design. Same argument as the shipped single-atom emitter, generalised.

## Part B — `bottom-reason` diagnostic

New `BottomReason` enum + `classify_bottom_reason(prop, stateless)` in [verify_auto.rs](crates/mununu-core/src/adapter/slang/verify_auto.rs):

- **`SafetyShapeNotReducible`** — Safety-class but neither reducer accepts the shape. NOT the same as a resource abstain — needs a property reshape or a new rescue reducer, not a bigger budget.
- **`NoStateModelNonSafety`** — non-Safety on a zero-state model (recoverability vacuous, response-l2s can't lasso).
- **`UnclassifiedBottom`** — none of the above; consumer looks at sibling engine notes.

Attached as `bottom-reason` `ScopeCaveat` verification notes at the tail of `escalate_bottom`. Consumers keying on `verification_notes[i].kind` can distinguish the classes.

## Tests (23 total pass)

- `adapter::reach_rescue::` — 20/20 (11 new + 9 preserved): 6 reducer shape tests + 4 e2e verdict tests on a hand-crafted `ZERO_STATE_MODEL` (exclusion / implication / tautology / conjunction) + single-atom regression on the wide-input FSM.
- `escalate_bottom` — 10/10 (2 updated to assert `bottom-reason` presence instead of `notes.is_empty()`).
- `bottom_reason` classifier — 3/3.

The ticket's exact shape (`AG(!a || !b)` on a zero-state model with `a=b=1`) is validated by `zero_state_exclusion_safety_gets_violated_via_compound_rescue` — now returns `Violated`.

## What did NOT change

- Wire format — 17/17 schema drift tests pass with zero regeneration.
- `PropertyVerdict` values — same canonical vocabulary.
- CLI surface — no new flags.
- Existing rescue paths — unchanged in behavior.

## Non-goals (documented)

- Compound with `CmpReg` register-vs-register leaves — classified `safety-shape-not-reducible` today.
- Non-Safety on zero-state models — classified `no-state-model-non-safety` with a modelling recommendation.
- `AG(a → AX b)` implication-with-next — separate reducer, not the ticket.

## Test plan

- [x] `cargo test -p mununu-core --lib adapter::reach_rescue::` — 20/20.
- [x] `cargo test -p mununu-core --lib --features api escalate_bottom` — 10/10.
- [x] `cargo test -p mununu-core --lib --features api bottom_reason` — 3/3.
- [x] `cargo test -p mununu-core --lib --features api api_schema_drift_ -- --test-threads=1` — 17/17.
- [x] `cargo check --workspace --features mununu-core/api --tests` clean.
- [x] `cargo clippy -p mununu-core --features api --lib -- -D warnings` clean.
- [x] Pre-commit hook green.
- [ ] GitHub Actions CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)