### PR TITLE
test(e2e): isolate the sweep per-process; drop a stale bit-cap assertion (mununu#504)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,15 @@ docker run --rm -v "$(pwd)":/work -v mununu-target:/cargo-target \
   mununu-sva cargo test -p mununu-core --lib --all-features e2e_ -- --ignored --nocapture
 ```
 
+**For the WHOLE sweep, use `make e2e`** (`scripts/e2e-sweep.sh`), which runs one test per
+process. A test that ABORTS rather than fails — a stack overflow, or a panic while unwinding
+an exhausted BDD arena — does not unwind, so in a single shared libtest process it kills the
+run: no summary line, no failure list, and every later test silently skipped. That is how the
+ignored set drifted to 19 unnoticed failures ([mununu#503](https://github.com/vscorza/mununu/issues/503),
+found while triaging [mununu#504](https://github.com/vscorza/mununu/issues/504)). Isolated, an
+abort becomes one `CRASH` row and the sweep still completes. The single-test command above stays
+the right tool for reproducing ONE test.
+
 **Host caveat.** slang ships prebuilts only for `linux-x86_64` and `macos-arm64`. On an Intel (x86_64) macOS host there is no native slang binary, and the workspace's `z3-sys` link also differs from the dev image — so the Linux `mununu-sva` image (which runs natively on x86_64 hosts) is the supported way to run these tests there. The `e2e_csrng_real_sva_verdict_breakdown` test reads only vendored fixtures (`examples/verify/m2_opentitan_csrng_main_sm` + the standard prim_assert macros from `examples/verify/m0_opentitan_prim_arbiter`), so it is fully reproducible.
 
 **[RULE] Validate any slang / SVA-touching change in the `mununu-sva` image — never on the bare host (added 2026-07-13).** The dev host commonly has `sv2v` + `yosys` but **not** `slang`. That combination is a trap, not a convenience:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BASELINE   ?= main
 PROPTEST_CASES ?= 64
 
 .PHONY: build test lint verify ci clean help \
-        test-fast e2e test-properties stress fuzz proptest-deep \
+        test-fast e2e e2e-oneshot test-properties stress fuzz proptest-deep \
         coverage mem-profile sweep \
         bench-baseline bench-compare bench-record \
         experiment replay publish-prep
@@ -27,7 +27,8 @@ help:
 	@echo "  build          - cargo build --release for mununu-cli and mununu-extract"
 	@echo "  test           - cargo test --workspace"
 	@echo "  test-fast      - cargo test --lib + integration tests, sub-minute (pre-commit gate)"
-	@echo "  e2e            - SVA-verification e2e suite (#[ignore]d; run inside the mununu-sva image)"
+	@echo "  e2e            - SVA-verification e2e suite, one test per process (#[ignore]d; run inside the mununu-sva image)"
+	@echo "  e2e-oneshot    - same suite in a single libtest process (an aborting test loses the run)"
 	@echo "  lint           - cargo fmt --check && cargo clippy -D warnings"
 	@echo "  verify         - cargo run mununu against $(VERIFY_FILE)"
 	@echo "  ci             - lint + test (the gate)"
@@ -115,7 +116,18 @@ test-fast:
 # corpus monotone-verdict ledger + census, the cegar↔symbolic↔exact parity
 # gate, the portfolio e2e, the Verilator counterexample-replay gate) plus the
 # adapter's `e2e_`-prefixed lib tests (verify-auto / extract-sva on real RTL).
+# mununu#504 — this runs ONE TEST PER PROCESS via scripts/e2e-sweep.sh. A test
+# that ABORTS (stack overflow, or a panic while unwinding an exhausted BDD
+# arena) does not unwind, so in a single shared libtest process it kills the
+# run: no summary, no failure list, and every later test silently skipped.
+# That is how the set drifted to 19 unnoticed failures (mununu#503). Isolated,
+# an abort becomes one CRASH row and the sweep still completes.
+#
+# `make e2e-oneshot` keeps the old single-process form for a quick local run.
 e2e:
+	./scripts/e2e-sweep.sh
+
+e2e-oneshot:
 	$(CARGO) test -p mununu-core --lib --all-features e2e_ -- --ignored --nocapture
 	$(CARGO) test -p mununu-core --test differential_oracle_e2e --all-features -- --ignored --nocapture
 

--- a/crates/mununu-core/src/adapter/btor2/dep_graph.rs
+++ b/crates/mununu-core/src/adapter/btor2/dep_graph.rs
@@ -68,6 +68,21 @@ impl DepGraphBuilder for Btor2File {
 /// Walk from `nid` through the operand DAG, collecting the symbols of
 /// every `State` and `Input` terminal reached. `visited` guards against
 /// cycles (BTOR2 is acyclic by definition but defensive coding is cheap).
+///
+/// # Recursion depth (measured 2026-09-07, mununu#504)
+///
+/// This recurses once per operand-DAG LEVEL, so its depth is bounded by the
+/// design's expression depth rather than by anything mununu chooses — which
+/// made it a suspect when the exact engine was reported aborting on a stack
+/// overflow. It is not: measured over every `.btor2` / `.btor` in the repo,
+/// the deepest operand DAG is **239** levels (`ponylink-slaveTXlen-sat`, 3950
+/// nodes); every RTL lift is under 50. At ~100-150 bytes per frame that is
+/// ~35 KB against a 2 MiB default thread stack — roughly 60x headroom.
+///
+/// BTOR2 stays word-level through `write_btor`, so depth tracks RTL expression
+/// nesting, not bit width: a 32-bit add is one level, not 32. Rewriting this
+/// iteratively would therefore buy nothing measurable today. Revisit if a
+/// frontend ever emits gate-level BTOR2, where the depth argument changes.
 fn collect_operand_terminals(
     file: &Btor2File,
     nid: Nid,

--- a/crates/mununu-core/src/adapter/reach_portfolio.rs
+++ b/crates/mununu-core/src/adapter/reach_portfolio.rs
@@ -447,7 +447,12 @@ pub fn decide_reach_portfolio_parallel_with_timeout(
 /// [`native_bmc::DEFAULT_MAX_K`] so a *deep* violation is caught, while the wall
 /// deadline + per-query timeout keep the (eagerly-built) unrolling bounded.
 const OWNED_DEEP_CEX_MAX_K: u32 = 128;
-/// Per-z3-check timeout inside the owned deep CEX search.
+/// Per-z3-check timeout inside the owned deep CEX search. Gated to match its only
+/// use site: with the `boolector` feature on, the deep-CEX direction runs through
+/// the native Boolector BMC instead, so an ungated const is dead code and fails the
+/// documented pre-push check (`clippy --workspace --all-features -D warnings`).
+/// `make ci` does not pass `--all-features`, which is why CI stayed green.
+#[cfg(not(feature = "boolector"))]
 const OWNED_CEX_QUERY_MS: u32 = 15_000;
 
 /// The **owned-standalone** driver: decide `bad`-reachability with ONLY the

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -8421,30 +8421,76 @@ endmodule
 
         eprintln!("\n=== R-F5.5d sysrst: explicit vs symbolic ===");
         eprintln!("explicit engine: {dt_x:?}   symbolic engine: {dt_s:?}");
-        // The full sysrst design exceeds the symbolic bit-blast cap (no COI yet;
-        // R-F5.6), so every property degrades to Skipped with the bit-cap reason
-        // — GRACEFULLY, not a mid-construction OoM panic. That the run completes
-        // (no panic) + reaches this assertion is the wiring + graceful-degradation
-        // validation on real RTL.
-        let mut sym_skipped_bitcap = 0;
+        // What this test is FOR: on a real design the symbolic engine either DECIDES or
+        // ABSTAINS HONESTLY — never a mid-construction OoM panic, and never a process abort
+        // (mununu#504). So the assertion is over the engine's ABSTENTION CONTRACT, not over
+        // which budget happens to fire.
+        //
+        // It used to require a Skip carrying the BIT-CAP reason. That pinned one mechanism,
+        // and the R-F5.6 COI restriction then made it unreachable: every cone now fits under
+        // the cap, so sysrst abstains on the NODE budget (and on two unsupported combinational
+        // predicates) instead. The test failed while the engine was behaving BETTER than when
+        // it was written — a stale assertion, not a regression. Measured 2026-09-07:
+        // bit-cap Skips = 0; every abstention named the NODE budget or a declared feature gap.
+        //
+        // Assert the NEGATIVE (no opaque/internal failure) and TALLY the positive. A whitelist
+        // of accepted reason strings would drift exactly the way the bit-cap assertion did, so
+        // the budgets below are counted for the diagnostic, never required.
+        let looks_like_a_defect = |reason: &str| {
+            let r = reason.to_ascii_lowercase();
+            [
+                "panic",
+                "internal error",
+                "unwrap",
+                "index out of bounds",
+                "overflowed its stack",
+            ]
+            .iter()
+            .any(|m| r.contains(m))
+        };
+        let mut sym_abstained = 0;
+        let mut named_budget = 0;
         for (px, ps) in explicit.properties.iter().zip(symbolic.properties.iter()) {
             assert_eq!(px.name, ps.name, "property order aligns across engines");
             eprintln!(
                 "  {}: explicit={:?}  symbolic={:?}",
                 px.name, px.outcome, ps.outcome
             );
-            if let VerifyOutcome::Skipped { reason } = &ps.outcome
-                && reason.contains("register+input bits")
-            {
-                sym_skipped_bitcap += 1;
+            if let VerifyOutcome::Skipped { reason } = &ps.outcome {
+                assert!(
+                    !reason.trim().is_empty(),
+                    "{}: an abstention must explain itself — an empty reason gives a consumer \
+                     nothing to act on",
+                    ps.name
+                );
+                assert!(
+                    !looks_like_a_defect(reason),
+                    "{}: the symbolic engine abstained by FAILING, not by deciding it could not \
+                     decide. An abstention is a supported outcome; a panic surfaced as a reason \
+                     string is a defect: {reason}",
+                    ps.name
+                );
+                sym_abstained += 1;
+                if [
+                    "register+input bits",
+                    "NODE budget",
+                    "ITERATION budget",
+                    "WALL-CLOCK budget",
+                ]
+                .iter()
+                .any(|m| reason.contains(m))
+                {
+                    named_budget += 1;
+                }
             }
         }
-        eprintln!("symbolic bit-cap Skips: {sym_skipped_bitcap}");
+        eprintln!("symbolic abstentions: {sym_abstained} (of which {named_budget} name a budget)");
         assert!(
-            sym_skipped_bitcap >= 1,
-            "the full sysrst design exceeds the symbolic bit-blast cap → every property \
-             degrades to a Skipped (bit-cap) verdict GRACEFULLY (no OoM panic); the R-F5.6 \
-             COI restriction is what lets the symbolic engine scale to real designs"
+            sym_abstained >= 1,
+            "sysrst is the graceful-degradation case: its 32-bit detect timer does not compress \
+             to a tractable BDD, so at least one property must ABSTAIN rather than panic or \
+             abort. Zero abstentions means this design no longer exercises the degradation path \
+             — pick a harder one rather than deleting the assertion"
         );
     }
 

--- a/scripts/e2e-sweep.sh
+++ b/scripts/e2e-sweep.sh
@@ -30,13 +30,20 @@ CARGO="${CARGO:-cargo}"
 FILTER="${FILTER:-e2e_}"
 
 echo "== building e2e test binaries =="
-lib_bin=$($CARGO test -p mununu-core --lib --all-features --no-run --message-format=json 2>/dev/null \
-  | grep -o '"executable":"[^"]*mununu_core[^"]*"' | tail -1 | cut -d'"' -f4)
-oracle_bin=$($CARGO test -p mununu-core --test differential_oracle_e2e --all-features --no-run --message-format=json 2>/dev/null \
-  | grep -o '"executable":"[^"]*differential_oracle_e2e[^"]*"' | tail -1 | cut -d'"' -f4)
+# `--message-format=json` puts artifact records on stdout and compiler
+# diagnostics on stderr. Keep stderr on the terminal: swallowing it turns a
+# build failure into a silent "could not locate the binary", which is exactly
+# the kind of opaque failure this script exists to prevent.
+build_bin() { # $1 = cargo target args (word-split intentionally), $2 = binary-name match
+  # shellcheck disable=SC2086
+  $CARGO test $1 --all-features --no-run --message-format=json \
+    | grep -o "\"executable\":\"[^\"]*$2[^\"]*\"" | tail -1 | cut -d'"' -f4
+}
+lib_bin=$(build_bin "-p mununu-core --lib" "mununu_core")
+oracle_bin=$(build_bin "-p mununu-core --test differential_oracle_e2e" "differential_oracle_e2e")
 
 if [ -z "${lib_bin:-}" ]; then
-  echo "FATAL: could not locate the mununu-core lib test binary — build failed?" >&2
+  echo "FATAL: could not locate the mununu-core lib test binary — see the build output above." >&2
   exit 2
 fi
 

--- a/scripts/e2e-sweep.sh
+++ b/scripts/e2e-sweep.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# mununu#504 (point 2) — run the `#[ignore]`d e2e suite ONE TEST PER PROCESS.
+#
+# WHY THIS EXISTS
+#
+# `make e2e` runs the whole suite inside a single libtest process. A test that
+# ABORTS rather than fails takes that process with it: a stack overflow calls
+# `rtabort!` and a panic while unwinding an exhausted BDD arena calls `abort()`
+# — neither unwinds, so neither is a catchable test failure. When that happens
+# libtest prints NO summary line and NO failure list, the run reads like a build
+# error, and every test scheduled after the aborting one silently never runs.
+#
+# That is not hypothetical: it is how the ignored set drifted to 19 unnoticed
+# failures (mununu#503), found while triaging mununu#504.
+#
+# Running each test in its own process turns an abort into ONE reported CRASH
+# row and lets the rest of the suite finish, so the sweep always produces a
+# complete picture of what passed, what failed, and what died.
+#
+# USAGE (inside the pinned image — see CLAUDE.md §"SVA-verification e2e validation")
+#
+#   docker run --rm -v "$(pwd)":/work -v mununu-target:/ct -w /work \
+#     -e CARGO_TARGET_DIR=/ct mununu-sva bash -c \
+#     'export PATH=$HOME/.cargo/bin:/opt/oss-cad-suite/bin:$PATH; ./scripts/e2e-sweep.sh'
+#
+#   FILTER=e2e_sysrst ./scripts/e2e-sweep.sh   # restrict to matching test names
+set -uo pipefail
+
+CARGO="${CARGO:-cargo}"
+FILTER="${FILTER:-e2e_}"
+
+echo "== building e2e test binaries =="
+lib_bin=$($CARGO test -p mununu-core --lib --all-features --no-run --message-format=json 2>/dev/null \
+  | grep -o '"executable":"[^"]*mununu_core[^"]*"' | tail -1 | cut -d'"' -f4)
+oracle_bin=$($CARGO test -p mununu-core --test differential_oracle_e2e --all-features --no-run --message-format=json 2>/dev/null \
+  | grep -o '"executable":"[^"]*differential_oracle_e2e[^"]*"' | tail -1 | cut -d'"' -f4)
+
+if [ -z "${lib_bin:-}" ]; then
+  echo "FATAL: could not locate the mununu-core lib test binary — build failed?" >&2
+  exit 2
+fi
+
+pass=0; fail=0; crash=0
+declare -a failed_names=() crashed_names=()
+
+run_binary() {
+  local bin="$1" label="$2"
+  [ -n "$bin" ] && [ -x "$bin" ] || { echo "(skipping $label — not built)"; return; }
+  echo
+  echo "== $label: $bin =="
+  # `--list` with `--ignored` enumerates exactly the ignored tests.
+  local names
+  names=$("$bin" --ignored --list --format terse 2>/dev/null | sed 's/: test$//' | grep -- "$FILTER" || true)
+  [ -n "$names" ] || { echo "(no tests matching '$FILTER')"; return; }
+
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    local t0 rc dt
+    t0=$(date +%s)
+    "$bin" --ignored --exact "$name" --nocapture > "/tmp/e2e-$$.log" 2>&1
+    rc=$?
+    dt=$(( $(date +%s) - t0 ))
+    case $rc in
+      0)   printf '  %-6s %4ds  %s\n' "PASS" "$dt" "$name"; pass=$((pass+1)) ;;
+      101) printf '  %-6s %4ds  %s\n' "FAIL" "$dt" "$name"; fail=$((fail+1)); failed_names+=("$name")
+           sed -n '/panicked at/,+3p' "/tmp/e2e-$$.log" | head -6 | sed 's/^/          /' ;;
+      *)   # 134 = SIGABRT (stack overflow / abort-on-unwind), 139 = SIGSEGV, ...
+           # Name the cause when the log says it — a stack overflow and an
+           # abort-while-unwinding both surface as SIGABRT but need different
+           # fixes, and telling them apart is the whole point of mununu#504.
+           local cause=""
+           grep -q "has overflowed its stack" "/tmp/e2e-$$.log" && cause=" — STACK OVERFLOW"
+           grep -q "memory allocation of" "/tmp/e2e-$$.log" && cause=" — allocator OOM"
+           printf '  %-6s %4ds  %s  (exit %d%s)%s\n' "CRASH" "$dt" "$name" "$rc" \
+             "$([ $rc -gt 128 ] && echo ", signal $((rc-128))")" "$cause"
+           crash=$((crash+1)); crashed_names+=("$name")
+           tail -8 "/tmp/e2e-$$.log" | sed 's/^/          /' ;;
+    esac
+    rm -f "/tmp/e2e-$$.log"
+  done <<< "$names"
+}
+
+run_binary "$lib_bin" "mununu-core lib e2e"
+run_binary "${oracle_bin:-}" "differential_oracle_e2e"
+
+echo
+echo "=========================================================="
+printf 'e2e sweep: %d passed, %d failed, %d CRASHED\n' "$pass" "$fail" "$crash"
+[ ${#failed_names[@]}  -gt 0 ] && printf '  failed:  %s\n' "${failed_names[@]}"
+[ ${#crashed_names[@]} -gt 0 ] && printf '  CRASHED: %s\n' "${crashed_names[@]}"
+echo "=========================================================="
+# A crash is worse than a failure: it means a test killed its process rather
+# than reporting a verdict. Surface both, but never swallow either.
+[ $((fail + crash)) -eq 0 ]


### PR DESCRIPTION
Closes mununu#504's **point 2**; re-scopes point 1 with a measurement record.

## The abort does not reproduce, and I did not ship a speculative fix for it

`e2e_sysrst_symbolic_engine_runs_on_real_rtl`, in `mununu-sva`, five full runs:

| `RUST_MIN_STACK` | result |
|---|---|
| 256 KiB | no overflow — ran the whole design |
| 512 KiB | no overflow |
| 1 MiB | no overflow |
| 2 MiB (libtest default) | no overflow |
| 64 MiB | no overflow |

**The engine survived a stack 8x smaller than the default.** That refutes the hypothesis I
started with — "the recursion is bounded, the caller's stack just isn't big enough, so
provision one" — and makes a stack-provisioning fix a **zero-measured-reach** change. Not
shipped.

Both engine-side suspects are eliminated by measurement:

- **OxiDD is level-bounded.** `apply_bin` / `apply_quant` descend one BDD *level* per frame
  (`oxidd-rules-bdd-0.11.0/src/simple/apply_rec.rs:75,621`), so depth is bounded by the
  variable count — exactly the bit cap (<= 192 default). sysrst's cone is ~85-90 bits, the
  manager is built with `threads = 1`, and 256 KiB sufficed.
- **The one genuinely unbounded recursion has ~60x headroom.**
  `dep_graph::collect_operand_terminals` walks the operand DAG with no depth bound and IS on
  the exact path, so I measured max DAG depth across every `.btor2`/`.btor` in the repo:

  ```
    depth=  239  nodes= 3950  ponylink-slaveTXlen-sat.btor2
    depth=   46  nodes=  241  csrng_main_sm.btor
    ... every other RTL lift < 50
  ```

  ~35 KB against a 2 MiB stack. The structural reason it stays shallow: BTOR2 remains
  **word-level** through `write_btor`, so a 32-bit add is one level, not 32. Recorded on the
  function together with the condition that would change the answer (a gate-level frontend).

A **hypothesis, offered as one**: #502 (no-`next` state is now an input) and #505 (no-`init`
state is now free) both landed after #504 was filed and both change the BDD shape on this
path. No trace ties either to the overflow.

## What this actually fixes

**1. The test's assertion was stale and failing.** It required >= 1 property to Skip with the
*bit-cap* reason. The R-F5.6 COI restriction made that unreachable — every cone now fits under
the cap, so sysrst abstains on the **NODE budget** instead. *The test was failing while the
engine behaved better than when the test was written.*

It now asserts the abstention **contract** as a **negative** — no empty reason, no `panic` /
`internal error` / `unwrap` / `overflowed its stack` in a reason — and merely **tallies** which
budget fired. My first draft was a whitelist of accepted reason strings; that would have
drifted into the same failure a few refactors later, so I inverted it. Verified **PASS** on the
real slang lift in `mununu-sva` (345s).

**2. An aborting test no longer destroys the run** (#504 point 2). `scripts/e2e-sweep.sh` runs
the ignored suite **one test per process**, classifying PASS / FAIL / **CRASH**, decoding
`exit 134` as SIGABRT and naming a stack overflow vs an allocator OOM when the log says so. An
abort becomes one row instead of eating the summary — which is how the set drifted to 19
unnoticed failures (#503). `make e2e` uses it; `make e2e-oneshot` keeps the single-process form.

Its first real run immediately surfaced two more failures:

- `e2e_sysrst_config_concretization_flips_timer_relationals` — expects `Holds`, got `Unknown { unknown_cells: 32 }`
- `e2e_sysrst_detect_real_sva_verdict_breakdown` — expects the `trigger_i != !trigger_i` **tautology** to hold, got `Unknown { unknown_cells: 1 }`

Both are `Holds -> Unknown`, which matches the direction #505 predicts, so I checked whether I
caused them: the lifted `design.btor` has **2 state lines and 0 `init` lines**, so
`inject_reset_init` covers every state and #505 is provably a **no-op** for this design.
**Cleared.** Cause not yet determined; they belong to #503.

## Drive-by

`OWNED_CEX_QUERY_MS` is used only under `#[cfg(not(feature = "boolector"))]`, so it is dead code
under `--all-features` and fails [CLAUDE.md's documented pre-push check](../blob/main/CLAUDE.md).
`make ci` does not pass `--all-features`, which is why CI stayed green. Gated to match its use
site. Unrelated to #504 — it blocked a check I'm required to run.

Also worth knowing: that pre-push check can only run with `mununu-private` mounted, because the
`adapter_syntcomp` tests `include_str!` fixtures from it.

## Verification

- `make lint` clean (fmt + `clippy -D warnings`), `cargo test --workspace` green incl. 57 doctests — both in `mununu-dev`.
- `e2e_sysrst_symbolic_engine_runs_on_real_rtl` **PASS** in `mununu-sva` (the CLAUDE.md-required image for an SVA-touching change).
- `FILTER=e2e_sysrst ./scripts/e2e-sweep.sh` exercises the new runner end-to-end.

**No consumer briefing** — test / script / doc only: no verdict value, verdict message, wire
shape, route, or CLI flag changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
