### PR TITLE
docs: retract the `mununu templates` drift claim — it exists; the claim came from a stale binary

### DIFF
--- a/docs/consumer-briefings/2026-09-ctxdsl-modelling-guide.md
+++ b/docs/consumer-briefings/2026-09-ctxdsl-modelling-guide.md
@@ -61,7 +61,7 @@ cause removed and the verdict must flip. Reusable as a template for any
 | Page | Was | Now |
 |---|---|---|
 | `wiki/CTXDSL-Language-Reference.md` | `variables { count: i64 = 0; }` | **does not parse** — the `var` keyword is required. Corrected, plus the three traps above called out inline. |
-| `wiki/Property-Templates.md` | documented `mununu templates` (4 invocations) and `context eval --template` / `--template-arg` | **none of these exist** in the shipped CLI. Replaced with a drift notice, the `verify.toml` form that does work, and the identifier-only `TARGET` restriction with its `formula = "…"` escape hatch. |
+| `wiki/Property-Templates.md` | *(the 2026-09-04 claim that `mununu templates` and `context eval --template` do not exist)* | **RETRACTED 2026-09-05 — they all exist.** That claim was read off a stale local binary; the page's original CLI documentation was correct and has been restored. What survives is a genuine addition: `Predicate`/`State` template parameters must be bare identifiers on **both** surfaces, with `formula = "…"` as the escape hatch for an expression target. |
 | `examples/verify/v2_tso_storebuffer` README + generator | "`r0 == 0` atoms do not bind through the verify composition path" | **correct for multi-source, over-broad as written** — atoms do bind on `context eval` and on single-source `verify` (that example's own shape). Scoped rather than removed. |
 
 Also: `wiki/Verify-Project-Flow.md` and `CLAUDE.md`'s reference index now point
@@ -71,9 +71,7 @@ at the guide.
 
 - **No Rust source.** `git diff --stat` touches zero `.rs` files.
 - Wire format, response shapes, verdict values, verdict semantics — unchanged.
-- CLI surface — no flags added, removed or renamed. (The `mununu templates`
-  subcommand documented in the wiki never existed; documenting its absence is
-  not a removal.)
+- CLI surface — no flags added, removed or renamed.
 - HTTP routes, sidecar schemas, `docs/api-schemas/` — unchanged.
 - Engine behaviour, soundness posture, subprocess tool versions — unchanged.
 

--- a/docs/ctxdsl-modelling-guide.md
+++ b/docs/ctxdsl-modelling-guide.md
@@ -340,9 +340,17 @@ Verified 2026-09-04 against the shipped binary. Fixed where noted.
 | Claim | Status |
 |---|---|
 | `wiki/CTXDSL-Language-Reference.md` "Variables" showed `count: i64 = 0;` | **wrong syntax** — the `var` keyword is required. Fixed. |
-| `wiki/Property-Templates.md` documents `mununu templates` (four invocations) | **no such subcommand** — flagged inline. |
-| `wiki/Property-Templates.md` documents `context eval --template` / `--template-arg` | **no such flags** — flagged inline. |
+| `wiki/Property-Templates.md` documents `mununu templates` and `context eval --template` / `--template-arg` | **NOT drift — these all exist.** A 2026-09-04 revision of this page wrongly called them missing; that was read off a stale local binary and is retracted. Corrected 2026-09-05. |
 | `examples/verify/v2_tso_storebuffer` README/generator: "`r0 == 0` atoms do not bind through the verify composition path" | **correct for multi-source `verify`, over-broad as written** — atoms bind on `context eval` and on single-source `verify` (which is that example's own shape). Scoped. |
+
+**A note on how this page is verified, added after getting one wrong.** Every
+claim here is checked two ways: run against a **freshly built** binary, and
+confirmed in the source with a `Source of truth:` anchor. The retracted row
+above failed the first check — it was run against a month-old `target/debug`
+build that predated the subcommand, and the source was never consulted because
+the CLI answer looked conclusive. A `--help` that lacks a subcommand is
+evidence about **your binary**, not about the tool. Rebuild before you file
+drift.
 
 ## Checklist before trusting a hand-authored model
 

--- a/wiki/Property-Templates.md
+++ b/wiki/Property-Templates.md
@@ -118,21 +118,33 @@ predicate, not a state hint.
 
 ### CLI
 
-> **Drift notice (verified 2026-09-04).** The `mununu templates` subcommand and
-> `mununu context eval --template` / `--template-arg` flags described in earlier
-> revisions of this page **do not exist** in the shipped CLI. `mununu --help`
-> lists `context`, `extraction`, `contract`, `codesign`, `verify`, `library`;
-> `mununu context eval --help` accepts `--formula`, not `--template`. Templates
-> are reachable from `verify.toml` and from extraction specs (below). Use
-> `--formula` with the instantiated body from the catalogue above when you want
-> a template's property on the `context eval` CLI.
-
 ```bash
-# Templates on the CLI: instantiate the catalogue body yourself and pass it
-# with --formula. `reachable` is `mu X. (${TARGET} || <> X)`.
-mununu context eval model.ctxdsl \
-    --formula reach_goal --automaton FSM
+# Zero-parameter template
+mununu context eval model.espec.json --template no_deadlock --automaton FSM
+
+# Template with arguments
+mununu context eval model.espec.json \
+    --template reachable --template-arg TARGET=GoalState --automaton FSM
+
+# Multiple arguments
+mununu context eval model.espec.json \
+    --template mutual_exclusion --template-arg A=P1_Active --template-arg B=P2_Active \
+    --automaton System
+
+# List all templates
+mununu templates
+
+# Filter by domain
+mununu templates --domain rtl
+
+# Show template details
+mununu templates --id reachable
+
+# JSON output
+mununu templates --json
 ```
+
+`--template` and `--formula` are mutually exclusive. When `--template` is provided, the template is instantiated and injected as an ad-hoc formula.
 
 ### In `verify.toml`
 
@@ -149,7 +161,8 @@ over = "System"
 **`TARGET` and other `Predicate`/`State` parameters must be bare identifiers**
 (alphanumeric plus `_`) — see
 [`validate_param_value`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/templates/mod.rs#L305).
-An expression is rejected:
+This applies to **both** template surfaces: `verify.toml` `args` and
+`context eval --template-arg`. An expression is rejected on either:
 
 ```
 template instantiation failed: parameter 'TARGET':


### PR DESCRIPTION
## The error

#494 added a "drift notice" to `wiki/Property-Templates.md` asserting that the `mununu templates` subcommand and `context eval --template` / `--template-arg` **do not exist**. That is wrong — all of them exist:

```
$ mununu templates --id reachable
Template: reachable (Reachable State)
  Formula: mu X. (${TARGET} || <> X)

$ mununu context eval --help
  --template <ID>             Instantiate a property template instead of selecting an existing formula
  --template-arg <KEY=VALUE>  Template argument bindings (KEY=VALUE). Repeatable
```

## How it happened

The claim was read off a `target/debug/mununu` built a month earlier, which predated the subcommand. `mununu --help` on that binary genuinely did not list it, and the source was never consulted because the CLI answer looked conclusive.

**A `--help` that lacks a subcommand is evidence about your binary, not about the tool.** The guide now says so, and records that every claim on it is checked two ways — against a freshly built binary *and* against a source anchor. The retracted row failed the first check.

This was published to the wiki as `08b3636`; the wiki is being re-pushed alongside this merge.

## What changes

- `wiki/Property-Templates.md` — original CLI section restored verbatim.
- `docs/ctxdsl-modelling-guide.md` §11 — the row becomes a retraction, plus the verification note above.
- `docs/consumer-briefings/2026-09-ctxdsl-modelling-guide.md` — corrected, including a "what did NOT change" bullet that leaned on the false claim.

## What survives

A separately-verified, genuine addition from #494: `Predicate`/`State` template parameters must be bare identifiers ([`validate_param_value`](https://github.com/vscorza/mununu/blob/main/crates/mununu-core/src/adapter/templates/mod.rs#L305)), so an expression target is rejected — now confirmed on **both** surfaces (`verify.toml` `args` **and** `context eval --template-arg`), where #494 had only checked the former. `formula = "…"` remains the escape hatch.

## Re-verified against a fresh build, all still standing

| Claim | Status |
|---|---|
| One-comparison guard fragment; `&&` silently disables the transition | holds |
| `effects` are simultaneous / read the pre-state | holds |
| `bool` and typo'd atoms evaluate **true** everywhere | holds |
| Multi-source `verify` composition returns **false** for variable atoms | holds |
| Identifier-only template `TARGET` | holds, and is broader than documented |

🤖 Generated with [Claude Code](https://claude.com/claude-code)