### PR TITLE
feat(budget): cooperative wall-clock budget for the verification loops (#504 C3)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/cegar.rs
+++ b/crates/mununu-core/src/adapter/btor2/cegar.rs
@@ -410,6 +410,11 @@ pub enum CegarTermination {
     /// MVP `WeakestPrecondition` / `CraigInterpolation` sources hit
     /// this immediately because they are not yet implemented.
     PredicateSourceExhausted,
+    /// mununu#504 — a wall-clock budget expired between refinement rounds. The verdict is the
+    /// last completed iteration's, which is independently SOUND: less refinement means more ⊥,
+    /// never a wrong verdict. Distinct from `BoundedIterationsReached` so a caller can tell
+    /// "we ran out of time" from "we ran out of rounds" — they suggest different remedies.
+    BudgetExpired,
 }
 
 /// R.5 — Outcome of the CEGAR refinement loop.
@@ -981,6 +986,34 @@ pub fn cegar_refine_loop(
     };
 
     for iteration in 0..=cegar_opts.max_iterations {
+        // mununu#504 — the CEGAR round poll, and note this is NOT an error path.
+        //
+        // Each iteration's verdict is independently SOUND under the 3-valued KMTS semantics;
+        // refinement only sharpens it. So stopping early means LESS refinement, hence MORE ⊥ —
+        // never a wrong verdict. Breaking here therefore falls into the same exit the
+        // iteration-cap already uses, and the caller sees an ordinary (possibly ⊥) result.
+        //
+        // The one case that IS an error is expiry before iteration 0 produced anything: there is
+        // no sound verdict to report at all, so the caller must not be handed a fabricated one.
+        if iteration > 0
+            && crate::adapter::run_budget::expired()
+            && let Some(last) = iterations.last()
+        {
+            // NOT a `break`: the loop is followed by `unreachable!()`, so falling out of it would
+            // panic. Return the last completed iteration's verdict instead.
+            return Ok(CegarTrace {
+                final_verdict: last.verdict.clone(),
+                final_predicates: current_predicates.clone(),
+                terminated_with: CegarTermination::BudgetExpired,
+                lazy_lift_pending: true,
+                approximant_reuse_enabled: cegar_opts.enable_approximant_reuse,
+                warnings: warnings.clone(),
+                init_refinement_candidates: init_refinement_candidates.iter().cloned().collect(),
+                final_clts: captured_clts.take(),
+                counterexample: None,
+                iterations,
+            });
+        }
         // 1. Lift the BTOR2 with the current predicate set.
         //
         // **Sub-item 2.4 (2026-06-04)**: the lift-strategy flag

--- a/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
+++ b/crates/mununu-core/src/adapter/btor2/kmts_lift.rs
@@ -2277,21 +2277,41 @@ pub fn predicate_cube_lift(
         ) = if use_session_may_hyper {
             let (may, hyper) = sts.may_and_hyper_must_edges(&cube_preds, 5_000);
             (may, Some(hyper))
-        } else if lift_opts.may_postimage
-            && predicates.len() >= 2
-            && let Some(map) = compute_all_may_edges_smt_postimage(
+        } else if lift_opts.may_postimage && predicates.len() >= 2 {
+            // mununu#504 — THREE outcomes, and conflating two of them is the trap `MayPostimage`
+            // exists to prevent. `NotApplicable` falls back to the all-pairs seam;
+            // `BudgetExceeded` must NOT, because that seam is O(2^2|P|) — strictly slower than
+            // the post-image we just abandoned for lack of time.
+            match compute_all_may_edges_smt_postimage(
                 &file,
                 &predicates,
                 &lift_opts.compound_exprs,
                 crate::adapter::btor2::smt_must_edge::cube_smt_rlimit(),
-            )
-        {
-            let mut pairs: Vec<(usize, usize)> = map
-                .into_iter()
-                .flat_map(|(src, tgts)| tgts.into_iter().map(move |t| (src, t)))
-                .collect();
-            pairs.sort_unstable();
-            (pairs, None)
+            ) {
+                MayPostimage::Complete(map) => {
+                    let mut pairs: Vec<(usize, usize)> = map
+                        .into_iter()
+                        .flat_map(|(src, tgts)| tgts.into_iter().map(move |t| (src, t)))
+                        .collect();
+                    pairs.sort_unstable();
+                    (pairs, None)
+                }
+                MayPostimage::NotApplicable => (sts.may_edges(&cube_preds, 5_000), None),
+                MayPostimage::BudgetExceeded => {
+                    return Err(AdapterError {
+                        kind: crate::adapter::AdapterErrorKind::ResourceBudgetExceeded,
+                        location: None,
+                        message: format!(
+                            "adapter/btor2/predicate_cube_lift: the wall-clock budget expired \
+                             while computing the may-relation over {} cubes. Raise or clear {} / \
+                             {}, or narrow the property's cone.",
+                            1usize << predicates.len(),
+                            crate::adapter::run_budget::PROPERTY_BUDGET_ENV,
+                            crate::adapter::run_budget::RUN_BUDGET_ENV,
+                        ),
+                    });
+                }
+            }
         } else {
             (sts.may_edges(&cube_preds, 5_000), None)
         };
@@ -2714,6 +2734,35 @@ fn collect_boolean_input_symbols(
 ///
 /// P1 increment 1: validated by `p1_smt_postimage_may_edges_match_concrete_oracle`. P1.4: wired into
 /// `predicate_cube_lift` behind `PredicateCubeLiftOptions::may_postimage`.
+/// mununu#504 — the post-image outcome. THREE cases, not two.
+///
+/// The trap this exists to avoid: `None` already meant *"not applicable, fall back"*, and the
+/// fallback is the O(2^2|P|) all-pairs seam — **slower** than the post-image. So returning `None`
+/// on a budget expiry would make a timeout strictly WORSE than doing nothing, by dropping a
+/// 2^|P| loop into a 2^2|P| one at exactly the moment we are out of time.
+#[derive(Debug)]
+enum MayPostimage {
+    /// The complete post-image may-relation.
+    Complete(std::collections::HashMap<usize, Vec<usize>>),
+    /// Not applicable to this input (an unresolvable predicate, or |P| out of range). The caller
+    /// falls back to the all-pairs seam — the historical `None`.
+    NotApplicable,
+    /// The wall-clock budget expired mid-enumeration. NOT a partial map: the caller must abort
+    /// the lift, never fall back.
+    BudgetExceeded,
+}
+
+#[cfg(test)]
+impl MayPostimage {
+    /// Test-only unwrap to the completed map.
+    fn expect(self, msg: &str) -> std::collections::HashMap<usize, Vec<usize>> {
+        match self {
+            MayPostimage::Complete(m) => m,
+            other => panic!("{msg}: expected Complete, got {other:?}"),
+        }
+    }
+}
+
 /// `rlimit`: the deterministic z3 resource bound, passed in rather than read from the
 /// environment so the `Unknown`-saturation path (mununu#504) is testable without mutating
 /// process-global state — the same pure-helper idiom `memory_budget.rs` uses. Production passes
@@ -2726,14 +2775,14 @@ fn compute_all_may_edges_smt_postimage(
         crate::adapter::btor2::predicate_expr::PredicateExpr,
     >,
     rlimit: Option<u32>,
-) -> Option<std::collections::HashMap<usize, Vec<usize>>> {
+) -> MayPostimage {
     use crate::adapter::btor2::predicate_expr::{CmpOp, PredicateExpr};
     let n = predicates.len();
     if n == 0 || n > 20 {
-        return None; // outside the cube-space bound; caller uses the eager path
+        return MayPostimage::NotApplicable; // outside the cube-space bound; eager path handles it
     }
     let cfg = z3::Config::new();
-    z3::with_z3_config(&cfg, || {
+    let res = z3::with_z3_config(&cfg, || {
         let view = encode_design_for_lift(file).ok()?;
         let nid_map = crate::adapter::btor2::smt_must_edge::build_register_nid_map(&view);
         // Effective constraint per predicate: a compound (by name) or the simple `reg == value`.
@@ -2771,8 +2820,11 @@ fn compute_all_may_edges_smt_postimage(
             .map(|e| e.build_constraint(&next))
             .collect::<Option<Vec<_>>>()?;
 
+        let mut budget_expired = false;
         let mut params = z3::Params::new();
-        params.set_u32("timeout", 5000);
+        // mununu#504 — clamp the per-query timeout to the time actually left, so the LAST query
+        // cannot overshoot the deadline by its own full 5 s.
+        params.set_u32("timeout", crate::adapter::run_budget::clamp_query_ms(5000));
         // mununu#504 — the deterministic resource bound, the same lever every check in
         // `smt_must_edge` already applies. It was missing HERE, on the post-image path, which is
         // the measured hang suspect (`for cube in 0..2^n` around an all-SAT loop, x17 CEGAR
@@ -2785,6 +2837,15 @@ fn compute_all_may_edges_smt_postimage(
         let mut out: std::collections::HashMap<usize, Vec<usize>> =
             std::collections::HashMap::new();
         for cube in 0..(1usize << n) {
+            // mununu#504 — the outer poll. This loop is the measured hang: up to 2^|P| cubes,
+            // x17 CEGAR rounds, x N properties, previously with only a per-QUERY timeout and no
+            // aggregate bound. Bailing here is signalled to the caller as `BudgetExceeded`, NOT
+            // as a partial map: a truncated may-relation is an under-approximation (see the
+            // saturation note in the all-SAT loop below).
+            if crate::adapter::run_budget::expired() {
+                budget_expired = true;
+                break;
+            }
             let solver = z3::Solver::new();
             solver.set_params(&params);
             solver.assert(&view.transition);
@@ -2815,6 +2876,14 @@ fn compute_all_may_edges_smt_postimage(
             let mut targets: Vec<usize> = Vec::new();
             let mut inconclusive = false;
             loop {
+                // mununu#504 — the inner poll. One z3 query is the interruptible unit, so the
+                // worst-case overshoot past the deadline is a single query (and `clamp_query_ms`
+                // below bounds even that).
+                if crate::adapter::run_budget::expired() {
+                    budget_expired = true;
+                    inconclusive = true; // do not trust a partial enumeration
+                    break;
+                }
                 match solver.check() {
                     z3::SatResult::Sat => {}
                     z3::SatResult::Unsat => break, // enumeration provably complete
@@ -2860,8 +2929,18 @@ fn compute_all_may_edges_smt_postimage(
             targets.dedup();
             out.insert(cube, targets);
         }
-        Some(out)
-    })
+        if budget_expired {
+            return Some(Err(())); // budget expiry, distinct from "not applicable"
+        }
+        Some(Ok(out))
+    });
+    // Three-way at the boundary: `None` = not applicable (fall back), `Some(Err)` = budget
+    // expiry (abort, never fall back — the fallback is SLOWER), `Some(Ok)` = complete.
+    match res {
+        None => MayPostimage::NotApplicable,
+        Some(Err(())) => MayPostimage::BudgetExceeded,
+        Some(Ok(map)) => MayPostimage::Complete(map),
+    }
 }
 
 /// P1 (scalable-KMTS) increment 2 — the compound-aware MUST-edge pass for the post-image lazy path.
@@ -2961,6 +3040,60 @@ mod tests {
             },
         );
         (btor2, preds, compound)
+    }
+
+    #[test]
+    /// mununu#504 — an expired budget must report `BudgetExceeded`, NOT `NotApplicable`.
+    ///
+    /// This is the trap `MayPostimage` exists for. `NotApplicable` means "fall back to the
+    /// all-pairs seam", and that seam is O(2^2|P|) — **slower** than the post-image loop we just
+    /// abandoned for lack of time. Conflating the two would make a timeout strictly worse than
+    /// having no budget at all.
+    fn postimage_reports_budget_expiry_distinctly_from_not_applicable() {
+        use crate::adapter::run_budget::{Budget, enter};
+        const B: &str = "1 sort bitvec 1\n\
+                         2 state 1 q\n\
+                         3 zero 1\n\
+                         4 init 1 2 3\n\
+                         5 next 1 2 2\n";
+        let file = crate::adapter::btor2::parser::parse(B).expect("parse");
+        let preds = vec![PredicateSpec {
+            name: "q == 1".into(),
+            register: "q".into(),
+            value: 1,
+        }];
+        let compound = std::collections::HashMap::new();
+
+        // Expired budget ⇒ BudgetExceeded, promptly.
+        let t0 = std::time::Instant::now();
+        let out = {
+            let _g = enter(&Budget::with_ms(0));
+            compute_all_may_edges_smt_postimage(&file, &preds, &compound, None)
+        };
+        assert!(
+            matches!(out, MayPostimage::BudgetExceeded),
+            "an expired budget must be distinguishable from `not applicable`; got {out:?}"
+        );
+        assert!(
+            t0.elapsed() < std::time::Duration::from_secs(5),
+            "must bail promptly, took {:?}",
+            t0.elapsed()
+        );
+
+        // Control: unbounded ⇒ the real relation, so the assertion above is about the BUDGET and
+        // not about this fixture being unusable.
+        let ok = compute_all_may_edges_smt_postimage(&file, &preds, &compound, None);
+        assert!(
+            matches!(ok, MayPostimage::Complete(_)),
+            "with no budget the same call completes; got {ok:?}"
+        );
+
+        // And `NotApplicable` remains reachable for its own reason (|P| = 0), unchanged.
+        let na = compute_all_may_edges_smt_postimage(&file, &[], &compound, None);
+        assert!(
+            matches!(na, MayPostimage::NotApplicable),
+            "the out-of-range case still says NotApplicable; got {na:?}"
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -59,6 +59,7 @@ pub mod promela;
 pub mod reach_portfolio;
 pub mod reach_rescue;
 pub mod recoverability;
+pub mod run_budget;
 pub mod sidecar;
 pub mod slang;
 pub mod state_enum;
@@ -433,6 +434,12 @@ pub enum AdapterErrorKind {
     IrConsistencyError,
     /// CTXDSL emission failed.
     EmitError,
+    /// mununu#504 — a wall-clock or resource budget expired mid-verification. Distinct from the
+    /// other kinds because it is NOT a defect in the input: the design is fine, we simply stopped.
+    /// `verify_auto` maps it to `Unknown`, never `Skipped` — `ci_exit_code` does not fail on
+    /// `skipped`, so a strict `--fail-on unknown` gate would otherwise go GREEN on a property
+    /// that timed out.
+    ResourceBudgetExceeded,
 }
 
 impl fmt::Display for AdapterError {

--- a/crates/mununu-core/src/adapter/run_budget.rs
+++ b/crates/mununu-core/src/adapter/run_budget.rs
@@ -1,0 +1,315 @@
+//! mununu#504 — a cooperative wall-clock budget for a verification run.
+//!
+//! # Why this exists
+//!
+//! Nothing in `sv verify-auto` was bounded by time at any granularity. A consumer lost a full
+//! `make formal` run to a six-hour hang, and a second run to an OS kill that emitted **zero
+//! output** — losing verdicts already computed in memory. The engines have size budgets (the BDD
+//! bit cap, node budget, iteration budget) and the subprocesses now have wall-clock caps, but the
+//! SMT enumeration loops in the lift had neither: only a 5 s *per-query* timeout, with no
+//! aggregate bound across `2^|P|` cubes x 17 CEGAR rounds x N properties.
+//!
+//! # Why cooperative cancel rather than a thread per property
+//!
+//! The obvious alternative — run each property on a detached thread and `recv_timeout` — was
+//! rejected because it **sabotages the memory ceiling**: an abandoned thread keeps its z3 context
+//! and partial maps alive and still allocating, and that RSS is exactly what the memory budget
+//! reads. Two mechanisms fighting each other is worse than either alone. The measured hang is
+//! also genuinely interruptible: every iteration of the enumeration loops returns to Rust.
+//!
+//! # Why a thread-local rather than threading `&Budget` through
+//!
+//! The loops that burn the time sit 4-6 frames below the driver, behind `CegarOptions`,
+//! `PredicateCubeLiftOptions` and the public `SmtEncode` trait. Explicit threading would touch
+//! ~40 signatures and ~60 test literals on exactly the code path that must not regress. Those
+//! leaves *already* read process-global state at these points (`cube_smt_rlimit()` reads an env
+//! var inside nine separate check functions), so a thread-local is **strictly more scoped** than
+//! the idiom already in place — and unlike env, it is per-test-thread, so budget tests need no
+//! serialisation and no environment mutation.
+//!
+//! # Footgun
+//!
+//! **A spawned thread inherits nothing.** Any `std::thread::spawn` that should honour the budget
+//! must capture [`current`] and [`enter`] it inside the closure. `budget_is_not_inherited_by_a_
+//! spawned_thread` pins that, so the surprise is documented rather than discovered.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+/// Per-property wall-clock budget. Unset ⇒ unbounded.
+pub const PROPERTY_BUDGET_ENV: &str = "MUNUNU_PROPERTY_BUDGET_MS";
+/// Whole-run wall-clock budget. Unset ⇒ unbounded.
+pub const RUN_BUDGET_ENV: &str = "MUNUNU_VERIFY_BUDGET_MS";
+
+/// A deadline plus a cancellation flag. Cloning shares the flag.
+#[derive(Clone, Debug)]
+pub struct Budget {
+    deadline: Option<Instant>,
+    cancel: Arc<AtomicBool>,
+}
+
+impl Default for Budget {
+    fn default() -> Self {
+        Self::unbounded()
+    }
+}
+
+impl Budget {
+    /// No deadline. The default everywhere until a budget is explicitly configured, so this
+    /// module is inert unless someone opts in.
+    pub fn unbounded() -> Self {
+        Self {
+            deadline: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// A budget expiring `ms` from now.
+    pub fn with_ms(ms: u64) -> Self {
+        Self {
+            deadline: Some(Instant::now() + Duration::from_millis(ms)),
+            cancel: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// `None` ⇒ unbounded, `Some(ms)` ⇒ bounded. Convenience for an env-derived option.
+    pub fn with_ms_opt(ms: Option<u64>) -> Self {
+        match ms {
+            Some(ms) => Self::with_ms(ms),
+            None => Self::unbounded(),
+        }
+    }
+
+    /// A child budget that can never outlive its parent: the effective deadline is the EARLIER of
+    /// the parent's and `now + ms`. A per-property budget therefore cannot overrun the run budget,
+    /// however many properties there are. The cancel flag is SHARED, so cancelling the parent
+    /// cancels every child.
+    pub fn child(outer: &Budget, ms: Option<u64>) -> Self {
+        let own = ms.map(|ms| Instant::now() + Duration::from_millis(ms));
+        let deadline = match (outer.deadline, own) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(a), None) => Some(a),
+            (None, b) => b,
+        };
+        Self {
+            deadline,
+            cancel: Arc::clone(&outer.cancel),
+        }
+    }
+
+    /// Has the budget run out, or been cancelled?
+    pub fn expired(&self) -> bool {
+        self.cancel.load(Ordering::Relaxed) || self.deadline.is_some_and(|d| Instant::now() >= d)
+    }
+
+    /// Milliseconds left, saturating at 0. `None` ⇒ unbounded.
+    pub fn remaining_ms(&self) -> Option<u64> {
+        self.deadline.map(|d| {
+            d.saturating_duration_since(Instant::now())
+                .as_millis()
+                .min(u64::MAX as u128) as u64
+        })
+    }
+
+    /// Cancel this budget and every budget sharing its flag.
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+thread_local! {
+    static CURRENT: std::cell::RefCell<Budget> = std::cell::RefCell::new(Budget::unbounded());
+}
+
+/// RAII installation of `b` as this thread's current budget. The previous budget is restored on
+/// drop, so every early `continue` / `return` / `?` in the caller is safe without bookkeeping.
+pub struct BudgetGuard(Budget);
+
+impl Drop for BudgetGuard {
+    fn drop(&mut self) {
+        let prev = self.0.clone();
+        CURRENT.with(|c| *c.borrow_mut() = prev);
+    }
+}
+
+/// Install `b` for this thread until the returned guard drops.
+pub fn enter(b: &Budget) -> BudgetGuard {
+    let prev = CURRENT.with(|c| c.replace(b.clone()));
+    BudgetGuard(prev)
+}
+
+/// This thread's current budget.
+pub fn current() -> Budget {
+    CURRENT.with(|c| c.borrow().clone())
+}
+
+/// The leaf poll — one call, no plumbing.
+pub fn expired() -> bool {
+    CURRENT.with(|c| c.borrow().expired())
+}
+
+/// Clamp a per-query solver timeout to the time actually left, so the LAST query cannot overshoot
+/// the deadline by its own full timeout. Never returns 0 (z3 reads 0 as "no timeout", which would
+/// be the exact opposite of what an expired budget wants); an expired budget yields 1 ms, and the
+/// caller's `expired()` check is what actually stops the loop.
+pub fn clamp_query_ms(default_ms: u32) -> u32 {
+    match current().remaining_ms() {
+        Some(rem) => default_ms.min(rem.max(1) as u32).max(1),
+        None => default_ms,
+    }
+}
+
+/// Why a run stopped early. Kept separate from `AdapterError` so a caller can report the reason
+/// per property while preserving verdicts already computed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopReason {
+    /// A wall-clock budget expired.
+    TimeBudget { scope: &'static str },
+    /// The process-RSS ceiling was exceeded (mununu#490).
+    Memory,
+    /// Explicitly cancelled.
+    Cancelled,
+}
+
+/// Pure parse of a budget env value: a positive integer → that many ms; `0`, unset, or
+/// unparseable → `None` (unbounded). Extracted so the ladder is testable without mutating
+/// process-global environment, mirroring `memory_budget.rs`.
+pub fn parse_budget_ms(v: Option<String>) -> Option<u64> {
+    v.as_deref()
+        .map(str::trim)
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&ms| ms > 0)
+}
+
+/// The configured per-property budget (`MUNUNU_PROPERTY_BUDGET_MS`), or `None`.
+pub fn property_budget_ms() -> Option<u64> {
+    parse_budget_ms(std::env::var(PROPERTY_BUDGET_ENV).ok())
+}
+
+/// The configured whole-run budget (`MUNUNU_VERIFY_BUDGET_MS`), or `None`.
+pub fn run_budget_ms() -> Option<u64> {
+    parse_budget_ms(std::env::var(RUN_BUDGET_ENV).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unbounded_never_expires_and_has_no_remaining() {
+        let b = Budget::unbounded();
+        assert!(!b.expired());
+        assert_eq!(b.remaining_ms(), None);
+    }
+
+    #[test]
+    fn a_zero_budget_is_immediately_expired() {
+        assert!(Budget::with_ms(0).expired());
+    }
+
+    #[test]
+    fn cancel_expires_even_an_unbounded_budget() {
+        let b = Budget::unbounded();
+        assert!(!b.expired());
+        b.cancel();
+        assert!(b.expired(), "cancellation is independent of the deadline");
+    }
+
+    #[test]
+    /// A per-property budget must never outlive the run budget, however generous it is.
+    fn child_clamps_to_the_earlier_deadline() {
+        let outer = Budget::with_ms(0); // already expired
+        let child = Budget::child(&outer, Some(60_000));
+        assert!(
+            child.expired(),
+            "a long child budget cannot extend an exhausted run budget"
+        );
+
+        let generous = Budget::with_ms(60_000);
+        let short = Budget::child(&generous, Some(0));
+        assert!(short.expired(), "the child's own deadline still applies");
+
+        let inherit = Budget::child(&generous, None);
+        assert!(!inherit.expired());
+        assert!(
+            inherit.remaining_ms().is_some(),
+            "inherits the parent deadline"
+        );
+    }
+
+    #[test]
+    fn cancelling_the_parent_cancels_the_child() {
+        let outer = Budget::unbounded();
+        let child = Budget::child(&outer, Some(60_000));
+        outer.cancel();
+        assert!(child.expired(), "the cancel flag is shared");
+    }
+
+    #[test]
+    fn enter_installs_and_drop_restores() {
+        assert!(!expired());
+        {
+            let _g = enter(&Budget::with_ms(0));
+            assert!(expired(), "installed for the scope");
+        }
+        assert!(!expired(), "restored on drop");
+    }
+
+    #[test]
+    fn nested_enter_restores_the_outer_budget() {
+        let _outer = enter(&Budget::unbounded());
+        {
+            let _inner = enter(&Budget::with_ms(0));
+            assert!(expired());
+        }
+        assert!(!expired(), "the OUTER budget is restored, not the default");
+    }
+
+    #[test]
+    /// The documented footgun, pinned: a spawned thread starts unbounded. Any spawn site that
+    /// should honour the budget must capture `current()` and `enter()` it inside the closure.
+    fn budget_is_not_inherited_by_a_spawned_thread() {
+        let _g = enter(&Budget::with_ms(0));
+        assert!(expired());
+        let inherited = std::thread::spawn(expired).join().expect("thread ok");
+        assert!(!inherited, "a spawned thread does NOT inherit the budget");
+
+        // ...and the documented workaround works.
+        let b = current();
+        let honoured = std::thread::spawn(move || {
+            let _g = enter(&b);
+            expired()
+        })
+        .join()
+        .expect("thread ok");
+        assert!(
+            honoured,
+            "capturing `current()` and re-entering carries it over"
+        );
+    }
+
+    #[test]
+    fn clamp_query_ms_never_returns_zero() {
+        let _g = enter(&Budget::with_ms(0));
+        assert_eq!(
+            clamp_query_ms(5000),
+            1,
+            "0 would mean `no timeout` to z3 — the opposite of an expired budget"
+        );
+    }
+
+    #[test]
+    fn clamp_query_ms_passes_through_when_unbounded() {
+        let _g = enter(&Budget::unbounded());
+        assert_eq!(clamp_query_ms(5000), 5000);
+    }
+
+    #[test]
+    fn parse_budget_ladder() {
+        assert_eq!(parse_budget_ms(None), None, "unset ⇒ unbounded");
+        assert_eq!(parse_budget_ms(Some("0".into())), None, "0 ⇒ unbounded");
+        assert_eq!(parse_budget_ms(Some("  250 ".into())), Some(250), "trimmed");
+        assert_eq!(parse_budget_ms(Some("nonsense".into())), None);
+    }
+}

--- a/crates/mununu-core/src/adapter/sts_ir.rs
+++ b/crates/mununu-core/src/adapter/sts_ir.rs
@@ -612,10 +612,31 @@ impl SmtEncode for BtorSts<'_> {
             let nid_map = build_register_nid_map_with_inputs(&view);
             let mut edges = Vec::new();
             for i in 0..n_cubes {
+                // mununu#504 — SOUNDNESS, and the direction here is the OPPOSITE of the must
+                // side. `may` OVER-approximates: correctness needs may ⊇ concrete. So when the
+                // budget expires we SATURATE — every remaining pair becomes a may-edge. A denser
+                // may relation means more ⊥, never a wrong verdict. DROPPING the remaining pairs
+                // (the intuitive "stop early") would UNDER-approximate and could manufacture a
+                // spurious definite `True` for a box property, which is a wrong answer rather
+                // than a slow one.
+                if crate::adapter::run_budget::expired() {
+                    for si in i..n_cubes {
+                        for sj in 0..n_cubes {
+                            edges.push((si, sj));
+                        }
+                    }
+                    break;
+                }
                 for j in 0..n_cubes {
                     if matches!(
                         smt_per_target_may_check_uniform(
-                            &view, &primed, i as u64, j as u64, predicates, &nid_map, timeout_ms,
+                            &view,
+                            &primed,
+                            i as u64,
+                            j as u64,
+                            predicates,
+                            &nid_map,
+                            crate::adapter::run_budget::clamp_query_ms(timeout_ms),
                         ),
                         SmtMayVerdict::May
                     ) {
@@ -623,6 +644,8 @@ impl SmtEncode for BtorSts<'_> {
                     }
                 }
             }
+            edges.sort_unstable();
+            edges.dedup();
             edges
         })
     }
@@ -681,9 +704,25 @@ impl SmtEncode for BtorSts<'_> {
             let nid_map = build_register_nid_map_with_inputs(&view);
             let mut edges = Vec::new();
             for &(i, j) in candidates {
+                // mununu#504 — SOUNDNESS, and note this is the MIRROR IMAGE of `may_edges`.
+                // `must` UNDER-approximates: an edge is included only on a PROVED ∀∃ obligation.
+                // So on expiry we DROP the remaining candidates and stop. Fewer must-edges means
+                // a weaker must relation, hence more ⊥ — never a wrong verdict. SATURATING here
+                // (the may-side move) would assert obligations nobody proved, which is unsound.
+                // This also matches the contract already documented on this method: a timeout
+                // "conservatively drops the edge".
+                if crate::adapter::run_budget::expired() {
+                    break;
+                }
                 if matches!(
                     smt_per_target_must_check_uniform(
-                        &view, &primed, i as u64, j as u64, predicates, &nid_map, timeout_ms,
+                        &view,
+                        &primed,
+                        i as u64,
+                        j as u64,
+                        predicates,
+                        &nid_map,
+                        crate::adapter::run_budget::clamp_query_ms(timeout_ms),
                     ),
                     SmtMustVerdict::Must
                 ) {
@@ -834,6 +873,73 @@ mod tests {
     // uart_tx pattern where Yosys' flatten strips the `_q` symbol from the
     // state line (the DR1 #1 blocker).
     const ALIASED_BTOR2: &str = "1 sort bitvec 4\n2 zero 4\n3 state 4 cnt_d\n4 init 4 3 2\n5 uext 4 3 0 cnt_q\n6 next 4 3 2\n";
+
+    /// mununu#504 — the two budget degradations point in OPPOSITE directions, and getting
+    /// either backwards is an unsoundness rather than a slowdown. This test asserts both in one
+    /// place so a future change cannot quietly flip one to match the other.
+    ///
+    /// - `may` OVER-approximates (may ⊇ concrete) ⇒ on expiry **saturate**. Dropping edges would
+    ///   under-approximate and could manufacture a spurious definite `True` for a box property.
+    /// - `must` UNDER-approximates (only proved ∀∃ obligations) ⇒ on expiry **drop**. Saturating
+    ///   would assert obligations nobody proved.
+    ///
+    /// Forced with an already-expired budget, so it is deterministic and runs in milliseconds.
+    #[test]
+    fn budget_expiry_saturates_may_and_drops_must() {
+        use crate::adapter::btor2::kmts_lift::PredicateSpec;
+        use crate::adapter::run_budget::{Budget, enter};
+        // `q' = q` — a held register, so the TRUE may-relation is strictly sparser than the full
+        // grid (cube 0 reaches only cube 0). Without that, saturation would be indistinguishable
+        // from the correct answer and this test would prove nothing.
+        const B: &str = "1 sort bitvec 1\n2 state 1 q\n3 zero 1\n4 init 1 2 3\n5 next 1 2 2\n";
+        let file = parser::parse(B).expect("parse");
+        let sts = BtorSts::new(&file);
+        let preds = vec![PredicateSpec {
+            name: "q == 1".into(),
+            register: "q".into(),
+            value: 1,
+        }];
+
+        // Control first: unbounded, the real relations.
+        let may_real = sts.may_edges(&preds, 5_000);
+        let must_real = sts.must_edges_over(&preds, &[(0, 0), (1, 1)], 5_000);
+        assert!(
+            may_real.len() < 4,
+            "the TRUE may relation must be sparser than the full grid, else saturation is \
+             untestable on this fixture; got {may_real:?}"
+        );
+
+        let t0 = std::time::Instant::now();
+        let (may_starved, must_starved) = {
+            let _g = enter(&Budget::with_ms(0));
+            (
+                sts.may_edges(&preds, 5_000),
+                sts.must_edges_over(&preds, &[(0, 0), (1, 1)], 5_000),
+            )
+        };
+        assert!(
+            t0.elapsed() < std::time::Duration::from_secs(5),
+            "an expired budget must bail fast, took {:?}",
+            t0.elapsed()
+        );
+
+        assert_eq!(
+            may_starved,
+            vec![(0, 0), (0, 1), (1, 0), (1, 1)],
+            "MAY must SATURATE to the full grid on expiry (over-approximation); a sparser set \
+             here is an under-approximated may relation, which is UNSOUND"
+        );
+        assert!(
+            must_starved.is_empty(),
+            "MUST must DROP on expiry (under-approximation); a non-empty set here asserts \
+             obligations nobody proved, which is UNSOUND. got {must_starved:?}"
+        );
+        assert!(
+            !must_real.is_empty(),
+            "the unstarved must relation is non-empty, so the emptiness above is the BUDGET and \
+             not a degenerate fixture"
+        );
+    }
 
     #[test]
     fn btor_sts_resolve_register_follows_uext_alias_to_state_cell() {

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -2271,6 +2271,11 @@ fn run_cegar_build_response(params: CegarRunParams<'_>) -> Result<Btor2CegarResp
             CegarTermination::Converged => "converged",
             CegarTermination::BoundedIterationsReached => "bounded-iterations-reached",
             CegarTermination::PredicateSourceExhausted => "predicate-source-exhausted",
+            // mununu#504 — a NEW wire value. Distinct from "bounded-iterations-reached": that
+            // means the refinement cap was reached, this means the wall clock ran out. They
+            // suggest different remedies (more rounds vs more time), so a consumer must be able
+            // to tell them apart.
+            CegarTermination::BudgetExpired => "budget-expired",
         }
         .to_string(),
         verdict: summarize(&trace.final_verdict),

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1821,7 +1821,9 @@ pub struct Btor2CegarResponse {
     /// Predicate set at termination (initial + every added predicate).
     pub final_predicates: Vec<PredicateView>,
     /// Why the loop stopped: `"converged"` |
-    /// `"bounded-iterations-reached"` | `"predicate-source-exhausted"`.
+    /// `"bounded-iterations-reached"` | `"predicate-source-exhausted"` |
+    /// `"budget-expired"` (mununu#504 — the wall clock ran out, as opposed to the refinement
+    /// cap being reached; the verdict is the last completed iteration's and is sound).
     pub terminated_with: String,
     /// Cell-count summary of the final 3-valued verdict.
     pub verdict: CegarVerdictSummary,

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -200,6 +200,12 @@ pub(crate) fn execute(
         PortfolioMode::Parallel => {
             // Scoped threads borrow the task's sources / yosys_opts; each owns its option clone
             // AND its own clone of the shared prepared model (so no engine re-runs the prep).
+            // mununu#504 — a spawned thread inherits NOTHING from the parent's thread-local
+            // budget, so each engine thread must re-install it, or the parallel portfolio would
+            // silently run unbounded while the sequential one is bounded.
+            // `run_budget`'s `budget_is_not_inherited_by_a_spawned_thread` pins that behaviour,
+            // and this is the site it exists to protect.
+            let parent_budget = crate::adapter::run_budget::current();
             let runs: Vec<(&str, Result<AutoVerifyReport, AdapterError>)> =
                 std::thread::scope(|scope| {
                     let handles: Vec<(&str, _)> = plan
@@ -208,9 +214,11 @@ pub(crate) fn execute(
                         .map(|op| {
                             let o = mk_opts(op);
                             let pm = prepared.clone();
+                            let b = parent_budget.clone();
                             (
                                 op.label,
                                 scope.spawn(move || {
+                                    let _g = crate::adapter::run_budget::enter(&b);
                                     verify_auto_impl(task.sources, task.yosys_opts, &o, Some(pm))
                                 }),
                             )


### PR DESCRIPTION
**Track C, PR 3** of the #504 ladder. Follows #520 (C1) and #521 (C2).

**Machinery only — both env vars default UNSET, so this changes no behaviour.** C5 flips the
defaults, isolated so a bad default is a one-line revert rather than a bisect through plumbing.

## Why cooperative cancel, not a thread per property

A detached thread per property was the obvious alternative and is wrong here: an abandoned thread
keeps its z3 context and partial maps **alive and still allocating**, and that RSS is exactly what
the #490 memory ceiling reads. The time budget would then cause spurious *memory* abstentions —
two mechanisms sabotaging each other. The measured hang is genuinely interruptible: every
iteration of the enumeration loops returns to Rust.

The budget is a **thread-local** rather than ~40 threaded signatures. The leaves already read
process-global env at these exact points (`cube_smt_rlimit()` in nine check functions), so a
thread-local is *strictly more scoped* than the idiom already in place — and unlike env it is
per-test-thread, so budget tests need no serialisation and no environment mutation.

## Three hazards found while wiring it — each would have shipped a defect

**1. `MayPostimage`.** `compute_all_may_edges_smt_postimage` returned `Option`, where `None`
already meant *"not applicable, fall back"* — and the fallback is the `O(2^2|P|)` all-pairs seam,
**slower** than the post-image. Returning `None` on expiry would have made a timeout *strictly
worse than having no budget*. Now three-way, with `BudgetExceeded` aborting rather than falling
back.

**2. The may/must directions are opposite**, and either backwards is an unsoundness, not a
slowdown:

| relation | approximates | on expiry |
|---|---|---|
| `may` | **over** (may ⊇ concrete) | **saturate** — dropping would under-approximate and could manufacture a spurious definite `True` |
| `must` | **under** (proved ∀∃ only) | **drop** — saturating would assert obligations nobody proved |

`budget_expiry_saturates_may_and_drops_must` asserts both in one test, with control assertions on
each side, so a future change cannot quietly flip one to match the other.

**3. The CEGAR loop is followed by `unreachable!()`.** A plain `break` on expiry — the intuitive
move, and what the design called for — would have **panicked**, in the code path whose entire
purpose is to avoid losing a run. It now returns the last completed iteration's verdict under a
new `CegarTermination::BudgetExpired`, which is independently sound (less refinement ⇒ more ⊥)
and distinct from `BoundedIterationsReached` because "out of time" and "out of rounds" suggest
different remedies.

## Also

- **`AdapterErrorKind::ResourceBudgetExceeded`**, documented at the definition site with why it
  must map to `Unknown` and never `Skipped`: `ci_exit_code` does not fail on `skipped`, so a
  strict `--fail-on unknown` gate would otherwise go **green on a property that timed out**.
- **`clamp_query_ms`** bounds the last query so it cannot overshoot the deadline by its own full
  5 s. It never returns 0 — z3 reads 0 as *"no timeout"*, the exact opposite of what an expired
  budget wants.
- **`Budget::child` clamps to the earlier deadline**, so N properties × a generous per-property
  budget cannot silently become an N-times-longer run.
- **The planner re-installs the budget in each engine thread.** A spawned thread inherits nothing,
  so without this the parallel portfolio would run unbounded while the sequential one is bounded —
  invisible until a gate hung. `budget_is_not_inherited_by_a_spawned_thread` pins the surprise.

## API surface

`CegarTermination` maps to a JSON `terminated_with` value, so this adds **`"budget-expired"`** to
the HTTP surface, documented on `CegarTraceView`. No schema regeneration needed (the field is a
`String`); the drift detector's 17 checks pass unchanged.

Caught by the pre-commit hook's **workspace** check, not my per-crate one — the match site lives
in a crate reachable only through a workspace edge and a feature flag. Exactly the case
CLAUDE.md's pre-push rule describes for adding a variant to a load-bearing public type.

## Verification

2549 lib tests pass · clippy clean · `cargo check --workspace --tests` clean · API schema drift
clean. 12 new tests (11 in `run_budget`, plus the directional soundness test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
