### PR TITLE
fix(cube): a zero-dimension lift is edgeless, so every derived-label-only property returned ⊥

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -2451,6 +2451,107 @@ mod tests {
     }
 
     #[test]
+    /// mununu#503 — a property whose atoms are ALL derived labels seeds ZERO cube dimensions.
+    /// Every may-edge path used to be gated on `!predicates.is_empty()`, so such a property got
+    /// a 1-cube, 0-edge KMTS, and `downgrade_unsatisfiable_cells` masked the cell to ⊥ because
+    /// its proxy reads "no outgoing edges" as "unsatisfiable cube". Result: the property
+    /// returned Unknown regardless of what it asserted.
+    ///
+    /// `nu X. ([] X)` is the sharpest witness: it contains NO atom at all, so a ⊥ here cannot be
+    /// blamed on atom binding — it is true at every state of every KMTS, by definition.
+    fn zero_dimension_lift_decides_a_formula_with_no_atoms() {
+        let formula = crate::mu_calculus::parser::parse("nu X. ([] X)").expect("formula parses");
+        let sidecar = serde_json::json!({
+            "module": "cegar",
+            "source": "zero_dim.btor2",
+            "compound_predicates": [
+                {"name": "trigger_i != trigger_active",
+                 "expr": "trigger_i != trigger_active",
+                 "derived": true}
+            ],
+            "combinational_predicates": [],
+            "signals": []
+        })
+        .to_string();
+        let opts = AdapterOptions {
+            sidecar_json: Some(sidecar),
+            ..Default::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            ZERO_DIM_BTOR2,
+            Vec::new(), // <- no cube dimensions: the whole point
+            &Environment::new(1),
+            &opts,
+            &CegarOptions::default(),
+        )
+        .expect("cegar runs");
+        let v = &trace.final_verdict;
+        let cells: Vec<Trit> = (0..v.len()).map(|i| v.verdict_at(i)).collect();
+        assert_eq!(
+            cells,
+            vec![Trit::True],
+            "`nu X. ([] X)` must be True at the single universal cube; ⊥ here means the cube \
+             was emitted edgeless and masked by downgrade_unsatisfiable_cells"
+        );
+    }
+
+    #[test]
+    /// mununu#503 — the same zero-dimension shape, now with the derived label carrying real
+    /// content. `trigger_active` is a `uext` alias of `not(trigger_i)`, so
+    /// `trigger_i != trigger_active` is a TAUTOLOGY over the combinational relation and must
+    /// reach a definite True. This is the reduction of the sysrst `sva_2` failure.
+    fn zero_dimension_lift_decides_a_derived_label_tautology() {
+        let formula =
+            crate::mu_calculus::parser::parse("nu X. (((trigger_i != trigger_active)) && [] X)")
+                .expect("formula parses");
+        let sidecar = serde_json::json!({
+            "module": "cegar",
+            "source": "zero_dim.btor2",
+            "compound_predicates": [
+                {"name": "trigger_i != trigger_active",
+                 "expr": "trigger_i != trigger_active",
+                 "derived": true}
+            ],
+            "combinational_predicates": [],
+            "signals": []
+        })
+        .to_string();
+        let opts = AdapterOptions {
+            sidecar_json: Some(sidecar),
+            ..Default::default()
+        };
+        let trace = cegar_refine_loop(
+            &formula,
+            ZERO_DIM_BTOR2,
+            Vec::new(),
+            &Environment::new(1),
+            &opts,
+            &CegarOptions::default(),
+        )
+        .expect("cegar runs");
+        let v = &trace.final_verdict;
+        assert_eq!(
+            v.verdict_at(0),
+            Trit::True,
+            "`b != !b` is valid over the combinational relation, so AG of it must HOLD"
+        );
+    }
+
+    /// mununu#503 fixture — one state, one free input, and a combinational alias
+    /// `trigger_active = uext(not(trigger_i))`. A property over `trigger_i != trigger_active`
+    /// binds ONLY as a derived label (an input operand is not a sound cube dimension), so it
+    /// seeds zero dimensions — the degenerate cube space this defect lived in.
+    const ZERO_DIM_BTOR2: &str = "1 sort bitvec 1\n\
+                                  2 state 1 q\n\
+                                  3 zero 1\n\
+                                  4 init 1 2 3\n\
+                                  5 input 1 trigger_i\n\
+                                  6 not 1 5\n\
+                                  7 uext 1 6 0 trigger_active\n\
+                                  8 next 1 2 5\n";
+
+    #[test]
     fn downgrade_unsatisfiable_cells_masks_edgeless_cells_to_bottom() {
         use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, LabelControllability};
         use bitvec::prelude::*;

