### PR TITLE
docs(wiki): use absolute GitHub URLs so repo links resolve on the published wiki

### DIFF
--- a/wiki/CTXDSL-Language-Reference.md
+++ b/wiki/CTXDSL-Language-Reference.md
@@ -244,7 +244,7 @@ Three behaviours are load-bearing and easy to get wrong:
 
 Bound every variable with a guard on the transition that increments it; an unbounded variable enumerates until it hits the state cap.
 
-See [`docs/ctxdsl-modelling-guide.md`](../docs/ctxdsl-modelling-guide.md) for the full list, each entry verified against the shipped binary, plus the checklist for trusting a hand-authored model.
+See [`docs/ctxdsl-modelling-guide.md`](https://github.com/vscorza/mununu/blob/main/docs/ctxdsl-modelling-guide.md) for the full list, each entry verified against the shipped binary, plus the checklist for trusting a hand-authored model.
 
 ### Transitions
 

--- a/wiki/Property-Templates.md
+++ b/wiki/Property-Templates.md
@@ -37,7 +37,7 @@ Templates resolve to standard `PropertyFormula::MuCalculus(String)` at instantia
 
 ## Behavioral property patterns by design class
 
-> Source of truth: [`scan_annotation_properties`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L995) — surface: (CLI+API+UI)
+> Source of truth: [`scan_annotation_properties`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/slang/verify_auto.rs#L995) — surface: (CLI+API+UI)
 
 Beyond the atomic templates above, common **behavior classes** warrant recurring *branching-time* patterns —
 `AG EF` recoverability, `EF` reachability, error-recovery round-trips — that a plain safety invariant cannot
@@ -85,7 +85,7 @@ Example — an I²C master (protocol + shared-bus classes), `<error>` = `AL == 1
 
 ## Abstraction-predicate hints (`@mununu_predicate`)
 
-> Source of truth: [`MununuTag::Predicate`](../crates/mununu-core/src/mununu_annotations/mod.rs) / [`seed_from_formula`](../crates/mununu-core/src/adapter/slang/verify_auto.rs) — surface: (CLI+API+UI)
+> Source of truth: [`MununuTag::Predicate`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/mununu_annotations/mod.rs) / [`seed_from_formula`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/slang/verify_auto.rs) — surface: (CLI+API+UI)
 
 When a cube ⊥ is caused by a *missing* abstraction predicate — the property's own atoms don't pin the
 inductive invariant that decides it — you can **seed extra cube dimensions** without changing the property.
@@ -136,7 +136,7 @@ mununu context eval model.ctxdsl \
 
 ### In `verify.toml`
 
-> Source of truth: [`PropertySpec`](../crates/mununu-core/src/verify/config.rs#L307) — surface: CLI+API.
+> Source of truth: [`PropertySpec`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/verify/config.rs#L307) — surface: CLI+API.
 
 ```toml
 [[properties]]
@@ -148,7 +148,7 @@ over = "System"
 
 **`TARGET` and other `Predicate`/`State` parameters must be bare identifiers**
 (alphanumeric plus `_`) — see
-[`validate_param_value`](../crates/mununu-core/src/adapter/templates/mod.rs#L305).
+[`validate_param_value`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/templates/mod.rs#L305).
 An expression is rejected:
 
 ```


### PR DESCRIPTION
`wiki/` is the source of truth for a **separate** git repo (`mununu.wiki`), so a relative `](../docs/…)` or `](../crates/…)` link resolves in the repo checkout but 404s once published.

The rest of the wiki already uses absolute `https://github.com/vscorza/mununu/blob/main/…` URLs — 148 of them. These five were the exception:

| Page | Link | Origin |
|---|---|---|
| `CTXDSL-Language-Reference.md` | `docs/ctxdsl-modelling-guide.md` | #494 |
| `Property-Templates.md` | `PropertySpec` | #494 |
| `Property-Templates.md` | `validate_param_value` | #494 |
| `Property-Templates.md` | `scan_annotation_properties` | pre-existing |
| `Property-Templates.md` | `MununuTag::Predicate` / `seed_from_formula` | pre-existing |

Docs only; no `.rs` touched. Already published to the wiki as [`08b3636`](https://github.com/vscorza/mununu/wiki) alongside the #494 sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)