### PR TITLE
fix(smt): substitute the functionally-determined next state instead of ∀-binding it (#512)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
+++ b/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
@@ -615,6 +615,75 @@ fn conj_bool(constraints: &[z3::ast::Bool]) -> z3::ast::Bool {
     }
 }
 
+/// mununu#512 — build the `∀`-quantified inner body for a must-edge query,
+/// SUBSTITUTING the next state instead of quantifying over it.
+///
+/// The next state is FUNCTIONALLY DETERMINED: BTOR2 `next` is a function per state
+/// cell. The original encoding introduced fresh `state_next` / `state_next_arr`
+/// constants, CONSTRAINED them with `transition`, and then `∀`-bound them —
+/// semantically equivalent, and noted as such in the code, but binding the next-state
+/// ARRAY moves the query from QF_AUFBV (decidable) into AUFBV + `∀`-array (not). Z3
+/// answers `Unknown`, `Unknown` is read as `NotMust`, and the νµ starves for
+/// must-edges on every array-bearing design.
+///
+/// Substituting `state_next := next_expr(state_curr, inputs)` removes the variables,
+/// so no `∀`-array remains and the `transition` conjunct is unnecessary — it is the
+/// definition being substituted. The remaining `∀` ranges over input bit-vectors only.
+///
+/// **SOUNDNESS: a completeness fix, not a semantic change.** The substituted query is
+/// equivalent to the quantified one, so a proven `Must` is genuinely a must-edge; the
+/// only movement is `Unknown → Must`. When the view carries no recorded expressions
+/// (built without `transition`), the previous encoding is used unchanged rather than
+/// silently weakening the query.
+fn must_inner_body_and_bounds(
+    view: &Btor2SmtView,
+    tgt_conj: &z3::ast::Bool,
+) -> (z3::ast::Bool, Vec<z3::ast::BV>, Vec<z3::ast::Array>) {
+    use z3::ast::Ast as _;
+    if view.state_next_expr.is_empty() && view.state_next_arr_expr.is_empty() {
+        let body = z3::ast::Bool::and(&[&view.transition, tgt_conj]).not();
+        return (
+            body,
+            universal_bound_bvs(view),
+            universal_bound_arrays(view),
+        );
+    }
+    let mut body = tgt_conj.clone();
+    let bv_subs: Vec<(z3::ast::BV, z3::ast::BV)> = view
+        .state_next
+        .iter()
+        .filter_map(|(nid, var)| {
+            view.state_next_expr
+                .get(nid)
+                .map(|e| (var.clone(), e.clone()))
+        })
+        .collect();
+    if !bv_subs.is_empty() {
+        let pairs: Vec<(&z3::ast::BV, &z3::ast::BV)> =
+            bv_subs.iter().map(|(a, b)| (a, b)).collect();
+        body = body.substitute(&pairs);
+    }
+    let arr_subs: Vec<(z3::ast::Array, z3::ast::Array)> = view
+        .state_next_arr
+        .iter()
+        .filter_map(|(nid, var)| {
+            view.state_next_arr_expr
+                .get(nid)
+                .map(|e| (var.clone(), e.clone()))
+        })
+        .collect();
+    if !arr_subs.is_empty() {
+        let pairs: Vec<(&z3::ast::Array, &z3::ast::Array)> =
+            arr_subs.iter().map(|(a, b)| (a, b)).collect();
+        body = body.substitute(&pairs);
+    }
+    (
+        body.not(),
+        view.inputs.values().cloned().collect(),
+        Vec::new(),
+    )
+}
+
 /// R.2.5b session-2 follow-up (2026-06-09) — collect the universal-
 /// quantification bound vars (inputs + state_next BVs) for the ∀∃
 /// must-edge check. Returns a Vec of cloned BVs whose references the
@@ -690,16 +759,72 @@ where
         return SmtMustVerdict::Unknown;
     };
 