--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -1574,12 +1574,12 @@ struct CubeSamplingCtx<'a> {
 /// callers' prior gating) or when every `simulate_one_step` invocation
 /// errors for this cube.
 fn cube_sampling_edges(cube_index: usize, ctx: &CubeSamplingCtx) -> Vec<(usize, LabelDescriptor)> {
-    // Gating: matches the eager lifter's `!predicates.is_empty()` check.
-    // We allow n_inputs == 0 (n_combos == 1) so a single iteration runs
-    // with empty input_values — both callers did the same.
-    if ctx.predicates.is_empty() {
-        return Vec::new();
-    }
+    // mununu#503 — the `ctx.predicates.is_empty()` early return is GONE. With zero dimensions
+    // there is one cube holding every concrete state, and the canonical representative below
+    // still simulates a step and maps back to cube 0, yielding the self-loop the KMTS must have.
+    // Returning empty here produced an edgeless cell that `downgrade_unsatisfiable_cells` then
+    // masked to ⊥. `n_inputs == 0` (n_combos == 1) was already allowed — a single iteration with
+    // empty `input_values` — and that is exactly the shape this case needs.
 
     // Build canonical representative for cube_index.
     let mut registers: std::collections::HashMap<String, u128> = std::collections::HashMap::new();
@@ -2213,9 +2213,17 @@ pub fn predicate_cube_lift(
     // this excludes an edge ONLY when Z3 proves it impossible. Edges
     // are collected inside the Z3 scope and emitted after it (the
     // builder is not borrowed into the closure).
-    if matches!(lift_opts.may_edge_inference, MayEdgeInference::SmtAllPairs)
-        && !predicates.is_empty()
-    {
+    // mununu#503 — NO `!predicates.is_empty()` guard. A property whose atoms are all DERIVED
+    // labels (relational-with-input / combinational-of-input) contributes ZERO cube dimensions,
+    // and this block used to be skipped for it — emitting a 1-cube, 0-edge KMTS. An edgeless
+    // cell is then masked to ⊥ by `downgrade_unsatisfiable_cells` (cegar.rs), whose proxy reads
+    // "no outgoing edges" as "unsatisfiable cube". The result was that EVERY such property
+    // returned Unknown regardless of what it asserted — even `nu X. ([] X)`, which is true at
+    // every state of every KMTS. At |P| = 0 this block does exactly one 0 -> 0 check, which is
+    // cheap and EXACT: a total design yields the self-loop, and a design whose `constraint`
+    // admits no transition correctly yields none (⊥ there is right). The `"step"` label is also
+    // interned here, so skipping the block left the KMTS with no labels at all.
+    if matches!(lift_opts.may_edge_inference, MayEdgeInference::SmtAllPairs) {
         let step_label = builder
             .labels()
             .intern(["step"])
@@ -2401,9 +2409,10 @@ pub fn predicate_cube_lift(
         predicate_image_pending = false;
     }
 
+    // mununu#503 — `!predicates.is_empty()` removed here too; see the note on the SmtAllPairs
+    // block above. `max_input_bits > 0` stays: that one is a real opt-out, not a shape guard.
     if !matches!(lift_opts.may_edge_inference, MayEdgeInference::SmtAllPairs)
         && lift_opts.max_input_bits > 0
-        && !predicates.is_empty()
     {
         let mut sampled_targets_per_source: Vec<std::collections::BTreeSet<usize>> =
             vec![std::collections::BTreeSet::new(); state_ids.len()];
@@ -2903,6 +2912,43 @@ mod tests {
             },
         );
         (btor2, preds, compound)
+    }
+
+    #[test]
+    /// mununu#503 — the LIFT-LEVEL pin for the zero-dimension defect. With no cube dimensions
+    /// there is exactly one cube (the universal set), and a lift from a TOTAL transition
+    /// relation must give it a self-loop. Every may-edge path used to be gated on
+    /// `!predicates.is_empty()`, so this lift produced a 1-state, 0-edge, 0-LABEL KMTS —
+    /// which `downgrade_unsatisfiable_cells` then masks to ⊥ (its proxy reads "no outgoing
+    /// edges" as "unsatisfiable cube"). Asserting the edge HERE localises a future regression
+    /// to the lift rather than to a verdict several layers up.
+    fn zero_dimension_lift_still_emits_the_universal_cube_self_loop() {
+        const B: &str = "1 sort bitvec 1\n\
+                         2 state 1 q\n\
+                         3 zero 1\n\
+                         4 init 1 2 3\n\
+                         5 input 1 en\n\
+                         6 next 1 2 5\n";
+        let out = lift_predicate_cube(
+            Vec::new(), // zero dimensions — the degenerate cube space
+            B,
+            &AdapterOptions::default(),
+            &PredicateCubeLiftOptions {
+                may_edge_inference: MayEdgeInference::SmtAllPairs,
+                ..Default::default()
+            },
+            crate::adapter::btor2::cegar::LiftStrategy::Eager,
+        )
+        .expect("zero-dimension lift succeeds");
+
+        assert_eq!(out.cube_count, 1, "|P| = 0 ⇒ exactly one universal cube");
+        assert_eq!(out.clts.state_count(), 1, "one cube ⇒ one state");
+        let s0 = crate::clts::StateId::<DefaultStateIdx>::from_index(0).expect("state 0");
+        assert!(
+            !out.clts.outgoing(s0).is_empty(),
+            "the universal cube of a TOTAL design must have a self-loop; an edgeless cell is \
+             indistinguishable from an unsatisfiable one and gets masked to ⊥"
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -360,9 +360,11 @@ impl<'a> BtorSts<'a> {
         };
         use crate::adapter::sidecar::predicate_image::btor2_encode::encode_primed;
 
-        if predicates.is_empty() {
-            return (Vec::new(), Vec::new());
-        }
+        // mununu#503 — no empty-predicate early return. At |P| = 0 there is ONE cube (the
+        // universal set) and the loops below reduce to a single 0 -> 0 check. Returning no
+        // edges here left that cube edgeless, which `downgrade_unsatisfiable_cells` masks to ⊥
+        // — silently making every derived-label-only property Unknown. See the note in
+        // `predicate_cube_lift`'s SmtAllPairs block.
         let n_cubes = 1usize << predicates.len();
         let cfg = z3::Config::new();
         z3::with_z3_config(&cfg, || {
@@ -575,9 +577,9 @@ impl SmtEncode for BtorSts<'_> {
         };
         use crate::adapter::sidecar::predicate_image::btor2_encode::encode_primed;
 
-        if predicates.is_empty() {
-            return Vec::new();
-        }
+        // mununu#503 — no empty-predicate early return: at |P| = 0 the single universal cube
+        // still has a self-loop to compute, and returning no edges left it edgeless (⇒ masked
+        // to ⊥ by `downgrade_unsatisfiable_cells`).
         // P0 — faithful, memory-aware encode (array theory for `$mem`
         // cells), matching the production `predicate_cube_lift`. (DR0 used
         // the BvOnly `encode_design`.)
@@ -630,9 +632,9 @@ impl SmtEncode for BtorSts<'_> {
         predicates: &[P],
         timeout_ms: u32,
     ) -> Vec<(usize, usize)> {
-        if predicates.is_empty() {
-            return Vec::new();
-        }
+        // mununu#503 — no empty-predicate early return: at |P| = 0 the single universal cube
+        // still has a self-loop to compute, and returning no edges left it edgeless (⇒ masked
+        // to ⊥ by `downgrade_unsatisfiable_cells`).
         // The all-pairs ∀∃ must is exactly `must_edges_over` applied to the
         // full `0..2^p × 0..2^p` grid — one image, two candidate shapes.
         let n_cubes = 1usize << predicates.len();
@@ -653,7 +655,9 @@ impl SmtEncode for BtorSts<'_> {
         };
         use crate::adapter::sidecar::predicate_image::btor2_encode::encode_primed;
 
-        if predicates.is_empty() || candidates.is_empty() {
+        // mununu#503 — the `predicates.is_empty()` half of this guard is gone (see the sibling
+        // note above); `candidates.is_empty()` stays, since no candidate targets means no work.
+        if candidates.is_empty() {
             return Vec::new();
         }
         // H.U.1c — same encode + the next-cycle node cache (`encode_primed`)
@@ -701,9 +705,9 @@ impl SmtEncode for BtorSts<'_> {
         };
         use crate::adapter::sidecar::predicate_image::btor2_encode::encode_primed;
 
-        if predicates.is_empty() {
-            return Vec::new();
-        }
+        // mununu#503 — no empty-predicate early return: at |P| = 0 the single universal cube
+        // still has a self-loop to compute, and returning no edges left it edgeless (⇒ masked
+        // to ⊥ by `downgrade_unsatisfiable_cells`).
         // Candidate hyper-must target set per source = its may-successor
         // set (sorted, deduped). A source with no may-successors gets no
         // hyper-must edge (an empty T is trivially NotMust).

--- a/docs/consumer-briefings/2026-09-zero-dimension-cube-bottom.md
+++ b/docs/consumer-briefings/2026-09-zero-dimension-cube-bottom.md
@@ -1,0 +1,82 @@
+# Consumer briefing — 2026-09 properties that only ever returned `unknown` now decide
+
+> **Audience:** monono, ROSF, anyone running `mununu sv verify-auto` or reading its verdicts.
+>
+> **Related:** [mununu#503](https://github.com/Mumunu-team/mununu/issues/503). Interacts with [mununu#377](https://github.com/Mumunu-team/mununu/pull/377) (the unsatisfiable-cube mask), which is unchanged.
+>
+> **TL;DR:** a whole class of properties — those whose atoms are *all* derived labels — was returning `unknown` **regardless of what the property asserted**, including tautologies. Fixed. **Verdicts change in one direction only: `unknown` → `holds` or `violated`. No definite verdict flips.**
+
+## What was wrong
+
+An atom over an input or an input-derived combinational signal is deliberately **not** a sound cube dimension — its value depends on the demonic environment, so it is labelled per-cube by SMT instead. That is correct and stays.
+
+But a property whose atoms are *all* of that kind seeds **zero cube dimensions**, and three shipped behaviours then composed into a wrong one:
+
+1. `|P| = 0` ⇒ exactly one cube: the universal set, holding every concrete state.
+2. **Every** may-edge path was gated on `!predicates.is_empty()`, so that cube was emitted with **no edges** — and no labels either, because the `step` label is interned inside the skipped blocks.
+3. `downgrade_unsatisfiable_cells` uses *"no outgoing edges"* as a proxy for *"unsatisfiable cube"*, and masks every edgeless cell to ⊥.
+
+So the verdict never depended on the property. Measured on the real sysrst lift — same design, same formulas, only the dimension count changed:
+
+| cube dimensions | `nu X. ([] X)` | `trigger_i != trigger_active` (a tautology) |
+|---|---|---|
+| **0** (the shipped shape) | `unknown` | `unknown` |
+| **1** (one dimension added) | **`holds`** | **`holds`** |
+
+`nu X. ([] X)` contains **no atom at all** and is true at every state of every KMTS. That it returned `unknown` is what showed the cause was structural rather than a binding failure.
+
+## What changed
+
+The guards were relaxed so `|P| = 0` is an ordinary case. **The ⊥ mask was not weakened.**
+
+That distinction matters: the mask's proxy rests on the invariant *"a cube lifted from a total transition relation is edgeless only if it is empty"*, and the defect was that the guards broke that invariant. Restoring it means the mask keeps protecting the spurious νμ-`violated` case it exists for (the i2c `AG EF` incident, #377). Both of its pinning tests pass unchanged.
+
+At `|P| = 0` the edge computation reduces to a single `0 → 0` check — cheap, and **exact**: a total design yields the self-loop; a design whose `constraint` admits no transition correctly yields none, and ⊥ there is right.
+
+## Direction of change — read this bit
+
+- `unknown` → `holds`, or `unknown` → `violated`.
+- **No `holds` becomes `violated`, and no `violated` becomes `holds`.**
+
+`violated` is in that list deliberately. The must-edge emitters live inside the same guard, so `<>` / `EF` properties in this class also become decidable — not just `[]` / ν ones. If a property in this class was masking a real violation, you will now see it.
+
+**If you pin expected verdicts**, expect some `unknown` rows to become definite. A row that changes is a property that was never actually being checked.
+
+## Who is affected
+
+| Path | Effect |
+|---|---|
+| A property whose atoms are **all** input-derived (e.g. `a != b` where both trace to inputs) | **Decides now.** Previously always `unknown` |
+| A property with **at least one** state-cell atom | **None** — it already had ≥1 dimension |
+| `btor2 cegar` / `verify` on a sidecar with only `derived: true` compounds | Same improvement |
+| The exact-symbolic engine (`--engine exact-symbolic`) | **None** — it does not use the cube path |
+
+## Verification
+
+```bash
+cargo test -p mununu-core --lib -- zero_dimension_lift downgrade_unsatisfiable unsatisfiable_cube_cell
+```
+
+Three new regressions, all of which **fail on the pre-fix code**; plus the two tests pinning the #377 mask, which pass unchanged. 2526 host lib tests green.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | verdict semantics on the cube path | **Yes** |
+| mununu `Dockerfile.dev` | binary bump | **Yes** |
+| mununu `Dockerfile.sva` | binary bump; the e2e runs here | **Yes** |
+| mununu `Dockerfile.extract`, `.extract-*` | no cube path | No |
+| rosf | consumes verdicts | **Yes if it pins expected verdicts**, else No |
+| monono Docker | formal lane pins verdicts in `verify.sh` | **Yes** |
+| mununu-ui | no type change | No |
+
+## For monono
+
+Your `verify.sh` files pin expected verdicts, so this is the change most likely to move a row for you. Any property that flips out of `unknown` is one that was previously not being checked at all — worth reading rather than just re-pinning.
+
+## Not covered here (follow-ups)
+
+- **`e2e_sysrst_detect_real_sva_verdict_breakdown` still fails**, on a *different* assertion (`sva_12`, `unknown_cells: 4`) over a **non-degenerate** cube space — so a different cause, not this defect. Tracked under #503.
+- **`e2e_sysrst_config_concretization_flips_timer_relationals`** likewise (`unknown_cells: 32`, 5 dimensions). Untouched.
+- The `predicate_image_pending` flag is still set for a zero-dimension lift; it now has edges, so this is cosmetic, but it was not audited here.


### PR DESCRIPTION
**Track A** of the approved plan. Refs #503.

A property whose atoms are **all** derived labels returned `unknown` **regardless of what it
asserted** — including tautologies, and including formulas with no atom at all.

## Three correct behaviours composing into a wrong one

1. An input-derived atom is deliberately **not** a sound cube dimension, so such a property
   seeds **zero dimensions** ⇒ exactly one cube, the universal set.
2. **Every** may-edge path was gated on `!predicates.is_empty()`, so that cube was emitted with
   **no edges** — and no labels, since `"step"` is interned inside the skipped blocks.
3. `downgrade_unsatisfiable_cells` uses *"no outgoing edges"* as a proxy for *"unsatisfiable
   cube"* and masks every edgeless cell to ⊥.

Measured on the real sysrst lift — same design, same formulas, only the dimension count changed:

| cube dimensions | `nu X. ([] X)` | `trigger_i != trigger_active` (a tautology) |
|---|---|---|
| **0** (the shipped shape) | `Unknown` | `Unknown` |
| **1** | `True` | `True` |

`nu X. ([] X)` contains **no atom at all** and is true at every state of every KMTS. Its ⊥ is
what proved the cause was structural rather than an atom-binding failure.

## Fix: relax the guards, do NOT weaken the mask

The mask's proxy rests on the invariant *"a cube lifted from a total transition relation is
edgeless only if it is empty"*. The defect is that the guards broke that invariant — so restore
it, and the mask keeps protecting the spurious νμ-`VIOLATED` case it was written for (`d245e21`,
#377, the i2c `AG EF` incident). **Both of its pinning tests pass unchanged.**

Seven guards, three more than the plan predicted — the seam had four further
`predicates.is_empty()` early returns (`may_edges`, `must_edges`, `must_edges_over`,
`hyper_must_edges`) beyond the three in `kmts_lift`. At `|P| = 0` each reduces to a single
`0 → 0` check: cheap, and **exact** — a total design yields the self-loop, and a design whose
`constraint` admits no transition correctly yields none (⊥ there is right).

## Direction

`Unknown` → `Holds`/`Violated`. **No definite verdict flips.** `Violated` is in that list
deliberately: the must-edge emitters live inside the same guard, so `<>`/`EF` properties in this
class decide too — a property masking a real violation will now show it.

## Tests

Three regressions, **all failing on the pre-fix code** (verified by stashing the fix):

- `zero_dimension_lift_decides_a_formula_with_no_atoms` — the sharpest, because a ⊥ on a formula
  with no atom cannot be blamed on binding.
- `zero_dimension_lift_decides_a_derived_label_tautology` — the sysrst `sva_2` reduction.
- `zero_dimension_lift_still_emits_the_universal_cube_self_loop` — lift-level, so a future
  regression localises to the lift rather than to a verdict several layers up.

Plus the two #377 mask tests, unchanged and passing.

## Verification

- **2526** host lib tests pass, 0 failed.
- In `mununu-sva`: the `sva_2` assertion that motivated this **now passes** — the e2e advances
  from line 7429 to a later assertion.

## What this does NOT fix — stated plainly

The plan predicted `e2e_sysrst_detect_real_sva_verdict_breakdown` would go green. **It does
not.** It has a second failing assertion (`sva_12`, `unknown_cells: 4`) over a **non-degenerate**
cube space, so a different cause. Same for `e2e_sysrst_config_concretization_flips_timer_relationals`
(`unknown_cells: 32`, 5 dimensions). Both stay with #503.

Consumer briefing: `docs/consumer-briefings/2026-09-zero-dimension-cube-bottom.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
