### PR TITLE
fix(engine): a BTOR2 `state` with no `next` is FREE, not a held register (closes #498)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -7462,6 +7462,124 @@ mod tests {
     /// arena during `eval_op`. The engine must degrade to a clean `Err` (→ Skipped), NEVER
     /// OoM-panic. Asserts only that a `Result` comes back — the value (Err on overflow, or Ok
     /// if it happens to fit) is immaterial; the point is no panic escapes. No env mutation.
+    /// mununu#498 — a BTOR2 `state` with NO `next` line is a FREE variable at
+    /// every step (the format's free variable; Yosys emits exactly this for
+    /// `$anyseq`, which is what `cutpoint` leaves behind). It must NOT be modelled
+    /// as a held register: doing so pins it to its absent-therefore-zero init and
+    /// freezes it, turning a cut point's documented OVER-approximation into an
+    /// UNDER-approximation.
+    ///
+    /// FSM: `st` leaves 0 only when the freed net `f` is 1.
+    ///   - `f` free  ⇒ `EF (st == 1)` HOLDS and `AG (st == 0)` VIOLATED.
+    ///   - `f` frozen at 0 (the bug) ⇒ exactly the opposite, both wrong.
+    ///
+    /// Both directions are asserted: the safety direction alone would pass an
+    /// implementation that special-cased `AG` (mununu#498 discussion).
+    const ANYSEQ_GATE: &str = r#"
+1 sort bitvec 1
+2 state 1 f
+3 state 1 st
+4 zero 1
+5 one 1
+6 ite 1 2 5 3
+7 next 1 3 6
+8 init 1 3 4
+"#;
+
+    #[test]
+    fn state_without_next_is_free_each_step_not_a_held_register() {
+        // `f` has no `next` line ⇒ free. `st` starts 0 and becomes 1 whenever f=1.
+        let reach = crate::mu_calculus::parser::parse("mu Z.((st == 1) || <> Z)").expect("parse");
+        assert_eq!(
+            exact_symbolic_verdict(ANYSEQ_GATE, &reach).expect("verdict"),
+            ExactVerdict::Holds,
+            "a state with no `next` is FREE, so the gated transition is reachable; \
+             modelling it as a register frozen at its zero init makes this VIOLATED \
+             — the mununu#498 under-approximation"
+        );
+    }
+
+    #[test]
+    fn state_without_next_does_not_freeze_a_safety_property_into_holding() {
+        // The same bug seen from the safety side: with `f` frozen at 0 the FSM never
+        // leaves 0 and `AG (st == 0)` wrongly HOLDS.
+        let ag = crate::mu_calculus::parser::parse("nu Y.((st == 0) && [] Y)").expect("parse");
+        assert_eq!(
+            exact_symbolic_verdict(ANYSEQ_GATE, &ag).expect("verdict"),
+            ExactVerdict::Violated,
+            "`st` can leave 0 because the no-`next` state is free; a HOLDS here is the \
+             mununu#498 unsound direction — a safety property passing on a model that \
+             cannot move"
+        );
+    }
+
+    #[test]
+    fn anyconst_shaped_state_with_self_next_stays_classified_as_a_register() {
+        // `$anyconst` is a DIFFERENT cell from `$anyseq` and must NOT be swept up by
+        // the mununu#498 fix: Yosys emits it as `next(k) = k`, so it HAS a next line
+        // and stays a state (held). Guards against the fix over-reaching into "every
+        // uninitialised state is free".
+        //
+        // Asserted at the CLASSIFICATION seam rather than through a verdict, on
+        // purpose: a verdict here would also depend on the SEPARATE `no init ⇒ pinned
+        // to zero` rule, which makes an `$anyconst` a constant ZERO rather than an
+        // arbitrary constant. That is its own soundness question with its own blast
+        // radius (RTL registers are legitimately pinned to their reset value), it is
+        // NOT fixed here, and entangling it would make this test assert something the
+        // fix does not claim.
+        const ANYCONST_GATE: &str = r#"
+1 sort bitvec 1
+2 state 1 k
+3 next 1 2 2
+4 state 1 st
+5 zero 1
+6 one 1
+7 ite 1 2 6 4
+8 next 1 4 7
+9 init 1 4 5
+"#;
+        let file = crate::adapter::btor2::parser::parse(ANYCONST_GATE).expect("parse");
+        let sts = crate::adapter::sts_ir::BtorSts::new(&file);
+        let cells = sts.leaf_cells().expect("leaf cells");
+        let by_name = |n: &str| cells.iter().find(|c| c.name == n).expect("cell").is_state;
+        assert!(
+            by_name("k"),
+            "an `$anyconst`-shaped state (next = itself) stays a REGISTER"
+        );
+        assert!(by_name("st"), "a normal register stays a register");
+    }
+
+    #[test]
+    fn anyseq_shaped_state_without_next_is_classified_as_an_input() {
+        // The other side of the same seam: `f` has no `next`, so it must classify as
+        // an INPUT (free each step, quantifiable) rather than a register.
+        let file = crate::adapter::btor2::parser::parse(ANYSEQ_GATE).expect("parse");
+        let sts = crate::adapter::sts_ir::BtorSts::new(&file);
+        let cells = sts.leaf_cells().expect("leaf cells");
+        let by_name = |n: &str| cells.iter().find(|c| c.name == n).expect("cell").is_state;
+        assert!(
+            !by_name("f"),
+            "a state with no `next` is a FREE variable and must classify as an input"
+        );
+        assert!(by_name("st"), "the real register is unaffected");
+        // And the seam's two views agree with the classification.
+        use crate::adapter::sts_ir::SymbolicTransitionSystem;
+        let inputs: Vec<String> = sts.input_vars().into_iter().map(|v| v.name).collect();
+        let states: Vec<String> = sts.state_vars().into_iter().map(|v| v.name).collect();
+        assert!(
+            inputs.contains(&"f".to_string()),
+            "f in input_vars: {inputs:?}"
+        );
+        assert!(
+            states.contains(&"st".to_string()),
+            "st in state_vars: {states:?}"
+        );
+        assert!(
+            !states.contains(&"f".to_string()),
+            "f must NOT be in state_vars"
+        );
+    }
+
     #[test]
     fn wide_multiplier_bails_gracefully_never_panics() {
         const MUL40: &str = r#"

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -2483,13 +2483,32 @@ pub(crate) fn verify_auto_impl(
         .filter(|l| matches!(l.node, crate::adapter::btor2::ast::Node::State { .. }))
         .filter_map(|l| symbols.get(&l.nid).cloned())
         .collect();
-    // Total `state` register lines (incl. any unnamed) — a zero/low count is
-    // the headline signal that state was cut or optimized away.
-    report.diagnostics.state_register_count = file
-        .lines
-        .iter()
-        .filter(|l| matches!(l.node, crate::adapter::btor2::ast::Node::State { .. }))
-        .count();
+    // Total REGISTER lines — a `state` that carries a `next` function. A zero/low
+    // count is the headline signal that state was cut or optimized away.
+    //
+    // mununu#498: a `state` with NO `next` is a free variable, not a register
+    // (Yosys emits that for `$anyseq`, i.e. every `--cutpoint`), and the engine
+    // now classifies it as an input. Counting those here would report a cut point
+    // as a register in the very diagnostic whose job is to reveal that state was
+    // cut — the count would go UP as more nets were freed. Designs without
+    // `$anyseq` are unaffected: every state has a `next`, so the number is
+    // unchanged.
+    {
+        use crate::adapter::btor2::ast::Node;
+        let with_next: std::collections::HashSet<_> = file
+            .lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                Node::Next { state, .. } => Some(*state),
+                _ => None,
+            })
+            .collect();
+        report.diagnostics.state_register_count = file
+            .lines
+            .iter()
+            .filter(|l| matches!(l.node, Node::State { .. }) && with_next.contains(&l.nid))
+            .count();
+    }
     // Init value of each state cell — pins the cube lift's initial cube to the
     // design's reset state (else it defaults to cube_0 = all-predicates-false).
     let init_values = state_cell_init_values(&file);
@@ -6290,6 +6309,102 @@ module uart_tx(); endmodule"#;
                 .iter()
                 .map(|p| &p.outcome)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// mununu#498 REGRESSION — a `--cutpoint` must be an OVER-approximation, so no
+    /// property may flip in the unsound direction when the cut is applied.
+    ///
+    /// `cutpoint` frees a net to a Yosys `$anyseq`, which BTOR2 encodes as a `state`
+    /// with NO `next` line. Reading that as a *held register* pinned it to its
+    /// absent-therefore-zero init, so the freed net was nailed to 0: `fits` could
+    /// never be 1, the FSM never left idle, and the cut model was an
+    /// UNDER-approximation. Reported from monono's `sprite_fetch`, reduced to this
+    /// 30-line FSM, and it flipped BOTH directions at once:
+    ///
+    ///   EF (st_q == 2)  HOLDS unabstracted -> VIOLATED under the cut
+    ///   AG (st_q == 0)  VIOLATED           -> HOLDS    under the cut
+    ///
+    /// Both are asserted: an implementation that special-cased safety would pass the
+    /// `AG` half and still fail the `EF` half. The `EF 3` row is the control — a
+    /// value the FSM never assigns, VIOLATED in both models, which also confirms the
+    /// cut is not merely freeing the initial states.
+    #[test]
+    #[ignore = "requires yosys-slang (mununu-sva docker image); run with --ignored"]
+    fn e2e_cutpoint_stays_an_over_approximation_no_verdict_flips() {
+        use crate::adapter::btor2::kmts_lift::MustEdgeInference;
+        let src = r#"// @mununu_guarantee mu Z.((st_q == 2) || <> Z)
+// @mununu_guarantee nu Y.((st_q == 0) && [] Y)
+// @mununu_guarantee mu Z.((st_q == 3) || <> Z)
+module mini_fetch (
+    input  logic clk, rst_n, req, acc, valid,
+    output logic busy
+);
+    logic [1:0]  st_q;
+    logic [10:0] left_q, spent_q;
+    logic fits;
+    assign fits = (spent_q + 11'd64) <= 11'd1024;
+    assign busy = (st_q != 2'd0);
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            st_q <= 2'd0; left_q <= 11'd0; spent_q <= 11'd0;
+        end else begin
+            case (st_q)
+                2'd0: if (req && fits) begin
+                          left_q <= 11'd64; spent_q <= spent_q + 11'd64; st_q <= 2'd1;
+                      end
+                2'd1: if (acc) st_q <= 2'd2;
+                2'd2: if (valid) begin
+                          if (left_q <= 11'd2) begin left_q <= 11'd0;          st_q <= 2'd0; end
+                          else                 begin left_q <= left_q - 11'd2; st_q <= 2'd1; end
+                      end
+                default: st_q <= 2'd0;
+            endcase
+        end
+    end
+endmodule
+"#;
+        let sources = vec![("mini_fetch.sv".to_string(), src.to_string())];
+        let opts = |cuts: Vec<String>| YosysOptions {
+            top: Some("mini_fetch".to_string()),
+            cutpoint_signals: cuts,
+            ..Default::default()
+        };
+        let vopts = || VerifyAutoOptions {
+            must_edge_inference: MustEdgeInference::SmtHyperMust,
+            exact_symbolic: true,
+            config_values: std::collections::HashMap::from([("rst_n".to_string(), 1u64)]),
+            ..Default::default()
+        };
+
+        let outcomes = |r: &AutoVerifyReport| -> Vec<(String, String)> {
+            r.properties
+                .iter()
+                .filter(|p| p.name.contains("guarantee"))
+                .map(|p| (p.name.clone(), format!("{:?}", p.outcome)))
+                .collect()
+        };
+
+        let plain = verify_auto(&sources, &opts(vec![]), &vopts()).expect("verify_auto (no cut)");
+        let cut = verify_auto(
+            &sources,
+            &opts(vec!["fits".to_string(), "left_q".to_string()]),
+            &vopts(),
+        )
+        .expect("verify_auto (cut)");
+
+        let (p, c) = (outcomes(&plain), outcomes(&cut));
+        eprintln!("no-cut: {p:?}\ncut:    {c:?}");
+        assert_eq!(
+            p.len(),
+            3,
+            "all three guarantees must translate un-cut; got {p:?}"
+        );
+        assert_eq!(
+            p, c,
+            "a cut point is an OVER-approximation: no property may change verdict \
+             when it is applied. Un-cut {p:?} vs cut {c:?} — a difference here is the \
+             mununu#498 under-approximation returning."
         );
     }
 

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -429,15 +429,45 @@ impl<'a> BtorSts<'a> {
         })
     }
 
+    /// NIDs of `state` lines that carry a `next` function.
+    ///
+    /// SOUNDNESS (mununu#498): a BTOR2 `state` with **no** `next` line is
+    /// unconstrained at every step — the format's free variable. Yosys emits
+    /// exactly that for `$anyseq`, which is what a `cutpoint` leaves behind.
+    /// Modelling it as a *held register* instead pins it to its (absent, hence
+    /// zero) init and freezes it, turning the abstraction into an
+    /// UNDER-approximation precisely where a cut point documents an
+    /// over-approximation — a freed net that can never be 1 removes behaviours
+    /// rather than adding them. So such a state is classified as an INPUT here,
+    /// which is free-each-step and quantifiable, and every consumer of this seam
+    /// inherits the correct semantics.
+    ///
+    /// `$anyconst` is a different cell and is already right: Yosys emits it as
+    /// `next(s) = s`, so it has a `next` line and stays a state (held, as
+    /// intended).
+    fn states_with_next(&self) -> std::collections::HashSet<Nid> {
+        self.file
+            .lines
+            .iter()
+            .filter_map(|l| match &l.node {
+                Node::Next { state, .. } => Some(*state),
+                _ => None,
+            })
+            .collect()
+    }
+
     fn vars_of(&self, want_state: bool) -> Vec<StsVar> {
         let symbols = parser::collect_symbols(self.file);
+        let with_next = self.states_with_next();
         let mut out: Vec<StsVar> = self
             .file
             .lines
             .iter()
             .filter_map(|line| {
                 let (sort, is_state) = match &line.node {
-                    Node::State { sort, .. } => (*sort, true),
+                    // A `state` with no `next` is a free variable, not a
+                    // register — see `states_with_next`.
+                    Node::State { sort, .. } => (*sort, with_next.contains(&line.nid)),
                     Node::Input { sort, .. } => (*sort, false),
                     _ => return None,
                 };
@@ -473,10 +503,16 @@ impl<'a> BtorSts<'a> {
     /// [`BddBitBlaster::build_with_keep`]: crate::adapter::btor2::symbolic_bitblast::BddBitBlaster::build_with_keep
     pub fn leaf_cells(&self) -> Result<Vec<LeafCell>, String> {
         let symbols = parser::collect_symbols(self.file);
+        let with_next = self.states_with_next();
         let mut out = Vec::new();
         for line in &self.file.lines {
             let (sort, raw, is_state, tag) = match &line.node {
-                Node::State { sort, symbol } => (*sort, symbol, true, "state"),
+                // A `state` with no `next` is a free variable, not a register —
+                // see `states_with_next`. It keeps the "state" naming tag so its
+                // symbol resolution is unchanged; only its CLASSIFICATION moves.
+                Node::State { sort, symbol } => {
+                    (*sort, symbol, with_next.contains(&line.nid), "state")
+                }
                 Node::Input { sort, symbol } => (*sort, symbol, false, "input"),
                 _ => continue,
             };

--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -255,7 +255,22 @@ pub struct YosysOptions {
     /// **SOUNDNESS — this is an OVER-APPROXIMATION.** A freed net becomes
     /// nondeterministic, which only *adds* transitions. A definite HOLDS
     /// therefore transfers to the concrete RTL (safety + over-approx =
-    /// sound). A definite VIOLATED is sound only when the counterexample
+    /// sound).
+    ///
+    /// That claim was **false in practice until mununu#498**: `cutpoint`
+    /// emits the freed net as a Yosys `$anyseq`, which BTOR2 encodes as a
+    /// `state` with no `next` line, and the engines read such a state as a
+    /// *held register* pinned to its (absent, therefore zero) init. The
+    /// freed net was nailed to 0 — an UNDER-approximation, the exact
+    /// opposite of what this paragraph promises, so a cut could turn a
+    /// concretely-false safety property into `HOLDS`. A `state` with no
+    /// `next` is now classified as a free input at the STS-IR seam
+    /// (`BtorSts::states_with_next`), and
+    /// `e2e_cutpoint_stays_an_over_approximation_no_verdict_flips` pins the
+    /// guarantee end-to-end: no property may change verdict when a cut is
+    /// applied to the reduced `mini_fetch` FSM.
+    ///
+    /// A definite VIOLATED is sound only when the counterexample
     /// is guard-independent — the canonical case being an *orphaned* FSM
     /// state (in-degree 0), which no freed guard can make reachable, so
     /// `AG EF <orphaned-state>` stays soundly VIOLATED. A general VIOLATED

--- a/docs/consumer-briefings/2026-09-cutpoint-anyseq-soundness.md
+++ b/docs/consumer-briefings/2026-09-cutpoint-anyseq-soundness.md
@@ -1,0 +1,104 @@
+# Consumer briefing — 2026-09 `--cutpoint` was an UNDER-approximation; verdicts under a cut change
+
+> **Audience:** monono (reported it; runs `--cutpoint` in its formal lane and has withdrawn a verdict over it), ROSF, any consumer that passes `cutpoint` / `--cutpoint`, and anyone feeding hand-written BTOR2 or a non-Yosys frontend to the exact engine.
+>
+> **Related:** [mununu#498](https://github.com/vscorza/mununu/issues/498).
+>
+> **⚠ TL;DR — this is a soundness fix, and it CHANGES VERDICTS.** `--cutpoint` documented an over-approximation and delivered the opposite: a freed net was frozen at 0, so the model had *fewer* behaviours than the design. A safety property that is concretely **false** could come back **`HOLDS`**. If you have acted on any verdict produced under `--cutpoint`, **re-run it.** Verdicts obtained without cut points are unaffected.
+
+## What was wrong
+
+`cutpoint` frees a net to a Yosys `$anyseq`. BTOR2 encodes that as a `state` line with **no `next`** — the format's free variable, unconstrained at every step. Two independent code paths together read it as something else:
+
+| | | Effect |
+|---|---|---|
+| no `next` | the next-state substitution only fires when a `next` function exists | left as identity ⇒ **held** |
+| no `init` | *"all-`⊥` (every bit 0) for a register with no `init` line"* | **pinned to zero** |
+
+A `$anyseq` therefore became a **constant zero**. On monono's reduced FSM, `fits` was nailed to 0, `req && fits` was never true, and the FSM never left idle — so the cut model was a strict *under*-approximation of the design.
+
+`$anyconst` was never affected: Yosys emits it as `next(k) = k`, so it has a `next` line and is a genuine held register.
+
+## The verdicts this produced
+
+monono's `mini_fetch` reduction, and the same flip on the real `sprite_fetch` block:
+
+| | unabstracted | cut, **before** | cut, **after** |
+|---|---|---|---|
+| `EF (st_q == 2)` | HOLDS | **VIOLATED** ✗ | **HOLDS** ✓ |
+| `EF (st_q == 1)` | HOLDS | **VIOLATED** ✗ | **HOLDS** ✓ |
+| `AG (st_q == 0)` | VIOLATED | **HOLDS** ✗ | **VIOLATED** ✓ |
+| `EF (st_q == 3)` *(never assigned — control)* | VIOLATED | VIOLATED | VIOLATED |
+| `AG EF (st_q == 0)` | HOLDS | HOLDS | HOLDS |
+
+Both directions moved. **`AG (st_q == 0)` returning `HOLDS` is the serious one** — a universal safety property passing on a model that cannot move, in precisely the direction the documentation called sound.
+
+## The fix
+
+A `state` with no `next` is now classified as a **free input** at the STS-IR seam (`BtorSts::states_with_next`), so it is free at every step and quantifiable. Every consumer of the seam inherits the correct semantics — this was never `cutpoint`-specific.
+
+**Scope is wider than `--cutpoint`.** Any BTOR2 reaching the engines with a no-`next` state was affected: `$anyseq` from any source, hand-written BTOR2, other frontends. `--cutpoint` is simply the shipped path that reliably produces one.
+
+## What did NOT change
+
+- Runs **without** `--cutpoint`, on designs with no `$anyseq`: every state has a `next`, so the classification is identical and **no verdict moves**. The full suite (2512 lib tests, 57 doctests) passes unchanged.
+- `$anyconst` — still a held register.
+- No wire format, no route, no CLI flag, no sidecar schema.
+- The `control-slice` ScopeCaveat note still fires and still says a general `VIOLATED` under a cut may be spurious. That remains true for **alternating** properties (`AG EF`, νμ); for a plain existential `EF` a `VIOLATED` under a genuine over-approximation is sound, and the cut is now genuinely one.
+
+## Diagnostic change: `state register(s)` count
+
+`model: N state register(s)` counted raw `state` lines. Now that a no-`next` state is not a register, that count would have gone **up** as more nets were freed — in the very diagnostic whose job is to show state being cut away (monono read `9 vs 8` as evidence). It now counts states carrying a `next`. **Designs without `$anyseq` see no change**; a cutpointed run reports fewer, correctly.
+
+## For monono
+
+1. **Re-run everything decided under `--cutpoint`.** Verdicts obtained without cut points are untouched.
+2. **`sprite_fetch`'s withdrawal was correct**, and it should now be re-decided rather than left withdrawn: under the fixed cut, `ann_guarantee_1` returns `HOLDS` and the guarantee/witness pair agrees. Whether the budget bound decides is a separate question — re-measure rather than assume.
+3. **Your regression is now shipped**, in both directions: `e2e_cutpoint_stays_an_over_approximation_no_verdict_flips` asserts that *no* property changes verdict when a cut is applied. It fails on the pre-fix code with exactly your reported flip.
+4. `verify.sh` files that pin expected verdicts under a cut will need updating — and the pinning is what let you catch this, so it earned its keep.
+
+**Docker rebuild:** yes. This is a binary change.
+
+## For ROSF
+
+If ROSF passes `cutpoint` through the API, the same re-run advice applies. If it never sets cut points and its designs have no `$anyseq`, this is a no-op.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | verdict semantics under `--cutpoint` | **Yes** |
+| mununu `Dockerfile.dev` | binary bump | **Yes** |
+| mununu `Dockerfile.sva` | binary bump; the e2e regression runs here | **Yes** |
+| mununu `Dockerfile.extract`, `.extract-*` | no engine path | No |
+| rosf `Dockerfile` / `.dev` / `.hw` | consumes verdicts; changes only if cut points are used | **Yes if it uses `cutpoint`**, else No |
+| monono Docker | reported it; formal lane uses cut points | **Yes** |
+| mununu-ui | no type change | No |
+
+## Verification
+
+```bash
+# Unit — the seam classification and both verdict directions (no slang needed):
+cargo test -p mununu-core --lib -- state_without_next anyseq_shaped anyconst_shaped
+
+# End-to-end through the real slang lift, in the pinned image:
+docker run --rm -v "$(pwd)":/work -v mununu-target:/ct -w /work -e CARGO_TARGET_DIR=/ct \
+  mununu-sva bash -c 'export PATH=$HOME/.cargo/bin:/opt/oss-cad-suite/bin:$PATH; \
+    cargo test -p mununu-core --lib e2e_cutpoint_stays -- --ignored'
+```
+
+Both were confirmed to **fail on the pre-fix code** — the e2e reproduces monono's flip verbatim — and pass after.
+
+## Provenance
+
+- Issue: [mununu#498](https://github.com/vscorza/mununu/issues/498), from monono's `sprite_fetch` formal lane, with a 30-line reduction (`mini_fetch`) supplied by the reporter.
+- Fix: `BtorSts::states_with_next` in `crates/mununu-core/src/adapter/sts_ir.rs`.
+- Policy: [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here (follow-ups)
+
+- **`no init ⇒ pinned to zero` is the same class, via a different mechanism.** It makes an `$anyconst` a constant *zero* rather than an arbitrary constant. Not fixed here: pinning uninitialised registers to their reset value is legitimate and often intended for RTL, so changing it has its own blast radius and deserves its own decision. The regression test for `$anyconst` deliberately asserts the *classification* rather than a verdict, to avoid entangling the two.
+- **The guarantee/witness disagreement flag**, which is what mununu#498 originally asked for. Still worth building — it is what would have surfaced this as a defect rather than leaving a careful author to catch it by hand — but this particular disagreement disappears with the fix.
+- **`coverage-summary` tallies ⊥ as `skipped`**, so a harness under-reports its own undecided properties. Separate issue.
+- **A pre-existing `#[ignore]`d test failure**, `e2e_cutpoint_frees_wide_counter_guard_so_exact_symbolic_fits`, which fails on a clean tree unrelated to this change — the `#[ignore]`d e2e set does not run in `make ci` and has drifted. Worth a scheduled run.
+- **A trailing `// comment` after a `@mununu_guarantee` body** makes the annotation unparsable (`trailing characters after formula`). Minor, unrelated, found while reproducing.


### PR DESCRIPTION
Closes #498. **Soundness fix — this changes verdicts under `--cutpoint`.**

`--cutpoint` documented an over-approximation and delivered the opposite. A safety property that is concretely **false** could come back **`HOLDS`**.

## The mechanism

`cutpoint` frees a net to a Yosys `$anyseq`, which BTOR2 encodes as a `state` with **no `next`** — the format's free variable, unconstrained at every step. Two independent paths together read it as something else:

| | | Effect |
|---|---|---|
| no `next` | substitution only fires when a `next` function exists | left as identity ⇒ **held** |
| no `init` | *"all-`⊥` … for a register with no `init` line"* | **pinned to zero** |

So a `$anyseq` became a **constant zero**. `fits` nailed to 0 → `req && fits` never true → the FSM never left idle → the cut model had *fewer* behaviours than the design.

## Verdicts

monono's `mini_fetch` reduction; same flip on the real `sprite_fetch`:

| | unabstracted | cut **before** | cut **after** |
|---|---|---|---|
| `EF (st_q == 2)` | HOLDS | **VIOLATED** ✗ | **HOLDS** ✓ |
| `EF (st_q == 1)` | HOLDS | **VIOLATED** ✗ | **HOLDS** ✓ |
| `AG (st_q == 0)` | VIOLATED | **HOLDS** ✗ | **VIOLATED** ✓ |
| `EF (st_q == 3)` *(never assigned — control)* | VIOLATED | VIOLATED | VIOLATED |

`AG (st_q == 0)` returning `HOLDS` is the serious one — a universal safety property passing on a model that cannot move.

## The fix

A `state` with no `next` is classified as a free **input** at the STS-IR seam (`BtorSts::states_with_next`). Every consumer of the seam inherits the correct semantics.

**This was never `cutpoint`-specific** — any BTOR2 with a no-`next` state was affected, from any frontend, hand-written included. `--cutpoint` is just the shipped path that reliably produces one.

`$anyconst` is untouched and was always correct: Yosys emits it as `next(k) = k`, so it has a `next` and stays a held register. I verified that by lifting both attributes and reading the emitted BTOR2 rather than assuming it.

## Blast radius

Designs with no `$anyseq` have a `next` on every state, so the classification is identical and **no verdict moves**. 2512 lib tests, 57 doctests, workspace + `api` + legacy root bin — all green, unchanged.

The `model: N state register(s)` diagnostic counted raw `state` lines, so post-fix it would have gone **up** as more nets were freed — in the very diagnostic whose job is to show state being cut away. Now counts states carrying a `next`; unchanged on designs without `$anyseq`.

## Tests — all confirmed to FAIL on the pre-fix code

- `state_without_next_is_free_each_step_not_a_held_register` — the `EF` side.
- `state_without_next_does_not_freeze_a_safety_property_into_holding` — the `AG` side. **Both directions**, because an implementation that special-cased safety would pass one and fail the other.
- `anyseq_shaped_…_classified_as_an_input` / `anyconst_shaped_…_stays_…_a_register` — the seam itself, asserted on *classification* rather than a verdict, so the separate `no init ⇒ zero` rule is not entangled.
- `e2e_cutpoint_stays_an_over_approximation_no_verdict_flips` (`#[ignore]`, `mununu-sva`) — the reporter's requested regression, generalised: **no** property may change verdict when a cut is applied. Reproduces their flip verbatim on the pre-fix code.

## Consumer impact

Briefing at `docs/consumer-briefings/2026-09-cutpoint-anyseq-soundness.md`. **Any verdict decided under `--cutpoint` must be re-run**; verdicts without cut points are unaffected.

Reported, reduced to a 30-line FSM, and cross-checked on the real block by monono — the reduction is what made this tractable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)