### PR TITLE
feat(sv-lint): flag a registered array read against a moving address (closes #496)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -5953,10 +5953,15 @@ fn sv_lint(args: SvLintArgs) -> Result<(), String> {
     let signals: Vec<serde_json::Value> = findings
         .iter()
         .map(|f| {
-            serde_json::json!({
+            let mut o = serde_json::json!({
                 "signal": f.signal,
                 "kind": f.kind.as_str(),
-            })
+                "rule": f.rule.as_str(),
+            });
+            if !f.detail.is_empty() {
+                o["detail"] = serde_json::Value::String(f.detail.clone());
+            }
+            o
         })
         .collect();
     let registers_flagged = findings

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -194,16 +194,53 @@ impl SvLintSignalKind {
     }
 }
 
-/// One `sv lint` finding — a named signal whose lift the engine cannot keep
-/// faithfully (monono#partsel): its cone reaches an ANONYMOUS free input, so a
-/// state predicate over it would be *refused* (skipped) by the verifier rather
-/// than mis-decided. See [`sv_lint_registers`].
+/// Which structural check produced a finding. Serialised as a stable
+/// lowercase-kebab tag on the CLI JSON / API / UI surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SvLintRule {
+    /// monono#partsel — the register's lift reaches an anonymous free input, so
+    /// a state predicate over it is *refused* by the verifier.
+    UndrivenPartialWrite,
+    /// mununu#496 — a registered array read (`q <= mem[a_q];`) whose address
+    /// register can change in the same cycle `q` is consumed, with no register
+    /// recording which address the current `q` corresponds to.
+    RegisteredArrayReadMovingAddress,
+}
+
+impl SvLintRule {
+    /// The stable tag used across the CLI JSON / API / UI surfaces.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SvLintRule::UndrivenPartialWrite => "undriven-partial-write",
+            SvLintRule::RegisteredArrayReadMovingAddress => "registered-array-read-moving-address",
+        }
+    }
+}
+
+/// One `sv lint` finding — a named signal a structural check flagged. See
+/// [`SvLintRule`] for what each check means and [`sv_lint_registers`] for the
+/// entry point.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SvLintFinding {
     /// The offending signal's symbol (register name or the combinational output).
     pub signal: String,
     /// Whether `signal` is the register itself or a downstream output.
     pub kind: SvLintSignalKind,
+    /// Which check fired. Defaults to the partial-write rule so an older
+    /// consumer deserialising a finding without the field keeps working.
+    #[serde(default = "SvLintFinding::default_rule")]
+    pub rule: SvLintRule,
+    /// Human-readable specifics — for the array-read rule, the address register
+    /// and why it is unsafe. Empty for rules that need no elaboration.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub detail: String,
+}
+
+impl SvLintFinding {
+    fn default_rule() -> SvLintRule {
+        SvLintRule::UndrivenPartialWrite
+    }
 }
 
 /// `sv lint` — lift SV and report, at CI time (~lift cost, no bit-blast / no
