### PR TITLE
fix(engine): a BTOR2 `state` with no `init` is FREE, per the format (#498 sibling)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -2198,14 +2198,28 @@ impl BddBitBlaster {
         }
     }
 
-    /// D1.3/D1.5 — the BDD of the design's **initial state**: EVERY state register
-    /// is pinned to its reset value — its BTOR2 `init <state> <value>` bits, or **0
-    /// when it has no `init` line** (the `setundef -zero` model convention Yosys +
-    /// verify-auto's `state_cell_init_values` use). Pinning the undefined-reset
-    /// registers to 0 (rather than leaving them free) is what keeps `AG …` from
-    /// seeing unreachable stuck states: the verdict is checked from the *actual*
-    /// modelled reset state, not an over-broad free-init set. `Holds` iff that
-    /// initial state satisfies the property.
+    /// D1.3/D1.5 — the BDD of the design's **initial states**, per the BTOR2 format:
+    /// a state with an `init <state> <value>` line is pinned to that value; a state
+    /// with **no `init` line is left FREE**, because the format leaves its initial
+    /// value unconstrained.
+    ///
+    /// **mununu#498 (sibling).** This used to pin an un-`init`ed state to all-zero
+    /// (the `setundef -zero` convention). That made the modelled initial set a strict
+    /// SUBSET of the design's, which is an UNDER-approximation: `Violated` stayed
+    /// sound (the pinned state is a genuine initial state) but `Holds` did not — φ
+    /// holding at one initial state says nothing about the others. mununu therefore
+    /// disagreed with `btormc` / Pono, which follow the format (the btor2tools
+    /// `noninitstate.btor2` case), and `exact_bad_reachable` had to *abstain* to stay
+    /// honest. Modelling the initial set exactly removes the approximation, so BOTH
+    /// directions are sound and no guard is needed.
+    ///
+    /// The SV path is unaffected: `reset_init::inject_reset_init` injects an `init`
+    /// line for EVERY state cell of a reset-gated design before the model is built
+    /// (all-or-nothing), so a lifted RTL design has no free-init state. Under
+    /// `--no-gate-reset` the design is *documented* to choose its own power-up, which
+    /// is what this now models.
+    ///
+    /// `Holds` iff EVERY initial state satisfies the property.
     pub fn initial_state_bdd(&self, file: &Btor2File) -> Result<BDDFunction, String> {
         // State-line nid → the value operand of its `init` line (if any).
         let mut init_value_nid: HashMap<Nid, Nid> = HashMap::new();
@@ -2248,13 +2262,17 @@ impl BddBitBlaster {
             let Some(cell) = cell_of_sym.get(sym.as_str()) else {
                 continue;
             };
-            // Reset-value bits: the `init` line's value BDD, or all-`⊥` (every bit
-            // 0) for a register with no `init` line.
-            let value_bits: Vec<BDDFunction> = init_value_nid
+            // No `init` line ⇒ the format leaves this state's initial value
+            // unconstrained, so contribute NO conjunct and leave its bits free.
+            // (Pinning them to all-zero here was the mununu#498 sibling
+            // under-approximation — see this method's doc comment.)
+            let Some(value_bits) = init_value_nid
                 .get(&line.nid)
                 .and_then(|vn| self.env.get(vn))
                 .cloned()
-                .unwrap_or_else(|| vec![self.ff.clone(); cell.vars.len()]);
+            else {
+                continue;
+            };
             for (var, val) in cell.vars.iter().zip(value_bits.iter()) {
                 // state_bit ⟺ value_bit  =  ¬(state_bit XOR value_bit)
                 let iff = oom(self.xor(var, val)?.not())?;
@@ -2845,38 +2863,14 @@ pub fn exact_bad_reachable(btor2_content: &str) -> Result<bool, String> {
     let init = bb.initial_state_bdd(&file)?;
     let reachable = init.and(&reach).unwrap() != bb.ff;
 
-    // A REACHABLE verdict is always sound: the modelled reset (uninitialised
-    // registers pinned to 0) is ONE of the initial states btormc explores, so a
-    // path found from it is a real path. An UNREACHABLE verdict, however, is sound
-    // only when every state cell is initialised — an uninitialised (free-init)
-    // register could reach `bad` from a non-reset value that btormc considers but
-    // the pin-to-reset model does not (the `noninitstate` differential case). So we
-    // decide REACHABLE freely, and refuse an UNREACHABLE verdict on a design with
-    // free-init state rather than emit a possibly-unsound "safe".
-    if reachable {
-        return Ok(true);
-    }
-    let init_states: std::collections::HashSet<Nid> = file
-        .lines
-        .iter()
-        .filter_map(|l| match &l.node {
-            Node::Init { state, .. } => Some(*state),
-            _ => None,
-        })
-        .collect();
-    let has_free_init_state = file
-        .lines
-        .iter()
-        .any(|l| matches!(l.node, Node::State { .. }) && !init_states.contains(&l.nid));
-    if has_free_init_state {
-        return Err(
-            "exact bad-reachability: unreachable from the pinned reset, but the design has \
-                    uninitialised (free-init) state — btormc explores non-reset initial values the \
-                    pin-to-reset model does not; undecided rather than unsound"
-                .into(),
-        );
-    }
-    Ok(false)
+    // BOTH directions are sound since mununu#498's sibling fix: `initial_state_bdd`
+    // models the design's initial set EXACTLY (a state with no `init` line is left
+    // free, per the BTOR2 format) rather than pinning un-`init`ed registers to 0.
+    // The engine therefore no longer has to refuse an UNREACHABLE verdict on a
+    // free-init design — the case that used to abstain (btor2tools `noninitstate`,
+    // where btormc reaches `bad` from a non-zero initial value the pinned model
+    // could not see) is now DECIDED, and decided the same way btormc decides it.
+    Ok(reachable)
 }
 
 /// D1.3 — exact full-state symbolic μ-calculus model checking end-to-end: parse the
@@ -7336,14 +7330,17 @@ mod tests {
         );
     }
 
-    /// `exact_bad_reachable` — an UNREACHABLE-from-reset verdict on a design with
-    /// UNINITIALISED (free-init) state is refused, not returned as `false`: the
-    /// register is held (`next = s`) with no `init` line, so from the pin-to-0 reset
-    /// `bad = (s == 1)` is unreachable, but btormc explores `s = 1` at cycle 0
-    /// (reachable). Returning `false` there would be unsound, so the engine is
-    /// undecided.
+    /// mununu#498 (sibling) — a design with UNINITIALISED (free-init) state is now
+    /// DECIDED, and decided the way `btormc` decides it.
+    ///
+    /// `s` is held (`next = s`) with no `init` line, so the BTOR2 format leaves its
+    /// initial value free and `s = 1` at cycle 0 is a genuine initial state: `bad`
+    /// IS reachable. The engine used to pin `s` to 0, find `bad` unreachable, and
+    /// then have to ABSTAIN to avoid emitting an unsound "safe" (this test formerly
+    /// asserted the abstention). Modelling the initial set exactly removes both the
+    /// wrong answer and the need to refuse.
     #[test]
-    fn exact_bad_reachable_refuses_unreachable_on_free_init_state() {
+    fn exact_bad_reachable_decides_free_init_design_like_btormc() {
         const FREE_INIT: &str = r#"
 1 sort bitvec 1
 2 state 1 s
@@ -7352,9 +7349,37 @@ mod tests {
 5 eq 1 2 4
 6 bad 5
 "#;
-        assert!(
-            exact_bad_reachable(FREE_INIT).is_err(),
-            "unreachable-from-reset + free-init state ⇒ undecided (btormc may reach from a non-0 init)"
+        assert_eq!(
+            exact_bad_reachable(FREE_INIT),
+            Ok(true),
+            "`s` is free at cycle 0, so `bad = (s == 1)` is reachable — the verdict btormc \
+             gives, and one the pin-to-zero model could not reach"
+        );
+    }
+
+    /// mununu#498 (sibling), against the third-party oracle case. `btor2tools`'
+    /// `noninitstate.btor2` exists precisely to test free-init semantics: `state0`
+    /// and `state1` carry no `init`, and a `constraint` forces them DIFFERENT in the
+    /// first step, so `bad = (state0 == state1)` is reachable — `btormc` returns
+    /// `sat`.
+    ///
+    /// Pinning both to 0 made them EQUAL at step 0, which contradicts that
+    /// constraint; the exact engine could not see the real initial states and had to
+    /// abstain, leaving `btormc` / Pono / SPACER to carry the portfolio. It now
+    /// decides, and agrees.
+    #[test]
+    fn exact_decides_btor2tools_noninitstate_like_btormc() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/btor2/btor2tools_suite/noninitstate.btor2"
+        );
+        let content = std::fs::read_to_string(path).expect("read noninitstate.btor2");
+        assert_eq!(
+            exact_bad_reachable(&content),
+            Ok(true),
+            "btormc reports `sat` on this design; the exact engine must now agree rather \
+             than abstain — a differential disagreement here is the mununu#498 sibling \
+             under-approximation returning"
         );
     }
 
@@ -8436,6 +8461,20 @@ mod tests {
         let btor2 = sv_to_btor2_with_blackboxes(&sv, &yopts)
             .expect("extract uart_tx")
             .btor2;
+        // Anchor the model at reset, exactly as `verify_auto` does before handing a
+        // design to this engine. `sv_to_btor2_with_blackboxes` is the raw lift: Yosys
+        // `async2sync` puts the reset in the next-state mux and emits NO `init` line,
+        // so without this step the BTOR2 does not say where the design starts — and
+        // since mununu#498's sibling fix the engine honours that and starts anywhere,
+        // which makes a bounded-counter invariant like `AG (bit_cnt_q < 12)` fail from
+        // a fabricated power-up of 12..15. Injecting the reset init is what makes this
+        // the model `sv verify-auto` actually builds, rather than one no shipped path
+        // produces. `rst_ni` is active-low, so its INACTIVE level is 1.
+        let btor2 = crate::adapter::btor2::reset_init::inject_reset_init(
+            &btor2,
+            &[("rst_ni".to_string(), 1u64)],
+        )
+        .expect("inject reset init");
         let verdict = |f: &str| -> ExactVerdict {
             let ff = crate::mu_calculus::parser::parse(f).expect("formula parses");
             exact_symbolic_verdict(&btor2, &ff).expect("definite verdict, binds")

--- a/crates/mununu-core/tests/fixtures/wall_classes/edn_boot_sm.btor
+++ b/crates/mununu-core/tests/fixtures/wall_classes/edn_boot_sm.btor
@@ -188,3 +188,8 @@
 187 ite 13 11 184 14
 188 next 13 15 187
 ; end of yosys output
+; mununu#498 (sibling): make the reset value EXPLICIT. `16 ite 13 11 15 14`
+; is the reset mux — `rst_ni ? state_q : 011000001` — so 011000001 (193) is the
+; FSM's reset encoding. Without this line the BTOR2 does not say where the design
+; starts, and the engine is free to begin anywhere (which is what the format means).
+189 init 13 15 14

--- a/docs/consumer-briefings/2026-09-free-init-state-semantics.md
+++ b/docs/consumer-briefings/2026-09-free-init-state-semantics.md
@@ -1,0 +1,91 @@
+# Consumer briefing — 2026-09 a BTOR2 `state` with no `init` is now FREE, per the format
+
+> **Audience:** anyone passing a BTOR2 file to `mununu btor2 verify*` / `cegar` / `game` — hand-written, third-party (HWMCC, btor2tools), or emitted by a non-mununu frontend. **`sv verify-auto` users are unaffected**; see below.
+>
+> **Related:** [mununu#498](https://github.com/vscorza/mununu/issues/498) (the sibling finding; the parent fix shipped in #502).
+>
+> **TL;DR:** the exact engine used to pin an un-`init`ed register to **zero**. The BTOR2 format leaves it **unconstrained**, which is what `btormc` and Pono implement. mununu now matches the format. Verdicts on the direct-BTOR2 path can change — **only ever `Holds` → `Violated`** — and the engine now *decides* cases where it previously had to abstain.
+
+## What was wrong
+
+`initial_state_bdd` conjoined `state_bit ⟺ value_bit` for **every** state, using all-zero for a state with no `init` line. The modelled initial set was therefore a strict **subset** of the design's, which is an **under-approximation**:
+
+- **`Violated` was sound** — the pinned state is a genuine initial state, so a counterexample from it is real.
+- **`Holds` was not** — φ holding at *one* initial state says nothing about the others.
+
+The consequence was a differential disagreement with the rest of the portfolio. On btor2tools' `noninitstate.btor2` — a case that exists precisely to test this — `state0`/`state1` have no `init` and a `constraint` forces them *different* in the first step. Pinning both to 0 made them *equal*, contradicting the constraint, so the exact engine could not see the real initial states. `exact_bad_reachable` handled that by **abstaining**, leaving btormc / Pono / SPACER to carry the portfolio.
+
+## What changed
+
+A state with an `init` line is pinned to that value; a state with **no `init` line is left free**. The modelled initial set now *equals* the design's, so **both verdict directions are sound** and the abstention is no longer needed — it has been removed.
+
+```
+examples/btor2/btor2tools_suite/noninitstate.btor2
+
+  before   reachable_by: [native, spacer, btormc, pono]        <- `exact` abstained
+  after    reachable_by: [exact, native, spacer, btormc, pono] <- decides, and agrees
+```
+
+## Who is affected
+
+| Path | Effect |
+|---|---|
+| **`sv verify-auto`, reset-gated (the default)** | **None.** `reset_init::inject_reset_init` injects an `init` line for *every* state cell before the model is built, so no free-init state exists |
+| `sv verify-auto --no-gate-reset` | Behaviour changes — and arguably corrects; that flag is documented as *"the design chooses its own power-up"*, which is now what it models |
+| `btor2 verify*` / `cegar` / `game` on files with free-init state | Verdicts may change, and previously-abstained cases now decide |
+| Fully-initialised BTOR2 (every state has `init`) | **None** — identical model |
+
+**Direction of change:** `Holds` gets harder (must hold from *every* initial state), `Violated` gets easier (one bad initial state suffices). Migrations only ever go `Holds → Violated`. A `Holds` that survives is now a stronger claim than the one it replaces.
+
+## Measured blast radius
+
+| | |
+|---|---|
+| Repo `.btor2` corpus | 7 fully-initialised (unaffected), 2 partially-initialised — both btor2tools cases where free-init is the *correct* semantics |
+| Test suite | **1** test changed behaviour: the guard's own test, which asserted the abstention. Rewritten to assert the engine now decides. 2513 pass |
+| Doctests, clippy, workspace | unchanged, clean |
+
+## The residual risk, stated plainly
+
+`inject_reset_init` is **all-or-nothing**: it no-ops entirely if the design already carries *any* `init` line. So an RTL design with *partial* init — some registers initialised by an `initial` block or an `(* init *)` attribute, the rest not — gets no injection, and under this change its uninitialised registers go free while reset is pinned inactive. That can produce a **spurious `VIOLATED`**.
+
+Yosys `async2sync` emits no `init` at all (checked on three designs), so this needs hand-written init to arise. It is uncommon in RTL, not impossible. **If you see a new `VIOLATED` on an SV design, check whether its BTOR2 has partial init** — that is the shape to suspect, and it is worth reporting.
+
+## For monono
+
+Your formal lane runs `sv verify-auto` reset-gated, so this should be a no-op for you. It is worth one confirming run: if any verdict moves, the partial-init shape above is the thing to check, and I would want to hear about it.
+
+The `--cutpoint` re-run advice from the #502 briefing still stands and is unrelated to this change.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | verdict semantics on the direct-BTOR2 path | **Yes** |
+| mununu `Dockerfile.dev` | binary bump | **Yes** |
+| mununu `Dockerfile.sva` | binary bump | **Yes** |
+| mununu `Dockerfile.extract`, `.extract-*` | no engine path | No |
+| rosf | changes only if it feeds BTOR2 with free-init state directly | **No** for the `sv` surface |
+| monono Docker | reset-gated SV path — expected no-op | Recommended, not forced |
+| mununu-ui | no type change | No |
+
+## Verification
+
+```bash
+cargo test -p mununu-core --lib -- exact_decides_btor2tools_noninitstate \
+                                   exact_bad_reachable_decides_free_init
+```
+
+The first runs against the real btor2tools file and asserts agreement with `btormc`'s `sat`; the second pins the mechanism on a minimal fixture. Both fail on the pre-fix code.
+
+## Provenance
+
+- Found while fixing [mununu#498](https://github.com/vscorza/mununu/issues/498) — a test asserting `$anyconst` reachability failed, and the honest reading was that the test was right and the code was not.
+- Fix: `BddBitBlaster::initial_state_bdd` in `crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs`.
+- Policy: [`../policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here (follow-ups)
+
+- **`--no-gate-reset` and CWE-1245.** That flag is documented as letting the design choose its own power-up "including the undefined-encoding scenarios CWE-1245 detection relies on". Under the old zero-pin every register powered up at 0, which may be a *legal* encoding — so that detection may have been blind to the scenario it exists for. This change plausibly fixes it. **Unverified**; worth one experiment.
+- **`state_cell_init_values`** (the cube path) still defaults to 0 for a state with no `init`. It feeds a different engine and was not touched here; whether it has the same asymmetry is a separate question.
+- **[mununu#504](https://github.com/vscorza/mununu/issues/504)** — the exact engine can stack-overflow rather than abstain on a large design. Unrelated, found in the same sweep.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -451,9 +451,16 @@ Only the initial cycles need care, because a history variable has no value befor
 the first transition. A state cell's stages mirror its `init`, so before the chain
 fills (cycles `< j` for stage `j`) `$past(b, j)` reads `b`'s reset value. An input
 has no `init` to mirror, so **every stage is pinned to an explicit zero** rather
-than left free: an init-less BTOR2 cell reads as 0 to the cube and exact engines
-but stays free for the reachability portfolio, and that split is a verdict
-disagreement, not a nuance.
+than left free — an emitted `init` line, not an implicit convention, which is why
+every engine reads the same value for it.
+
+That explicitness became load-bearing in 2026-09 (mununu#498 sibling). An
+init-*less* BTOR2 cell used to read as 0 to the cube and exact engines while
+staying free for the reachability portfolio, and that split was a verdict
+disagreement rather than a nuance. The exact engine now follows the BTOR2 format —
+no `init` line means the initial value is unconstrained — so it agrees with the
+portfolio, and only the cube path still applies the zero default. A `$past` stage
+is unaffected either way precisely because its `init` is written down.
 
 That invented value is read only in the first few cycles after reset. The lift
 settles it structurally: `|=>` places the atom under a `[]`, so it is evaluated


### PR DESCRIPTION
The sibling of #498, found while fixing it: a test asserting `$anyconst` reachability failed, and the honest reading was that the test was right and the code was not.

## What was wrong

`initial_state_bdd` pinned every un-`init`ed state to all-zero. The BTOR2 format leaves it **unconstrained** — which is what btormc and Pono implement. The modelled initial set was a strict **subset** of the design's, an under-approximation:

- **`Violated` was sound** — the pinned state *is* a genuine initial state.
- **`Holds` was not** — φ holding at *one* initial state says nothing about the rest.

The visible cost was a differential disagreement. btor2tools' `noninitstate.btor2` exists to test exactly this: `state0`/`state1` carry no `init`, and a `constraint` forces them *different* in step 0. Pinning both to 0 made them *equal*, contradicting the constraint, so the exact engine couldn't see the real initial states and had to abstain:

```
before   reachable_by: [native, spacer, btormc, pono]        ← exact abstained
after    reachable_by: [exact, native, spacer, btormc, pono] ← decides, and agrees
```

Modelling the initial set exactly makes **both** directions sound, so the abstention is no longer needed and is **removed**. Migrations only ever go `Holds → Violated`; a surviving `Holds` is a strictly stronger claim.

## Measured before implementing

| | Guard the μ path (option A) | **This (option B)** |
|---|---|---|
| Tests broken | **9** | **1** — the guard's own |

So the `no init = 0` convention was **implicit, not load-bearing**. Repo corpus: 7 fully-initialised `.btor2` (unaffected), 2 partial — both btor2tools cases where free-init is the *correct* semantics.

## Two fixtures were under-specified — exposed, not broken

**No expectation was changed.** Both models were made faithful:

- **`edn_boot_sm.btor`** had 1 state / 0 init, so the game could start *at the goal*. Line 16 is the reset mux (`rst_ni ? state_q : 011000001`) — so **193** is the design's reset encoding, and the fixture's *old* start of `0` wasn't its reset either. Added the explicit `init` at 193, justified by the mux rather than guessed. **The two-player counterstrategy finding survives** — it was not an artifact of the arbitrary zero start.
- **`e2e_d1_uart_tx_exact_liveness_verdict`** lifted via `sv_to_btor2_with_blackboxes` directly, skipping the `inject_reset_init` step `verify_auto` applies — so it built a model no shipped path builds, and `AG (bit_cnt_q < 12)` failed from a fabricated power-up of 12–15. It now anchors at reset like production; all four assertions hold, including the headline `AG AF` Violated.

## Blast radius

The **SV path is unaffected**: `inject_reset_init` injects an `init` for *every* state cell of a reset-gated design (all-or-nothing), so a lifted RTL design has no free-init state. Under `--no-gate-reset` the design is *documented* to choose its own power-up — which is now what it models.

**Residual risk**, in the briefing: because injection is all-or-nothing, an RTL design carrying *partial* `init` gets none, and its uninitialised registers go free while reset is pinned inactive — a possible spurious `VIOLATED`. Yosys `async2sync` emits no `init` at all, so this needs hand-written init to arise.

## Validation

2513 lib tests, all integration tests, 57 doctests, workspace + `cli` feature, clippy, fmt. Container sweep returns to its pre-existing failures with no new ones. New regressions pin the mechanism on a minimal fixture *and* against the real btor2tools file with btormc as the oracle.

Consumer briefing: `docs/consumer-briefings/2026-09-free-init-state-semantics.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)