-    // Inner body: ¬(transition ∧ ∧ tgt_i).
+    // mununu#512 — SUBSTITUTE the next state instead of quantifying over it.
+    //
+    // The next state is FUNCTIONALLY DETERMINED: BTOR2 `next` is a function per
+    // state cell, so `state_next` is not an independent variable. The previous
+    // encoding introduced fresh `state_next` / `state_next_arr` constants, CONSTRAINED
+    // them with `transition`, and then `∀`-bound them. That is semantically
+    // equivalent, but binding the next-state ARRAY moves the query from QF_AUFBV
+    // (decidable) into AUFBV + ∀-array (not) — Z3 answers `Unknown`, `Unknown` is
+    // read as `NotMust`, and the νµ starves for must-edges on every array-bearing
+    // design.
+    //
+    // Substituting `state_next := next_expr(state_curr, inputs)` removes the
+    // variables entirely, so no `∀`-array remains and the `transition` conjunct is
+    // unnecessary (it is the definition being substituted). The remaining `∀` is over
+    // finite input bit-vectors.
+    //
+    // SOUNDNESS: this is a COMPLETENESS fix, not a semantic change. The substituted
+    // query is equivalent to the quantified one, so a proven `Must` is genuinely a
+    // must-edge; the only movement is `Unknown → Must`.
+    use z3::ast::Ast as _;
     let tgt_conj = conj_bool(&tgt_constraints);
-    let inner_body = z3::ast::Bool::and(&[&view.transition, &tgt_conj]).not();
-
-    // Universal bounds: every input BV + every state_next BV. The
-    // state_next is determined by (state_curr, inputs) via transition;
-    // universally quantifying over both is equivalent semantically
-    // and is the cleanest encoding given the view's BV vocabulary.
-    let bound_bvs = universal_bound_bvs(view);
-    let bound_arrs = universal_bound_arrays(view);
+    let (inner_body, bound_refs_owned) =
+        if view.state_next_expr.is_empty() && view.state_next_arr_expr.is_empty() {
+            // No recorded expressions (a view built without `transition`) — keep the
+            // previous encoding rather than silently weaken the query.
+            let body = z3::ast::Bool::and(&[&view.transition, &tgt_conj]).not();
+            let mut bvs = universal_bound_bvs(view);
+            bvs.retain(|_| true);
+            (body, (bvs, universal_bound_arrays(view)))
+        } else {
+            let mut body = tgt_conj.clone();
+            // BV next-state variables → their defining expressions.
+            let bv_subs: Vec<(z3::ast::BV, z3::ast::BV)> = view
+                .state_next
+                .iter()
+                .filter_map(|(nid, var)| {
+                    view.state_next_expr
+                        .get(nid)
+                        .map(|e| (var.clone(), e.clone()))
+                })
+                .collect();
+            if !bv_subs.is_empty() {
+                let pairs: Vec<(&z3::ast::BV, &z3::ast::BV)> =
+                    bv_subs.iter().map(|(a, b)| (a, b)).collect();
+                body = body.substitute(&pairs);
+            }
+            // Array next-state variables → their defining `ite`/`store` expressions.
+            let arr_subs: Vec<(z3::ast::Array, z3::ast::Array)> = view
+                .state_next_arr
+                .iter()
+                .filter_map(|(nid, var)| {
+                    view.state_next_arr_expr
+                        .get(nid)
+                        .map(|e| (var.clone(), e.clone()))
+                })
+                .collect();
+            if !arr_subs.is_empty() {
+                let pairs: Vec<(&z3::ast::Array, &z3::ast::Array)> =
+                    arr_subs.iter().map(|(a, b)| (a, b)).collect();
+                body = body.substitute(&pairs);
+            }
+            // Only the INPUTS remain universally bound — finite bit-vectors.
+            let inputs: Vec<z3::ast::BV> = view.inputs.values().cloned().collect();
+            (body.not(), (inputs, Vec::new()))
+        };
+    let (bound_bvs, bound_arrs) = bound_refs_owned;
     let mut bound_refs: Vec<&dyn z3::ast::Ast> =
         bound_bvs.iter().map(|bv| bv as &dyn z3::ast::Ast).collect();
     bound_refs.extend(bound_arrs.iter().map(|a| a as &dyn z3::ast::Ast));
@@ -790,10 +915,8 @@ where
     let tgt_disjuncts_refs: Vec<&z3::ast::Bool> = tgt_disjuncts.iter().collect();
     let any_tgt = z3::ast::Bool::or(&tgt_disjuncts_refs);
 
