### PR TITLE
fix(rescue): resolve named internal nets in the monitor — sva_10/11 now decide (#503)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -155,6 +155,35 @@ pub(crate) fn input_nid_and_sort(
 /// never-granted path). A *negated* output operand is skipped — binding its
 /// un-negated net would flip the comparison sense — so it falls through to the
 /// caller's bind error rather than binding the wrong polarity.
+/// mununu#503 — resolve a named INTERNAL COMBINATIONAL net.
+///
+/// The monitor compiler could resolve a state cell, an output port, or a primary input — but not
+/// an internal wire, and that is what a great many SVA leaves actually are. `sysrst`'s
+/// `assign trigger_active = (trigger_i == 1'b0)` is the canonical case: every `|->` property over
+/// it was declined by the rescue lane with *"leaf atom `trigger_active` does not resolve to a
+/// state cell, output port, or primary input"*, so the ⊥ stood even though the property was fine
+/// and the monitor was one node reference away from being emittable.
+///
+/// Yosys names an internal net with a no-op alias line — `<nid> uext <sort> <src> 0 <name>` — so
+/// the symbol sits on an ordinary `Op` node. Referencing that nid from the `bad` expression is
+/// legal BTOR2: it is a combinational node in the same file, evaluated in the same cycle.
+///
+/// Tried LAST in the resolution chain, so a name that is also a state cell, output port, or input
+/// still binds to that first — this only widens what resolves, it never re-points an existing one.
+pub(crate) fn comb_nid_and_sort(
+    file: &crate::adapter::btor2::ast::Btor2File,
+    signal: &str,
+) -> Option<(Nid, Nid)> {
+    file.lines.iter().find_map(|l| match &l.node {
+        Node::Op {
+            sort,
+            symbol: Some(sym),
+            ..
+        } if sym == signal => Some((l.nid, *sort)),
+        _ => None,
+    })
+}
+
 pub(crate) fn output_nid_and_sort(
     file: &crate::adapter::btor2::ast::Btor2File,
     signal: &str,
@@ -615,10 +644,13 @@ pub fn emit_ag_boolean_invariant_monitor(
                     let (sig_nid, sig_sort) = state_nid_and_sort(file, &register, reset_pinned)
                         .or_else(|| output_nid_and_sort(file, &register))
                         .or_else(|| input_nid_and_sort(file, &register))
+                        // mununu#503 — last: a named internal combinational net.
+                        .or_else(|| comb_nid_and_sort(file, &register))
                         .ok_or_else(|| {
                             err(format!(
                                 "adapter/btor2/bad_monitor: leaf atom `{register}` does not \
-                                 resolve to a state cell, output port, or primary input"
+                                 resolve to a state cell, output port, primary input, or named \
+                                 internal net"
                             ))
                         })?;
                     let const_nid = *next_nid;

--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -564,6 +564,51 @@ mod tests {
 4 input 1 c
 ";
 
+    /// mununu#503 — a design whose leaf is a NAMED INTERNAL NET, as yosys emits them
+    /// (`<nid> uext <sort> <src> 0 <name>` — a no-op alias line carrying the symbol).
+    ///
+    /// `hot` aliases `a`, so `AG(!(a == 1) || !(hot == 1))` is FALSIFIED by `a = 1`: the two
+    /// leaves are the same net, so they are true together. This is the NEGATIVE control for the
+    /// internal-net resolver — the check that actually matters, because a verdict comparison
+    /// cannot tell a correct encoding from one that silently observes the wrong node. A resolver
+    /// that mis-binds the leaf would most likely MISS this violation and report `Holds`.
+    const NAMED_INTERNAL_NET: &str = "\
+1 sort bitvec 1
+2 input 1 a
+3 input 1 b
+4 uext 1 2 0 hot
+";
+
+    #[test]
+    fn internal_net_leaf_is_observed_by_the_monitor() {
+        // `hot` IS `a`, so `!(a==1) || !(hot==1)` is false whenever a = 1 ⇒ VIOLATED.
+        let f = parse("nu X. (((!(a == 1)) || (!(hot == 1))) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(NAMED_INTERNAL_NET, &f, false)
+            .expect("an internal-net leaf must resolve, so the rescue fires");
+        assert_eq!(
+            verdict,
+            RescueVerdict::Violated,
+            "`hot` aliases `a`, so a = 1 falsifies the invariant. A monitor that mis-binds the \
+             internal net would miss this and report Holds — which is why the negative control \
+             is the test that matters here, not a verdict comparison"
+        );
+    }
+
+    #[test]
+    /// The positive twin: over the SAME design an invariant that genuinely holds must still hold,
+    /// so the resolver is not simply making everything violated.
+    fn internal_net_leaf_holds_when_the_invariant_is_true() {
+        // `!(hot==1) || (a==1)` — `hot` IS `a`, so this is a tautology ⇒ HOLDS.
+        let f = parse("nu X. (((!(hot == 1)) || (a == 1)) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(NAMED_INTERNAL_NET, &f, false)
+            .expect("an internal-net leaf must resolve");
+        assert_eq!(
+            verdict,
+            RescueVerdict::Holds,
+            "`hot` aliases `a`, so `hot -> a` is a tautology over the net"
+        );
+    }
+
     #[test]
     fn zero_state_exclusion_safety_gets_violated_via_compound_rescue() {
         // `AG(!(a == 1) || !(b == 1))` — a=1,b=1 falsifies. Expected: VIOLATED.

--- a/docs/consumer-briefings/2026-09-internal-net-monitor-resolution.md
+++ b/docs/consumer-briefings/2026-09-internal-net-monitor-resolution.md
@@ -1,0 +1,102 @@
+# Consumer briefing — 2026-09 SVA properties over internal nets now decide
+
+> **Audience:** monono (pins verdicts in its formal lane), ROSF, anyone running `mununu sv verify-auto` on SVA with implication properties.
+>
+> **Related:** [mununu#503](https://github.com/Mumunu-team/mununu/issues/503). Builds on #527 and #528.
+>
+> **TL;DR:** a `|->` property whose antecedent or consequent is an **internal combinational wire** (`assign trigger_active = …`) was returning `unknown` — not because the property was hard, but because the safety-rescue monitor could not reference that net. Fixed. **Verdicts change in one direction only: `unknown` → `holds` or `violated`.** No definite verdict flips.
+
+## What was wrong
+
+When the predicate-cube abstraction leaves an AG-safety property ⊥, mununu escalates it to the
+**safety-rescue lane**: it compiles the property into a `bad`-monitor and runs the *concrete*
+reachability portfolio (native BMC, k-induction, SPACER, btormc, pono) on the real design.
+
+That monitor could resolve a leaf that named a **state cell**, an **output port**, or a **primary
+input**. It could not resolve a **named internal net** — so it refused to compile, the rescue
+declined, and the ⊥ stood.
+
+Internal nets are extremely common in real SVA. `sysrst_ctrl_detect` is typical:
+
+```systemverilog
+assign trigger_active = (trigger_i == 1'b0);
+...
+`ASSERT(DetectedOut_A, state_q == StableSt && trigger_active && cfg_enable_i |-> event_detected_o)
+```
+
+Every property over `trigger_active` was undecidable for this reason alone.
+
+## What changed
+
+Yosys names an internal net with a no-op alias line — `<nid> uext <sort> <src> 0 <name>` — so the
+symbol sits on an ordinary combinational node carrying both nid and sort. The monitor now resolves
+those, **last** in the chain: a name that is also a state cell, output port, or input still binds
+to that first, so no existing binding is re-pointed.
+
+## Direction of change
+
+- **`unknown` → `holds`**, or **`unknown` → `violated`**.
+- **No `holds` becomes `violated`, and no `violated` becomes `holds`.**
+
+`violated` is in that list deliberately: if one of these properties was masking a real failure, you
+will now see it. That is the point.
+
+## Measured
+
+On `sysrst_ctrl_detect` with the config timers concretized:
+
+| property | before | after |
+|---|---|---|
+| `sva_10` (`DetectedOut_A`) | `unknown` (32 cells) | **`holds`** |
+| `sva_11` | `unknown` (16 cells) | **`holds`** |
+
+Both had been undecided since mid-July.
+
+## Scope — what is NOT measured
+
+**I have not measured how many properties across a real corpus this affects.** The rule is
+mechanical — any AG-safety property the cube leaves ⊥ whose leaves are internal nets can now reach
+the rescue lane — but the *count* on your designs is unknown to me. If you pin verdicts, expect
+some `unknown` rows to move; each one is a property that was never actually being checked.
+
+**There is no independent verdict-level cross-check for `sva_10`/`sva_11`.** I ran the
+exact-symbolic engine as a differential and it `skipped` both (it abstains on this shape). The
+verdicts do come from the concrete reachability portfolio rather than the abstraction that was
+returning ⊥, so they are not self-confirming — but I would rather say this plainly than imply a
+corroboration I did not obtain.
+
+The mechanism is pinned by a **negative control**: a fixture where `hot` aliases `a`, so
+`AG(!(a==1) || !(hot==1))` is falsified by `a = 1`, and the monitor must report `violated`. A
+resolver that mis-bound the leaf would most likely *miss* that and report `holds` — which no
+verdict comparison would catch. A positive twin rules out the opposite error.
+
+## Docker rebuild table
+
+| Image | Impact | Rebuild required? |
+|-------|--------|-------------------|
+| mununu `Dockerfile` (prod) | verdict semantics on the rescue lane | **Yes** |
+| mununu `Dockerfile.dev` | binary bump | **Yes** |
+| mununu `Dockerfile.sva` | binary bump; the e2e runs here | **Yes** |
+| mununu `Dockerfile.extract`, `.extract-*` | no rescue path | No |
+| rosf | consumes verdicts | **Yes if it pins expected verdicts**, else No |
+| monono Docker | pins verdicts in `verify.sh` | **Yes** |
+| mununu-ui | no type change | No |
+
+## Verification
+
+```bash
+cargo test -p mununu-core --lib -- internal_net_leaf
+```
+
+The negative and positive controls above. End-to-end in `mununu-sva`:
+`e2e_sysrst_config_concretization_flips_timer_relationals` now passes.
+
+## Still undecided, and why — no longer a mystery
+
+Properties that remain ⊥ on this design now say what blocks them
+(`safety-rescue-declined`, added in #528):
+
+- `sva_12` — `AG(a → AX b)`, the `|=>` shape; the rescue lane has no reducer for it yet.
+- `sva_13/14/15` — relational leaves (`cnt_q >= cnt_q__past`) the compound monitor cannot encode.
+
+Both are shape gaps, not resource limits: a bigger budget will not move them.


### PR DESCRIPTION
Refs #503. Follows #527 and #528 — this is what those diagnostics pointed at.

## The gap

The bad-monitor compiler could resolve a **state cell**, an **output port**, or a **primary
input** — but not a **named internal combinational net**, which is what a great many SVA leaves
actually are.

`sysrst`'s `assign trigger_active = (trigger_i == 1'b0)` is the canonical case. Every `|->`
property over it was declined with *"leaf atom `trigger_active` does not resolve to a state cell,
output port, or primary input"* — so the ⊥ stood, even though the property was fine and the
monitor was one node reference away from being emittable.

Yosys names an internal net with a no-op alias line, `<nid> uext <sort> <src> 0 <name>`, so the
symbol sits on an ordinary `Op` node carrying both nid and sort. Referencing it from the `bad`
expression is legal BTOR2: a combinational node in the same file, evaluated in the same cycle.

`comb_nid_and_sort` is tried **last** in the chain, so a name that is also a state cell, output
port, or input still binds to that first. This only widens what resolves; it never re-points an
existing binding.

## Measured

| | before | after |
|---|---|---|
| `sva_10` | `Unknown { 32 }` | **`Holds`** |
| `sva_11` | `Unknown { 16 }` | **`Holds`** |
| `e2e_sysrst_config_concretization_flips_timer_relationals` | FAILED | **ok** |

Two properties undecided since mid-July now reach definite verdicts.

## How the verdicts were checked — and what was NOT checked

The verdicts come from the **concrete** reachability portfolio (native BMC, k-induction, SPACER,
btormc, pono) on a `bad` monitor — **not** from the cube abstraction — so they are already
independent of the engine that was returning ⊥.

I ran the exact-symbolic engine as a verdict-level differential. **It `skipped` both** (it abstains
on this shape), so **there is no independent verdict-level corroboration for these two
properties** — only mechanism-level evidence. Stating that rather than implying a cross-check I did
not get.

The mechanism evidence is a **negative control**, which is the sharper test anyway:

```
NAMED_INTERNAL_NET:  4 uext 1 2 0 hot     // `hot` aliases `a`
AG(!(a==1) || !(hot==1))  is FALSIFIED by a = 1   ⇒  monitor must report Violated
```

A resolver that mis-bound the leaf (wrong nid, stale alias, wrong sort) would most plausibly
**miss** that violation and report `Holds` — which no verdict comparison would catch. A positive
twin over the same design rules out the opposite error.

## Chain

#527 got the property past the gate → #528's decline note named `trigger_active` → this resolves
it, in ~15 lines. **The plan had prescribed the `|=>` reducer for `sva_10`; that would have been
the wrong build entirely.**

Still declining on **shape**, honestly: `sva_12` (needs the `|=>` reducer), `sva_13/14/15`
(relational leaves the compound monitor cannot encode).

## Verification

2557 lib tests · clippy `--workspace --all-targets -D warnings` clean · `cargo check --workspace
--tests` clean · e2e measured in `mununu-sva`.

**Consumer briefing: needed but not in this PR** — this turns ⊥ into definite verdicts for a
property class (`|->` over internal nets). Flagging it explicitly rather than letting it ship
silently; happy to add one before merge if you want it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
