### PR TITLE
chore(ci): disable the e2e nightly — it has never produced a verification signal

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,15 +9,46 @@ name: E2E (SVA verification)
 # cegar↔symbolic↔exact parity gate, the portfolio e2e, and the RTL-replay gate
 # run automatically instead of only on a manual local docker invocation.
 #
-# Nightly (schedule) + on-demand (workflow_dispatch); not per-PR — building the
-# sva image + running the full corpus under real slang/yosys/Verilator costs
-# minutes, disproportionate for every push. A red run here is a soundness/
-# precision regression the fast PR gate cannot see.
+# ⚠ THE NIGHTLY SCHEDULE IS DISABLED (2026-09-09). This workflow has NEVER
+# produced a verification signal.
+#
+# Every scheduled run since it was added (2026-07-06) failed at the "Build
+# mununu-sva image" step, before a single test executed:
+#
+#   failed to resolve source metadata for docker.io/library/hw-verif:latest:
+#   pull access denied, repository does not exist
+#
+# `docker/Dockerfile.sva` does `COPY --from=hw-verif:latest /opt/oss-cad-suite`.
+# That image is built from the SIBLING repo `hw-verification-uba` and exists only
+# on a contributor's machine — it is never published, so CI cannot pull it.
+#
+# This matters beyond a red badge: it explains how the `#[ignore]`d set drifted to
+# 19 failures unnoticed (mununu#503). The assumption was "nobody read the
+# nightly"; the truth is there was nothing to read. A workflow that is
+# permanently red signals nothing, and worse, it trains people to ignore it.
+#
+# TO RESTORE, pick one and re-add the `schedule:` block below:
+#   (a) drop the sibling-image dependency — `Dockerfile.sva` needs ONLY
+#       `/opt/oss-cad-suite`, and `hw-verification-uba/Dockerfile` itself gets
+#       that from a PUBLIC YosysHQ release
+#       (`oss-cad-suite-build/releases/.../oss-cad-suite-linux-x64-*.tgz`),
+#       exactly how this repo already fetches slang and sv2v. Self-contained,
+#       ~1GB download in CI (buildx-cached);
+#   (b) publish `hw-verif` to `ghcr.io/mumunu-team/` and pull it here — keeps the
+#       reuse, but publishes another repo's image and needs `packages: write`
+#       plus a cross-repo build. Someone should review what that image carries
+#       before it goes to a registry.
+#
+# Until then the suite runs LOCALLY, which is where it has always actually run:
+#   docker run --rm -v "$(pwd)":/work -v mununu-target:/cargo-target \
+#     mununu-sva make e2e
+# (`make e2e` runs one test per process — mununu#504 — so an aborting test
+# reports as one CRASH row instead of destroying the run's summary.)
+#
+# `workflow_dispatch` is kept so the workflow can still be triggered by hand once
+# the image problem is fixed.
 
 on:
-  schedule:
-    # 04:00 UTC nightly (after typical merge activity settles).
-    - cron: "0 4 * * *"
   workflow_dispatch: {}
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,15 @@ found while triaging [mununu#504](https://github.com/Mumunu-team/mununu/issues/5
 abort becomes one `CRASH` row and the sweep still completes. The single-test command above stays
 the right tool for reproducing ONE test.
 
+**The CI nightly is DISABLED and never worked (2026-09-09).** `.github/workflows/e2e.yml` has
+produced no verification signal since it was added: every scheduled run failed at *"Build
+mununu-sva image"*, because `docker/Dockerfile.sva` does `COPY --from=hw-verif:latest`, and that
+image is built from the sibling `hw-verification-uba` repo and never published — CI cannot pull it.
+This is how the `#[ignore]`d set drifted to 19 failures unnoticed ([mununu#503](https://github.com/Mumunu-team/mununu/issues/503)):
+not "nobody read the nightly", but nothing to read. **So the e2e suite is verified LOCALLY, in the
+image, as the commands above show — treat that as the only e2e signal.** The workflow file records
+the two ways to restore it.
+
 **Host caveat.** slang ships prebuilts only for `linux-x86_64` and `macos-arm64`. On an Intel (x86_64) macOS host there is no native slang binary, and the workspace's `z3-sys` link also differs from the dev image — so the Linux `mununu-sva` image (which runs natively on x86_64 hosts) is the supported way to run these tests there. The `e2e_csrng_real_sva_verdict_breakdown` test reads only vendored fixtures (`examples/verify/m2_opentitan_csrng_main_sm` + the standard prim_assert macros from `examples/verify/m0_opentitan_prim_arbiter`), so it is fully reproducible.
 
 **[RULE] Validate any slang / SVA-touching change in the `mununu-sva` image — never on the bare host (added 2026-07-13).** The dev host commonly has `sv2v` + `yosys` but **not** `slang`. That combination is a trap, not a convenience:


### PR DESCRIPTION
Refs #503.

## The e2e nightly has never produced a verification signal

Every scheduled run since it was added (2026-07-06) failed at **"Build mununu-sva image"**, before
a single test executed:

```
failed to resolve source metadata for docker.io/library/hw-verif:latest:
pull access denied, repository does not exist
```

`docker/Dockerfile.sva` does `COPY --from=hw-verif:latest /opt/oss-cad-suite`. That image is built
from the **sibling repo `hw-verification-uba`** and exists only on a contributor's machine — it is
never published, so CI cannot pull it.

## Why this matters beyond a red badge

**It explains how the `#[ignore]`d set drifted to 19 failures unnoticed (#503).** The standing
assumption — in #503's own write-up, and in my analysis earlier today — was *"the nightly runs but
nobody reads it."* The truth is **there was nothing to read**. A permanently-red workflow signals
nothing and trains people to ignore it, which is worse than not having one.

It also bounds my #515 work honestly: the per-process sweep improves what happens **when** the
suite runs; on CI it never got that far.

## Disabled, not deleted

`schedule:` removed, `workflow_dispatch:` kept. The file records the two restore routes:

| | |
|---|---|
| **(a) drop the sibling-image dependency** | `Dockerfile.sva` needs **only** `/opt/oss-cad-suite`, and `hw-verification-uba/Dockerfile` itself fetches that from a **public** YosysHQ release — exactly how this repo already fetches slang and sv2v. Self-contained; ~1GB download in CI (buildx-cached). |
| **(b) publish `hw-verif` to GHCR** | keeps the ~1GB reuse, but publishes another repo's image and needs `packages: write` plus a cross-repo build. What that image carries should be reviewed before it goes to a registry. |

I did not take (b) unilaterally: it is an outward-facing publish of a private sibling repo's image
contents, to obtain a file a public tarball already provides.

## Documentation

`CLAUDE.md`'s e2e section now states plainly that the **local image run is the only e2e signal**,
so nobody infers coverage that does not exist.

No consumer briefing: CI/doc only — no verdict, wire, route or flag change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