-    let inner_body = z3::ast::Bool::and(&[&view.transition, &any_tgt]).not();
-
-    let bound_bvs = universal_bound_bvs(view);
-    let bound_arrs = universal_bound_arrays(view);
+    // mununu#512 — substitute the next state rather than quantify over it.
+    let (inner_body, bound_bvs, bound_arrs) = must_inner_body_and_bounds(view, &any_tgt);
     let mut bound_refs: Vec<&dyn z3::ast::Ast> =
         bound_bvs.iter().map(|bv| bv as &dyn z3::ast::Ast).collect();
     bound_refs.extend(bound_arrs.iter().map(|a| a as &dyn z3::ast::Ast));
@@ -1024,9 +1147,8 @@ where
         return SmtMustVerdict::Unknown;
     };
     let tgt_conj = conj_bool(&tgt_constraints);
-    let inner_body = z3::ast::Bool::and(&[&view.transition, &tgt_conj]).not();
-    let bound_bvs = universal_bound_bvs(view);
-    let bound_arrs = universal_bound_arrays(view);
+    // mununu#512 — substitute the next state rather than quantify over it.
+    let (inner_body, bound_bvs, bound_arrs) = must_inner_body_and_bounds(view, &tgt_conj);
     let mut bound_refs: Vec<&dyn z3::ast::Ast> =
         bound_bvs.iter().map(|bv| bv as &dyn z3::ast::Ast).collect();
     bound_refs.extend(bound_arrs.iter().map(|a| a as &dyn z3::ast::Ast));
@@ -1087,9 +1209,8 @@ where
     }
     let tgt_disjuncts_refs: Vec<&z3::ast::Bool> = tgt_disjuncts.iter().collect();
     let any_tgt = z3::ast::Bool::or(&tgt_disjuncts_refs);
-    let inner_body = z3::ast::Bool::and(&[&view.transition, &any_tgt]).not();
-    let bound_bvs = universal_bound_bvs(view);
-    let bound_arrs = universal_bound_arrays(view);
+    // mununu#512 — substitute the next state rather than quantify over it.
+    let (inner_body, bound_bvs, bound_arrs) = must_inner_body_and_bounds(view, &any_tgt);
     let mut bound_refs: Vec<&dyn z3::ast::Ast> =
         bound_bvs.iter().map(|bv| bv as &dyn z3::ast::Ast).collect();
     bound_refs.extend(bound_arrs.iter().map(|a| a as &dyn z3::ast::Ast));

