### PR TITLE
feat(rescue): say WHY the safety-rescue lane declined instead of returning a bare None (#503)

### DIFF
--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -264,11 +264,55 @@ fn is_box_to_var(formula: &Formula, id: NodeId, var: FormulaVarId) -> bool {
 ///
 /// On `Some`, the second component is the raw [`ReachOutcome`] (which engines
 /// decided each side), for diagnostics / a witness note.
+/// mununu#503 — why the safety-rescue lane declined a property, when it did.
+///
+/// Every decline used to be a bare `None`, and one of them threw away a fully descriptive
+/// `AdapterError` via `.ok()?`. A consumer following the `bottom-reason` note's advice — *"check
+/// for a sibling `bit-cap` / `abstained` note"* — found nothing, because the lane emitted nothing.
+/// The trail ended, and a residual ⊥ could not be attributed at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RescueDecline {
+    /// Neither reducer matched the formula's shape (`AG(atom)` / `AG(boolean-of-atoms)`).
+    ShapeNotReducible,
+    /// The shape reduced, but the monitor emitter refused it — carries the emitter's own
+    /// message, which names the offending leaf. This is the one that was being discarded.
+    MonitorEmissionFailed(String),
+    /// The emitted monitor did not re-parse as BTOR2 (an internal inconsistency).
+    MonitoredDesignUnparseable(String),
+}
+
+impl std::fmt::Display for RescueDecline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RescueDecline::ShapeNotReducible => write!(
+                f,
+                "the formula matched neither `AG(atom)` nor `AG(boolean-of-atoms)`"
+            ),
+            RescueDecline::MonitorEmissionFailed(m) => {
+                write!(f, "the bad-monitor emitter refused the reduced body: {m}")
+            }
+            RescueDecline::MonitoredDesignUnparseable(m) => {
+                write!(f, "the emitted monitor did not re-parse: {m}")
+            }
+        }
+    }
+}
+
+/// Thin wrapper preserving the original signature for existing callers.
 pub fn reach_portfolio_rescue(
     design_btor2: &str,
     formula: &Formula,
     reset_pinned: bool,
 ) -> Option<(RescueVerdict, ReachOutcome)> {
+    reach_portfolio_rescue_diagnosed(design_btor2, formula, reset_pinned).ok()
+}
+
+/// As [`reach_portfolio_rescue`], but reports WHY it declined instead of returning a bare `None`.
+pub fn reach_portfolio_rescue_diagnosed(
+    design_btor2: &str,
+    formula: &Formula,
+    reset_pinned: bool,
+) -> Result<(RescueVerdict, ReachOutcome), RescueDecline> {
     // Try the existing single-atom reducer first — preserves byte-for-byte
     // emission on the shipped case. Fall back to the compound-atom reducer
     // (mununu#492) for `AG(compound_boolean_expression)` and for atoms bound
@@ -284,16 +328,20 @@ pub fn reach_portfolio_rescue(
                 // The single-atom emitter refused the signal (zero-state atom
                 // on a primary input, say). Try the compound path — its leaf
                 // resolution includes primary inputs.
-                let root = reduce_ag_boolean_body(formula)?;
-                emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned).ok()?
+                let root =
+                    reduce_ag_boolean_body(formula).ok_or(RescueDecline::ShapeNotReducible)?;
+                emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned)
+                    .map_err(|e| RescueDecline::MonitorEmissionFailed(e.message))?
             }
         }
     } else {
         // Non-single-atom shape — try compound.
-        let root = reduce_ag_boolean_body(formula)?;
-        emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned).ok()?
+        let root = reduce_ag_boolean_body(formula).ok_or(RescueDecline::ShapeNotReducible)?;
+        emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned)
+            .map_err(|e| RescueDecline::MonitorEmissionFailed(e.message))?
     };
-    let file = parser::parse(&monitored).ok()?;
+    let file = parser::parse(&monitored)
+        .map_err(|e| RescueDecline::MonitoredDesignUnparseable(e.message))?;
     let outcome = decide_reach_portfolio(&file);
     let verdict = match outcome.verdict {
         ReachVerdict::Unreachable => RescueVerdict::Holds,
@@ -301,7 +349,7 @@ pub fn reach_portfolio_rescue(
         // Undecided, or a contradiction alarm — never silently pick a side.
         ReachVerdict::Unknown | ReachVerdict::Contradiction => RescueVerdict::Inconclusive,
     };
-    Some((verdict, outcome))
+    Ok((verdict, outcome))
 }
 
 /// The concrete counterexample trace for an AG-invariant the reachability portfolio

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -3371,7 +3371,7 @@ pub(crate) fn escalate_bottom(
         LivenessVerdict, reduce_ag_ef_target, reduce_response_af, response_liveness_rescue,
         response_liveness_rescue_under_fairness,
     };
-    use crate::adapter::reach_rescue::{RescueVerdict, reach_portfolio_rescue};
+    use crate::adapter::reach_rescue::RescueVerdict;
     use crate::adapter::recoverability::{verify_recoverability, verify_recoverability_scalable};
     use crate::mu_calculus::{PropertyClass, parser as mu_parser};
     use crate::verdict::PropertyVerdict;
