### PR TITLE
test(e2e): the cutpoint test's premise is obsolete — re-scope it to what is still true (#503)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -6825,7 +6825,31 @@ endmodule
             ..Default::default()
         };
 
-        // (1) WITHOUT cut points: the 48-bit counter is in the state cone → Skipped.
+        // (1) WITHOUT cut points.
+        //
+        // mununu#503 — this used to assert `Skipped`, i.e. that the wide-counter cone was beyond
+        // the exact engine. **That premise is now unsatisfiable by ANY counter width**, and it is
+        // worth recording why, because the obvious repair does not work:
+        //
+        //   - narrow counter  ⇒ `default_cap_for_cone(c) = max(40, min(c, 192))` admits the cone
+        //     (it rejects only above 192 bits), so the exact engine decides directly;
+        //   - wide counter    ⇒ the exact engine DOES abstain, but the `Err` arm then routes to
+        //     `try_ranking_recoverability`, and a well-founded datapath descent decides
+        //     `AG EF (reg == N)` **without caring about the width at all**.
+        //
+        // Measured: at 256 bits the no-cut run still returns `Holds`, in 5.2 s. So bumping the
+        // fixture — the repair #380 applied to every other exact-abstention fixture, and what I
+        // first tried here — cannot work: the deciding mechanism is not width-sensitive.
+        //
+        // The engine simply got better than this demonstration. What remains true, and is what
+        // this test now pins:
+        //   - the cut is APPLIED and the control-slice note names the cut net (assertion 3);
+        //   - cutting does not COST the verdict — the property still decides under the cut.
+        //
+        // What this test no longer demonstrates is the cut's *value* (turning an undecidable cone
+        // into a decidable one). Showing that needs a property shape the ranking rescue cannot
+        // reduce; inventing one here would be fabricating a demo, so it is left undone and
+        // recorded in #503 instead.
         let no_cut = verify_auto(&sources, &base, &vopts()).expect("verify_auto runs (no cut)");
         let g0 = no_cut
             .properties
@@ -6834,8 +6858,9 @@ endmodule
             .expect("annotated guarantee present");
         eprintln!("no-cut:   {} => {:?}", g0.name, g0.outcome);
         assert!(
-            matches!(g0.outcome, VerifyOutcome::Skipped { .. }),
-            "without cut points the wide-counter cone should be Skipped, got {:?}",
+            !matches!(g0.outcome, VerifyOutcome::Violated { .. }),
+            "the guarantee must not be VIOLATED without cut points — the FSM does reach DONE; \
+             a violation here would be a real regression rather than a capacity effect, got {:?}",
             g0.outcome
         );
 


### PR DESCRIPTION
Refs #503. First of the four e2e failures diagnosed in that issue.

## The premise is obsolete, and **no counter width can restore it**

`e2e_cutpoint_frees_wide_counter_guard_so_exact_symbolic_fits` asserted that *without* cut points
the wide-counter cone is `Skipped`, then that `--cutpoint tick` rescues it to a definite verdict.
The first half no longer holds.

The diagnosis said this was a **missed fixture bump**: `6a1b435` (#380) moved the exact cap 40→64
and bumped *"every fixture asserting exact-abstention to 80-bit"*, skipping this one; `086ebe4`
then raised the ceiling to 192. So I bumped the counter. **That was wrong, and the test caught it
in 5.2 s:**

- **80 bits would not have sufficed either** — `default_cap_for_cone(c) = max(40, min(c, 192))`
  rejects *only* above 192 bits, and #380's number was for the 64-bit ceiling;
- **at 256 bits the exact engine does abstain — and the run still returns `Holds`**, because the
  `Err` arm routes to `try_ranking_recoverability`, whose well-founded datapath descent decides
  `AG EF (reg == N)` **regardless of width**.

| counter | what happens | verdict |
|---|---|---|
| narrow | cap admits the cone | exact decides → `Holds` |
| wide | exact abstains | **ranking rescue** decides → `Holds` |

The assertion is unsatisfiable by construction, so the width change was **reverted** rather than
pushed higher. The engine simply got better than this demonstration — the same story as the stale
bit-cap assertion in #515, but with a mechanism no fixture parameter can defeat.

## What the test pins now

- the cut is **applied** and the control-slice note names the cut net;
- cutting does not **cost** the verdict — the property still decides under the cut;
- the guarantee is not **violated** without cut points (a violation there would be a real
  regression, not a capacity effect).

## What it no longer demonstrates — stated, not papered over

The cut's **value**: turning an undecidable cone into a decidable one. That needs a property shape
the ranking rescue cannot reduce. Inventing one here would be fabricating a demo, so it is left
undone and recorded in #503.

Worth knowing downstream: **`--cutpoint`'s benefit is currently unproven by any test.**

## Verification

`mununu-sva`: no-cut `Holds`, with-cut `Holds`, test **passes** (13 s). clippy `-D warnings` clean.

No consumer briefing: test-only, no verdict/wire/route/flag change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
