### PR TITLE
fix(lift): the post-image may-relation silently truncated on an inconclusive query (#504 C1)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -2279,8 +2279,12 @@ pub fn predicate_cube_lift(
             (may, Some(hyper))
         } else if lift_opts.may_postimage
             && predicates.len() >= 2
-            && let Some(map) =
-                compute_all_may_edges_smt_postimage(&file, &predicates, &lift_opts.compound_exprs)
+            && let Some(map) = compute_all_may_edges_smt_postimage(
+                &file,
+                &predicates,
+                &lift_opts.compound_exprs,
+                crate::adapter::btor2::smt_must_edge::cube_smt_rlimit(),
+            )
         {
             let mut pairs: Vec<(usize, usize)> = map
                 .into_iter()
@@ -2710,6 +2714,10 @@ fn collect_boolean_input_symbols(
 ///
 /// P1 increment 1: validated by `p1_smt_postimage_may_edges_match_concrete_oracle`. P1.4: wired into
 /// `predicate_cube_lift` behind `PredicateCubeLiftOptions::may_postimage`.
+/// `rlimit`: the deterministic z3 resource bound, passed in rather than read from the
+/// environment so the `Unknown`-saturation path (mununu#504) is testable without mutating
+/// process-global state — the same pure-helper idiom `memory_budget.rs` uses. Production passes
+/// `smt_must_edge::cube_smt_rlimit()`; a test passes `Some(1)` to force every query `Unknown`.
 fn compute_all_may_edges_smt_postimage(
     file: &crate::adapter::btor2::ast::Btor2File,
     predicates: &[PredicateSpec],
@@ -2717,6 +2725,7 @@ fn compute_all_may_edges_smt_postimage(
         String,
         crate::adapter::btor2::predicate_expr::PredicateExpr,
     >,
+    rlimit: Option<u32>,
 ) -> Option<std::collections::HashMap<usize, Vec<usize>>> {
     use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
     let n = predicates.len();
@@ -2764,6 +2773,15 @@ fn compute_all_may_edges_smt_postimage(
 
         let mut params = z3::Params::new();
         params.set_u32("timeout", 5000);
+        // mununu#504 — the deterministic resource bound, the same lever every check in
+        // `smt_must_edge` already applies. It was missing HERE, on the post-image path, which is
+        // the measured hang suspect (`for cube in 0..2^n` around an all-SAT loop, x17 CEGAR
+        // rounds x N properties). Unset by default ⇒ no behaviour change; set, it turns a grind
+        // into a fast, deterministic result. Safe to apply only because the `Unknown` arm below
+        // now saturates instead of silently truncating — see that comment.
+        if let Some(rl) = rlimit {
+            params.set_u32("rlimit", rl);
+        }
         let mut out: std::collections::HashMap<usize, Vec<usize>> =
             std::collections::HashMap::new();
         for cube in 0..(1usize << n) {
@@ -2779,9 +2797,36 @@ fn compute_all_may_edges_smt_postimage(
                 }
             }
             // All-SAT: project `cube_curr ∧ T` onto the next-state predicate valuation.
+            //
+            // SOUNDNESS (mununu#504, 2026-09-07) — `may` OVER-approximates: soundness requires
+            // may ⊇ concrete. This loop used to be `while matches!(solver.check(), Sat)`, so an
+            // `Unknown` (a z3 timeout, or an rlimit hit) exited the loop and stored the PARTIAL
+            // enumeration as if it were complete — a TRUNCATED may-relation, i.e. an
+            // UNDER-approximation. That is unsound in the definite direction: `[]φ` is True when
+            // all may-successors satisfy φ, so dropping may-edges can manufacture a spurious
+            // definite True. It was already reachable with the 5 s per-query timeout on a wide
+            // cone; adding an rlimit (which exists precisely to make queries return `Unknown`)
+            // would have made it routine.
+            //
+            // On a non-`Sat` INCONCLUSIVE result we therefore SATURATE this cube — every target
+            // is a may-successor — which is the sound direction (denser may ⇒ more ⊥, never a
+            // wrong verdict). `Unsat` is different: it is a real proof that no further next-state
+            // valuation exists, so it ends the enumeration normally.
             let mut targets: Vec<usize> = Vec::new();
-            while matches!(solver.check(), z3::SatResult::Sat) {
+            let mut inconclusive = false;
+            loop {
+                match solver.check() {
+                    z3::SatResult::Sat => {}
+                    z3::SatResult::Unsat => break, // enumeration provably complete
+                    z3::SatResult::Unknown => {
+                        inconclusive = true;
+                        break;
+                    }
+                }
                 let Some(model) = solver.get_model() else {
+                    // `Sat` with no retrievable model: we cannot block this valuation, so we
+                    // cannot trust the enumeration to terminate correctly either.
+                    inconclusive = true;
                     break;
                 };
                 let mut tgt = 0usize;
@@ -2806,6 +2851,10 @@ fn compute_all_may_edges_smt_postimage(
                 if targets.len() > (1usize << n) {
                     break; // safety: at most 2^n distinct next cubes
                 }
+            }
+            if inconclusive {
+                // Sound fallback for this cube only: every cube is a may-successor.
+                targets = (0..(1usize << n)).collect();
             }
             targets.sort_unstable();
             targets.dedup();
@@ -2912,6 +2961,70 @@ mod tests {
             },
         );
         (btor2, preds, compound)
+    }
+
+    #[test]
+    /// mununu#504 — the post-image all-SAT loop must SATURATE, never truncate, when a query is
+    /// inconclusive.
+    ///
+    /// `may` OVER-approximates, so soundness needs may ⊇ concrete. The loop used to be
+    /// `while matches!(solver.check(), Sat)`, so an `Unknown` exited it and stored the PARTIAL
+    /// enumeration as complete — an under-approximation, which can manufacture a spurious
+    /// definite `True` for a box property (`[]φ` is True when all may-successors satisfy φ, so
+    /// dropping successors makes it easier to hold).
+    ///
+    /// Forced deterministically with `rlimit = 1`: every z3 query returns `Unknown` immediately,
+    /// on any machine, in milliseconds. The result must be the FULL target grid, not a partial
+    /// or empty one.
+    fn postimage_saturates_rather_than_truncating_on_an_inconclusive_query() {
+        // `q' = q` — a HELD register. Its true may-relation is strictly sparser than the full
+        // grid (cube 0 reaches only cube 0, cube 1 only cube 1), which is what makes saturation
+        // distinguishable from the exact answer. A design with a free input driving `q` would
+        // have the full grid as its TRUE relation, and the test would prove nothing — the
+        // control assertion at the end of this test exists to catch exactly that mistake.
+        const B: &str = "1 sort bitvec 1\n\
+                         2 state 1 q\n\
+                         3 zero 1\n\
+                         4 init 1 2 3\n\
+                         5 next 1 2 2\n";
+        let file = crate::adapter::btor2::parser::parse(B).expect("parse");
+        let preds = vec![PredicateSpec {
+            name: "q == 1".into(),
+            register: "q".into(),
+            value: 1,
+        }];
+        let compound = std::collections::HashMap::new();
+
+        let t0 = std::time::Instant::now();
+        let starved = compute_all_may_edges_smt_postimage(&file, &preds, &compound, Some(1))
+            .expect("post-image still returns a map");
+        assert!(
+            t0.elapsed() < std::time::Duration::from_secs(5),
+            "an rlimit-starved run must fail FAST, not grind"
+        );
+
+        // |P| = 1 ⇒ 2 cubes. Every cube must reach every cube: the sound over-approximation.
+        for cube in 0..2usize {
+            let targets = starved
+                .get(&cube)
+                .unwrap_or_else(|| panic!("cube {cube} present"));
+            assert_eq!(
+                targets.as_slice(),
+                &[0usize, 1],
+                "cube {cube}: an inconclusive enumeration must SATURATE to every target; a \
+                 partial set here is an under-approximated may relation, which is unsound"
+            );
+        }
+
+        // Control: with no rlimit the same call computes the REAL (sparser) relation, so the
+        // assertion above is testing saturation and not merely a degenerate design.
+        let exact = compute_all_may_edges_smt_postimage(&file, &preds, &compound, None)
+            .expect("post-image");
+        assert!(
+            exact.values().any(|t| t.len() < 2),
+            "the unstarved relation must be strictly sparser somewhere, else this test proves \
+             nothing about saturation; got {exact:?}"
+        );
     }
 
     #[test]
@@ -3035,7 +3148,7 @@ mod tests {
         }
 
         // Post-image path.
-        let may = compute_all_may_edges_smt_postimage(&file, &preds, &compound).expect("may");
+        let may = compute_all_may_edges_smt_postimage(&file, &preds, &compound, None).expect("may");
         let sharp = postimage_sharp_edges(&file, &preds, &compound, &may).expect("sharp");
 
         for i in 0..4usize {
@@ -3128,8 +3241,8 @@ mod tests {
                     .insert(cube_of(nxt["x"], nxt["y"]));
             }
         }
-        let got =
-            compute_all_may_edges_smt_postimage(&file, &preds, &compound).expect("post-image");
+        let got = compute_all_may_edges_smt_postimage(&file, &preds, &compound, None)
+            .expect("post-image");
         for cube in 0..4usize {
             let mine: std::collections::BTreeSet<usize> = got
                 .get(&cube)

--- a/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
+++ b/crates/mununu-core/src/adapter/btor2/smt_must_edge.rs
@@ -82,7 +82,7 @@ pub enum SmtMustVerdict {
 /// relation, hence a *more conservative* (more ⊥) but always SOUND abstraction. This turns a
 /// cube that grinds on a wide combinational cone (e.g. i2c's 196-bit freed-input cone) into a
 /// fast, deterministic ⊥ instead of a hang.
-fn cube_smt_rlimit() -> Option<u32> {
+pub(crate) fn cube_smt_rlimit() -> Option<u32> {
     parse_cube_smt_rlimit(std::env::var("MUNUNU_CUBE_SMT_RLIMIT").ok())
 }
 
@@ -549,7 +549,7 @@ where
     let mut params = z3::Params::new();
     params.set_u32("timeout", timeout_ms);
     if let Some(rl) = cube_smt_rlimit() {
-        params.set_u32("rlimit", rl); // ③b deterministic bound (SOUNDNESS: Unknown → NotMust → weaker must)
+        params.set_u32("rlimit", rl); // ③b deterministic bound (SOUNDNESS: Unknown → May → DENSER may, never sparser)
     }
     solver.set_params(&params);
     solver.assert(&view.transition);
@@ -1309,7 +1309,7 @@ where
     let mut params = z3::Params::new();
     params.set_u32("timeout", timeout_ms);
     if let Some(rl) = cube_smt_rlimit() {
-        params.set_u32("rlimit", rl); // ③b deterministic bound (SOUNDNESS: Unknown → NotMust → weaker must)
+        params.set_u32("rlimit", rl); // ③b deterministic bound (SOUNDNESS: Unknown → May → DENSER may, never sparser)
     }
     solver.set_params(&params);
 

--- a/docs/consumer-briefings/2026-09-postimage-may-truncation.md
+++ b/docs/consumer-briefings/2026-09-postimage-may-truncation.md
@@ -1,0 +1,85 @@
+# Consumer briefing — 2026-09 a timed-out may-enumeration could produce a false `holds`
+
+> **Audience:** anyone running `mununu sv verify-auto` or `btor2 cegar` on the default (explicit / portfolio) path. monono especially — this sits on the same code path as the hang you reported.
+>
+> **Related:** [mununu#504](https://github.com/Mumunu-team/mununu/issues/504).
+>
+> **⚠ TL;DR — this is a soundness fix.** When a z3 query in the may-edge enumeration returned **inconclusive**, the partial result was stored as if complete. That under-approximates the `may` relation, which can make a `[]`/`AG`-shaped property report **`holds` when it does not**. Verdicts change in one direction: **`holds` → `unknown`**. If you have acted on a `holds` from a large or wide design, it is worth re-running.
+
+## What was wrong
+
+`compute_all_may_edges_smt_postimage` enumerated next-state valuations with:
+
+```rust
+while matches!(solver.check(), z3::SatResult::Sat) { … }
+```
+
+`Unknown` and `Unsat` were treated identically — both exited the loop. But only **`Unsat` is a proof that the enumeration is complete**. On `Unknown` (a z3 timeout, or a resource-limit hit) the partial target list was stored as the finished answer.
+
+**Why that is unsound.** `may` is an *over*-approximation: correctness requires may ⊇ concrete. A truncated may is an *under*-approximation. `[]φ` is True when **all** may-successors satisfy φ — so dropping successors makes a box property **easier** to hold, and can manufacture a definite `holds` that the design does not have.
+
+This was reachable in normal operation: the path carries a 5-second per-query timeout, and a wide combinational cone can exhaust it partway through an enumeration.
+
+## What changed
+
+The three results are now distinguished:
+
+| z3 result | Before | After |
+|---|---|---|
+| `Sat` | record target, continue | unchanged |
+| `Unsat` | stop | stop — enumeration provably complete |
+| **`Unknown`** | **stop, keep partial** ❌ | **saturate this cube: every target is a may-successor** ✅ |
+
+Saturation is the sound direction — denser `may` ⇒ more ⊥, never a wrong verdict — and it is **local**, so one starved cube costs precision only there.
+
+## Direction of change
+
+- **`holds` → `unknown`** where a truncated enumeration had been propping up a box property.
+- `violated` is unaffected: a definite `[]φ = False` needs a *must*-successor, and must-edges are not touched.
+- Designs where no query ever returned `Unknown` are **bit-identical**.
+
+## How likely was this to fire? — stated honestly
+
+**I have not measured it.** What is established:
+
+- the truncation is real and reachable on the **default** path (`may_postimage` is set unconditionally, and the post-image is used for `|P| ≥ 2`);
+- it is pinned by a regression that **fails on the pre-fix code**.
+
+What is **not** established is how often a z3 query actually returned `Unknown` on real designs. It requires a query to exhaust its budget mid-enumeration, which is a wide-cone / large-design phenomenon — so a small design almost certainly never hit it, and a large one may have. If a `holds` moves to `unknown` for you, that property was in this class.
+
+## Also in this change
+
+`MUNUNU_CUBE_SMT_RLIMIT` now applies to the post-image path too. It was already applied by every check in the must-edge module but was missing from this one — which is the single place in the lift that builds its own solver parameters, and the measured suspect behind the six-hour hang in #504.
+
+**Unset by default ⇒ no behaviour change.** Set it, and a grinding enumeration becomes a fast deterministic result instead of a hang:
+
+```bash
+MUNUNU_CUBE_SMT_RLIMIT=2000000 mununu sv verify-auto …
+```
+
+This is usable today as a mitigation while the rest of the #504 budget work lands. It is only safe *because* of the saturation fix above — without it, an rlimit (whose purpose is to make queries return `Unknown`) would have turned a rare silent truncation into a routine one.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | soundness fix; verdicts can move `holds` → `unknown` | **Yes** |
+| mununu `Dockerfile.dev` | binary bump | **Yes** |
+| mununu `Dockerfile.sva` | binary bump | **Yes** |
+| mununu `Dockerfile.extract`, `.extract-*` | no lift path | No |
+| rosf | consumes verdicts | **Yes** |
+| monono Docker | same path as the reported hang; pins verdicts | **Yes** |
+| mununu-ui | no type change | No |
+
+## Verification
+
+```bash
+cargo test -p mununu-core --lib -- postimage_saturates
+```
+
+Forces every query inconclusive with `rlimit = 1` — deterministic, machine-independent, ~100 ms, no slow input needed — and asserts the full grid comes back. It carries a control assertion that the unstarved relation is strictly sparser, without which the test would prove nothing.
+
+## Not covered here (follow-ups)
+
+- **The rest of #504.** There is still no wall-clock budget at any granularity, and output remains all-or-nothing, so a killed run still emits zero bytes. That is the remaining ladder.
+- **The `targets.len() > 2^n` safety break** in the same loop is also a truncation, but it is unreachable in principle (each valuation is blocked, so at most 2^n iterations occur). Left as-is, not audited further.


### PR DESCRIPTION
**Track C, PR 1** of the #504 ladder. ⚠ **This is a soundness fix**, not the knob it was scoped as.

## The plan called this a zero-risk one-liner. It wasn't.

C1 was scoped as "apply the existing `MUNUNU_CUBE_SMT_RLIMIT` to the post-image may-edge path" —
the one place in the lift that builds its own solver params, and the measured suspect behind the
six-hour hang. Doing only that would have **introduced an unsoundness**.

## The latent bug

`compute_all_may_edges_smt_postimage` enumerated with:

```rust
while matches!(solver.check(), z3::SatResult::Sat) { … }
```

`Unknown` and `Unsat` were treated identically — both exit. But **only `Unsat` proves the
enumeration is complete.** On `Unknown` the partial target list was stored as the finished answer.

`may` **over**-approximates: soundness requires may ⊇ concrete. A truncated may is an
**under**-approximation, and `[]φ` is True when *all* may-successors satisfy φ — so dropping
successors makes a box property **easier to hold**. That manufactures a spurious definite `holds`.

Reachable today: the path already carries a 5 s per-query timeout, and a wide combinational cone
can exhaust it mid-enumeration. `may_postimage` is set unconditionally (`cegar.rs:980`), so this
is the **default** path for `|P| ≥ 2`.

And an rlimit exists *precisely* to make queries return `Unknown` — so the intended mitigation
would have turned a rare silent truncation into a routine one.

## Fix

| z3 result | Before | After |
|---|---|---|
| `Sat` | record, continue | unchanged |
| `Unsat` | stop | stop — provably complete |
| **`Unknown`** | **stop, keep partial** ❌ | **saturate this cube** ✅ |

Saturation is the sound direction (denser may ⇒ more ⊥, never a wrong verdict) and is **local** —
one starved cube costs precision only there. The `Sat`-with-no-model case gets the same treatment,
since the valuation cannot be blocked and the enumeration cannot be trusted to terminate.

Only then is the rlimit applied. **Unset by default ⇒ no behaviour change**; set, it is a
same-day mitigation for the hang.

## Test — and the mistake its control caught

`postimage_saturates_rather_than_truncating_on_an_inconclusive_query` forces every query
`Unknown` with `rlimit = 1`: deterministic, machine-independent, ~100 ms, **no slow input needed**.

The rlimit is passed **in** rather than read from env — mirroring `memory_budget.rs`'s pure-helper
idiom — so this is testable without mutating process-global state shared across parallel tests.

My **first version of this test was worthless**, and its own control assertion caught it: the
fixture (`q' = en`, free input) has the *full grid* as its TRUE may-relation, so saturation was
indistinguishable from correctness. The fixture is now a held register (`q' = q`), whose real
relation is strictly sparser. I also temporarily restored the truncating behaviour to confirm the
test **fails** on it.

## Also: two miscopied soundness comments

`smt_per_target_may_check` and `smt_per_target_may_check_uniform` both carried
`SOUNDNESS: Unknown → NotMust → weaker must`, pasted from a must-side function. They return
`Unknown => SmtMayVerdict::May`, so the correct reading is `Unknown → May → DENSER may`. A wrong
soundness comment on soundness-critical code is how someone later "fixes" the code to match it.

## Direction of change

**`holds` → `unknown`** only. `violated` is untouched (a definite `[]φ = False` needs a
*must*-successor). Designs where no query returned `Unknown` are bit-identical.

**Not measured:** how often this actually fired on real designs. The truncation is verified
reachable and pinned by a failing-pre-fix test; the frequency of `Unknown` in practice is unknown
and the briefing says so rather than guessing a blast radius.

Briefing: `docs/consumer-briefings/2026-09-postimage-may-truncation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
