### PR TITLE
fix(rescue): the gate and the monitor compiler disagreed about bare identifiers (#503)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -502,7 +502,7 @@ pub fn emit_ag_boolean_invariant_monitor(
     root: crate::mu_calculus::NodeId,
     reset_pinned: bool,
 ) -> Result<String, AdapterError> {
-    use crate::adapter::btor2::predicate_expr::{PredicateExpr, parse_predicate_expr};
+    use crate::adapter::btor2::predicate_expr::{PredicateExpr, parse_predicate_atom_bool};
     use crate::mu_calculus::Node as MuNode;
 
     let file = parser::parse(content).map_err(|mut e| {
@@ -601,7 +601,12 @@ pub fn emit_ag_boolean_invariant_monitor(
                 appended.push(format!("{n} or {bool_sort} {a} {b}"));
                 Ok(n)
             }
-            MuNode::Predicate(atom) => match parse_predicate_expr(atom) {
+            // mununu#503 — `parse_predicate_atom_bool`, matching the gate in
+            // `reach_rescue::is_compilable_boolean_body`. A bare identifier is "signal is
+            // true" ⇒ `!= 0` (sound for any width; `== 1` would exclude truthy 2, 3, …).
+            // The gate and this compiler MUST use the same entry point: if the gate accepts a
+            // leaf this rejects, a property passes reducibility and then fails to compile.
+            MuNode::Predicate(atom) => match parse_predicate_atom_bool(atom) {
                 Ok(PredicateExpr::Cmp {
                     register,
                     op,

--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -191,6 +191,20 @@ pub fn reduce_ag_boolean_body(formula: &Formula) -> Option<NodeId> {
 /// Walk the subtree; verify it is only And/Or/Not/True/False/Predicate and every
 /// Predicate leaf parses as `PredicateExpr::Cmp`. A single modal / fixpoint /
 /// variable / CmpReg / CmpRegAddend / Select rejects the whole tree.
+///
+/// mununu#503 — uses [`parse_predicate_atom_bool`], NOT the strict
+/// [`parse_predicate_expr`]. A **bare 1-bit identifier** (`trigger_active`,
+/// `event_detected_o`) is how the SVA translator emits "signal is true", and the strict
+/// parser requires an operator, so it returns `Err` and rejected the ENTIRE tree. That is
+/// why every sysrst `|->` property was classified `safety-shape-not-reducible` and never
+/// reached the rescue lane at all — a whole property class turned away at the gate by a
+/// leaf-parsing detail.
+///
+/// The relaxed reading is `signal != 0`, not `== 1`: for a multi-bit signal `== 1` would
+/// spuriously exclude the truthy values 2, 3, … (see that function's own soundness note).
+/// [`crate::adapter::btor2::bad_monitor`]'s compound compiler uses the same entry point, so
+/// the gate and the compiler cannot disagree about what a leaf means — the disagreement
+/// being precisely this bug.
 fn is_compilable_boolean_body(formula: &Formula, id: NodeId) -> bool {
     match formula.node(id) {
         Node::True | Node::False => true,
@@ -199,7 +213,10 @@ fn is_compilable_boolean_body(formula: &Formula, id: NodeId) -> bool {
             is_compilable_boolean_body(formula, *l) && is_compilable_boolean_body(formula, *r)
         }
         Node::Predicate(atom) => {
-            matches!(parse_predicate_expr(atom), Ok(PredicateExpr::Cmp { .. }))
+            matches!(
+                crate::adapter::btor2::predicate_expr::parse_predicate_atom_bool(atom),
+                Ok(PredicateExpr::Cmp { .. })
+            )
         }
         _ => false,
     }
@@ -412,6 +429,39 @@ mod tests {
         assert!(
             reduce_ag_invariant(&f).is_none(),
             "the single-atom reducer must stay strict on compound shapes"
+        );
+    }
+
+    #[test]
+    /// mununu#503 — a body whose leaves are BARE 1-bit identifiers must be reducible.
+    ///
+    /// This is the shape every SVA `|->` produces once the translator emits `sig` rather than
+    /// `sig == 1`. The strict `parse_predicate_expr` requires an operator, so it returned `Err`
+    /// and rejected the whole tree — which is why every sysrst `|->` property was classified
+    /// `safety-shape-not-reducible` and never reached the rescue lane. The gate and the monitor
+    /// compiler now share `parse_predicate_atom_bool`, so they cannot disagree about a leaf.
+    fn bare_identifier_leaves_are_reducible() {
+        // `AG(!(a && b) || c)` with every leaf a bare identifier — the `|->` shape.
+        let f = crate::mu_calculus::parser::parse(
+            "nu X. (((!((trigger_active && cfg_enable_i))) || event_detected_o) && [] X)",
+        )
+        .expect("formula parses");
+        assert!(
+            reduce_ag_boolean_body(&f).is_some(),
+            "bare 1-bit identifiers are the SVA translator's `signal is true` form; rejecting \
+             them turns away an entire property class at the reducibility gate"
+        );
+    }
+
+    #[test]
+    /// The relaxation must not widen what else is accepted: a relational leaf (`CmpReg`) is
+    /// still rejected, because the compound monitor cannot compile it.
+    fn relational_leaves_are_still_rejected() {
+        let f = crate::mu_calculus::parser::parse("nu X. ((cnt_q >= cnt_q__past) && [] X)")
+            .expect("formula parses");
+        assert!(
+            reduce_ag_boolean_body(&f).is_none(),
+            "a reg-vs-reg relational leaf has no compound-monitor encoding and must stay rejected"
         );
     }
 


### PR DESCRIPTION
Refs #503. Second of the four e2e failures diagnosed there.

> **⚠ Read the reach section: this does NOT fix its target test.** It fixes a real pipeline
> self-contradiction and a *misleading* diagnostic, and I measured that distinction rather than
> assuming it.

## The bug: two parts of one pipeline disagreed about a leaf

`is_compilable_boolean_body` required every leaf to parse via the **strict**
`parse_predicate_expr`, which needs an operator. A bare 1-bit identifier — `trigger_active`,
`event_detected_o`, which is exactly how the SVA translator emits *"signal is true"* — returns
`Err` and **rejected the entire tree**.

So every sysrst `|->` property was turned away at the reducibility gate and classified
`safety-shape-not-reducible` **without the rescue lane ever running**. Meanwhile
`seed_from_formula` already normalises those same atoms.

## Reusing the existing helper corrected my plan

`parse_predicate_atom_bool` already exists for this, and its doc corrects the encoding I had
written into the plan:

> *"`!= 0` — **not** `== 1` — is the SOUND encoding (for a multi-bit signal `== 1` would
> spuriously exclude the truthy values 2, 3, …)"*

My plan specified `Cmp { op: Eq, value: 1 }`. **That would have been unsound for multi-bit
signals.** Hand-rolling beside a soundness-argued helper was the mistake.

## Both sites, not one

The gate (`reach_rescue`) **and** the compound monitor compiler (`bad_monitor`) now use the same
entry point. Fixing only the gate would let a property pass reducibility and then fail to
*compile* — trading one failure for a worse one, since the disagreement **is** the bug.

## Measured reach — not what I wanted

| | before | after |
|---|---|---|
| `sva_10`, `sva_11` classification | `safety-shape-not-reducible` | **`unclassified`** (gate accepts) |
| `sva_12/13/14/15` | unchanged | unchanged (Modal body / relational leaves) |
| **`sva_10` verdict** | `Unknown { 32 }` | **`Unknown { 32 }` — no change** |

**`e2e_sysrst_config_concretization_flips_timer_relationals` is still red.** The gate now passes
the property through, the rescue lane runs, and it still does not decide.

What this *does* fix is a **misleading** diagnostic. The old classification's own advice was
*"needs a property reshape or a new rescue reducer, **not a bigger budget**"* — wrong for these
properties, and it would have sent someone reshaping correct SVA.

## Open, and the natural next step

The new classification says *"check for a sibling `bit-cap` / `abstained` note"* — and **there is
none**. `reach_portfolio_rescue` declines without emitting anything, so the trail ends and
`sva_10`'s actual blocker cannot be named. **Making the rescue lane say why it declined** is the
next fix, and it is worth more than either remaining e2e repair: it is the diagnostics gap
consumers actually reported.

## Verification

2555 lib tests · clippy `--workspace --all-targets -D warnings` clean · `cargo check --workspace
--tests` clean · measured in `mununu-sva`.

Two regressions: bare identifiers are reducible; **relational leaves are still rejected**, so the
relaxation did not widen the gate.

No consumer briefing: no verdict, wire, route or flag change — only a diagnostic classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