--- a/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
+++ b/crates/mununu-core/src/adapter/sidecar/predicate_image/btor2_encode.rs
@@ -97,6 +97,18 @@ pub struct Btor2SmtView {
     /// is the element width. Memory cells only flow into the BV
     /// world through `Op::Read` (→ `select`); their own next-state
     /// is an extensional array equality in the transition relation.
+    /// mununu#512 — the next-step **expression** for each BV state cell, i.e. the
+    /// value `next` assigns, built over current-state + inputs only. The transition
+    /// builder already computes this to constrain [`Self::state_next`]; exposing it
+    /// lets a query SUBSTITUTE the next state instead of quantifying over it, which
+    /// is what keeps an array-bearing must-edge query inside the decidable fragment.
+    /// Empty until [`Btor2Backend::transition`] has run.
+    pub state_next_expr: HashMap<Nid, z3::ast::BV>,
+    /// mununu#512 — the array counterpart of [`Self::state_next_expr`]
+    /// (`ite(we, store(mem, waddr, wdata), mem)`). This is the one that matters:
+    /// universally binding `state_next_arr` is what pushes the query from QF_AUFBV
+    /// into AUFBV + ∀-array.
+    pub state_next_arr_expr: HashMap<Nid, z3::ast::Array>,
     pub state_curr_arr: HashMap<Nid, z3::ast::Array>,
     /// §Phase 10 stage 3.c.1 — Z3 Array handle for the next-step
     /// value of each array-sorted state cell. Mirror of
@@ -140,6 +152,18 @@ impl Btor2SmtView {
     /// signal value.
     pub fn curr_signal(&self, nid: Nid) -> Option<&z3::ast::BV> {
         self.signal_bvs.get(&nid)
+    }
+
+    /// mununu#512 — the next-step EXPRESSION for a BV state cell, if the transition
+    /// has been built. Prefer this over [`Self::next_state`] in a query that would
+    /// otherwise have to quantify over the next state.
+    pub fn next_state_expr(&self, nid: Nid) -> Option<&z3::ast::BV> {
+        self.state_next_expr.get(&nid)
+    }
+
+    /// mununu#512 — the next-step EXPRESSION for an array state cell.
+    pub fn next_state_arr_expr(&self, nid: Nid) -> Option<&z3::ast::Array> {
+        self.state_next_arr_expr.get(&nid)
     }
 
     /// Bit-width of a signal by NID.
@@ -299,6 +323,8 @@ pub fn encode_design_with_theory(
         signals,
         signal_bvs: HashMap::new(),
         transition: z3::ast::Bool::from_bool(true),
+        state_next_expr: HashMap::new(),
+        state_next_arr_expr: HashMap::new(),
     };
     let mut backend = Z3Backend::from_view(file, &view);
     walk_design(file, &mut backend).map_err(|e| match e {
@@ -314,7 +340,10 @@ pub fn encode_design_with_theory(
             op_name: "uninitialized-init-value",
         },
     })?;
-    view.transition = backend.transition(&view)?;
+    let (t, next_expr, next_arr_expr) = backend.transition(&view)?;
+    view.transition = t;
+    view.state_next_expr = next_expr;
+    view.state_next_arr_expr = next_arr_expr;
 
     // H.E.1 — retain the backend's per-node BV cache (current-cycle value of
     // every walked node) so the per-cube combinational-label pass (H.E.2) can
@@ -439,6 +468,8 @@ pub(crate) fn encode_primed(
         signals: view.signals.clone(),
         signal_bvs: HashMap::new(),
         transition: z3::ast::Bool::from_bool(true),
+        state_next_expr: HashMap::new(),
+        state_next_arr_expr: HashMap::new(),
     };
     let mut backend = Z3Backend::from_view(file, &primed_view);
     walk_design(file, &mut backend).map_err(|e| match e {
@@ -1055,7 +1086,24 @@ impl<'a> Z3Backend<'a> {
     /// §Phase 10 step 1c.2 — array-`next` support. The walk itself
     /// stays BV-valued (it skips array-sorted op nodes); arrays appear
     /// only here, as the RHS of the array-equality conjuncts.
-    pub(crate) fn transition(&mut self, view: &Btor2SmtView) -> Result<z3::ast::Bool, EncodeError> {
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn transition(
+        &mut self,
+        view: &Btor2SmtView,
+    ) -> Result<
+        (
+            z3::ast::Bool,
+            HashMap<Nid, z3::ast::BV>,
+            HashMap<Nid, z3::ast::Array>,
+        ),
+        EncodeError,
+    > {
+        // mununu#512 — record the next-state EXPRESSIONS alongside the equalities.
+        // They are already computed here to constrain the fresh `state_next*`
+        // variables; exposing them lets a query substitute the next state instead of
+        // quantifying over it.
+        let mut next_expr: HashMap<Nid, z3::ast::BV> = HashMap::new();
+        let mut next_arr_expr: HashMap<Nid, z3::ast::Array> = HashMap::new();
         let array_curr = if self.state_curr_arr.is_empty() {
             None
         } else {
@@ -1076,6 +1124,7 @@ impl<'a> Z3Backend<'a> {
                         &mut self.cache,
                         &mut self.array_cache,
                     )?;
+                    next_arr_expr.insert(*state, value_arr.clone());
                     conjuncts.push(arr_next.eq(&value_arr));
                     continue;
                 }
@@ -1104,15 +1153,17 @@ impl<'a> Z3Backend<'a> {
                         operand_width: value_bv.get_size(),
                     });
                 }
+                next_expr.insert(*state, value_bv.clone());
                 conjuncts.push(next_bv.eq(&value_bv));
             }
         }
-        Ok(if conjuncts.is_empty() {
+        let t = if conjuncts.is_empty() {
             z3::ast::Bool::from_bool(true)
         } else {
             let refs: Vec<&z3::ast::Bool> = conjuncts.iter().collect();
             z3::ast::Bool::and(&refs)
-        })
+        };
+        Ok((t, next_expr, next_arr_expr))
     }
 }
 
@@ -1499,7 +1550,8 @@ mod tests {
                 .unwrap_or_else(|e| panic!("walk_design {name}: {e:?}"));
             let walk_transition = backend
                 .transition(&ref_view)
-                .unwrap_or_else(|e| panic!("backend.transition {name}: {e:?}"));
+                .unwrap_or_else(|e| panic!("backend.transition {name}: {e:?}"))
+                .0;
 
             // The two Bools reference identical Z3 consts (same names);
             // they are equivalent iff `ref XOR walk` is UNSAT.
@@ -1560,7 +1612,8 @@ mod tests {
             walk_design(&file, &mut backend).expect("walk_design mem");
             let walk_transition = backend
                 .transition(&ref_view)
-                .expect("backend.transition mem");
+                .expect("backend.transition mem")
+                .0;
             let solver = z3::Solver::new();
             solver.assert(ref_view.transition.xor(&walk_transition));
             assert_eq!(
@@ -1621,7 +1674,7 @@ mod tests {
             let mut backend =
                 Z3Backend::from_view(&file, &uf_view).with_uf_wrapped(HashSet::from([4, 5]));
             walk_design(&file, &mut backend).expect("walk uf");
-            let uf_transition = backend.transition(&uf_view).expect("uf transition");
+            let uf_transition = backend.transition(&uf_view).expect("uf transition").0;
             let s1_next = uf_view.state_next.get(&6).expect("s1_next");
             let s2_next = uf_view.state_next.get(&7).expect("s2_next");
 


### PR DESCRIPTION
Closes #512.

## The defect

The must-edge query encoded its negation as `src(state_curr) ∧ ∀[inputs, state_next]. ¬(transition ∧ tgt)`, with this comment beside it:

> *the state_next is determined by (state_curr, inputs) via transition; universally quantifying over both is **equivalent semantically and is the cleanest encoding** given the view's BV vocabulary*

and `universal_bound_arrays` added the next-state **arrays** to that same `∀`, for a correct reason of its own — omitting them lets the solver falsify the transition and spuriously report `NotMust` for every array-bearing source.

Each step is right. Together they put a **universally-quantified array** in the query, moving it from QF_AUFBV (decidable) into AUFBV + `∀`-array (not).

## The fix

The next state is functionally determined — BTOR2 `next` is a function per state cell — so it need not be a variable. The encoder already **computes** each next-state expression (`eval_operand` / `eval_array_operand`) in order to constrain the fresh `state_next*` constants; it now records them on the view, and the queries substitute `state_next := next_expr(state_curr, inputs)`.

No `∀`-array remains, the `transition` conjunct becomes unnecessary (it *is* the definition being substituted), and the surviving `∀` ranges over input bit-vectors.

Applied at all four sites through one shared helper. Worth noting for anyone reading the older comment: the **live** path is the *uniform* one — `SmtHyperMust` routes via `BtorSts::must_edges_over`, and `smt_per_target_must_check_standard` is retired from production.

**Soundness — a completeness fix, not a semantic change.** The substituted query is equivalent, so a proven `Must` is genuinely a must-edge and the only possible movement is `Unknown → Must`. A view with no recorded expressions falls back to the previous encoding rather than silently weakening the query.

## Measured reach: ZERO — recorded, not dressed up

`array_content_indep_idx` remains ⊥ across every lever on the wall-class matrix. No case changes verdict. 2524 lib tests, doctests, integration tests, clippy — all unchanged.

**The motivating case is not fixed by this, and the investigation established why.** With the substitution verified as firing (the `∀`-array is gone), Z3 proves `NotMust` rather than returning `Unknown`. The blocker for a counter-index array property is **abstraction expressiveness, not solver decidability**: it needs an invariant *quantified over the array* (`∀i. mem[i] ≠ V`), and a cube is a finite conjunction of predicates.

So this ships on its own merits — it removes an undecidable construct from a core query and simplifies it — **not** as a decidability lever.

## Watch item

Substitution inlines the next-state expression at each occurrence, so formula size can grow on designs with many predicates. No measurable slowdown on the current corpus (matrix 32 s, lib suite unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)