@@ -227,7 +264,10 @@ pub struct SvLintFinding {
 /// a register alias and an output is reported once, as a `Register`.
 pub fn sv_lint_registers(lift: &SvLift) -> Result<Vec<SvLintFinding>, String> {
     let btor2 = lift.lift()?;
-    lint_undriven_partial_writes(&btor2)
+    let mut findings = lint_undriven_partial_writes(&btor2)?;
+    findings.extend(lint_registered_array_read_moving_address(&btor2)?);
+    findings.sort_by(|a, b| (a.rule.as_str(), &a.signal).cmp(&(b.rule.as_str(), &b.signal)));
+    Ok(findings)
 }
 
 /// The pure BTOR2 core of [`sv_lint_registers`] — parse the flattened design and
@@ -289,8 +329,168 @@ fn lint_undriven_partial_writes(btor2: &str) -> Result<Vec<SvLintFinding>, Strin
     Ok(kinds
         .into_iter()
         .filter(|(name, _)| signal_reaches_anonymous_input(&file, name))
-        .map(|(signal, kind)| SvLintFinding { signal, kind })
+        .map(|(signal, kind)| SvLintFinding {
+            signal,
+            kind,
+            rule: SvLintRule::UndrivenPartialWrite,
+            detail: String::new(),
+        })
         .collect())
+}
+
+/// mununu#496 — flag a **registered array read whose address register can change
+/// in the same cycle its data is consumed**, with nothing recording which address
+/// the current data corresponds to.
+///
+/// The shape, in RTL:
+///
+/// ```systemverilog
+/// always_ff @(posedge clk) begin
+///     if (advance) a_q <= a_q + 1;   // the address register moves
+///     q <= mem[a_q];                 // registered read against it
+/// end
+/// ```
+///
+/// `q` holds the word at the address `a_q` held *last* cycle, but a consumer
+/// reading `q` alongside the live `a_q` sees a pair that never coexisted. monono
+/// hit this twice in the same block — the second time with a prose rule against
+/// it in force — shipping a 2 KB sprite bank shifted by one halfword. Prose did
+/// not prevent the recurrence; this check is the structural refusal.
+///
+/// In BTOR2 the fault is three facts about one `next`:
+///
+/// ```text
+/// 8  state 7 a_q          the address register
+/// 11 read 4 10 8          read(mem, a_q)
+/// 12 next 4 5 11          q <= read(...)        <- registered array read
+/// 17 next 7 8 16          a_q <= (moving)       <- and the address moves
+/// ```
+///
+/// **The satisfying form** registers the address alongside the data, so some
+/// register captures `a_q` in the very cycle the read is issued:
+///
+/// ```text
+/// 11 next 4 5 10          a_d <= a_q            <- the tracking signal
+/// ```
+///
+/// So the check is: a registered read whose address is a *mutable* register and
+/// for which **no** register's `next` is that address register. Like the existing
+/// lift-form checks, it is satisfiable by writing the supported form — here, by
+/// naming the tracking signal. Purely structural: no bit-blast, no properties, no
+/// environment.
+fn lint_registered_array_read_moving_address(btor2: &str) -> Result<Vec<SvLintFinding>, String> {
+    use crate::adapter::btor2::ast::{Node, Op};
+
+    let file = parser::parse(btor2).map_err(|e| format!("BTOR2 parse: {e}"))?;
+
+    // `next` edges, indexed by the state they drive, plus the set of state nids
+    // that some OTHER register captures verbatim (`t <= a`) — the tracking
+    // signals that satisfy the rule.
+    let mut next_of: std::collections::HashMap<i64, i64> = std::collections::HashMap::new();
+    let mut tracked: std::collections::HashSet<i64> = std::collections::HashSet::new();
+    for line in &file.lines {
+        if let Node::Next { state, value, .. } = &line.node {
+            next_of.insert(*state, value.nid());
+            // `t <= a` where a is a *different* state: a records which `a` the
+            // current cycle used. A register's own hold (`a <= a`) is not tracking.
+            if *state != value.nid()
+                && matches!(node_of(&file, value.nid()), Some(Node::State { .. }))
+            {
+                tracked.insert(value.nid());
+            }
+        }
+    }
+
+    // A state's display name: its own symbol, else a `uext … 0 NAME` alias, else
+    // an `output` that names it. Mirrors how the partial-write lint recovers names.
+    let name_of = |nid: i64| -> Option<String> {
+        if let Some(Node::State {
+            symbol: Some(s), ..
+        }) = node_of(&file, nid)
+        {
+            return Some(s.clone());
+        }
+        for line in &file.lines {
+            match &line.node {
+                Node::Output {
+                    signal,
+                    symbol: Some(s),
+                } if signal.nid() == nid => {
+                    return Some(s.clone());
+                }
+                Node::Op {
+                    symbol: Some(s),
+                    args,
+                    ..
+                } if args.first().map(|a| a.nid()) == Some(nid) => {
+                    return Some(s.clone());
+                }
+                _ => {}
+            }
+        }
+        None
+    };
+
+    let mut findings = Vec::new();
+    for line in &file.lines {
+        let Node::Next { state, value, .. } = &line.node else {
+            continue;
+        };
+        // Is this register's next value an array read?
+        let Some(Node::Op {
+            op: Op::Read, args, ..
+        }) = node_of(&file, value.nid())
+        else {
+            continue;
+        };
+        // `read <sort> <array> <index>` — the address is the second operand.
+        let Some(addr) = args.get(1).map(|a| a.nid()) else {
+            continue;
+        };
+        // The address must itself be a register. An address that is a pure input
+        // or a combinational function of inputs has no "moving register" to
+        // mis-pair with, so it is out of scope for this rule.
+        if !matches!(node_of(&file, addr), Some(Node::State { .. })) {
+            continue;
+        }
+        // Does the address actually move? A register held constant (`a <= a`, or
+        // no `next` at all) can never be mis-paired.
+        let moves = next_of.get(&addr).is_some_and(|v| *v != addr);
+        if !moves {
+            continue;
+        }
+        // Satisfied if some register captures the address in the same cycle.
+        if tracked.contains(&addr) {
+            continue;
+        }
+
+        let data = name_of(*state).unwrap_or_else(|| format!("<nid {state}>"));
+        let address = name_of(addr).unwrap_or_else(|| format!("<nid {addr}>"));
+        findings.push(SvLintFinding {
+            signal: data.clone(),
+            kind: SvLintSignalKind::Register,
+            rule: SvLintRule::RegisteredArrayReadMovingAddress,
+            detail: format!(
+                "`{data}` is a registered array read addressed by `{address}`, which can change \
+                 in the same cycle `{data}` is consumed, and no register captures `{address}` \
+                 alongside it — so `{data}` and the live `{address}` are a pair that never \
+                 coexisted. Register the address alongside the data (`{address}_q <= {address};`) \
+                 and consume that."
+            ),
+        });
+    }
+
+    findings.sort_by(|a, b| a.signal.cmp(&b.signal));
+    findings.dedup_by(|a, b| a.signal == b.signal);
+    Ok(findings)
+}
+
+/// Borrow the `Node` at `nid`, if the file declares it.
+fn node_of(
+    file: &crate::adapter::btor2::ast::Btor2File,
+    nid: i64,
+) -> Option<&crate::adapter::btor2::ast::Node> {
+    file.lookup(nid).map(|l| &l.node)
 }
 
 #[cfg(test)]
