### PR TITLE
fix(verify-auto): drop infeasible initial cubes so `$onehot` over an input decides (mununu#503)

### DIFF
--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -1758,8 +1758,64 @@ fn const_to_u64(
 /// `free_bits` returns `[base]` (the pre-H.B single reset cube), so state-only
 /// properties read exactly one cube. Bit `free_bits[k]` is toggled by bit `k` of
 /// the combination index.
+///
+/// Production always calls [`free_input_init_cubes_feasible`]; this unfiltered form is retained
+/// as the CONTROL the feasibility tests measure against — it is what shows the filter drops 26
+/// of 32 rather than silently dropping nothing.
+#[cfg(test)]
 fn free_input_init_cubes(base: usize, free_bits: &[u32]) -> Vec<usize> {
+    free_input_init_cubes_feasible(base, free_bits, &[])
+}
+
+/// mununu#503 — as `free_input_init_cubes`, but dropping cube valuations that are
+/// **mathematically empty**.
+///
+/// `free_dims` pairs each entry of `free_bits` with the `(register, value)` its dimension
+/// asserts. Two `Eq` dimensions over the SAME register with DIFFERENT values cannot both hold, so
+/// any combination setting both describes no concrete state at all.
+///
+/// # Why this matters
+///
+/// `$onehot0(oh_i)` over a primary input expands to one atom PER VALUE — `oh_i == 0`,
+/// `oh_i == 1`, `oh_i == 2`, `oh_i == 4`, `oh_i == 8` — i.e. five mutually exclusive dimensions on
+/// one register. Of the 2⁵ = 32 valuations only **6** are satisfiable (one per value, plus the
+/// all-false case realised by `oh_i ∈ {3,5,6,7,9..15}`). The other **26 are contradictory**, and
+/// `downgrade_unsatisfiable_cells` correctly masks them to ⊥ — but they were still enumerated as
+/// INITIAL cubes here, so `any_unknown` read an empty cube's ⊥ as an abstention and the whole
+/// property came back `Unknown { unknown_cells: 26 }`. 26 = 32 − 6, exactly.
+///
+/// The sibling test `e2e_onehot0_state_invariant_holds` isolates the variable: the same property
+/// over a STATE register has no free-input dimensions, so it yields ONE initial cube and decides.
+///
+/// # Soundness
+///
+/// Dropping a cube that asserts `reg == v₁ ∧ reg == v₂` (v₁ ≠ v₂) cannot lose a reachable initial
+/// state, because no state satisfies it. This is an exact reduction, not an approximation. The
+/// symbolic path already takes the same view — `symbolic_final_verdict` projects infeasible cubes
+/// to `F` as "never a reachable reset cube"; this brings the explicit path into line.
+fn free_input_init_cubes_feasible(
+    base: usize,
+    free_bits: &[u32],
+    free_dims: &[(String, u64)],
+) -> Vec<usize> {
     (0..(1usize << free_bits.len()))
+        .filter(|combo| {
+            if free_dims.len() != free_bits.len() {
+                return true; // no dimension metadata — enumerate as before
+            }
+            // Reject if any register is asserted at two DIFFERENT values at once.
+            let mut claimed: Vec<(&str, u64)> = Vec::new();
+            for (k, (reg, val)) in free_dims.iter().enumerate() {
+                if (combo >> k) & 1 != 1 {
+                    continue;
+                }
+                if claimed.iter().any(|(r, v)| *r == reg.as_str() && v != val) {
+                    return false;
+                }
+                claimed.push((reg.as_str(), *val));
+            }
+            true
+        })
         .map(|combo| {
             let mut c = base;
             for (k, &b) in free_bits.iter().enumerate() {
@@ -3124,11 +3180,15 @@ pub(crate) fn verify_auto_impl(
         }
         let mut base_init_cube = 0usize;
         let mut free_input_bits: Vec<u32> = Vec::new();
+        // mununu#503 — carry each free dimension's `(register, value)` so mutually exclusive
+        // combinations (two `Eq`s on one register) are not enumerated as initial cubes.
+        let mut free_input_dims: Vec<(String, u64)> = Vec::new();
         let mut bit = 0u32;
         for s in &seeded.specs {
             if seeded.input_registers.contains(&s.register) {
                 // Free input dimension — left unset in the base; enumerated below.
                 free_input_bits.push(bit);
+                free_input_dims.push((s.register.clone(), s.value));
             } else if init_for_cube.get(&s.register).copied().unwrap_or(0) == s.value {
                 base_init_cube |= 1 << bit;
             }
@@ -3142,7 +3202,8 @@ pub(crate) fn verify_auto_impl(
         }
         // All initial cubes = base ⊗ every combination of the free-input bits.
         // No free inputs ⇒ a single cube, identical to the pre-H.B single-read.
-        let init_cubes = free_input_init_cubes(base_init_cube, &free_input_bits);
+        let init_cubes =
+            free_input_init_cubes_feasible(base_init_cube, &free_input_bits, &free_input_dims);
 
         // R-F5.5d — the final 3-valued verdict over the cube space, from the
         // selected engine. The explicit path runs `cegar_refine_loop`; the
@@ -7151,6 +7212,72 @@ endmodule
             cb.items.iter().any(|i| i.contains("cnt_q <= 7")),
             "counter-bound note names the inferred bound; got {:?}",
             cb.items
+        );
+    }
+
+    #[test]
+    /// mununu#503 — the one-hot arithmetic, pinned without needing a lift.
+    ///
+    /// `$onehot0(oh_i)` over a primary INPUT expands to one atom per value, so five mutually
+    /// exclusive `Eq` dimensions land on one register. Only 6 of the 2⁵ = 32 valuations are
+    /// satisfiable — one per value, plus the all-false case (`oh_i ∈ {3,5,6,7,9..15}`). The other
+    /// 26 assert two different values for `oh_i` at once and describe no state at all.
+    ///
+    /// They were still enumerated as INITIAL cubes, so `any_unknown` read an empty cube's ⊥ as an
+    /// abstention: `Unknown { unknown_cells: 26 }`, and 26 = 32 − 6 exactly.
+    fn infeasible_free_input_cubes_are_not_initial() {
+        let bits: Vec<u32> = (0..5).collect();
+        let dims: Vec<(String, u64)> = [0u64, 1, 2, 4, 8]
+            .iter()
+            .map(|v| ("oh_i".to_string(), *v))
+            .collect();
+
+        let all = free_input_init_cubes(0, &bits);
+        assert_eq!(
+            all.len(),
+            32,
+            "unfiltered enumerates the whole polarity product"
+        );
+
+        let feasible = free_input_init_cubes_feasible(0, &bits, &dims);
+        assert_eq!(
+            feasible.len(),
+            6,
+            "5 single-value cubes + 1 all-false; the other 26 assert two values for `oh_i` at \
+             once and are empty. 32 - 6 = 26 — exactly the `unknown_cells` this produced"
+        );
+        assert!(
+            feasible.contains(&0),
+            "the all-false cube is feasible (oh_i takes a value outside the set)"
+        );
+    }
+
+    #[test]
+    /// The filter must not touch dimensions over DIFFERENT registers — those are independent, and
+    /// every combination of them is satisfiable.
+    fn distinct_registers_are_still_fully_enumerated() {
+        let bits: Vec<u32> = (0..3).collect();
+        let dims: Vec<(String, u64)> = vec![
+            ("a".to_string(), 1),
+            ("b".to_string(), 1),
+            ("c".to_string(), 1),
+        ];
+        assert_eq!(
+            free_input_init_cubes_feasible(0, &bits, &dims).len(),
+            8,
+            "three independent registers ⇒ all 2^3 combinations remain feasible"
+        );
+    }
+
+    #[test]
+    /// Same register, SAME value repeated is not a contradiction — only distinct values are.
+    fn same_register_same_value_is_not_excluded() {
+        let bits: Vec<u32> = (0..2).collect();
+        let dims: Vec<(String, u64)> = vec![("a".to_string(), 1), ("a".to_string(), 1)];
+        assert_eq!(
+            free_input_init_cubes_feasible(0, &bits, &dims).len(),
+            4,
+            "`a == 1` twice is consistent; excluding it would drop reachable states"
         );
     }
 

--- a/docs/consumer-briefings/2026-09-infeasible-initial-cubes.md
+++ b/docs/consumer-briefings/2026-09-infeasible-initial-cubes.md
@@ -1,0 +1,120 @@
+# Consumer briefing — infeasible initial cubes no longer abstain (`$onehot` / enum properties over inputs)
+
+> **Audience:** consumers of `mununu sv verify-auto` (CLI, `POST /api/sv/verify-auto`, mununu-ui)
+> and anything that parses a `PropertyVerdict`. **ROSF, monono, mununu-ui.**
+
+## TL;DR
+
+A property whose atoms place **two or more mutually exclusive equalities on the same input
+register** used to come back `Unknown` even when it plainly held. It now decides.
+
+The canonical case is `$onehot0(oh_i)` / `$onehot(oh_i)` over a **primary input**, and any
+enum-valued property (`sig == A`, `sig == B`, …) over one. Verdicts move
+`Unknown { unknown_cells: N }` → `Holds` (or `Violated`). No verdict that was already definite
+changes.
+
+## What actually changed
+
+`$onehot0(oh_i)` expands to one atom **per value** — `oh_i == 0`, `== 1`, `== 2`, `== 4`, `== 8`.
+Over an input each becomes its own free cube dimension, so the reset state enumerated all
+2⁵ = 32 polarity combinations. Only **6** of those are satisfiable (one per value, plus the
+all-false case). The other **26 are contradictory** — no concrete state satisfies `oh_i == 1`
+and `oh_i == 2` at once.
+
+`downgrade_unsatisfiable_cells` already masked those 26 to ⊥ correctly. The defect was that they
+were still enumerated as **initial** cubes, so the abstention census read an empty cube's ⊥ as a
+genuine abstention: `Unknown { unknown_cells: 26 }`, and 26 = 32 − 6 exactly.
+
+Initial-cube enumeration now drops valuations that assert one register at two different values.
+
+### Soundness
+
+This is an **exact reduction, not an approximation**. A cube asserting `reg == v₁ ∧ reg == v₂`
+with `v₁ ≠ v₂` describes no state, so dropping it cannot lose a reachable initial state, and the
+verdict it yields is the verdict over the same set of reachable states as before.
+
+The symbolic path already took this view — `symbolic_final_verdict` projects infeasible cubes to
+`F` as "never a reachable reset cube". This brings the explicit path into line with it; the two
+paths previously disagreed.
+
+## Scope — how to tell if you are affected
+
+Unlike the internal-net change in `2026-09-internal-net-monitor-resolution.md`, this scope is
+exactly characterisable. A property is affected **iff** its atoms put ≥ 2 mutually exclusive
+equality dimensions on a single register that is a **primary input**.
+
+- Over a **state** register the property already decided (one initial cube) — unaffected.
+- With a **single** equality per register — unaffected.
+- Properties that were already `Holds` / `Violated` — unaffected.
+
+## Per-consumer
+
+### ROSF / monono
+
+- **What to update:** nothing required. Some properties reported as `unknown` now return a
+  definite verdict.
+- **What to expect:** `ci_exit_code` fails on `unknown` but never on `skipped`. If a suite was
+  passing *because* a `$onehot`-over-input property abstained and something downstream tolerated
+  it, that property now decides — and if it decides `Violated`, the gate will fail where it
+  previously did not. **That is the gate working, not a regression**; the property was never
+  checked before.
+- **Report parsing:** no shape change. `unknown_cells` disappears from affected properties only
+  because they no longer abstain.
+
+### mununu-ui
+
+- **What to update:** nothing. No wire-format change.
+- **What to expect:** fewer ⊥ badges on one-hot / enum input properties.
+
+## Docker rebuild disposition
+
+| Image | Impact | Rebuild required? |
+|---|---|---|
+| `mununu-dev` | Rust toolchain only; no tool pins touched | No |
+| `mununu-sva` | Inherits `mununu-dev`; slang/sv2v/yosys pins unchanged | No |
+| `mununu-sva-pono` | Inherits `mununu-sva`; MathSAT/pono pins unchanged | No |
+| `hw-verif` | Not involved | No |
+
+Consumers pick this up with a normal `cargo build` of the workspace.
+
+## Test the transition
+
+The change ships with a controlled contrast already in the suite:
+
+- `e2e_opentitan_prim_onehot_check_holds` — `$onehot0` over an **input**. Was
+  `Unknown { unknown_cells: 26 }`; now `Holds`.
+- `e2e_onehot0_state_invariant_holds` — the same property over a **state** register, which always
+  passed. It is the control: it confirms the filter did not disturb the path that already worked.
+
+Both were measured in the `mununu-sva` image (a bare-host green on an SVA path is presumed
+vacuous per CLAUDE.md):
+
+```
+running 2 tests
+test adapter::slang::verify_auto::tests::e2e_onehot0_state_invariant_holds ... ok
+test adapter::slang::verify_auto::tests::e2e_opentitan_prim_onehot_check_holds ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2795 filtered out; finished in 13.16s
+```
+
+Unit-level, `infeasible_free_input_cubes_are_not_initial` pins 32 → 6, with
+`distinct_registers_are_still_fully_enumerated` (8 stays 8) and
+`same_register_same_value_is_not_excluded` (4 stays 4) as negative controls — a filter that
+over-fires would drop those too.
+
+## Provenance
+
+- Issue: mununu#503 (e2e non-regression gate), surfaced by the #504 C5 gate.
+- Fix: `free_input_init_cubes_feasible` in
+  `crates/mununu-core/src/adapter/slang/verify_auto.rs`.
+- Diagnosis: `.claude/plans/agile-munching-bear.md` § "Cause 1".
+- Policy: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here
+
+- **`sva_12`** (`|=>` with a compound antecedent and a combinational consequent) is still ⊥. It
+  is a different cause — the reducer for it does not exist yet — and is tracked separately.
+- The feasibility check is **syntactic**: mutually exclusive equalities on one register. It does
+  not detect semantic infeasibility arising across different registers (e.g. two dimensions made
+  contradictory by an invariant). Those cubes are still enumerated, still masked to ⊥ by
+  `downgrade_unsatisfiable_cells`, and can still abstain. Threading CEGAR's full `unsat_cells`
+  set out of the trace is the complete fix and remains open.


### PR DESCRIPTION
## What

`$onehot0(oh_i)` expands to one atom **per value** — `oh_i == {0,1,2,4,8}`. Over a primary **input** each becomes its own free cube dimension, so the reset state enumerated all 2⁵ = 32 polarity combinations. Only **6** are satisfiable (one per value, plus the all-false case); the other **26** assert one register at two different values at once and are contradictory.

`downgrade_unsatisfiable_cells` already masked those 26 to ⊥ correctly. The defect was that they were still enumerated as **initial** cubes, so `any_unknown` read an empty cube's ⊥ as a genuine abstention:

```
e2e_opentitan_prim_onehot_check_holds -> Unknown { unknown_cells: 26 }
```

and **26 = 32 − 6, exactly**. The arithmetic is what identified the cause.

## Soundness

An **exact reduction, not an approximation**. A cube asserting `reg == v₁ ∧ reg == v₂` with `v₁ ≠ v₂` describes no state, so dropping it cannot lose a reachable initial state.

The symbolic path already took this view — `symbolic_final_verdict` projects infeasible cubes to `F` as "never a reachable reset cube". The explicit path was the one out of line; this reconciles them.

## Measurement

In the `mununu-sva` image (a bare-host green on an SVA path is presumed vacuous per CLAUDE.md):

```
test e2e_onehot0_state_invariant_holds ... ok        <- control, already passed
test e2e_opentitan_prim_onehot_check_holds ... ok    <- was Unknown{26}
test result: ok. 2 passed; 0 failed; finished in 13.16s
```

The **control is load-bearing**: it is the same property over a **state** register (one initial cube, unaffected by the filter). It confirms the fix didn't disturb the path that already worked — if the filter had over-fired, this is where it would show.

Unit-level, `infeasible_free_input_cubes_are_not_initial` pins 32 → 6, with two negative controls a too-eager filter would break: `distinct_registers_are_still_fully_enumerated` (8 stays 8) and `same_register_same_value_is_not_excluded` (4 stays 4).

## Context

Third of the four e2e failures surfaced by the #504 C5 gate. Each turned out to have a **different** cause — the original plan assumed one shared cause and prescribed the same reducer for all four; that premise was wrong and was rewritten after diagnosis. Only `sva_12` still needs that reducer.

## Scope and limits

Affects a property **iff** its atoms place ≥2 mutually exclusive equality dimensions on a single **input** register (`$onehot`/`$onehot0`/enum-valued over inputs). Over a state register, or with one equality per register, nothing changes.

The check is **syntactic**. Semantic infeasibility across *different* registers is not detected; those cubes are still enumerated and can still abstain. Threading CEGAR's full `unsat_cells` set out of the trace is the complete fix and stays open.

Consumer briefing: `docs/consumer-briefings/2026-09-infeasible-initial-cubes.md` — this is a verdict-semantics change (`unknown` → definite), so a suite that passed *because* such a property abstained will now see it decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)