### PR TITLE
feat(lift): bound the yosys / slang / sv2v subprocesses (#504 C2)

### DIFF
--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -505,6 +505,42 @@ pub(crate) fn locate_tool(
 /// std-only (no `wait-timeout` crate, no coreutils `timeout`) so it is portable
 /// and adds no dependency: model checkers like Pono's IC3 can run unbounded, and
 /// this is the portfolio's guard against a single member hanging the whole run.
+/// mununu#504 — the wall-clock cap for the three lift subprocesses (yosys, slang, sv2v).
+///
+/// All three used a bare `Command::output()`, which blocks forever. That is the *first* way a
+/// consumer loses a whole run: the lift runs BEFORE any property is attempted, so a hung tool
+/// emits zero output and every property reads as absent. btormc and pono have been bounded by
+/// `run_with_timeout` for a long time; this closes the gap for the lift.
+///
+/// Env-overridable via `MUNUNU_LIFT_TIMEOUT_MS` (one variable for all three — YAGNI over three
+/// until a measurement says otherwise). `0` disables the cap, matching the escape-hatch
+/// convention the other budgets use.
+pub(crate) const LIFT_TIMEOUT_ENV: &str = "MUNUNU_LIFT_TIMEOUT_MS";
+
+/// Default lift cap: 15 minutes. Deliberately generous — a large multi-file elaboration under
+/// `--single-unit` legitimately takes minutes, and a cap that fires on real work is worse than
+/// no cap at all (it converts a slow success into a spurious failure).
+const DEFAULT_LIFT_TIMEOUT_MS: u64 = 15 * 60 * 1000;
+
+/// The lift subprocess cap. `None` ⇒ uncapped (`MUNUNU_LIFT_TIMEOUT_MS=0`).
+pub(crate) fn lift_timeout() -> Option<std::time::Duration> {
+    parse_lift_timeout_ms(std::env::var(LIFT_TIMEOUT_ENV).ok())
+}
+
+/// Pure parse of `MUNUNU_LIFT_TIMEOUT_MS`, extracted so the ladder is unit-testable without
+/// touching process-global environment: a positive integer → that many ms; `0` → uncapped;
+/// unset or unparseable → the default.
+pub(crate) fn parse_lift_timeout_ms(v: Option<String>) -> Option<std::time::Duration> {
+    match v.as_deref().map(str::trim) {
+        Some("0") => None,
+        Some(s) => match s.parse::<u64>() {
+            Ok(ms) if ms > 0 => Some(std::time::Duration::from_millis(ms)),
+            _ => Some(std::time::Duration::from_millis(DEFAULT_LIFT_TIMEOUT_MS)),
+        },
+        None => Some(std::time::Duration::from_millis(DEFAULT_LIFT_TIMEOUT_MS)),
+    }
+}
+
 pub(crate) fn run_with_timeout(
     command: &mut std::process::Command,
     stdin_data: Option<&[u8]>,

--- a/crates/mununu-core/src/adapter/slang/mod.rs
+++ b/crates/mununu-core/src/adapter/slang/mod.rs
@@ -102,7 +102,19 @@ pub fn run_ast_json(
         cmd.arg(f);
     }
 
-    let output = cmd.output().map_err(|e| AdapterError {
+    // mununu#504 — bounded. This ran as a bare `.output()`. slang runs FIRST, before anything is
+    // known about the design, so a hang here loses the run with no output and nothing to report.
+    let outcome = match crate::adapter::lift_timeout() {
+        Some(t) => crate::adapter::run_with_timeout(&mut cmd, None, t),
+        None => cmd.output().map(|o| {
+            Some((
+                o.status,
+                String::from_utf8_lossy(&o.stdout).into_owned(),
+                String::from_utf8_lossy(&o.stderr).into_owned(),
+            ))
+        }),
+    }
+    .map_err(|e| AdapterError {
         kind: AdapterErrorKind::UnsupportedConstruct,
         message: format!(
             "adapter/slang: failed to run `{} --ast-json`: {e}",
@@ -110,6 +122,26 @@ pub fn run_ast_json(
         ),
         location: None,
     })?;
+    // A slang timeout stays a hard error, unlike yosys/sv2v: slang is what DISCOVERS the
+    // properties, so at this point there is no property list to degrade into an all-`unknown`
+    // report. The honest outcome is a clear failure naming the cap.
+    let Some((status, stdout, stderr_s)) = outcome else {
+        return Err(AdapterError {
+            kind: AdapterErrorKind::ParseError,
+            message: format!(
+                "adapter/slang: `slang --ast-json` exceeded the lift timeout and was killed. \
+                 slang runs before the property list exists, so there is nothing to report a \
+                 partial verdict for. Raise or disable the cap with {}=<ms> (0 disables).",
+                crate::adapter::LIFT_TIMEOUT_ENV
+            ),
+            location: None,
+        });
+    };
+    let output = std::process::Output {
+        status,
+        stdout: stdout.into_bytes(),
+        stderr: stderr_s.into_bytes(),
+    };
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     if stdout.trim().is_empty() {

--- a/crates/mununu-core/src/adapter/yosys/mod.rs
+++ b/crates/mununu-core/src/adapter/yosys/mod.rs
@@ -597,16 +597,32 @@ fn run_sv_flatten_btor2_concrete(
     if let Some(plugin) = &slang_plugin {
         yosys_cmd.arg("-m").arg(plugin);
     }
-    let output = yosys_cmd
-        .arg("-q")
-        .arg("-p")
-        .arg(&script)
-        .output()
-        .map_err(|e| AdapterError {
-            kind: AdapterErrorKind::ParseError,
-            message: format!("adapter/yosys: failed to spawn yosys: {e}"),
-            location: None,
-        })?;
+    yosys_cmd.arg("-q").arg("-p").arg(&script);
+    // mununu#504 — bounded. This ran as a bare `.output()`, i.e. forever. The lift precedes every
+    // property, so a hung yosys emits ZERO output and the whole run reads as absent — one of the
+    // two ways a consumer loses a full gate run. `run_yosys` 700 lines below has used this same
+    // helper for the per-module path all along.
+    let outcome = match crate::adapter::lift_timeout() {
+        Some(t) => crate::adapter::run_with_timeout(&mut yosys_cmd, None, t),
+        None => yosys_cmd.output().map(|o| {
+            Some((
+                o.status,
+                String::from_utf8_lossy(&o.stdout).into_owned(),
+                String::from_utf8_lossy(&o.stderr).into_owned(),
+            ))
+        }),
+    }
+    .map_err(|e| AdapterError {
+        kind: AdapterErrorKind::ParseError,
+        message: format!("adapter/yosys: failed to spawn yosys: {e}"),
+        location: None,
+    })?;
+    let (status, stdout_s, stderr_s) = lift_timeout_outcome(outcome, "yosys")?;
+    let output = std::process::Output {
+        status,
+        stdout: stdout_s.into_bytes(),
+        stderr: stderr_s.into_bytes(),
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1325,6 +1341,27 @@ fn run_yosys(yosys: &Path, script: &str, timeout: Duration) -> Result<(), Adapte
 /// (timed out ⇒ killed) becomes an actionable scope error rather than a hang;
 /// a non-zero exit surfaces yosys's own stderr. Split out so the error paths are
 /// unit-testable without spawning a slow subprocess.
+/// mununu#504 — map a bounded lift-subprocess outcome, splitting the TIMEOUT case out from the
+/// normal one. Pure (`Option<(ExitStatus, String, String)>` in, `Result` out) so the timeout path
+/// is unit-testable without spawning anything — the same shape as
+/// [`yosys_run_outcome_to_result`], for the same reason.
+fn lift_timeout_outcome(
+    outcome: Option<(std::process::ExitStatus, String, String)>,
+    tool: &str,
+) -> Result<(std::process::ExitStatus, String, String), AdapterError> {
+    outcome.ok_or_else(|| AdapterError {
+        kind: AdapterErrorKind::ParseError,
+        message: format!(
+            "adapter/yosys: `{tool}` exceeded the lift timeout and was killed. The lift runs \
+             before any property is attempted, so this would otherwise hang with no output at \
+             all. Raise or disable the cap with {}=<ms> (0 disables), or reduce the design \
+             (fewer sources, a narrower --top).",
+            crate::adapter::LIFT_TIMEOUT_ENV
+        ),
+        location: None,
+    })
+}
+
 fn yosys_run_outcome_to_result(
     outcome: Option<(std::process::ExitStatus, String, String)>,
     script: &str,
@@ -1954,11 +1991,28 @@ fn run_sv2v(
         cmd.arg(format!("-I{}", dir.display()));
     }
     cmd.args(sources);
-    let result = cmd.output().map_err(|e| AdapterError {
+    // mununu#504 — bounded; see the note on the main yosys lift.
+    let outcome = match crate::adapter::lift_timeout() {
+        Some(t) => crate::adapter::run_with_timeout(&mut cmd, None, t),
+        None => cmd.output().map(|o| {
+            Some((
+                o.status,
+                String::from_utf8_lossy(&o.stdout).into_owned(),
+                String::from_utf8_lossy(&o.stderr).into_owned(),
+            ))
+        }),
+    }
+    .map_err(|e| AdapterError {
         kind: AdapterErrorKind::ParseError,
         message: format!("adapter/yosys: failed to spawn sv2v: {e}"),
         location: None,
     })?;
+    let (status, stdout_s, stderr_s) = lift_timeout_outcome(outcome, "sv2v")?;
+    let result = std::process::Output {
+        status,
+        stdout: stdout_s.into_bytes(),
+        stderr: stderr_s.into_bytes(),
+    };
     if !result.status.success() {
         let stderr = String::from_utf8_lossy(&result.stderr);
         let stdout = String::from_utf8_lossy(&result.stdout);
@@ -2343,6 +2397,81 @@ mod tests {
 
     // P1.1 — Auto-frontend fallback attempt ordering (the slang branch itself needs the plugin /
     // mununu-sva image; the ordering is deterministic + host-testable).
+    #[test]
+    /// mununu#504 — a lift-subprocess timeout must produce an ACTIONABLE error naming the cap,
+    /// not a bare failure. Pure mapper, so this runs without spawning anything.
+    fn lift_timeout_outcome_maps_a_kill_to_an_actionable_error() {
+        let err = lift_timeout_outcome(None, "yosys").expect_err("timeout is an error");
+        assert!(
+            err.message.contains("exceeded the lift timeout"),
+            "{}",
+            err.message
+        );
+        assert!(
+            err.message.contains("MUNUNU_LIFT_TIMEOUT_MS"),
+            "must name the knob that changes it: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("before any property"),
+            "must explain WHY this costs the whole run: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    /// The non-timeout path is passed through untouched, so bounding the call cannot change
+    /// behaviour on a design that completes.
+    fn lift_timeout_outcome_passes_a_completed_run_through() {
+        let st = std::process::Command::new("true")
+            .status()
+            .expect("`true` runs");
+        let (status, out, err) =
+            lift_timeout_outcome(Some((st, "OUT".into(), "ERR".into())), "yosys")
+                .expect("completed run is not an error");
+        assert!(status.success());
+        assert_eq!(out, "OUT");
+        assert_eq!(err, "ERR");
+    }
+
+    #[test]
+    /// mununu#504 — the ladder, pure. `0` disables (the escape-hatch convention the other
+    /// budgets use); a positive value is honoured; unset or garbage falls back to the default.
+    fn lift_timeout_ms_parses_the_whole_ladder() {
+        use crate::adapter::parse_lift_timeout_ms;
+        assert_eq!(parse_lift_timeout_ms(Some("0".into())), None, "0 disables");
+        assert_eq!(
+            parse_lift_timeout_ms(Some("1500".into())),
+            Some(std::time::Duration::from_millis(1500))
+        );
+        let default = parse_lift_timeout_ms(None).expect("unset ⇒ default");
+        assert_eq!(default, std::time::Duration::from_secs(15 * 60));
+        assert_eq!(
+            parse_lift_timeout_ms(Some("garbage".into())),
+            Some(default),
+            "unparseable falls back to the default rather than disabling the cap"
+        );
+        assert_eq!(parse_lift_timeout_ms(Some("  0  ".into())), None, "trimmed");
+    }
+
+    #[test]
+    /// mununu#504 — the helper really does kill a hung child, and fast. This is what turns
+    /// "does it hang?" into a deterministic sub-second test instead of a six-hour one.
+    fn run_with_timeout_kills_a_hanging_child_quickly() {
+        let t0 = std::time::Instant::now();
+        let mut cmd = std::process::Command::new("sleep");
+        cmd.arg("30");
+        let outcome =
+            crate::adapter::run_with_timeout(&mut cmd, None, std::time::Duration::from_millis(150))
+                .expect("spawn ok");
+        assert!(outcome.is_none(), "a killed child reports as a timeout");
+        assert!(
+            t0.elapsed() < std::time::Duration::from_secs(5),
+            "must return promptly after the cap, took {:?}",
+            t0.elapsed()
+        );
+    }
+
     #[test]
     fn auto_frontend_attempt_order() {
         // No slang plugin → the sole attempt is read_verilog (unchanged legacy behaviour).


### PR DESCRIPTION
**Track C, PR 2** of the #504 ladder. Follows #520 (C1).

## The problem

All three lift subprocesses used a bare `Command::output()`, which blocks **forever**:

| Site | |
|---|---|
| `yosys/mod.rs` — the main `sv verify-auto` lift | unbounded |
| `slang/mod.rs` — `run_ast_json` | unbounded |
| `yosys/mod.rs` — `run_sv2v` | unbounded |

This is the **first** of the two ways a consumer loses a whole run. The lift precedes every
property, so a hung tool emits **zero output** and every property reads as absent — exactly what
monono reported for `sprite_fetch`.

btormc and pono have been bounded by `run_with_timeout` all along, and `run_yosys` uses that
same helper for the per-module path **700 lines below** the unguarded main-lift call. The helper
needed no changes; this just closes the gap.

## slang is treated differently, deliberately

yosys and sv2v run **after** slang has discovered the property list, so a timeout there can
eventually degrade into a report with every property `unknown`.

slang runs **first** — nothing about the design is known yet, and there is no property list to
degrade into. Its timeout therefore stays a hard error whose message says exactly that.
Manufacturing an empty report would be inventing a result.

## Configuration

`MUNUNU_LIFT_TIMEOUT_MS` — **one** variable for all three rather than three, until a measurement
distinguishes them. `0` disables, matching the escape-hatch convention the other budgets use.

**Default 15 minutes**, deliberately generous: a large multi-file `--single-unit` elaboration
legitimately takes minutes, and a cap that fires on real work turns a slow success into a
spurious failure — worse than no cap.

Uncapped mode keeps the **original `.output()` call path**, so `=0` is byte-identical to today
rather than "a very large timeout" — the escape hatch is a true escape hatch, not a slightly
different code path to reason about.

## Tests — four, all sub-second, none needing a slow input

- the timeout mapper yields an **actionable** error: it names the knob *and* explains why a lift
  hang costs the whole run;
- a completed run passes through untouched, so bounding cannot change behaviour on a design that
  finishes;
- the parse ladder, including `0` ⇒ uncapped and garbage ⇒ **default** (falling back to the
  default rather than silently uncapping is the safe direction);
- `run_with_timeout` really kills a hung child — `sleep 30` under a 150 ms cap, asserted to
  return in under 5 s. That is what turns "does it hang?" into a deterministic test.

The mappers are pure (`Option<(ExitStatus, String, String)>` in, `Result` out), mirroring the
existing `yosys_run_outcome_to_result` — which is in that shape for precisely this reason: the
error paths are testable without spawning anything.

## Deliberately NOT in this PR

**Degrading a yosys/sv2v timeout into an all-`unknown` report.** It is genuinely useful — the
other half of monono's "absent for every property" — but it needs the `StopReason` /
`push_abstention` refactor from C4. Building it now would create a second, divergent way of
producing a degraded report that C4 then has to unify.

## Verification

2535 lib tests pass, clippy clean.

No consumer briefing: this adds a cap where there was none. No verdict, wire, route or flag
changes; a run that completes today is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