@@ -3400,9 +3400,44 @@ pub(crate) fn escalate_bottom(
         };
         match formula.property_class() {
             PropertyClass::Safety if opts.rescue_bottom_safety => {
-                if let Some((verdict, reach)) =
-                    reach_portfolio_rescue(design_btor2, &formula, reset_pinned)
-                {
+                // mununu#503 — use the DIAGNOSED variant so a decline is reported instead of
+                // vanishing. Before this, every decline was a bare `None`: the `bottom-reason`
+                // note told the consumer to "check for a sibling `bit-cap` / `abstained` note",
+                // and there was none, so a residual ⊥ could not be attributed at all.
+                let rescued = crate::adapter::reach_rescue::reach_portfolio_rescue_diagnosed(
+                    design_btor2,
+                    &formula,
+                    reset_pinned,
+                );
+                let rescued = match rescued {
+                    Ok(v) => Some(v),
+                    Err(why) => {
+                        notes.push(VerificationNote {
+                            kind: "safety-rescue-declined".into(),
+                            level: NoteLevel::ScopeCaveat,
+                            summary: format!(
+                                "`{}`: the safety-rescue lane declined — {why}",
+                                prop.name
+                            ),
+                            detail: "mununu#503 — the reachability rescue is what decides an \
+                                     AG-safety property the cube abstraction left ⊥, by \
+                                     compiling it to a `bad`-monitor and running the concrete \
+                                     portfolio. When it declines, the ⊥ stands. The reason above \
+                                     distinguishes the two cases a consumer must act on \
+                                     differently: a SHAPE the reducers do not match (reshape the \
+                                     property, or a new reducer is needed) versus a LEAF the \
+                                     monitor emitter cannot resolve to a state cell, output port \
+                                     or primary input (an internal combinational wire, typically \
+                                     — the property is fine, the monitor simply has nothing to \
+                                     observe). Neither is a resource abstain, so a bigger budget \
+                                     will not help either one."
+                                .into(),
+                            items: Vec::new(),
+                        });
+                        None
+                    }
+                };
+                if let Some((verdict, reach)) = rescued {
                     let engines = engines_of(&reach);
                     match verdict {
                         RescueVerdict::Holds => {


### PR DESCRIPTION
Refs #503. Follows #526 and #527.

## The diagnostic dead end

The `bottom-reason` classifier told consumers to *"check for a sibling `bit-cap` / `abstained`
note"* on a residual ⊥ — and for the sysrst properties **there was no such note**, because
`reach_portfolio_rescue` declined silently. The trail ended and the ⊥ could not be attributed.

One decline path was actively destroying the answer:

```rust
emit_ag_boolean_invariant_monitor(...).ok()?
```

The emitter produces *"leaf atom `X` does not resolve to a state cell, output port, or primary
input"* — **naming the exact blocker** — and `.ok()?` discarded it into a `None`.

## What this adds

`RescueDecline` distinguishes the three ways the lane bows out;
`reach_portfolio_rescue_diagnosed` returns it. The original `reach_portfolio_rescue` remains as a
thin wrapper, so **no existing caller changes**. `escalate_bottom` emits a
`safety-rescue-declined` note carrying the reason.

The note separates the two cases a consumer must act on **differently**:

| reason | what to do |
|---|---|
| **shape** not matched by either reducer | reshape the property, or a new reducer is needed |
| **leaf** the emitter cannot resolve | the property is fine — the monitor has nothing to observe (an internal combinational wire, typically) |

Neither is a resource abstain, so a bigger budget helps neither — precisely the wrong conclusion
the previous `unclassified` note invited.

## Measured — and it splits a group the diagnosis had treated as one

```
sva_10, sva_11:  emitter refused — leaf `trigger_active` does not resolve
sva_12..15:      shape — matched neither AG(atom) nor AG(boolean-of-atoms)
```

`trigger_active` is `assign trigger_active = (trigger_i == 1'b0)` — an internal wire, so not a
state cell, output port, or primary input.

**So `sva_10` does not need the `|=>` reducer at all.** It needs the emitter to resolve internal
combinational signals — a different, likely smaller change. Only `sva_12` needs the reducer. The
plan had these as one group; without this note I would have built the wrong thing.

This also completes the #527 story: I reported its reach as zero, which was right about *verdicts*
but understated it — #527 is what moved `sva_10` past the gate, which is what let the emitter reach
the leaf and produce a specific error instead of silence.

## A process note, because the first measurement was invalid

The initial run reported `ShapeNotReducible` for all six, contradicting my prediction, and I nearly
reported *"my analysis was wrong"*. The branch had been cut from `main` **minutes before #527
merged**, so it did not contain the fix under test — `grep -c parse_predicate_atom_bool` returned
`0` where it should have returned `3`. A wrong self-correction is still wrong. Rebasing and
re-running confirmed the prediction exactly.

## Verification

2555 lib tests · clippy `--workspace --all-targets -D warnings` clean · `cargo check --workspace
--tests` clean · measured in `mununu-sva`.

No consumer briefing: additive diagnostic only — no verdict, wire, route or flag change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
