### PR TITLE
test(e2e): opt-in probes and tool-gated tests skip when unconfigured, instead of failing

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/abs_safety.rs
+++ b/crates/mununu-core/src/adapter/btor2/abs_safety.rs
@@ -1177,8 +1177,12 @@ mod tests {
     #[test]
     #[ignore = "reads an external BTOR2 file named by MUNUNU_INTERP_PROBE"]
     fn probe_ic3_on_external_design() {
-        let path = std::env::var("MUNUNU_INTERP_PROBE")
-            .expect("set MUNUNU_INTERP_PROBE=/path/to/design.btor2");
+        let Ok(path) = std::env::var("MUNUNU_INTERP_PROBE") else {
+            eprintln!(
+                "SKIPPED: opt-in probe — set MUNUNU_INTERP_PROBE=/path/to/design.btor2 to run it."
+            );
+            return;
+        };
         let content = std::fs::read_to_string(&path).expect("read design");
         let file = parser::parse(&content).expect("parse btor2");
         let eu = |k: &str, d: u32| {

--- a/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
+++ b/crates/mununu-core/src/adapter/btor2/array_prophecy.rs
@@ -1594,7 +1594,10 @@ mod tests {
     #[test]
     #[ignore]
     fn spcr_applicability_probe_over_dir() {
-        let dir = std::env::var("MUNUNU_SPCR_PROBE_DIR").expect("set MUNUNU_SPCR_PROBE_DIR");
+        let Ok(dir) = std::env::var("MUNUNU_SPCR_PROBE_DIR") else {
+            eprintln!("SKIPPED: opt-in probe — set MUNUNU_SPCR_PROBE_DIR to run it.");
+            return;
+        };
         let mut total = 0usize;
         let mut no_array = 0usize;
         let mut applied: Vec<(String, usize)> = Vec::new();

--- a/crates/mununu-core/src/adapter/btor2/bit_blast.rs
+++ b/crates/mununu-core/src/adapter/btor2/bit_blast.rs
@@ -6451,7 +6451,13 @@ mod tests {
         use crate::adapter::btor2::dep_graph::cone_leaf_nids;
         use std::collections::{BTreeMap, HashMap, HashSet};
 
-        let path = std::env::var("MUNUNU_PROBE_BTOR2").expect("set MUNUNU_PROBE_BTOR2");
+        let Ok(path) = std::env::var("MUNUNU_PROBE_BTOR2") else {
+            eprintln!(
+                "SKIPPED: this is an opt-in measurement probe, not an assertion — set \
+                 MUNUNU_PROBE_BTOR2=<design.btor2> to run it."
+            );
+            return;
+        };
         let content = std::fs::read_to_string(&path).expect("read btor2");
         let file = parser::parse(&content).expect("parse btor2");
         let atoms: Vec<String> = std::env::var("MUNUNU_PROBE_ATOMS")
@@ -6736,7 +6742,13 @@ mod tests {
         use crate::adapter::btor2::dep_graph::cone_leaf_nids;
         use std::collections::{HashMap, HashSet};
 
-        let path = std::env::var("MUNUNU_PROBE_BTOR2").expect("set MUNUNU_PROBE_BTOR2");
+        let Ok(path) = std::env::var("MUNUNU_PROBE_BTOR2") else {
+            eprintln!(
+                "SKIPPED: this is an opt-in measurement probe, not an assertion — set \
+                 MUNUNU_PROBE_BTOR2=<design.btor2> to run it."
+            );
+            return;
+        };
         let content = std::fs::read_to_string(&path).expect("read btor2");
         let file = parser::parse(&content).expect("parse btor2");
         let atoms: Vec<String> = std::env::var("MUNUNU_PROBE_ATOMS")
@@ -7004,7 +7016,13 @@ mod tests {
     #[test]
     #[ignore = "MK.0 cross-check — set MUNUNU_PROBE_BTOR2 + MUNUNU_PROBE_GOOD"]
     fn probe_recoverability_bot_diagnosis() {
-        let path = std::env::var("MUNUNU_PROBE_BTOR2").expect("set MUNUNU_PROBE_BTOR2");
+        let Ok(path) = std::env::var("MUNUNU_PROBE_BTOR2") else {
+            eprintln!(
+                "SKIPPED: this is an opt-in measurement probe, not an assertion — set \
+                 MUNUNU_PROBE_BTOR2=<design.btor2> to run it."
+            );
+            return;
+        };
         let good = std::env::var("MUNUNU_PROBE_GOOD").expect("set MUNUNU_PROBE_GOOD");
         let content = std::fs::read_to_string(&path).expect("read btor2");
         let verdict =
@@ -7210,7 +7228,13 @@ mod tests {
     #[ignore = "measurement — real-design structural automaton size"]
     fn measure_structural_automaton_size() {
         use crate::adapter::btor2::ast::{Node, Op};
-        let path = std::env::var("MUNUNU_PROBE_BTOR2").expect("set MUNUNU_PROBE_BTOR2");
+        let Ok(path) = std::env::var("MUNUNU_PROBE_BTOR2") else {
+            eprintln!(
+                "SKIPPED: this is an opt-in measurement probe, not an assertion — set \
+                 MUNUNU_PROBE_BTOR2=<design.btor2> to run it."
+            );
+            return;
+        };
         let content = std::fs::read_to_string(&path).expect("read btor2");
         let file = parser::parse(&content).expect("parse btor2");
 

--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -2633,6 +2633,16 @@ mod tests {
     #[test]
     #[ignore = "requires MathSAT (mununu-sva image); run with --ignored + MUNUNU_MATHSAT_PATH"]
     fn e2e_craig_must_precondition_decides_emergent_recoverability() {
+        // MathSAT is not in the `mununu-sva` image (it ships in `mununu-sva-pono`).
+        // Skip rather than fail: an absent optional tool is not a regression, and a
+        // red result here masks the genuine failures in the `--ignored` sweep.
+        if crate::adapter::btor2::native_interp::mathsat_available().is_err() {
+            eprintln!(
+                "SKIPPED: MathSAT unavailable — run in `mununu-sva-pono` or set \
+                 MUNUNU_MATHSAT_PATH."
+            );
+            return;
+        }
         use crate::adapter::btor2::kmts_lift::{MayEdgeInference, MustEdgeInference};
         use crate::adapter::btor2::symbolic_bitblast::exact_symbolic_verdict;
         const D: &str = "1 sort bitvec 1\n2 sort bitvec 3\n3 state 1 busy\n4 state 2 data\n\

--- a/crates/mununu-core/src/adapter/btor2/native_interp.rs
+++ b/crates/mununu-core/src/adapter/btor2/native_interp.rs
@@ -801,6 +801,16 @@ pub(crate) fn run_cvc5_raw(query: &str, timeout_ms: u32) -> Result<String, Strin
 /// `locate_tool` (which invokes `--version`), MathSAT uses `-version` (single dash), so this does
 /// a light `-version` probe purely to confirm the binary is invokable; the actual interpolation
 /// query surfaces any real problem as an `Err`.
+/// Is MathSAT invokable? The optional-tool gate for tests that need it: MathSAT
+/// ships in the `mununu-sva-pono` image, not `mununu-sva`, so a test that requires
+/// it must SKIP rather than fail when it is absent — an absent optional tool is not
+/// a regression, and a red result masks the genuine failures in the `--ignored`
+/// sweep (mununu#498 follow-up).
+#[cfg(test)]
+pub(crate) fn mathsat_available() -> Result<(), String> {
+    locate_mathsat().map(|_| ())
+}
+
 fn locate_mathsat() -> Result<std::path::PathBuf, String> {
     use std::path::PathBuf;
     let path = std::env::var("MUNUNU_MATHSAT_PATH")
@@ -1053,8 +1063,16 @@ mod tests {
     #[test]
     #[ignore = "sweeps the external HWMCC corpus named by MUNUNU_HWMCC_GT/FLAT"]
     fn differential_soundness_hwmcc() {
-        let gt_path = std::env::var("MUNUNU_HWMCC_GT").expect("set MUNUNU_HWMCC_GT");
-        let flat = std::env::var("MUNUNU_HWMCC_FLAT").expect("set MUNUNU_HWMCC_FLAT");
+        let (Ok(gt_path), Ok(flat)) = (
+            std::env::var("MUNUNU_HWMCC_GT"),
+            std::env::var("MUNUNU_HWMCC_FLAT"),
+        ) else {
+            eprintln!(
+                "SKIPPED: external-corpus differential sweep — set MUNUNU_HWMCC_GT and \
+                 MUNUNU_HWMCC_FLAT to run it."
+            );
+            return;
+        };
         let max_bytes: u64 = std::env::var("MUNUNU_HWMCC_MAXBYTES")
             .ok()
             .and_then(|s| s.parse().ok())
@@ -1123,8 +1141,12 @@ mod tests {
     #[test]
     #[ignore = "reads an external BTOR2 file named by MUNUNU_INTERP_PROBE"]
     fn probe_safety_verdict_on_external_design() {
-        let path = std::env::var("MUNUNU_INTERP_PROBE")
-            .expect("set MUNUNU_INTERP_PROBE=/path/to/design.btor2");
+        let Ok(path) = std::env::var("MUNUNU_INTERP_PROBE") else {
+            eprintln!(
+                "SKIPPED: opt-in probe — set MUNUNU_INTERP_PROBE=/path/to/design.btor2 to run it."
+            );
+            return;
+        };
         let content = std::fs::read_to_string(&path).expect("read design");
         let file = parser::parse(&content).expect("parse btor2");
         let env_u = |k: &str, d: u32| {
@@ -1160,8 +1182,12 @@ mod tests {
     #[test]
     #[ignore = "reads an external BTOR2 file named by MUNUNU_INTERP_PROBE"]
     fn probe_one_step_interpolant_on_external_design() {
-        let path = std::env::var("MUNUNU_INTERP_PROBE")
-            .expect("set MUNUNU_INTERP_PROBE=/path/to/design.btor2");
+        let Ok(path) = std::env::var("MUNUNU_INTERP_PROBE") else {
+            eprintln!(
+                "SKIPPED: opt-in probe — set MUNUNU_INTERP_PROBE=/path/to/design.btor2 to run it."
+            );
+            return;
+        };
         let content = std::fs::read_to_string(&path).expect("read design");
         let file = parser::parse(&content).expect("parse btor2");
         match one_step_interpolant(&file) {

--- a/crates/mununu-core/src/adapter/btor2/refine.rs
+++ b/crates/mununu-core/src/adapter/btor2/refine.rs
@@ -1066,6 +1066,16 @@ mod tests {
     #[test]
     #[ignore = "requires MathSAT (mununu-sva image); run with --ignored + MUNUNU_MATHSAT_PATH"]
     fn must_precondition_resolves_combinational_good() {
+        // MathSAT is not in the `mununu-sva` image (it ships in `mununu-sva-pono`).
+        // Skip rather than fail: an absent optional tool is not a regression, and a
+        // red result here masks the genuine failures in the `--ignored` sweep.
+        if crate::adapter::btor2::native_interp::mathsat_available().is_err() {
+            eprintln!(
+                "SKIPPED: MathSAT unavailable — run in `mununu-sva-pono` or set \
+                 MUNUNU_MATHSAT_PATH."
+            );
+            return;
+        }
         use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
         const D: &str = "1 sort bitvec 1\n2 sort bitvec 3\n3 state 1 busy\n4 state 2 data\n\
 5 state 2 target\n6 one 1\n7 zero 1\n8 zero 2\n9 one 2\n10 init 1 3 6\n11 init 2 4 8\n\
@@ -1104,7 +1114,10 @@ mod tests {
     #[test]
     #[ignore = "sweeps an external BTOR2 dir named by MUNUNU_DISCOVER_DIR"]
     fn sweep_discovery_on_external_designs() {
-        let dir = std::env::var("MUNUNU_DISCOVER_DIR").expect("set MUNUNU_DISCOVER_DIR");
+        let Ok(dir) = std::env::var("MUNUNU_DISCOVER_DIR") else {
+            eprintln!("SKIPPED: opt-in sweep — set MUNUNU_DISCOVER_DIR to run it.");
+            return;
+        };
         let max_bytes: u64 = std::env::var("MUNUNU_DISCOVER_MAXBYTES")
             .ok()
             .and_then(|s| s.parse().ok())

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -898,7 +898,10 @@ mod tests {
     #[test]
     #[ignore = "owned-only HWMCC ceiling sweep; set MUNUNU_HWMCC_FLAT (+ optional MUNUNU_HWMCC_GT), MUNUNU_OWNED_TIMEOUT_MS default 240000"]
     fn owned_only_hwmcc_ceiling() {
-        let flat = std::env::var("MUNUNU_HWMCC_FLAT").expect("set MUNUNU_HWMCC_FLAT");
+        let Ok(flat) = std::env::var("MUNUNU_HWMCC_FLAT") else {
+            eprintln!("SKIPPED: external-corpus sweep — set MUNUNU_HWMCC_FLAT to run it.");
+            return;
+        };
         let to_ms: u32 = std::env::var("MUNUNU_OWNED_TIMEOUT_MS")
             .ok()
             .and_then(|s| s.parse().ok())


### PR DESCRIPTION
The `#[ignore]`d sweep (`cargo test -p mununu-core --lib -- --ignored`, the `mununu-sva` set) had drifted to **19 failures out of 66**. Triage:

| Category | Count | Reality |
|---|---|---|
| Opt-in probes that `expect()` an env var and **panic** when unset | **11** | Never a failure |
| Need MathSAT — ships in `mununu-sva-pono`, not `mununu-sva` | **2** | Never a failure |
| Genuine | **6** | The real signal |

**Thirteen of the nineteen were never failures.** That is why the sweep drifted unnoticed: nobody can see six real problems behind thirteen fake ones, and the set does not run in `make ci` (it needs the image), so nothing flagged it.

An opt-in measurement harness with no input has nothing to assert. It now prints which variable to set and returns. Same for MathSAT — an absent *optional* tool is not a regression. `mathsat_available()` is a `#[cfg(test)]` wrapper over the existing `locate_mathsat`; no production surface changes.

Verified in the image — all 13 now report `ok`:

```
probe_ic3_on_external_design                   ok
spcr_applicability_probe_over_dir              ok
measure_structural_automaton_size              ok
probe_cone_register_width_decomposition        ok
probe_mixed_precision_reach_c_partition        ok
probe_recoverability_bot_diagnosis             ok
differential_soundness_hwmcc                   ok
probe_one_step_interpolant_on_external_design  ok
probe_safety_verdict_on_external_design        ok
sweep_discovery_on_external_designs            ok
owned_only_hwmcc_ceiling                       ok
must_precondition_resolves_combinational_good  ok
e2e_craig_must_precondition_decides…           ok
```

## Deliberately not touched

- **`r5_subitem_33_invoke_cvc5_for_known_interpolation_query`** — cvc5 **is** present in the image (1.0.1-dev) and returns no interpolant, so this is a genuine result, not a missing tool. Silently skipping it would have hidden a real finding; the image's cvc5 is far older than the 1.3.4 this line of work has depended on.
- **The 5 other genuine failures** — stale expectations and abstentions needing individual judgement, not a blanket gate.

## Separate finding from this run

`e2e_sysrst_symbolic_engine_runs_on_real_rtl` **overflowed its stack and aborted the process** (SIGABRT), taking the whole sweep's summary with it. That test exists to assert the engine degrades *gracefully* on an over-cap design; a stack overflow cannot be caught by the existing `catch_unwind` node-budget backstop. On the previous run the same test failed by assertion instead, so it is pressure-dependent. Worth its own issue — an engine that aborts rather than abstains on a large real design is a robustness bug, and one aborting test hides every result after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)