@@ -323,6 +523,118 @@ mod tests {
     fn recoverability_rejects_malformed_target_before_lift() {
         let e = sv_verify_recoverability(&lift_of("module m; endmodule"), "not an atom !!");
         assert!(e.is_err(), "a malformed target must be rejected pre-lift");
+    }
+
+    // mununu#496 lint core — the yosys-slang lift (Yosys 0.60+70, slang plugin, in
+    // the pinned `mununu-sva` image) of a registered array read, captured verbatim
+    // so the regression runs in make-ci without slang.
+    //
+    //     always_ff @(posedge clk) begin
+    //         if (advance) a_q <= a_q + 8'd1;   // the address register moves
+    //         q <= mem[a_q];                    // registered read against it
+    //     end
+    //
+    // `12 next 4 5 11` is the registered read (`11 read 4 10 8` = mem[a_q]) and
+    // `17 next 7 8 16` is `a_q` moving. Nothing captures `a_q` alongside `q`, so
+    // `q` and the live `a_q` are a pair that never coexisted.
+    const SLANG_REGISTERED_READ_MOVING_ADDR: &str = r#"1 sort bitvec 1
+2 input 1 advance
+3 input 1 clk
+4 sort bitvec 16
+5 state 4
+6 output 5 q
+7 sort bitvec 8
+8 state 7 a_q
+9 sort array 7 4
+10 state 9 mem
+11 read 4 10 8
+12 next 4 5 11
+13 const 1 1
+14 uext 7 13 7
+15 add 7 8 14
+16 ite 7 2 15 8
+17 next 7 8 16
+18 next 9 10 10 mem
+"#;
+
+    // The SATISFYING form, same lift path: the address is registered ALONGSIDE the
+    // data (`a_d <= a_q`, nid `11 next 4 5 10`), so a consumer can tell which
+    // address the current `q` corresponds to. Same read, same moving address — the
+    // only difference is the tracking register, which is exactly what the rule asks
+    // for. This is the contrast twin: a check that flags this too is useless.
+    const SLANG_REGISTERED_READ_TRACKED: &str = r#"1 sort bitvec 1
+2 input 1 advance
+3 input 1 clk
+4 sort bitvec 8
+5 state 4
+6 output 5 a_d
+7 sort bitvec 16
+8 state 7
+9 output 8 q
+10 state 4 a_q
+11 next 4 5 10
+12 sort array 4 7
+13 state 12 mem
+14 read 7 13 10
+15 next 7 8 14
+16 const 1 1
+17 uext 4 16 7
+18 add 4 10 17
+19 ite 4 2 18 10
+20 next 4 10 19
+21 next 12 13 13 mem
+"#;
+
+    #[test]
+    fn flags_registered_array_read_against_a_moving_address() {
+        let f = lint_registered_array_read_moving_address(SLANG_REGISTERED_READ_MOVING_ADDR)
+            .expect("lint");
+        assert_eq!(f.len(), 1, "expected exactly one finding, got {f:?}");
+        assert_eq!(f[0].signal, "q");
+        assert_eq!(f[0].rule, SvLintRule::RegisteredArrayReadMovingAddress);
+        assert!(
+            f[0].detail.contains("a_q"),
+            "the finding must name the address register: {}",
+            f[0].detail
+        );
+    }
+
+    #[test]
+    fn registering_the_address_alongside_the_data_satisfies_the_rule() {
+        let f =
+            lint_registered_array_read_moving_address(SLANG_REGISTERED_READ_TRACKED).expect("lint");
+        assert!(
+            f.is_empty(),
+            "the tracked form must NOT be flagged — the rule is satisfiable by naming \
+             the tracking signal; got {f:?}"
+        );
+    }
+
+    #[test]
+    fn a_held_address_register_is_not_flagged() {
+        // Same registered read, but `a_q` never changes (`next` is itself), so `q`
+        // and the live `a_q` can never disagree. No finding.
+        let held = SLANG_REGISTERED_READ_MOVING_ADDR.replace("17 next 7 8 16", "17 next 7 8 8");
+        let f = lint_registered_array_read_moving_address(&held).expect("lint");
+        assert!(
+            f.is_empty(),
+            "a register whose address is held constant cannot be mis-paired; got {f:?}"
+        );
+    }
+
+    #[test]
+    fn the_partial_write_rule_is_unaffected_by_the_array_read_rule() {
+        // The two checks are independent: neither fixture trips the other rule.
+        let a = lint_undriven_partial_writes(SLANG_REGISTERED_READ_MOVING_ADDR).expect("lint");
+        assert!(
+            a.is_empty(),
+            "array-read fixture must not trip partsel: {a:?}"
+        );
+        let b = lint_registered_array_read_moving_address(SLANG_PARTSEL_LIFT).expect("lint");
+        assert!(
+            b.is_empty(),
+            "partsel fixture must not trip array-read: {b:?}"
+        );
     }
 
     // monono#partsel lint core — the yosys-slang lift of a plain-vector partial
@@ -559,6 +871,80 @@ endmodule
         assert!(
             !names.contains(&"b_q"),
             "the fully-written register b_q is faithful and must NOT be flagged; got {names:?}"
+        );
+    }
+
+    /// mununu#496 end-to-end, through the REAL slang lift: the faulty form is
+    /// flagged and its satisfying twin is not. The unit tests above pin the
+    /// structural query against captured BTOR2; this pins the *lift* — that
+    /// yosys-slang really does emit `next(q) = read(mem, a_q)` with `a_q` carrying
+    /// its own moving `next`, which is the shape the query depends on.
+    ///
+    /// Run in the pinned image (host has no slang):
+    ///   docker run --rm -v "$(pwd)":/work -v mununu-target:/cargo-target -w /work \
+    ///     mununu-sva cargo test -p mununu-core --lib e2e_sv_lint_registered_array -- --ignored
+    #[test]
+    #[ignore = "requires yosys-slang (mununu-sva docker image); run with --ignored"]
+    fn e2e_sv_lint_registered_array_read_moving_address() {
+        const BAD: &str = r#"module rom_bad (
+  input  logic        clk,
+  input  logic        advance,
+  output logic [15:0] q
+);
+  logic [15:0] mem [0:255];
+  logic [7:0]  a_q;
+  always_ff @(posedge clk) begin
+    if (advance) a_q <= a_q + 8'd1;
+    q <= mem[a_q];
+  end
+endmodule
+"#;
+        // Identical, plus the tracking register the rule asks for.
+        const OK: &str = r#"module rom_ok (
+  input  logic        clk,
+  input  logic        advance,
+  output logic [15:0] q,
+  output logic [7:0]  a_d
+);
+  logic [15:0] mem [0:255];
+  logic [7:0]  a_q;
+  always_ff @(posedge clk) begin
+    if (advance) a_q <= a_q + 8'd1;
+    q   <= mem[a_q];
+    a_d <= a_q;
+  end
+endmodule
+"#;
+        let lift_of = |src: &str, top: &str| SvLift {
+            source: src.to_string(),
+            additional_sources: Vec::new(),
+            top: Some(top.into()),
+            use_sv2v: false,
+            include_dirs: Vec::new(),
+            frontend: SvFrontend::Slang,
+        };
+
+        let bad = sv_lint_registers(&lift_of(BAD, "rom_bad")).expect("lint lifts rom_bad");
+        let hit: Vec<_> = bad
+            .iter()
+            .filter(|f| f.rule == SvLintRule::RegisteredArrayReadMovingAddress)
+            .collect();
+        assert_eq!(
+            hit.len(),
+            1,
+            "the registered read against a moving address must be flagged; got {bad:?}"
+        );
+        assert!(
+            hit[0].detail.contains("a_q"),
+            "the finding must name the address register; got {}",
+            hit[0].detail
+        );
+
+        let ok = sv_lint_registers(&lift_of(OK, "rom_ok")).expect("lint lifts rom_ok");
+        assert!(
+            ok.iter()
+                .all(|f| f.rule != SvLintRule::RegisteredArrayReadMovingAddress),
+            "registering the address alongside the data satisfies the rule; got {ok:?}"
         );
     }
 

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -474,8 +474,9 @@ fn lint_registered_array_read_moving_address(btor2: &str) -> Result<Vec<SvLintFi
                 "`{data}` is a registered array read addressed by `{address}`, which can change \
                  in the same cycle `{data}` is consumed, and no register captures `{address}` \
                  alongside it — so `{data}` and the live `{address}` are a pair that never \
-                 coexisted. Register the address alongside the data (`{address}_q <= {address};`) \
-                 and consume that."
+                 coexisted. Register the address alongside the data — add a register that \
+                 captures `{address}` in the same cycle as the read — and consume that instead \
+                 of the live `{address}`."
             ),
         });
     }

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1452,6 +1452,8 @@ fn sv_lint_handler_impl(request: SvLintRequest) -> ApiResult<Json<SvLintResponse
         .map(|f| SvLintFinding {
             signal: f.signal,
             kind: f.kind.as_str().to_string(),
+            rule: f.rule.as_str().to_string(),
+            detail: f.detail,
         })
         .collect::<Vec<_>>();
 

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1348,9 +1348,8 @@ pub struct SvLintRequest {
     pub use_slang: bool,
 }
 
