### PR TITLE
fix(sv-lint,verify-auto): resolve address aliases (#506); stop asserting an unseen refusal cause (#507)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -946,6 +946,95 @@ struct Seeded {
 /// Bare atoms are admitted (`parse_predicate_atom_bool` reads `o_partsel` as
 /// `o_partsel != 0`), so a combinational-output property is caught as well as a
 /// register-comparison one.
+/// mununu#507 — is the anonymous free input in `name`'s cone reached through a
+/// `concat`, the shape the slang partial-write lift produces?
+///
+/// `q[hi:lo] <= d` makes slang model `q`'s UNWRITTEN bits as free inputs and alias
+/// the register name to the `concat` that mixes them. So a `concat` with an
+/// anonymous-input operand in the cone is positive evidence for that specific
+/// cause. Anything else — a blackboxed submodule's freed outputs, an undriven net,
+/// an unconnected port — reaches an anonymous input WITHOUT that shape, and the
+/// refusal must not claim a partial write it cannot see.
+fn undriven_via_partial_write_concat(
+    file: &crate::adapter::btor2::ast::Btor2File,
+    name: &str,
+) -> bool {
+    use crate::adapter::btor2::ast::{Node, Op};
+    let symbols = crate::adapter::btor2::parser::collect_symbols(file);
+    let starts: Vec<crate::adapter::btor2::ast::Nid> = file
+        .lines
+        .iter()
+        .filter(|l| match &l.node {
+            Node::State { .. } => symbols.get(&l.nid).map(String::as_str) == Some(name),
+            Node::Op {
+                symbol: Some(s), ..
+            } => s == name,
+            Node::Output {
+                symbol: Some(s), ..
+            } => s == name,
+            _ => false,
+        })
+        .map(|l| l.nid)
+        .collect();
+
+    let is_anon_input = |nid| {
+        matches!(
+            file.lookup(nid).map(|l| &l.node),
+            Some(Node::Input { symbol: None, .. })
+        )
+    };
+
+    let mut seen = std::collections::HashSet::new();
+    let mut work = starts;
+    while let Some(nid) = work.pop() {
+        if !seen.insert(nid) {
+            continue;
+        }
+        let Some(line) = file.lookup(nid) else {
+            continue;
+        };
+        match &line.node {
+            Node::Op {
+                op: Op::Concat,
+                args,
+                ..
+            } => {
+                if args.iter().any(|a| is_anon_input(a.nid())) {
+                    return true;
+                }
+                for a in args {
+                    work.push(a.nid());
+                }
+            }
+            Node::Op { args, .. } => {
+                for a in args {
+                    work.push(a.nid());
+                }
+            }
+            Node::Output { signal, .. } => work.push(signal.nid()),
+            _ => {}
+        }
+    }
+    false
+}
+
+/// mununu#507 — does any staged source carry a module-scope `bind`?
+///
+/// Assertions live in a bound `*_sva.sv` file BECAUSE THEY MUST: `read_verilog -sv`
+/// cannot parse `assert property`, and verify-auto has no `--define`, so an `ifdef`
+/// guard would hide them from the verifier too. And sv2v 0.0.13 cannot parse `bind`
+/// at all (verified 2026-09-06: `Parse error: unexpected token 'bind'`). So the
+/// `--frontend verilog --preprocess-sv2v` remedy is not merely awkward for such a
+/// design — it cannot run, and recommending it sends the reader into a parse error.
+fn sources_use_bind(sources: &[(String, String)]) -> bool {
+    sources.iter().any(|(_, body)| {
+        body.lines().any(|l| {
+            let t = l.trim_start();
+            t.starts_with("bind ") && !t.starts_with("bind_") && !l.trim_start().starts_with("//")
+        })
+    })
+}
+
 fn formula_atom_over_undriven_register(
     formula: &Formula,
     file: &crate::adapter::btor2::ast::Btor2File,
@@ -2696,19 +2785,69 @@ pub(crate) fn verify_auto_impl(
         // sub-*registers*, no free inputs — is NOT refused: the NID-indexed
         // cone-of-influence keeps those cells, so that case now decides.)
         if let Some(reg) = formula_atom_over_undriven_register(&formula, &file) {
+            // mununu#507 — report the CONDITION, and the cause only when it is
+            // actually derivable. The condition this guard tests is "`reg`'s cone
+            // reaches an unnamed free input"; a partial register write is only ONE
+            // of the ways that happens (a blackboxed submodule's freed outputs, an
+            // undriven net and an unconnected port are others, and on an integrator
+            // blackboxing is far likelier). Asserting the partial-write cause
+            // unconditionally pointed consumers at correct RTL — `f_slot_q <= 7'd0
+            // / f_slot[6:0]` is a part-select of the SOURCE, written whole, with no
+            // `f_slot_q[hi:lo] <= …` anywhere.
+            let partial_write = undriven_via_partial_write_concat(&file, &reg);
+            let cause = if partial_write {
+                format!(
+                    " The lift shows the partial-write shape: `{reg}`'s name aliases a \
+                     `concat` mixing a free input, which is how the slang front-end models \
+                     the UNWRITTEN bits of a plain-vector partial assignment \
+                     (`{reg}[hi:lo] <= …`)."
+                )
+            } else {
+                let bb = &report.diagnostics.blackboxed_modules;
+                let bb_hint = if bb.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        " This run black-boxed {} module(s) ({}), whose outputs ARE freed to \
+                         unnamed inputs — the most likely source here; provide their source to \
+                         model them.",
+                        bb.len(),
+                        bb.join(", ")
+                    )
+                };
+                format!(
+                    " The cause is NOT attributed: this lift shows no partial-write shape for \
+                     `{reg}`, so do not assume a `{reg}[hi:lo] <= …` in the RTL. An unnamed \
+                     free input also comes from a black-boxed submodule, an undriven net or an \
+                     unconnected port.{bb_hint}"
+                )
+            };
+            // The sv2v remedy only exists for a design sv2v can parse. It cannot
+            // parse `bind` (0.0.13), and bound SVA is not optional for these
+            // designs — `read_verilog -sv` cannot parse `assert property`, and there
+            // is no `--define` to guard an `ifdef` with.
+            let remedy = if partial_write && !sources_use_bind(sources) {
+                " Re-lift with the read_verilog / sv2v front-end \
+                 (`--frontend verilog --preprocess-sv2v`), which models the register faithfully."
+                    .to_string()
+            } else if partial_write {
+                " The usual remedy (`--frontend verilog --preprocess-sv2v`) is NOT available \
+                 here: these sources use `bind`, which sv2v cannot parse. Rewriting the \
+                 assignment to write the register whole is the route that works."
+                    .to_string()
+            } else {
+                String::new()
+            };
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
                 kind: t.kind,
                 formula: formula_str.clone(),
                 outcome: VerifyOutcome::Skipped {
                     reason: format!(
-                        "property references `{reg}`, whose unwritten bits the RTL front-end \
-                         left undriven (modelled as free inputs) while lifting a partial \
-                         register assignment (`{reg}[hi:lo] <= …`) — a verdict over it would \
-                         read those havoc inputs and be unsound, so it is refused rather than \
-                         silently decided. Re-lift with the read_verilog / sv2v front-end \
-                         (`--frontend verilog --preprocess-sv2v`), which models `{reg}` \
-                         faithfully."
+                        "property references `{reg}`, whose cone reaches a free input the lift \
+                         could not attribute to a driver — a verdict over it would read that \
+                         havoc value and be unsound, so it is refused rather than silently \
+                         decided.{cause}{remedy}"
                     ),
                 },
                 seeded_predicates: Vec::new(),
@@ -5368,6 +5507,76 @@ module uart_tx(); endmodule"#;
 
         // No front end recorded (a non-lift path) → no note.
         assert!(note_of(&base(None, None)).is_none());
+    }
+
+    /// mununu#507 — the refusal must attribute a partial write ONLY when the lift
+    /// shows that shape, because an unnamed free input has several other sources.
+    #[test]
+    fn partial_write_shape_is_distinguished_from_other_undriven_sources() {
+        use crate::adapter::btor2::parser;
+
+        // (a) THE PARTSEL SHAPE: `q`'s name aliases a `concat` mixing an anonymous
+        // input — how slang models the unwritten bits of `q[hi:lo] <= d`.
+        const PARTSEL: &str = r#"1 sort bitvec 4
+2 sort bitvec 8
+3 input 1
+4 state 1 lo
+5 concat 2 3 4
+6 uext 2 5 0 q
+"#;
+        let f = parser::parse(PARTSEL).expect("parse");
+        assert!(
+            undriven_via_partial_write_concat(&f, "q"),
+            "the concat-over-anonymous-input shape IS the partial-write evidence"
+        );
+
+        // (b) A BLACKBOXED SUBMODULE's freed output: `q` reads an anonymous input
+        // through ordinary logic, with no concat. Same guard condition, different
+        // cause — and the message must not claim a partial write.
+        const BLACKBOX: &str = r#"1 sort bitvec 1
+2 input 1
+3 state 1 r
+4 and 1 2 3
+5 uext 1 4 0 q
+"#;
+        let f = parser::parse(BLACKBOX).expect("parse");
+        assert!(
+            parser::signal_reaches_anonymous_input(&f, "q"),
+            "the guard still fires — the property is still refused"
+        );
+        assert!(
+            !undriven_via_partial_write_concat(&f, "q"),
+            "but there is NO partial-write shape, so the refusal must not name one \
+             (mununu#507: the old message pointed at correct, whole-written RTL)"
+        );
+    }
+
+    /// mununu#507 — the sv2v remedy must not be offered to a design that uses
+    /// `bind`, because sv2v 0.0.13 cannot parse it (`Parse error: unexpected token
+    /// 'bind'`). Bound SVA is not optional for these designs: `read_verilog -sv`
+    /// cannot parse `assert property` and there is no `--define` for an `ifdef`.
+    #[test]
+    fn bound_sva_sources_are_detected_so_the_sv2v_remedy_is_withheld() {
+        let bound = vec![
+            ("dut.sv".to_string(), "module dut; endmodule\n".to_string()),
+            (
+                "dut_sva.sv".to_string(),
+                "module dut_sva; endmodule\nbind dut dut_sva u_sva();\n".to_string(),
+            ),
+        ];
+        assert!(
+            sources_use_bind(&bound),
+            "a module-scope `bind` is detected"
+        );
+
+        let plain = vec![(
+            "dut.sv".to_string(),
+            "module dut;\n  // no bind here\n  logic bind_addr;\n endmodule\n".to_string(),
+        )];
+        assert!(
+            !sources_use_bind(&plain),
+            "a commented mention and an identifier PREFIXED `bind_` are not a bind"
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/sv_verify.rs
+++ b/crates/mununu-core/src/adapter/sv_verify.rs
@@ -338,6 +338,68 @@ fn lint_undriven_partial_writes(btor2: &str) -> Result<Vec<SvLintFinding>, Strin
         .collect())
 }
 
+/// mununu#506 — resolve `nid` back to the state register it names, through the
+/// IDENTITY-PRESERVING wrappers Yosys leaves after `flatten` / `async2sync` /
+/// `dffunmap`.
+///
+/// A register's identity rarely survives on its raw `state` line. `async2sync`
+/// lifts an async reset into a mux, so the value everything downstream reads is
+/// `ite(rst_n, state, RESET_VALUE)`, and the register's NAME lands on a `uext`
+/// alias of that mux:
+///
+/// ```text
+/// 10 state 8                 <- the register (unnamed)
+/// 11 ite 8 4 10 9            <- rst_n ? state : 0     (the reset mux)
+/// 12 uext 8 11 0 ld_q        <- the NAME is here
+/// 17 read 5 16 11            <- and the read indexes the MUX, not the state
+/// ```
+///
+/// Requiring a bare `state` therefore made the rule fire only on registers with
+/// NO reset — close to none in real RTL, which is why it reported nothing on the
+/// design that motivated it (mununu#506). Same class as the 2026-07-05
+/// `next_funcs` alias-keying fix.
+///
+/// Walks ONLY through wrappers that preserve identity:
+/// * `uext` / `sext` — width padding.
+/// * `slice` — a part-select still names the same register (`.addr(ld_q[10:0])`).
+/// * `ite` where one arm is a constant — the reset-mux shape; follow the other arm.
+///
+/// It deliberately does NOT walk arithmetic or multi-register logic, so
+/// `mem[a_q + 1]` and `mem[a ^ b]` stay out of scope (documented as such).
+fn resolve_to_state_register(
+    file: &crate::adapter::btor2::ast::Btor2File,
+    nid: i64,
+) -> Option<i64> {
+    use crate::adapter::btor2::ast::{Node, Op};
+    let mut nid = nid;
+    for _ in 0..64 {
+        match node_of(file, nid)? {
+            Node::State { .. } => return Some(nid),
+            Node::Op {
+                op: Op::Uext | Op::Sext | Op::Slice,
+                args,
+                ..
+            } => {
+                nid = args.first()?.nid();
+            }
+            Node::Op {
+                op: Op::Ite, args, ..
+            } => {
+                // Reset-mux shape: exactly one arm is a constant.
+                let (t, e) = (args.get(1)?.nid(), args.get(2)?.nid());
+                let is_const = |n| matches!(node_of(file, n), Some(Node::Const { .. }));
+                match (is_const(t), is_const(e)) {
+                    (false, true) => nid = t,
+                    (true, false) => nid = e,
+                    _ => return None,
+                }
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
 /// mununu#496 — flag a **registered array read whose address register can change
 /// in the same cycle its data is consumed**, with nothing recording which address
 /// the current data corresponds to.
@@ -386,17 +448,24 @@ fn lint_registered_array_read_moving_address(btor2: &str) -> Result<Vec<SvLintFi
     // `next` edges, indexed by the state they drive, plus the set of state nids
     // that some OTHER register captures verbatim (`t <= a`) — the tracking
     // signals that satisfy the rule.
-    let mut next_of: std::collections::HashMap<i64, i64> = std::collections::HashMap::new();
+    let mut next_of: std::collections::HashMap<i64, Option<i64>> = std::collections::HashMap::new();
     let mut tracked: std::collections::HashSet<i64> = std::collections::HashSet::new();
     for line in &file.lines {
         if let Node::Next { state, value, .. } = &line.node {
-            next_of.insert(*state, value.nid());
-            // `t <= a` where a is a *different* state: a records which `a` the
+            // mununu#506: resolve the next-value through the same identity-preserving
+            // wrappers as the address. BOTH sides must resolve, or the rule breaks in
+            // the WORSE direction — `a_d <= a_q` lifts to
+            // `next(a_d) = ite(rst, <alias of a_q>, 0)`, so a resolver applied only to
+            // the address would stop recognising the SATISFYING form and start firing
+            // on exactly the designs that already do the right thing.
+            let resolved = resolve_to_state_register(&file, value.nid());
+            next_of.insert(*state, resolved);
+            // `t <= a` where `a` is a DIFFERENT register: `t` records which `a` the
             // current cycle used. A register's own hold (`a <= a`) is not tracking.
-            if *state != value.nid()
-                && matches!(node_of(&file, value.nid()), Some(Node::State { .. }))
+            if let Some(src) = resolved
+                && src != *state
             {
-                tracked.insert(value.nid());
+                tracked.insert(src);
             }
         }
     }
@@ -418,11 +487,19 @@ fn lint_registered_array_read_moving_address(btor2: &str) -> Result<Vec<SvLintFi
                 } if signal.nid() == nid => {
                     return Some(s.clone());
                 }
+                // mununu#506: the alias carrying the name usually sits over the RESET
+                // MUX, not the raw state (`12 uext 8 11 0 a_q`, where nid 11 is
+                // `ite(rst_n, state, 0)`). Match on the alias operand RESOLVED to its
+                // register, else the finding degrades to `<nid 10>` and loses the name
+                // that makes it actionable.
                 Node::Op {
                     symbol: Some(s),
                     args,
                     ..
-                } if args.first().map(|a| a.nid()) == Some(nid) => {
+                } if args.first().map(|a| a.nid()).is_some_and(|n| {
+                    n == nid || resolve_to_state_register(&file, n) == Some(nid)
+                }) =>
+                {
                     return Some(s.clone());
                 }
                 _ => {}
@@ -447,15 +524,25 @@ fn lint_registered_array_read_moving_address(btor2: &str) -> Result<Vec<SvLintFi
         let Some(addr) = args.get(1).map(|a| a.nid()) else {
             continue;
         };
-        // The address must itself be a register. An address that is a pure input
-        // or a combinational function of inputs has no "moving register" to
-        // mis-pair with, so it is out of scope for this rule.
-        if !matches!(node_of(&file, addr), Some(Node::State { .. })) {
+        // The address must resolve to a register. mununu#506: it is almost never a
+        // bare `state` — `async2sync` puts a reset mux in front of it and the name
+        // lands on a `uext` alias — so resolve through the identity-preserving
+        // wrappers. An address that is a pure input, or a genuine arithmetic
+        // function, resolves to nothing and stays out of scope.
+        let Some(addr) = resolve_to_state_register(&file, addr) else {
             continue;
-        }
+        };
         // Does the address actually move? A register held constant (`a <= a`, or
         // no `next` at all) can never be mis-paired.
-        let moves = next_of.get(&addr).is_some_and(|v| *v != addr);
+        // A register that HOLDS (`a <= a`, which lifts to
+        // `next(a) = ite(rst, <alias of a>, RESET)`) or has no `next` at all can
+        // never be mis-paired with its own data. Resolving the next-value is what
+        // distinguishes a genuine hold from the reset mux wrapped around it.
+        let moves = match next_of.get(&addr) {
+            None => false,                   // no `next` — free/held, cannot move
+            Some(Some(src)) => *src != addr, // resolves to another register
+            Some(None) => true,              // real logic ⇒ it moves
+        };
         if !moves {
             continue;
         }
@@ -585,6 +672,116 @@ mod tests {
 20 next 4 10 19
 21 next 12 13 13 mem
 "#;
+
+    // mununu#506 — the SAME design as `SLANG_REGISTERED_READ_MOVING_ADDR`, except
+    // `a_q` has a reset. That one change was enough to make the shipped rule blind:
+    // `async2sync` lifts the async reset into a mux, so the read indexes the MUX
+    // (`11 ite 8 4 10 9`) rather than the bare state (`10 state 8`), and requiring a
+    // bare `state` meant the rule fired only on registers with NO reset — close to
+    // none in real RTL. Captured from the real slang lift.
+    const SLANG_RESET_GATED_MOVING_ADDR: &str = r#"1 sort bitvec 1
+2 input 1 advance
+3 input 1 clk
+4 input 1 rst_n
+5 sort bitvec 16
+6 state 5
+7 output 6 q
+8 sort bitvec 8
+9 const 8 00000000
+10 state 8
+11 ite 8 4 10 9
+12 uext 8 11 0 a_q
+13 sort array 8 5
+14 state 13 mem
+15 read 5 14 11
+16 next 5 6 15
+17 const 1 1
+18 uext 8 17 7
+19 add 8 11 18
+20 ite 8 2 19 11
+21 ite 8 4 20 9
+22 next 8 10 21
+23 next 13 14 14 mem
+"#;
+
+    // The reset-bearing SATISFYING twin: `a_d <= a_q` alongside the read. This is
+    // the false-positive guard for the #506 fix — the tracking `next` is itself
+    // wrapped in a reset mux (`16 ite 5 4 14 6` → `17 next 5 7 16`), so a resolver
+    // applied only to the ADDRESS side would stop recognising this form and start
+    // firing on exactly the designs that already do the right thing. Worse than the
+    // original silence, hence a first-class regression.
+    const SLANG_RESET_GATED_TRACKED: &str = r#"1 sort bitvec 1
+2 input 1 advance
+3 input 1 clk
+4 input 1 rst_n
+5 sort bitvec 8
+6 const 5 00000000
+7 state 5
+8 ite 5 4 7 6
+9 output 8 a_d
+10 sort bitvec 16
+11 state 10
+12 output 11 q
+13 state 5
+14 ite 5 4 13 6
+15 uext 5 14 0 a_q
+16 ite 5 4 14 6
+17 next 5 7 16
+18 sort array 5 10
+19 state 18 mem
+20 read 10 19 14
+21 next 10 11 20
+22 const 1 1
+23 uext 5 22 7
+24 add 5 14 23
+25 ite 5 2 24 14
+26 ite 5 4 25 6
+27 next 5 13 26
+28 next 18 19 19 mem
+"#;
+
+    #[test]
+    fn flags_a_reset_gated_address_register_through_the_mux_alias() {
+        let f =
+            lint_registered_array_read_moving_address(SLANG_RESET_GATED_MOVING_ADDR).expect("lint");
+        assert_eq!(
+            f.len(),
+            1,
+            "a reset on the address register must not hide the fault (mununu#506): {f:?}"
+        );
+        assert_eq!(f[0].signal, "q");
+        assert!(
+            f[0].detail.contains("a_q"),
+            "the address register's NAME lives on the uext alias of the reset mux and \
+             must still be recovered: {}",
+            f[0].detail
+        );
+    }
+
+    #[test]
+    fn a_reset_gated_tracking_register_still_satisfies_the_rule() {
+        let f = lint_registered_array_read_moving_address(SLANG_RESET_GATED_TRACKED).expect("lint");
+        assert!(
+            f.is_empty(),
+            "the tracking register is recognised THROUGH its own reset mux; flagging this \
+             would be a false positive on correctly-written RTL — strictly worse than the \
+             under-firing the #506 fix removes. Got {f:?}"
+        );
+    }
+
+    #[test]
+    fn an_arithmetic_address_is_still_out_of_scope() {
+        // `mem[a_q + 1]` — the resolver walks identity-preserving wrappers only, so
+        // an address that is a genuine FUNCTION of a register stays out of scope, as
+        // the briefing's known-limits list states. Guards against the resolver
+        // quietly widening the rule.
+        let arith = SLANG_RESET_GATED_MOVING_ADDR.replace("15 read 5 14 11", "15 read 5 14 19");
+        let f = lint_registered_array_read_moving_address(&arith).expect("lint");
+        assert!(
+            f.is_empty(),
+            "an arithmetic address is documented as out of scope; got {f:?}"
+        );
+    }
 
     #[test]
     fn flags_registered_array_read_against_a_moving_address() {
@@ -946,6 +1143,70 @@ endmodule
             ok.iter()
                 .all(|f| f.rule != SvLintRule::RegisteredArrayReadMovingAddress),
             "registering the address alongside the data satisfies the rule; got {ok:?}"
+        );
+
+        // mununu#506 — the same pair, but with a RESET on the address register, which
+        // is what real RTL looks like. `async2sync` lifts the reset into a mux so the
+        // read indexes the mux rather than the bare state; requiring a bare state made
+        // the rule fire only on reset-less registers, i.e. almost never. Through the
+        // REAL lift, both directions must still be right.
+        const BAD_RST: &str = r#"module rom_bad_rst (
+  input  logic        clk, rst_n,
+  input  logic        advance,
+  output logic [15:0] q
+);
+  logic [15:0] mem [0:255];
+  logic [7:0]  a_q;
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) a_q <= 8'd0;
+    else if (advance) a_q <= a_q + 8'd1;
+  end
+  always_ff @(posedge clk) q <= mem[a_q];
+endmodule
+"#;
+        const OK_RST: &str = r#"module rom_ok_rst (
+  input  logic        clk, rst_n,
+  input  logic        advance,
+  output logic [15:0] q,
+  output logic [7:0]  a_d
+);
+  logic [15:0] mem [0:255];
+  logic [7:0]  a_q;
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin a_q <= 8'd0; a_d <= 8'd0; end
+    else begin
+      if (advance) a_q <= a_q + 8'd1;
+      a_d <= a_q;
+    end
+  end
+  always_ff @(posedge clk) q <= mem[a_q];
+endmodule
+"#;
+        let bad_rst =
+            sv_lint_registers(&lift_of(BAD_RST, "rom_bad_rst")).expect("lint lifts rom_bad_rst");
+        let hit_rst: Vec<_> = bad_rst
+            .iter()
+            .filter(|f| f.rule == SvLintRule::RegisteredArrayReadMovingAddress)
+            .collect();
+        assert_eq!(
+            hit_rst.len(),
+            1,
+            "a reset on the address register must not hide the fault; got {bad_rst:?}"
+        );
+        assert!(
+            hit_rst[0].detail.contains("a_q"),
+            "the address name must survive the reset-mux alias: {}",
+            hit_rst[0].detail
+        );
+
+        let ok_rst =
+            sv_lint_registers(&lift_of(OK_RST, "rom_ok_rst")).expect("lint lifts rom_ok_rst");
+        assert!(
+            ok_rst
+                .iter()
+                .all(|f| f.rule != SvLintRule::RegisteredArrayReadMovingAddress),
+            "the reset-gated TRACKING register still satisfies the rule — flagging it \
+             would be a false positive on correct RTL; got {ok_rst:?}"
         );
     }
 

--- a/docs/consumer-briefings/2026-09-lint-alias-resolution-and-refusal-honesty.md
+++ b/docs/consumer-briefings/2026-09-lint-alias-resolution-and-refusal-honesty.md
@@ -1,0 +1,108 @@
+# Consumer briefing — 2026-09 `sv lint` sees reset-bearing registers; the partial-write refusal stops guessing its cause
+
+> **Audience:** monono (reported both), ROSF, anyone running `mununu sv lint` or reading a `verify-auto` `Skipped` reason.
+>
+> **Related:** [mununu#506](https://github.com/vscorza/mununu/issues/506), [mununu#507](https://github.com/vscorza/mununu/issues/507). Follows #496 / #502.
+>
+> **TL;DR:** the #496 registered-read rule was **near-vacuous** — it fired only on registers with *no reset*, which is almost none. Fixed. And the partial-write refusal asserted a cause it could not see, pointing consumers at correct RTL; it now reports what it actually knows. **`sv lint` will report findings it previously missed.**
+
+## 1 — The registered-read rule was blind to almost all real RTL (#506)
+
+Reported as a **cross-module** blind spot. It is not: mununu's lift **flattens**, so the flattened netlist contains the whole pattern. The rule failed one step later.
+
+`async2sync` lifts an async reset into a mux, so what the read indexes is not the register:
+
+```
+10 state 8              <- the address register (unnamed)
+11 ite 8 4 10 9         <- rst_n ? state : 0     the RESET MUX
+12 uext 8 11 0 ld_q     <- the NAME lives here, on an alias of the mux
+17 read 5 16 11         <- the read indexes nid 11, NOT the state nid 10
+```
+
+The rule required a bare `state` and bailed. **The discriminating experiment** — the same single-module design that #496 catches, with a reset added and nothing else changed:
+
+| | findings |
+|---|---|
+| address register with **no** reset | 1 |
+| address register **with** a reset, one module, no boundary | **0** |
+
+So the blind spot was never the module boundary. **The rule fired only on reset-less registers.** That is why it was clean on all six of monono's memory blocks and on the loader.
+
+### What changed
+
+The address, the tracking register, and the reported name all resolve back through the identity-preserving wrappers (`uext` / `sext` / `slice` / a reset-shaped `ite`).
+
+**Both sides had to move together.** `a_d <= a_q` also lifts to `next(a_d) = ite(rst, <alias of a_q>, 0)`. Resolving only the address would have stopped the rule recognising the *satisfying* form and made it fire on exactly the designs that already do the right thing — strictly worse than the original silence. A reset-bearing satisfying twin is now a first-class regression, in the unit tests and through the real slang lift.
+
+Arithmetic is still not walked, so `mem[a_q + 1]` remains out of scope, as documented — with a regression pinning that too.
+
+**Because the lift flattens, the cross-module form is now covered** — array and destination register in a child, address register in the parent. That is the shape that motivated #496, and it now flags.
+
+### What to expect
+
+**`sv lint` will report findings it previously missed**, and on real RTL that is most of the fault class. Run it and expect hits:
+
+```bash
+mununu sv lint <rtl> --frontend slang
+```
+
+Each hit is either a real mis-pairing or a place where the correspondence is recorded in a way the check cannot see. The second case is a false positive worth reporting so it can be narrowed — the rule recognises exactly one satisfying form (a register whose `next` resolves to the address register).
+
+## 2 — The partial-write refusal asserted a cause it could not see (#507)
+
+The guard's actual condition is **"the property's atom has a cone reaching an unnamed free input."** The message hardcoded one cause:
+
+> *…while lifting a partial register assignment (`{reg}[hi:lo] <= …`)*
+
+An unnamed free input has several sources: a partial write, a **black-boxed submodule's freed outputs**, an undriven net, an unconnected port. On an integrator wiring ~25 submodules, black-boxing is far likelier. monono's RTL confirms the misattribution — `f_slot_q` is written whole in both branches, and `f_slot[6:0]` is a part-select of the *source*.
+
+**Now:** the message leads with the condition, and names the cause only when the lift shows it. The partial-write shape is detectable (the register's name aliases a `concat` mixing a free input) and is still reported as such. Otherwise the message says the cause is **not attributed**, lists the possibilities, and — when the run black-boxed anything — **names those modules**, which is the likely source and was already in the diagnostics.
+
+## 3 — The suggested remedy could not run (#507)
+
+The message recommended `--frontend verilog --preprocess-sv2v`. For a bound-SVA design that is not merely awkward — **sv2v 0.0.13 cannot parse `bind` at all**:
+
+```
+$ sv2v dut.sv dut_sva.sv
+dut_sva.sv:4:1: Parse error: unexpected token 'bind' (KW_bind)
+```
+
+(monono hoped sv2v could elaborate it away; it cannot, at this version.) And `bind` is not optional for them: `read_verilog -sv` cannot parse `assert property`, and `verify-auto` has no `--define`, so an `ifdef` guard would hide the assertions from the verifier too.
+
+**Now:** the sv2v remedy is offered only when the partial-write shape is actually present *and* the sources do not use `bind`. For a bound-SVA design the message says the remedy is unavailable and why, and points at the route that does work (write the register whole). An honest dead end beats a false lead.
+
+## What did NOT change
+
+- Verdicts. The #507 work is message-only; no property changes outcome.
+- The `undriven-partial-write` lint rule, its fixture, and the `sv lint` exit codes.
+- `signal`, `kind`, `rule`, `detail` field shapes; routes; CLI flags.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | new lint findings; corrected refusal text | **Yes** |
+| mununu `Dockerfile.dev` | binary bump | **Yes** |
+| mununu `Dockerfile.sva` | binary bump; the e2e regressions run here | **Yes** |
+| mununu `Dockerfile.extract`, `.extract-*` | no lint / verify-auto path | No |
+| rosf | reads refusal text if surfaced | **No** — rebuild when adopting |
+| monono Docker | reported both | **Yes** |
+| mununu-ui | no type change | No |
+
+## Verification
+
+```bash
+cargo test -p mununu-core --lib -- sv_verify partial_write_shape bound_sva_sources
+
+docker run --rm -v "$(pwd)":/work -v mununu-target:/ct -w /work -e CARGO_TARGET_DIR=/ct \
+  mununu-sva bash -c 'export PATH=$HOME/.cargo/bin:/opt/oss-cad-suite/bin:$PATH; \
+    cargo test -p mununu-core --lib e2e_sv_lint -- --ignored'
+```
+
+The e2e lifts the reset-bearing faulty design **and its satisfying twin** with real yosys-slang and asserts the first flags and the second does not.
+
+## Still open, and worth knowing
+
+- **`sv lint` skips every dotted (`u_inst.sig`) Op symbol.** That filter exists to suppress `<function>.<arg>` false positives (mununu#475), but on a flattened integrator *every* hierarchical alias is dotted. This is why `sv lint` reported 0 findings while `verify-auto` refused on the same file — they were not disagreeing; `sv lint` was not looking. **Not fixed here**; it needs the #475 fixture as a false-positive guard and its own change.
+- **Declaration-order divergence.** monono found `video_sdram.sv` / `video_out_core.sv` used 47 and 12 signals *above their declarations*; verilator accepts this, slang rejects it, and bound SVA forces the slang lift. Such a file is invisible to both `sv lint` and the formal lane, and a verilator-first lint lane cannot see the gap. Worth recording in the RTL-frontend docs as a known divergence.
+- [mununu#504](https://github.com/vscorza/mununu/issues/504) — the exact engine can stack-overflow rather than abstain on a large design.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -579,6 +579,21 @@ flagged: an address that is not a register (no moving register to mis-pair
 with), and a register held constant (`a_q <= a_q`, or no `next` at all — it can
 never disagree with `q`).
 
+**Aliases are resolved** (mununu#506). A register's identity rarely survives on
+its raw `state` line: `async2sync` lifts an async reset into a mux, so what the
+read actually indexes is `ite(rst_n, state, RESET)`, and the register's *name*
+lands on a `uext` alias of that mux. The rule resolves the address — and the
+tracking register, and the reported name — back through the identity-preserving
+wrappers (`uext` / `sext` / `slice` / a reset-shaped `ite`). Before that it
+required a bare `state`, which meant it fired **only on registers with no
+reset** — close to none in real RTL, and the reason it reported nothing on the
+design that motivated it. It does **not** walk arithmetic, so an address that is
+a genuine function of a register (`mem[a_q + 1]`) remains out of scope.
+
+Because the lift **flattens**, this also covers the cross-module form — the array
+and destination register in a child, the address register in the parent — which
+no per-module reading of the RTL would catch.
+
 ```jsonc
 // POST /api/v1/sv/lint  →
 { "signals_flagged": 1, "registers_flagged": 1,


### PR DESCRIPTION
Closes #506 and #507. In both, the **verified root cause differs from the reported one**, and in both the difference makes the defect **wider**.

## #506 — the registered-read rule was near-vacuous

Reported as a **cross-module** blind spot. It is not: the lift **flattens**, so the flattened netlist contains the whole pattern. The rule failed one step later.

```
10 state 8              ← the address register (unnamed)
11 ite 8 4 10 9         ← rst_n ? state : 0     the async2sync RESET MUX
12 uext 8 11 0 ld_q     ← the NAME lives on an alias of the mux
17 read 5 16 11         ← the read indexes nid 11, NOT the state nid 10
```

**The discriminating experiment** — the same single-module design #496 catches, with a reset added and nothing else changed:

| | findings |
|---|---|
| address register with **no** reset | 1 |
| address register **with** a reset, one module, no boundary | **0** |

So the blind spot was never the module boundary. **The rule fired only on reset-less registers** — almost never on real RTL, which is why it was clean on all six of monono's memory blocks and on the loader it was written for.

**Fix:** resolve the address, the tracking register, *and* the reported name back through identity-preserving wrappers (`uext` / `sext` / `slice` / reset-shaped `ite`). Same class as the 2026-07-05 `next_funcs` alias-keying fix.

**Both sides had to move together.** `a_d <= a_q` also lifts to `next(a_d) = ite(rst, <alias of a_q>, 0)` — resolving only the address would have stopped the rule recognising the *satisfying* form and made it fire on designs that already do the right thing, which is strictly worse than the original silence. The reset-bearing satisfying twin is a first-class regression, in unit tests and through the real lift.

Arithmetic is still not walked (`mem[a_q + 1]` out of scope, as documented), pinned by its own regression so the resolver cannot quietly widen.

**The cross-module form now flags too**, because the lift flattens — so the shape that motivated #496 is covered.

## #507 — the refusal asserted a cause it could not see

The guard's condition is *"the atom's cone reaches an unnamed free input"*; the message hardcoded **one** cause. An unnamed free input also comes from a black-boxed submodule, an undriven net, or an unconnected port — and on an integrator wiring ~25 submodules, black-boxing is far likelier. monono's RTL confirms it: `f_slot_q` is written whole in both branches, and `f_slot[6:0]` is a part-select of the *source*.

Now the message leads with the condition and names the cause only when the lift shows it (the partial-write `concat` shape is detectable and still reported as such). Otherwise it says the cause is **not attributed**, lists the possibilities, and **names the black-boxed modules** — data already in the diagnostics, and the one line that would have resolved this report immediately.

## #507 — the suggested remedy could not run

Verified: **sv2v 0.0.13 cannot parse `bind` at all** — `Parse error: unexpected token 'bind'`. So `--frontend verilog --preprocess-sv2v` is impossible for a bound-SVA design, not merely awkward. And `bind` is not optional there: `read_verilog -sv` cannot parse `assert property`, and there is no `--define` to guard an `ifdef`.

The remedy is now offered only when the partial-write shape is present **and** the sources do not use `bind`; otherwise the message says it is unavailable and points at the route that works. Message-only — no verdict changes.

## Validation

2518 lib tests, doctests, clippy, fmt. Both `e2e_sv_lint` tests pass through the real slang lift in `mununu-sva`, including the new reset-bearing faulty/satisfying pair.

## Left open, deliberately

- **`sv lint` skips every dotted (`u_inst.sig`) Op symbol** — the mununu#475 function-arg filter also suppresses every hierarchical alias on a flattened integrator. This is why `sv lint` reported 0 findings while `verify-auto` refused on the same file: they were not disagreeing, `sv lint` was not looking. Needs the #475 fixture as a false-positive guard and its own change.
- **slang/verilator declaration-order divergence** — a file verilator accepts and slang rejects is invisible to both `sv lint` and the formal lane, and a verilator-first lint lane cannot see the gap.

Briefing: `docs/consumer-briefings/2026-09-lint-alias-resolution-and-refusal-honesty.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)