### PR TITLE
feat(verify-auto): turn the wall-clock budgets ON by default (#504 C5)

### DIFF
--- a/crates/mununu-core/src/adapter/run_budget.rs
+++ b/crates/mununu-core/src/adapter/run_budget.rs
@@ -391,7 +391,10 @@ mod tests {
     fn shipped_defaults_are_the_measured_ones() {
         assert_eq!(DEFAULT_PROPERTY_BUDGET_MS, 900_000, "15 min/property");
         assert_eq!(DEFAULT_RUN_BUDGET_MS, 3_600_000, "1 h/run");
-        assert!(
+        // `const` block: both operands are constants, so this is a COMPILE-TIME check rather
+        // than a runtime one — stronger, and it satisfies clippy's `assertions_on_constants`
+        // (which CI enforces via `-D warnings`).
+        const _: () = assert!(
             DEFAULT_PROPERTY_BUDGET_MS * 2 < DEFAULT_RUN_BUDGET_MS,
             "the run budget must comfortably exceed a single property's, else one slow property \
              consumes the whole run"

--- a/crates/mununu-core/src/adapter/run_budget.rs
+++ b/crates/mununu-core/src/adapter/run_budget.rs
@@ -172,9 +172,60 @@ pub enum StopReason {
     Cancelled,
 }
 
-/// Pure parse of a budget env value: a positive integer → that many ms; `0`, unset, or
-/// unparseable → `None` (unbounded). Extracted so the ladder is testable without mutating
-/// process-global environment, mirroring `memory_budget.rs`.
+/// Default per-property budget: **15 minutes**.
+///
+/// MEASURED, not guessed (mununu#504, 2026-09-07, `MUNUNU_PROPERTY_TIMING=1` over the real-design
+/// e2e corpus, n = 122 properties):
+///
+/// | p50 | p90 | p99 | max |
+/// |---|---|---|---|
+/// | 2.2 s | 14.7 s | 41.3 s | **49.1 s** |
+///
+/// 15 minutes is ~18x the observed maximum. That is deliberately far more headroom than the
+/// "3x p99" rule of thumb, for two reasons:
+///
+/// 1. **The corpus is smaller than a consumer's real gate.** Tuning a default to our own e2e set
+///    would be tuning to the easy case.
+/// 2. **The two failure modes are not symmetric.** Too high means a hang takes longer to catch —
+///    annoying. Too low means mununu abstains on work that was *succeeding*, and since a budget
+///    abstention is `unknown` (never `skipped`, so that a gate still fails), that turns
+///    currently-GREEN gates RED across every consumer, for properties that were fine. The
+///    asymmetry says: err high.
+///
+/// A single ⊥ property routed through the full rescue ladder can also legitimately spend minutes
+/// (btormc 60 s + pono 60 s + SPACER + native + interpolation, sequentially), which the corpus
+/// above did not fully exercise.
+const DEFAULT_PROPERTY_BUDGET_MS: u64 = 15 * 60 * 1000;
+
+/// Default whole-run budget: **1 hour**.
+///
+/// This is the one that addresses the reported incident. monono lost a full `make formal` run to
+/// a SIX-HOUR hang; a per-property cap alone would not have saved them (42 properties x 15 min is
+/// still 10 hours in the worst case), but an hour-long run budget turns that six-hour loss into a
+/// report after one hour with the undecided tail marked `unknown`.
+const DEFAULT_RUN_BUDGET_MS: u64 = 60 * 60 * 1000;
+
+/// Pure parse of a budget env value against a default: a positive integer → that many ms;
+/// **`0` → `None` (explicitly disabled)**; unset or unparseable → the default.
+///
+/// Note the ladder differs from the pre-default version: unset now means "use the default", not
+/// "unbounded". `0` is the escape hatch, matching the convention the other budgets use, and
+/// unparseable falls back to the default rather than silently uncapping — the safe direction.
+pub fn parse_budget_ms_with_default(v: Option<String>, default_ms: u64) -> Option<u64> {
+    match v.as_deref().map(str::trim) {
+        Some("0") => None,
+        Some(s) => Some(
+            s.parse::<u64>()
+                .ok()
+                .filter(|&ms| ms > 0)
+                .unwrap_or(default_ms),
+        ),
+        None => Some(default_ms),
+    }
+}
+
+/// Pure parse with NO default — a positive integer or `None`. Retained for callers that want an
+/// explicit-only reading.
 pub fn parse_budget_ms(v: Option<String>) -> Option<u64> {
     v.as_deref()
         .map(str::trim)
@@ -182,14 +233,18 @@ pub fn parse_budget_ms(v: Option<String>) -> Option<u64> {
         .filter(|&ms| ms > 0)
 }
 
-/// The configured per-property budget (`MUNUNU_PROPERTY_BUDGET_MS`), or `None`.
+/// The per-property budget: `MUNUNU_PROPERTY_BUDGET_MS`, else [`DEFAULT_PROPERTY_BUDGET_MS`].
+/// `0` disables.
 pub fn property_budget_ms() -> Option<u64> {
-    parse_budget_ms(std::env::var(PROPERTY_BUDGET_ENV).ok())
+    parse_budget_ms_with_default(
+        std::env::var(PROPERTY_BUDGET_ENV).ok(),
+        DEFAULT_PROPERTY_BUDGET_MS,
+    )
 }
 
-/// The configured whole-run budget (`MUNUNU_VERIFY_BUDGET_MS`), or `None`.
+/// The whole-run budget: `MUNUNU_VERIFY_BUDGET_MS`, else [`DEFAULT_RUN_BUDGET_MS`]. `0` disables.
 pub fn run_budget_ms() -> Option<u64> {
-    parse_budget_ms(std::env::var(RUN_BUDGET_ENV).ok())
+    parse_budget_ms_with_default(std::env::var(RUN_BUDGET_ENV).ok(), DEFAULT_RUN_BUDGET_MS)
 }
 
 #[cfg(test)]
@@ -303,6 +358,44 @@ mod tests {
     fn clamp_query_ms_passes_through_when_unbounded() {
         let _g = enter(&Budget::unbounded());
         assert_eq!(clamp_query_ms(5000), 5000);
+    }
+
+    #[test]
+    /// mununu#504 C5 — the DEFAULTED ladder. Unset now means "use the default", not "unbounded";
+    /// `0` is the escape hatch; garbage falls back to the default rather than silently uncapping.
+    fn parse_budget_with_default_ladder() {
+        assert_eq!(
+            parse_budget_ms_with_default(None, 900_000),
+            Some(900_000),
+            "unset ⇒ the DEFAULT (this is the C5 behaviour change)"
+        );
+        assert_eq!(
+            parse_budget_ms_with_default(Some("0".into()), 900_000),
+            None,
+            "0 is the explicit escape hatch"
+        );
+        assert_eq!(
+            parse_budget_ms_with_default(Some(" 250 ".into()), 900_000),
+            Some(250),
+            "an explicit value wins, trimmed"
+        );
+        assert_eq!(
+            parse_budget_ms_with_default(Some("garbage".into()), 900_000),
+            Some(900_000),
+            "unparseable falls back to the default, NOT to unbounded — the safe direction"
+        );
+    }
+
+    #[test]
+    /// The shipped defaults, pinned so a change is deliberate and shows up in review.
+    fn shipped_defaults_are_the_measured_ones() {
+        assert_eq!(DEFAULT_PROPERTY_BUDGET_MS, 900_000, "15 min/property");
+        assert_eq!(DEFAULT_RUN_BUDGET_MS, 3_600_000, "1 h/run");
+        assert!(
+            DEFAULT_PROPERTY_BUDGET_MS * 2 < DEFAULT_RUN_BUDGET_MS,
+            "the run budget must comfortably exceed a single property's, else one slow property \
+             consumes the whole run"
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -2767,6 +2767,15 @@ pub(crate) fn verify_auto_impl(
             report.properties.push(abstained(t));
             continue;
         }
+        // mununu#504 — per-property wall time, opt-in via `MUNUNU_PROPERTY_TIMING=1`.
+        //
+        // This exists because a per-property budget DEFAULT must be MEASURED, not guessed: a cap
+        // that fires on legitimate work turns a slow success into a spurious `unknown` across
+        // every consumer's gate, which is worse than having no cap. It is also useful on its own
+        // — it answers "which property is eating the run?", which no existing diagnostic does.
+        let prop_t0 = std::env::var("MUNUNU_PROPERTY_TIMING")
+            .is_ok()
+            .then(std::time::Instant::now);
         // mununu#504 — install the PER-PROPERTY budget for this iteration. `child` clamps to the
         // earlier of (now + per-property) and the run deadline, so a generous per-property value
         // cannot extend the run. RAII: the guard restores the previous budget on EVERY exit from
@@ -3207,6 +3216,14 @@ pub(crate) fn verify_auto_impl(
         // definite cube verdict is sound by over-approximation; the A.4 honest-⊥
         // downgrade (a stopgap for the retired sampling-may under-approximation)
         // is no longer needed.
+        if let Some(t0) = prop_t0 {
+            eprintln!(
+                "[mununu-timing] property={} outcome={} elapsed_ms={}",
+                t.name,
+                outcome.label(),
+                t0.elapsed().as_millis()
+            );
+        }
         report.properties.push(PropertyVerdict {
             name: t.name.clone(),
             kind: t.kind,

--- a/docs/consumer-briefings/2026-09-verify-auto-time-budgets.md
+++ b/docs/consumer-briefings/2026-09-verify-auto-time-budgets.md
@@ -1,0 +1,105 @@
+# Consumer briefing — 2026-09 `sv verify-auto` now has wall-clock budgets, ON by default
+
+> **Audience:** monono (reported the incident), ROSF, anyone running `mununu sv verify-auto` in a gate.
+>
+> **Related:** [mununu#504](https://github.com/Mumunu-team/mununu/issues/504). Follows the C1–C4 machinery (#520, #521, #522, #523).
+>
+> **TL;DR:** a run had **no time bound at any granularity**. It does now: **15 min per property, 1 h per run**, both on by default. On expiry the remaining properties abstain as `unknown` and **every verdict already computed is preserved** — a run that used to hang, or be killed with no output at all, now reports what it decided. Set either variable to `0` to restore the old unbounded behaviour.
+
+## What changed
+
+| | Before | After |
+|---|---|---|
+| per property | unbounded | **15 min** (`MUNUNU_PROPERTY_BUDGET_MS`) |
+| whole run | unbounded | **1 h** (`MUNUNU_VERIFY_BUDGET_MS`) |
+| lift subprocesses | unbounded | 15 min (`MUNUNU_LIFT_TIMEOUT_MS`, shipped in C2) |
+
+`0` disables any of them.
+
+## Why these numbers — measured, not guessed
+
+Per-property wall time over the real-design e2e corpus (`MUNUNU_PROPERTY_TIMING=1`, n = 122):
+
+| p50 | p90 | p99 | max |
+|---|---|---|---|
+| 2.2 s | 14.7 s | 41.3 s | **49.1 s** |
+
+The default is **15 minutes — about 18× the observed maximum**, deliberately far above the usual
+"3× p99" rule. Two reasons the numbers alone don't show:
+
+1. **That corpus is the easy case.** It is our own e2e set; your designs are larger. Tuning a
+   default to it would be tuning to what we already handle comfortably.
+2. **The failure modes are not symmetric.** Too high means a hang takes longer to catch —
+   annoying. Too low means mununu abstains on work that was *succeeding*, and a budget abstention
+   is `unknown`, which **fails a strict gate**. That would turn currently-green gates red for
+   properties that were fine. So: err high.
+
+**The run budget is the one that addresses the reported incident.** A per-property cap alone
+would not have helped — 42 properties × 15 min is still 10 hours worst case. An hour-long *run*
+budget turns a six-hour loss into a report after an hour with the undecided tail marked `unknown`.
+
+## What you will see
+
+A `time-budget-exceeded` note, and `unknown` for every property not reached:
+
+```
+note: time-budget-exceeded — wall-clock budget reached; the remaining properties
+      abstained rather than hanging (MUNUNU_PROPERTY_BUDGET_MS / MUNUNU_VERIFY_BUDGET_MS)
+```
+
+**Abstentions are `unknown`, never `skipped`.** That is deliberate: `ci_exit_code` does not fail
+on `skipped`, so classifying a timed-out property as skipped would let a strict
+`--fail-on unknown` gate pass **green on a property that was never decided**. A silent pass is
+worse than a red gate.
+
+## Will this change my verdicts?
+
+**Only if a property currently takes longer than the budget.** If your run completes today inside
+15 min/property and 1 h/run — and the corpus above suggests that is a wide margin — nothing moves.
+
+If something does move, it moves `holds`/`violated` → `unknown`, never between definite verdicts.
+
+**If a gate goes red after this, that is the intended signal, not a regression**: it means a
+property genuinely exceeded the budget. Raise the variable, or investigate why that property is
+slow — `MUNUNU_PROPERTY_TIMING=1` prints per-property wall time and will tell you which one.
+
+## New diagnostic
+
+```bash
+MUNUNU_PROPERTY_TIMING=1 mununu sv verify-auto …
+# [mununu-timing] property=foo_sva_3 outcome=holds elapsed_ms=2212
+```
+
+One line per property. This is how the defaults above were chosen, and it is the tool for tuning
+them for your designs. Off by default, zero cost when unset.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | new default time bounds | **Yes** |
+| mununu `Dockerfile.dev` | binary bump | **Yes** |
+| mununu `Dockerfile.sva` | binary bump | **Yes** |
+| mununu `Dockerfile.extract`, `.extract-*` | no verify path | No |
+| rosf | runs verify-auto | **Yes** |
+| monono Docker | reported the incident; gate runs verify-auto | **Yes** |
+| mununu-ui | no type change | No |
+
+## Verification
+
+```bash
+cargo test -p mununu-core --lib -- run_budget shipped_defaults
+```
+
+The defaults are pinned by a test, with an invariant that the run budget must comfortably exceed
+a single property's — otherwise one slow property consumes the whole run.
+
+The pre-merge gate is the e2e suite run **with defaults on**, asserting no property changes
+verdict, in the `mununu-sva` image.
+
+## Not covered here (follow-ups)
+
+- **The memory ceiling default** (C6) is separate and still opt-in as of this change. It will
+  supersede the #490 briefing's *"unset ⇒ disabled"* line when it lands.
+- **A SIGKILL-survivable partial report** (C7). These budgets degrade gracefully in-process; they
+  do nothing if the gate `kill -9`s you or the OOM killer fires.


### PR DESCRIPTION
**Track C, PR 5** of the #504 ladder. Follows #520, #521, #522, #523.

**The first rung that changes what a DEFAULT run does:** 15 min/property, 1 h/run. `0` disables
either.

## The numbers are measured, not guessed

Added `MUNUNU_PROPERTY_TIMING=1` (opt-in, zero cost when unset) and ran it over the real-design e2e
corpus — **n = 122 properties**:

| p50 | p90 | p99 | max |
|---|---|---|---|
| 2.2 s | 14.7 s | 41.3 s | **49.1 s** |

15 minutes is **~18× the observed maximum** — deliberately far above the "3× p99" rule of thumb,
for two reasons the numbers alone do not show:

1. **That corpus is the easy case.** It is our own e2e set; consumer designs are larger. Tuning a
   default to it would be tuning to what we already handle.
2. **The failure modes are not symmetric.** Too high ⇒ a hang takes longer to catch: annoying. Too
   low ⇒ mununu abstains on work that was *succeeding*, and since C4 makes a budget abstention
   `unknown` (so a strict gate still fails), that turns currently-**green** gates **red** for
   properties that were fine. Err high.

**The run budget is what actually addresses the reported incident.** A per-property cap alone would
not have saved monono — 42 properties × 15 min is still 10 hours worst case — but an hour-long
*run* budget turns their six-hour loss into a report after an hour with the undecided tail marked
`unknown`.

## The non-regression gate, and what it actually showed

Full `#[ignore]`d e2e set in `mununu-sva` with the defaults **active**: 29 passed, 4 failed, and —
the load-bearing number — **zero `time-budget-exceeded` notes**. C5's only behavioural change is the
default budget values, so zero firings means it affected nothing in that run.

All four failures are pre-existing. Three were already confirmed. The fourth,
`e2e_opentitan_prim_onehot_check_holds`, I had never seen, so I did not assume:

- re-ran it with `MUNUNU_PROPERTY_BUDGET_MS=0 MUNUNU_VERIFY_BUDGET_MS=0` — **identical** failure,
  same `unknown_cells: 26`, same line. C5 exonerated by experiment, not by my inference about note
  counts;
- then **bisected** it, because its signature (`holds → unknown`) is exactly what C1's briefing
  predicts for the may-truncation soundness fix — and a soundness fix retracting a `holds` on
  shipped OpenTitan RTL would have been a finding worth telling consumers about. It fails at
  `519082d` too, **before** Track A and before C1. Hypothesis refuted; it is #503 drift.

Reported to #503 rather than left unattributed. Subsequent diagnosis identified its actual cause:
`$onehot0` over an **input** register produces 5 mutually-exclusive dimensions, of which only 6 of
32 valuations are satisfiable — and `free_input_init_cubes` enumerates all 32 as initial with no
feasibility filter. **26 = 32 − 6**, exactly. Unrelated to budgets.

## Verification

2553 lib tests · clippy clean · `cargo check --workspace --tests` clean · e2e gate as above.

Briefing: `docs/consumer-briefings/2026-09-verify-auto-time-budgets.md`. It leads with **how to read
a red gate** — *"that is the intended signal, not a regression"* — because this is the first change
here that can fail someone's passing run, and the wrong reaction to a new `unknown` is to distrust
the tool rather than look at which property is slow (`MUNUNU_PROPERTY_TIMING=1` names it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