-/// One `sv lint` finding — a named signal whose partial-write lift reaches an
-/// undriven (free-input) register bit, so a state predicate over it would be
-/// *refused* (skipped) by the verifier. Element of [`SvLintResponse`].
+/// One `sv lint` finding — a named signal a structural check flagged. Element of
+/// [`SvLintResponse`].
 #[derive(Debug, Serialize)]
 pub struct SvLintFinding {
     /// The offending signal's symbol (register name or a combinational output of one).
@@ -1358,6 +1357,17 @@ pub struct SvLintFinding {
     /// `"register"` (the root — the register itself) | `"output"` (a downstream
     /// combinational output that reads it).
     pub kind: String,
+    /// Which check fired:
+    /// `"undriven-partial-write"` — the partial-write lift reaches a free input,
+    /// so a state predicate over the signal would be *refused* by the verifier;
+    /// `"registered-array-read-moving-address"` (mununu#496) — a registered array
+    /// read whose address register can change in the same cycle its data is
+    /// consumed, with nothing recording the correspondence.
+    pub rule: String,
+    /// Human-readable specifics (the address register and the fix, for the
+    /// array-read rule). Absent when the rule needs no elaboration.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub detail: String,
 }
 
 /// Response for `POST /api/v1/sv/lint`.
@@ -1367,7 +1377,7 @@ pub struct SvLintResponse {
     pub signals_flagged: usize,
     /// Number of the flagged signals that are state registers (the root findings).
     pub registers_flagged: usize,
-    /// Per-signal findings (sorted by name).
+    /// Per-signal findings (sorted by rule, then by name).
     pub findings: Vec<SvLintFinding>,
 }
 

--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -102,7 +102,12 @@ When `--predicate-source craig` is selected but CVC5 isn't found at runtime, mun
 
 > Source of truth: [`sv_lint_registers`](../crates/mununu-core/src/adapter/sv_verify.rs#L228) — surface: (CLI+API+UI)
 
-`mununu sv lint` lifts a SystemVerilog design and reports — at CI time (~lift cost, **no** model checking, ~0.1 s) — every register whose partial-write lift the verifier cannot keep faithfully (a plain-vector `q[hi:lo] <= d` whose unwritten bits the front end models as free inputs). These are exactly the registers a state predicate would be *refused* on by the formal gate, surfaced *before* the minutes-long verify. It changes no verdict.
+`mununu sv lint` lifts a SystemVerilog design and runs purely structural checks — at CI time (~lift cost, **no** model checking, ~0.1 s). Each finding carries a `rule` tag:
+
+- `undriven-partial-write` — a plain-vector `q[hi:lo] <= d` whose unwritten bits the front end models as free inputs. These are exactly the registers a state predicate would be *refused* on by the formal gate, surfaced *before* the minutes-long verify.
+- `registered-array-read-moving-address` (mununu#496) — `q <= mem[a_q];` where `a_q` can change in the same cycle `q` is consumed and no register records the correspondence. Satisfied by registering the address alongside the data (`a_d <= a_q;`).
+
+It changes no verdict.
 
 ```bash
 # Report the unfaithful partial-write registers; exit 2 if any (a CI gate).

--- a/docs/consumer-briefings/2026-09-sv-lint-registered-array-read.md
+++ b/docs/consumer-briefings/2026-09-sv-lint-registered-array-read.md
@@ -43,7 +43,7 @@ no `next` at all — it can never disagree with `q`).
   "findings": [ { "signal": "q",
                   "kind": "register",
                   "rule": "registered-array-read-moving-address",   // NEW
-                  "detail": "`q` is a registered array read addressed by ..." } ] }  // NEW, optional
+                  "detail": "`q` is a registered array read addressed by `a_q`, which can change in the same cycle ..." } ] }  // NEW, optional
 ```
 
 - **`rule`** — `"undriven-partial-write"` | `"registered-array-read-moving-address"`. Always present on the API and CLI JSON. On the Rust type it carries `#[serde(default)]` to `undriven-partial-write`, so deserialising an older payload still works.

--- a/docs/consumer-briefings/2026-09-sv-lint-registered-array-read.md
+++ b/docs/consumer-briefings/2026-09-sv-lint-registered-array-read.md
@@ -1,0 +1,127 @@
+# Consumer briefing — 2026-09 `sv lint` gains a second rule, and findings gain `rule` / `detail`
+
+> **Audience:** monono (direct CLI consumer; runs `sv lint` in its formal gate — and the design this rule comes from), ROSF (API consumer via `POST /api/v1/sv/lint`), mununu-ui, any orchestrator that parses `sv lint` findings.
+>
+> **Related:** [mununu#496](https://github.com/vscorza/mununu/issues/496).
+>
+> **TL;DR:** `sv lint` now runs **two** structural checks instead of one, and every finding carries a **`rule`** tag saying which fired (plus an optional **`detail`**). The new rule flags a **registered array read whose address register can change in the same cycle its data is consumed** — the fault that shipped a sprite bank shifted by one halfword, twice, in the same block. **Additive JSON only**; existing fields are unchanged. A consumer that ignores unknown fields needs no change, but **a clean design may now report findings it did not before**, so the CI gate can newly fail — which is the point.
+
+## What changed
+
+**New rule — `registered-array-read-moving-address`.**
+
+```systemverilog
+always_ff @(posedge clk) begin
+    if (advance) a_q <= a_q + 1;   // the address register moves
+    q <= mem[a_q];                 // registered read against it
+end
+```
+
+`q` holds the word at the address `a_q` held *last* cycle, but a consumer reading
+`q` alongside the live `a_q` sees a pair that never coexisted, and nothing in the
+design records the correspondence. Purely structural — no bit-blast, no
+properties, no environment; it is a query over the netlist `sv lint` already
+builds, at the same ~lift cost.
+
+**Satisfied by writing the supported form**, like the other lift-form checks —
+register the address alongside the data:
+
+```systemverilog
+    q   <= mem[a_q];
+    a_d <= a_q;        // <-- the tracking signal
+```
+
+Two shapes are deliberately **not** flagged: an address that is not a register
+(nothing moving to mis-pair with), and a register held constant (`a_q <= a_q`, or
+no `next` at all — it can never disagree with `q`).
+
+**Finding shape — two additive fields.**
+
+```jsonc
+// POST /api/v1/sv/lint  →
+{ "signals_flagged": 1, "registers_flagged": 1,
+  "findings": [ { "signal": "q",
+                  "kind": "register",
+                  "rule": "registered-array-read-moving-address",   // NEW
+                  "detail": "`q` is a registered array read addressed by ..." } ] }  // NEW, optional
+```
+
+- **`rule`** — `"undriven-partial-write"` | `"registered-array-read-moving-address"`. Always present on the API and CLI JSON. On the Rust type it carries `#[serde(default)]` to `undriven-partial-write`, so deserialising an older payload still works.
+- **`detail`** — human-readable specifics, naming the address register and the fix. **Omitted entirely** when a rule needs no elaboration (so absent on every `undriven-partial-write` finding).
+- Findings are now sorted **by rule, then by name** (was: by name).
+
+## What did NOT change
+
+- `signal` and `kind` — identical meaning and values.
+- `signals_flagged` / `registers_flagged` — same counting.
+- Exit codes: a finding is still the shared CI gate's `violated`, so `--fail-on violated` (default) exits `2`, a lift failure exits `1`, clean exits `0`.
+- The `undriven-partial-write` rule's behaviour — byte-for-byte the same findings on the same designs. Its regression fixture is unchanged and the two rules are cross-tested for independence.
+- No verdict, no route, no CLI flag, no sidecar schema, no engine behaviour. `sv lint` remains read-only.
+
+## For monono
+
+**This rule exists because of your postmortem** (`docs/postmortem-v04c-sprite-path.md`), and the fault it names occurred twice in the same block — the second time with the prose rule already in `CLAUDE.md`. That is the whole argument for making it structural.
+
+**What to update:**
+
+1. **Run it and expect hits.** `mununu sv lint <rtl> --frontend slang`. Any hit is a real instance of the pattern; the preloader and `sprite_bank` paths are the obvious first place to look.
+2. **Fix by naming the tracking signal** — `a_d <= a_q;` alongside the read, and consume `a_d` rather than the live `a_q`. That is the form the check is satisfied by, and it is the same rule your `CLAUDE.md` already states in prose.
+3. **If you filter findings by `kind`, add a `rule` filter too.** A gate that treated every finding as a partial-write problem will now mis-describe array-read findings in its output.
+4. **Expect the gate to fail where it passed.** That is the rule working. Do not suppress it; each hit is either a real mis-pairing or a place where the correspondence is recorded in a way the check cannot see — and the second case is worth reporting back, because it is a false positive we should narrow.
+
+**Report-parsing impact:** additive. If your parser rejects unknown JSON fields, relax it; otherwise no change.
+
+**Docker rebuild:** yes if you want the new rule — it is a binary change. See the table.
+
+## For ROSF
+
+`POST /api/v1/sv/lint` responses gain `rule` (always) and `detail` (optional). Additive; a consumer ignoring unknown fields is unaffected. If ROSF surfaces lint findings to a user, showing `rule` and `detail` makes them actionable — `detail` already contains the address register and the suggested fix.
+
+## For mununu-ui
+
+`SvLintFinding` in `src/api/endpoints.ts` gains `rule: SvLintRule` (required) and `detail?: string` (optional), with a new exported `SvLintRule` union. Any code constructing an `SvLintFinding` literal must add `rule`. Shipped in this PR.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | carries the new rule; `sv lint` may report new findings | **Yes** — to get the rule |
+| mununu `Dockerfile.dev` | binary bump | **Yes** — if the dev workflow runs `sv lint` |
+| mununu `Dockerfile.sva` | binary bump; the e2e regression for this rule runs here | **Yes** — to run the `#[ignore]`d e2e |
+| mununu `Dockerfile.extract`, `.extract-*` | no impact (no `sv lint` path) | No |
+| rosf `Dockerfile` / `Dockerfile.dev` / `.hw` | consumes the API; response gains two fields | **No** — additive; rebuild when adopting the rule |
+| monono Docker (if any) | primary beneficiary | **Yes** — this is the rule you asked for |
+| mununu-ui deployment | type-only change | **No** — rebuild on next UI deploy |
+
+## Verification steps
+
+```bash
+# Unit — the structural query, against captured BTOR2 (no slang needed):
+cargo test -p mununu-core --lib sv_verify
+
+# End-to-end through the REAL slang lift, in the pinned image:
+docker run --rm -v "$(pwd)":/work -v mununu-target:/cargo-target -w /work \
+  -e CARGO_TARGET_DIR=/cargo-target mununu-sva \
+  bash -c 'export PATH=$HOME/.cargo/bin:/opt/oss-cad-suite/bin:$PATH; \
+           cargo test -p mununu-core --lib e2e_sv_lint -- --ignored'
+```
+
+Both pass. The e2e test lifts the faulty design **and its satisfying twin** with
+yosys-slang and asserts the first is flagged and the second is not — so the rule
+is pinned against the real lift, not only against a captured fixture. Per the
+CLAUDE.md rule, every slang-touching change here was validated in `mununu-sva`,
+never on the bare host.
+
+## Provenance
+
+- Issue: [mununu#496](https://github.com/vscorza/mununu/issues/496), filed from monono's `docs/postmortem-v04c-sprite-path.md`.
+- Core: `lint_registered_array_read_moving_address` in `crates/mununu-core/src/adapter/sv_verify.rs`.
+- Docs: [`docs/verifying-rtl.md`](../verifying-rtl.md) §"Registered array reads against a moving address", [`docs/cli-cookbook.md`](../cli-cookbook.md).
+- Policy: [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here (follow-ups)
+
+- **Tracking signals the check cannot see.** The rule recognises exactly one satisfying form: some register whose `next` *is* the address register. A design that records the correspondence differently — a wider tag, a shift register, an address reconstructed downstream — will be flagged as a false positive. The issue anticipates this ("false positives are expected wherever the design *does* record the correspondence"); narrowing wants real examples, so report them rather than suppressing.
+- **Multi-cycle reads.** Only a one-cycle registered read is modelled. A two-stage read pipeline where the address must be delayed *twice* is not distinguished from a correctly-tracked one-stage read.
+- **Write-side mis-pairing.** The dual fault — `mem[a_q] <= d` where `d` corresponds to a different `a_q` — is not checked.
+- **Address cones, not just direct registers.** An address that is a combinational *function* of a moving register (`mem[a_q + 1]`) is currently out of scope; only a bare register address is flagged.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -486,9 +486,18 @@ portfolio engines) — an agent can trust a definite verdict and treat `unknown`
 
 ---
 
-## Preflight: `sv lint` — the partial-write registers the lift can't keep
+## Preflight: `sv lint` — structural faults refused at write time
 
 > Source of truth: [`sv_lint_registers`](../crates/mununu-core/src/adapter/sv_verify.rs#L228) — surface: (CLI+API+UI)
+
+`sv lint` runs a set of **purely structural** checks over the lifted netlist — no
+bit-blast, no properties, no environment, ~lift cost. Each finding carries a
+`rule` tag:
+
+| `rule` | Catches |
+|---|---|
+| `undriven-partial-write` | a register whose partial-write lift reaches a free input, so a state predicate over it would be *refused* by the verifier |
+| `registered-array-read-moving-address` | a registered array read whose address register can change in the same cycle its data is consumed ([below](#registered-array-reads-against-a-moving-address)) |
 
 Some SystemVerilog is **not lifted faithfully**, and the verifier is honest about
 it: a plain-vector partial register assignment (`q[hi:lo] <= d`) leaves `q`'s other
@@ -512,8 +521,8 @@ mununu --quiet sv lint rtl/mod.sv --frontend slang        # exit 2 ⇒ a registe
 ```jsonc
 // POST /api/v1/sv/lint  →
 { "signals_flagged": 2, "registers_flagged": 1,
-  "findings": [ { "signal": "a_q", "kind": "register" },     // the root
-                { "signal": "o_partsel", "kind": "output" } ] }   // a downstream output of it
+  "findings": [ { "signal": "a_q", "kind": "register", "rule": "undriven-partial-write" },
+                { "signal": "o_partsel", "kind": "output", "rule": "undriven-partial-write" } ] }
 ```
 
 `kind` is `"register"` (the root — the register whose bits are undriven) or
@@ -521,6 +530,57 @@ mununu --quiet sv lint rtl/mod.sv --frontend slang        # exit 2 ⇒ a registe
 the same reason). A finding maps to the shared CI gate's `violated` verdict, so the
 default `--fail-on violated` fails the build; `--fail-on none` makes it advisory. A
 clean design reports zero findings and exits `0`.
+
+### Registered array reads against a moving address
+
+> Source of truth: [`lint_registered_array_read_moving_address`](../crates/mununu-core/src/adapter/sv_verify.rs) — surface: (CLI+API+UI)
+
+```systemverilog
+always_ff @(posedge clk) begin
+    if (advance) a_q <= a_q + 1;   // the address register moves
+    q <= mem[a_q];                 // registered read against it
+end
+```
+
+`q` holds the word at the address `a_q` held **last** cycle, but a consumer that
+reads `q` alongside the live `a_q` sees a pair that never coexisted. Nothing in
+the design records the correspondence, so the mismatch is silent and survives
+every property that compares the design to itself.
+
+This is not hypothetical: monono hit it **twice in the same block**, the second
+time with a prose rule against it in force, shipping a 2 KB sprite bank shifted
+by one halfword. Eleven properties, a contrast twin, a CTXDSL model and a frame
+CRC all passed; what found it was rebuilding the memory image from the fetcher's
+own returns and diffing against the source. Prose did not prevent the
+recurrence, which is why the rule is now structural and refused at write time
+(mununu#496).
+
+**The satisfying form** registers the address alongside the data, so some
+register captures `a_q` in the very cycle the read is issued:
+
+```systemverilog
+always_ff @(posedge clk) begin
+    if (advance) a_q <= a_q + 1;
+    q   <= mem[a_q];
+    a_d <= a_q;        // <-- records which address `q` corresponds to
+end
+```
+
+Like the other lift-form checks, the rule is **satisfiable by writing the
+supported form** — here, by naming the tracking signal. Two shapes are never
+flagged: an address that is not a register (no moving register to mis-pair
+with), and a register held constant (`a_q <= a_q`, or no `next` at all — it can
+never disagree with `q`).
+
+```jsonc
+// POST /api/v1/sv/lint  →
+{ "signals_flagged": 1, "registers_flagged": 1,
+  "findings": [ { "signal": "q", "kind": "register",
+                  "rule": "registered-array-read-moving-address",
+                  "detail": "`q` is a registered array read addressed by `a_q`, which can \
+                             change in the same cycle `q` is consumed, and no register \
+                             captures `a_q` alongside it ..." } ] }
+```
 
 **Exit codes** (2026-08, mununu#475 item 5). `sv lint --fail-on violated` (the
 default) exits `0` on a clean design, `2` when a bad register is found — a


### PR DESCRIPTION
Closes #496.

## The fault

```systemverilog
always_ff @(posedge clk) begin
    if (advance) a_q <= a_q + 1;   // the address register moves
    q <= mem[a_q];                 // registered read against it
end
```

`q` holds the word at the address `a_q` held **last** cycle, but a consumer reading `q` alongside the live `a_q` sees a pair that never coexisted, and nothing in the design records the correspondence. The mismatch is silent and survives every property that compares the design to itself.

Per the issue: this occurred **twice in the same block**. The first occurrence wrote the rule into monono's `CLAUDE.md` as prose; the second happened *in that same preloader with the rule in force*, shipped a 2 KB sprite bank shifted by one halfword, drew structured garbage on a board, and cost five bring-up cycles. Eleven properties, a contrast twin, a CTXDSL model and a frame CRC all passed — because they all compare the design to itself. **Prose did not prevent the recurrence.**

## The check

Purely structural, over the netlist `sv lint` already builds — no bit-blast, no properties, no environment, same ~lift cost:

```
next(q) = read(mem, a)         a registered array read
a is a State                   the address is a register
next(a) != a                   and it moves
no State t with next(t) = a    no register captures it alongside the data
=> flag q
```

**Satisfiable by writing the supported form**, like the existing lift-form checks — `a_d <= a_q;` alongside the read makes the tracking `next` appear and the finding goes away.

Two shapes are deliberately **not** flagged: a non-register address (nothing moving to mis-pair with), and a held register (`a_q <= a_q` can never disagree with `q`).

## Shape change (additive)

`SvLintFinding` gains `rule` (which check fired; `#[serde(default)]` so older payloads still deserialise) and an optional `detail` naming the address register and the fix. `signal` / `kind` / the counts / exit codes are unchanged, and the partial-write rule's findings are byte-identical — the two rules are cross-tested for independence.

**Surface parity:** CLI JSON, `POST /api/v1/sv/lint`, and the mununu-ui typed client ([mununu-ui#76](https://github.com/vscorza/mununu-ui/pull/76)).

## Validation

Per the CLAUDE.md slang rule, this was validated in the pinned image, never on the bare host:

```
running 2 tests
test adapter::sv_verify::tests::e2e_sv_lint_flags_slang_partial_write_register ... ok
test adapter::sv_verify::tests::e2e_sv_lint_registered_array_read_moving_address ... ok
```

The e2e test lifts the faulty design **and its satisfying twin** with real yosys-slang and asserts the first is flagged and the second is not — so the rule is pinned against the real lift, not only a captured fixture. Four unit tests pin the structural query against captured BTOR2 so they run in `make ci` without slang, including a held-address negative and a cross-rule independence check.

Workspace check (default + `api` + legacy root bin), 2508 lib tests, 57 doctests, clippy and fmt all green.

Consumer briefing at `docs/consumer-briefings/2026-09-sv-lint-registered-array-read.md` records the additive-JSON disposition, the rebuild table, and four honest follow-ups — chief among them that the rule recognises exactly one satisfying form, so a design recording the correspondence differently will false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)