### PR TITLE
feat(rescue): reduce `A |=> C` to a bad monitor — sva_12 and sva_14 now decide (mununu#503)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
+++ b/crates/mununu-core/src/adapter/btor2/bad_monitor.rs
@@ -510,6 +510,268 @@ pub fn emit_latched_predicate_state_named(
     Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
 }
 
+/// mununu#503 — compile a pure-boolean mu-calculus subtree into BTOR2 nodes, returning the NID of
+/// the resulting 1-bit expression.
+///
+/// Extracted verbatim from [`emit_ag_boolean_invariant_monitor`] so the `|=>` monitor
+/// ([`emit_ag_implies_next_compound_monitor`]) compiles its antecedent and consequent through the
+/// SAME code path. Two monitors that disagree about what a leaf means is exactly the class of bug
+/// mununu#503 already hit once (the gate and the compiler disagreeing about bare identifiers), so
+/// there is deliberately one compiler, not two.
+///
+/// Accepts `And`/`Or`/`Not`/`True`/`False`/`Predicate` only — a modal, fixpoint, or variable node
+/// is an error, not a silent skip. Leaves resolve state cell → output net → primary input →
+/// named combinational net.
+pub(crate) fn compile_boolean_subtree(
+    formula: &crate::mu_calculus::Formula,
+    id: crate::mu_calculus::NodeId,
+    file: &crate::adapter::btor2::ast::Btor2File,
+    reset_pinned: bool,
+    bool_sort: Nid,
+    next_nid: &mut Nid,
+    appended: &mut Vec<String>,
+) -> Result<Nid, AdapterError> {
+    use crate::adapter::btor2::predicate_expr::{PredicateExpr, parse_predicate_atom_bool};
+    use crate::mu_calculus::Node as MuNode;
+
+    match formula.node(id) {
+        MuNode::True => {
+            let n = *next_nid;
+            *next_nid += 1;
+            appended.push(format!("{n} constd {bool_sort} 1"));
+            Ok(n)
+        }
+        MuNode::False => {
+            let n = *next_nid;
+            *next_nid += 1;
+            appended.push(format!("{n} constd {bool_sort} 0"));
+            Ok(n)
+        }
+        MuNode::Not(inner) => {
+            let a = compile_boolean_subtree(
+                formula,
+                *inner,
+                file,
+                reset_pinned,
+                bool_sort,
+                next_nid,
+                appended,
+            )?;
+            let n = *next_nid;
+            *next_nid += 1;
+            appended.push(format!("{n} not {bool_sort} {a}"));
+            Ok(n)
+        }
+        MuNode::And(l, r) => {
+            let a = compile_boolean_subtree(
+                formula,
+                *l,
+                file,
+                reset_pinned,
+                bool_sort,
+                next_nid,
+                appended,
+            )?;
+            let b = compile_boolean_subtree(
+                formula,
+                *r,
+                file,
+                reset_pinned,
+                bool_sort,
+                next_nid,
+                appended,
+            )?;
+            let n = *next_nid;
+            *next_nid += 1;
+            appended.push(format!("{n} and {bool_sort} {a} {b}"));
+            Ok(n)
+        }
+        MuNode::Or(l, r) => {
+            let a = compile_boolean_subtree(
+                formula,
+                *l,
+                file,
+                reset_pinned,
+                bool_sort,
+                next_nid,
+                appended,
+            )?;
+            let b = compile_boolean_subtree(
+                formula,
+                *r,
+                file,
+                reset_pinned,
+                bool_sort,
+                next_nid,
+                appended,
+            )?;
+            let n = *next_nid;
+            *next_nid += 1;
+            appended.push(format!("{n} or {bool_sort} {a} {b}"));
+            Ok(n)
+        }
+        // mununu#503 — `parse_predicate_atom_bool`, matching the gate in
+        // `reach_rescue::is_compilable_boolean_body`. A bare identifier is "signal is
+        // true" ⇒ `!= 0` (sound for any width; `== 1` would exclude truthy 2, 3, …).
+        // The gate and this compiler MUST use the same entry point: if the gate accepts a
+        // leaf this rejects, a property passes reducibility and then fails to compile.
+        MuNode::Predicate(atom) => match parse_predicate_atom_bool(atom) {
+            Ok(PredicateExpr::Cmp {
+                register,
+                op,
+                value,
+            }) => {
+                let (sig_nid, sig_sort) = state_nid_and_sort(file, &register, reset_pinned)
+                    .or_else(|| output_nid_and_sort(file, &register))
+                    .or_else(|| input_nid_and_sort(file, &register))
+                    // mununu#503 — last: a named internal combinational net.
+                    .or_else(|| comb_nid_and_sort(file, &register))
+                    .ok_or_else(|| {
+                        err(format!(
+                            "adapter/btor2/bad_monitor: leaf atom `{register}` does not \
+                             resolve to a state cell, output port, primary input, or named \
+                             internal net"
+                        ))
+                    })?;
+                let const_nid = *next_nid;
+                *next_nid += 1;
+                appended.push(format!("{const_nid} constd {sig_sort} {value}"));
+                let cmp_kw = btor2_cmp_keyword(op);
+                let n = *next_nid;
+                *next_nid += 1;
+                appended.push(format!("{n} {cmp_kw} {bool_sort} {sig_nid} {const_nid}"));
+                Ok(n)
+            }
+            Ok(_) => Err(err(format!(
+                "adapter/btor2/bad_monitor: leaf atom `{atom}` uses a relational / addend / \
+                 select shape not supported by the compound monitor"
+            ))),
+            Err(e) => Err(err(format!(
+                "adapter/btor2/bad_monitor: leaf atom `{atom}` did not parse as a predicate \
+                 expression: {e:?}"
+            ))),
+        },
+        other => Err(err(format!(
+            "adapter/btor2/bad_monitor: compound safety monitor accepts \
+             And/Or/Not/True/False/Predicate only; found {other:?}"
+        ))),
+    }
+}
+
+/// mununu#503 — append a `bad` monitor for `AG (A → AX C)`, the shape SVA's `A |=> C` lifts to
+/// (`nu X. ((¬A ∨ [] C) ∧ [] X)`).
+///
+/// Widens [`emit_ag_implies_next_monitor`] on the two axes that kept it from reaching real
+/// properties: the antecedent may be a **compound** boolean expression (it took a single
+/// [`OracleAtom`]), and the consequent may be **combinational** (it required a state cell).
+/// `sysrst_ctrl_detect_sva_12` — `event_detected_pulse_o |=> !event_detected_pulse_o` — needs
+/// both: `event_detected_pulse_o` is a combinational output of state AND inputs, so it is neither
+/// a state cell nor a primary input.
+///
+/// `neg_ante` is the `¬A` disjunct **as it appears in the formula**, not `A`; the antecedent is
+/// recovered as `not(compile(neg_ante))`. Taking it in that form is what lets a compound
+/// antecedent through unchanged — whatever `¬A` is, the same compiler handles it.
+///
+/// Emits `bad = mununu_ante_prev ∧ ¬C`, where `mununu_ante_prev` ([`ANTE_PREV_SYMBOL`]) is a fresh
+/// 1-bit latch with `init 0`, `next = A`.
+///
+/// # Soundness
+///
+/// `bad` is reachable ⟺ ∃ a trace and a cycle `t` with `A` true at `t` and `C` false at `t+1` —
+/// exactly a violation of `AG (A → AX C)`. Three things make that equivalence hold:
+///
+/// - **`init 0` fabricates no obligation at reset.** Nothing precedes cycle 0, so the latch must
+///   read false there; an `init 1` would report a violation on a design that never asserted `A`.
+/// - **The latch is a pure monitor.** It adds no input, no constraint, and never feeds back into
+///   the original transition relation, so the reachable-state set of the design is unchanged and
+///   the counterexample projects back to the original registers.
+/// - **A free next-cycle input is the correct reading of `[] C`.** `C` combinational means its
+///   value at `t+1` depends on the inputs at `t+1`; `bad` reachability quantifies existentially
+///   over those, which is precisely `¬(∀ successors. C)`. SVA agrees: `A |=> C` is violated iff
+///   SOME trace has `A` then `¬C`. This is why the monitor decides a property the predicate cube
+///   cannot — the cube must pin an input-dependent label to a cube dimension and abstains instead.
+///
+/// Note the contrast with [`crate::adapter::btor2::concrete_oracle::ag_implies_next`], which
+/// REFUSES an input-dependent consequent (`ag_implies_next_rejects_input_consequent`). That is a
+/// real limitation of an oracle that evaluates the consequent as a function of the next STATE: it
+/// has no next-cycle input to evaluate against. A `bad` monitor has no such gap — the next cycle's
+/// inputs are part of the trace — which is why this path decides properties the oracle cannot
+/// cross-check, and why the oracle is not the differential for them.
+pub fn emit_ag_implies_next_compound_monitor(
+    content: &str,
+    formula: &crate::mu_calculus::Formula,
+    neg_ante: crate::mu_calculus::NodeId,
+    cons: crate::mu_calculus::NodeId,
+    reset_pinned: bool,
+) -> Result<String, AdapterError> {
+    let file = parser::parse(content).map_err(|mut e| {
+        e.message = format!("adapter/btor2/bad_monitor: {}", e.message);
+        e
+    })?;
+
+    let mut next_nid: Nid = file.lines.iter().map(|l| l.nid).max().unwrap_or(0) + 1;
+    let mut appended: Vec<String> = Vec::new();
+    let bool_sort = find_or_make_bool_sort(&file, &mut next_nid, &mut appended);
+
+    // A = ¬(¬A) — the formula carries the negated antecedent, so undo it here.
+    let neg_ante_nid = compile_boolean_subtree(
+        formula,
+        neg_ante,
+        &file,
+        reset_pinned,
+        bool_sort,
+        &mut next_nid,
+        &mut appended,
+    )?;
+    let ante = next_nid;
+    next_nid += 1;
+    appended.push(format!("{ante} not {bool_sort} {neg_ante_nid}"));
+
+    // ¬C, evaluated at the cycle the latch exposes.
+    let cons_nid = compile_boolean_subtree(
+        formula,
+        cons,
+        &file,
+        reset_pinned,
+        bool_sort,
+        &mut next_nid,
+        &mut appended,
+    )?;
+    let cons_fail = next_nid;
+    next_nid += 1;
+    appended.push(format!("{cons_fail} not {bool_sort} {cons_nid}"));
+
+    // mununu_ante_prev latch: init 0, next = A. (`init` requires the state NID > the value NID,
+    // so `zero` is emitted before the state — the ordering emit_ag_implies_next_monitor relies on.)
+    let zero_bool = next_nid;
+    next_nid += 1;
+    appended.push(format!("{zero_bool} zero {bool_sort}"));
+    let ante_prev = next_nid;
+    next_nid += 1;
+    appended.push(format!("{ante_prev} state {bool_sort} {ANTE_PREV_SYMBOL}"));
+    let ante_prev_init = next_nid;
+    next_nid += 1;
+    appended.push(format!(
+        "{ante_prev_init} init {bool_sort} {ante_prev} {zero_bool}"
+    ));
+    let ante_prev_next = next_nid;
+    next_nid += 1;
+    appended.push(format!(
+        "{ante_prev_next} next {bool_sort} {ante_prev} {ante}"
+    ));
+
+    // bad = ante_prev && !C; named for `observe`.
+    let bad_cond = next_nid;
+    next_nid += 1;
+    appended.push(format!(
+        "{bad_cond} and {bool_sort} {ante_prev} {cons_fail} {BAD_COND_SYMBOL}"
+    ));
+    let bad_line = next_nid;
+    appended.push(format!("{bad_line} bad {bad_cond}"));
+
+    Ok(format!("{}\n{}\n", content.trim_end(), appended.join("\n")))
+}
+
 /// mununu#492 — append a `bad` monitor for `AG (COMPOUND)` where `COMPOUND` is a
 /// boolean expression tree over `And`/`Or`/`Not`/`True`/`False`/`Predicate` mu-calc
 /// nodes; each `Predicate` leaf resolves via state cell → output net → primary input.
@@ -531,9 +793,6 @@ pub fn emit_ag_boolean_invariant_monitor(
     root: crate::mu_calculus::NodeId,
     reset_pinned: bool,
 ) -> Result<String, AdapterError> {
-    use crate::adapter::btor2::predicate_expr::{PredicateExpr, parse_predicate_atom_bool};
-    use crate::mu_calculus::Node as MuNode;
-
     let file = parser::parse(content).map_err(|mut e| {
         e.message = format!("adapter/btor2/bad_monitor: {}", e.message);
         e
@@ -543,142 +802,7 @@ pub fn emit_ag_boolean_invariant_monitor(
     let mut appended: Vec<String> = Vec::new();
     let bool_sort = find_or_make_bool_sort(&file, &mut next_nid, &mut appended);
 
-    // Walk the mu-calc subtree rooted at `id`; emit BTOR2 nodes; return the
-    // NID of the compiled boolean expression (1-bit).
-    fn compile(
-        formula: &crate::mu_calculus::Formula,
-        id: crate::mu_calculus::NodeId,
-        file: &crate::adapter::btor2::ast::Btor2File,
-        reset_pinned: bool,
-        bool_sort: Nid,
-        next_nid: &mut Nid,
-        appended: &mut Vec<String>,
-    ) -> Result<Nid, AdapterError> {
-        match formula.node(id) {
-            MuNode::True => {
-                let n = *next_nid;
-                *next_nid += 1;
-                appended.push(format!("{n} constd {bool_sort} 1"));
-                Ok(n)
-            }
-            MuNode::False => {
-                let n = *next_nid;
-                *next_nid += 1;
-                appended.push(format!("{n} constd {bool_sort} 0"));
-                Ok(n)
-            }
-            MuNode::Not(inner) => {
-                let a = compile(
-                    formula,
-                    *inner,
-                    file,
-                    reset_pinned,
-                    bool_sort,
-                    next_nid,
-                    appended,
-                )?;
-                let n = *next_nid;
-                *next_nid += 1;
-                appended.push(format!("{n} not {bool_sort} {a}"));
-                Ok(n)
-            }
-            MuNode::And(l, r) => {
-                let a = compile(
-                    formula,
-                    *l,
-                    file,
-                    reset_pinned,
-                    bool_sort,
-                    next_nid,
-                    appended,
-                )?;
-                let b = compile(
-                    formula,
-                    *r,
-                    file,
-                    reset_pinned,
-                    bool_sort,
-                    next_nid,
-                    appended,
-                )?;
-                let n = *next_nid;
-                *next_nid += 1;
-                appended.push(format!("{n} and {bool_sort} {a} {b}"));
-                Ok(n)
-            }
-            MuNode::Or(l, r) => {
-                let a = compile(
-                    formula,
-                    *l,
-                    file,
-                    reset_pinned,
-                    bool_sort,
-                    next_nid,
-                    appended,
-                )?;
-                let b = compile(
-                    formula,
-                    *r,
-                    file,
-                    reset_pinned,
-                    bool_sort,
-                    next_nid,
-                    appended,
-                )?;
-                let n = *next_nid;
-                *next_nid += 1;
-                appended.push(format!("{n} or {bool_sort} {a} {b}"));
-                Ok(n)
-            }
-            // mununu#503 — `parse_predicate_atom_bool`, matching the gate in
-            // `reach_rescue::is_compilable_boolean_body`. A bare identifier is "signal is
-            // true" ⇒ `!= 0` (sound for any width; `== 1` would exclude truthy 2, 3, …).
-            // The gate and this compiler MUST use the same entry point: if the gate accepts a
-            // leaf this rejects, a property passes reducibility and then fails to compile.
-            MuNode::Predicate(atom) => match parse_predicate_atom_bool(atom) {
-                Ok(PredicateExpr::Cmp {
-                    register,
-                    op,
-                    value,
-                }) => {
-                    let (sig_nid, sig_sort) = state_nid_and_sort(file, &register, reset_pinned)
-                        .or_else(|| output_nid_and_sort(file, &register))
-                        .or_else(|| input_nid_and_sort(file, &register))
-                        // mununu#503 — last: a named internal combinational net.
-                        .or_else(|| comb_nid_and_sort(file, &register))
-                        .ok_or_else(|| {
-                            err(format!(
-                                "adapter/btor2/bad_monitor: leaf atom `{register}` does not \
-                                 resolve to a state cell, output port, primary input, or named \
-                                 internal net"
-                            ))
-                        })?;
-                    let const_nid = *next_nid;
-                    *next_nid += 1;
-                    appended.push(format!("{const_nid} constd {sig_sort} {value}"));
-                    let cmp_kw = btor2_cmp_keyword(op);
-                    let n = *next_nid;
-                    *next_nid += 1;
-                    appended.push(format!("{n} {cmp_kw} {bool_sort} {sig_nid} {const_nid}"));
-                    Ok(n)
-                }
-                Ok(_) => Err(err(format!(
-                    "adapter/btor2/bad_monitor: leaf atom `{atom}` uses a relational / addend / \
-                     select shape not supported by the compound monitor"
-                ))),
-                Err(e) => Err(err(format!(
-                    "adapter/btor2/bad_monitor: leaf atom `{atom}` did not parse as a predicate \
-                     expression: {e:?}"
-                ))),
-            },
-            other => Err(err(format!(
-                "adapter/btor2/bad_monitor: compound safety monitor accepts \
-                 And/Or/Not/True/False/Predicate only; found {other:?}"
-            ))),
-        }
-    }
-
-    let inv_expr = compile(
+    let inv_expr = compile_boolean_subtree(
         formula,
         root,
         &file,

--- a/crates/mununu-core/src/adapter/reach_rescue.rs
+++ b/crates/mununu-core/src/adapter/reach_rescue.rs
@@ -188,6 +188,93 @@ pub fn reduce_ag_boolean_body(formula: &Formula) -> Option<NodeId> {
     Some(compound_id)
 }
 
+/// mununu#503 — the `|=>` shape: `nu X. ((¬A ∨ [] C) ∧ [] X)`, i.e. `AG (A → AX C)`.
+///
+/// Returns `(neg_ante_id, cons_id)` — the `¬A` disjunct **as written** and the boolean subtree
+/// under the consequent box. The caller recovers `A` by negating; see
+/// [`crate::adapter::btor2::bad_monitor::emit_ag_implies_next_compound_monitor`].
+///
+/// This is the sibling of [`reduce_ag_boolean_body`], which handles the OVERLAPPED `|->`
+/// (`nu X. ((¬A ∨ C) ∧ [] X)` — no inner box). The two are distinguished by exactly one thing:
+/// whether a disjunct of the implication is a box.
+///
+/// # What it deliberately does not match
+///
+/// - **Both disjuncts boxes** (`[] p ∨ [] q`) — ambiguous about which is the consequent, so the
+///   shape match stays unambiguous rather than guessing.
+/// - **A nested box consequent** (`a |=> ##1 b` ⇒ `[] [] b`, and multi-element antecedents, which
+///   [`crate::adapter::slang::translate`] emits as nested `(!(b) || [] (!(a) || [] c))`). The inner
+///   box is not a compilable boolean body, so these decline — honestly, rather than by
+///   mis-compiling a modality into a boolean.
+/// - **`[] X` as the consequent.** The recursion variable is not a boolean body either, so a
+///   degenerate `nu X. ((¬A ∨ [] X) ∧ [] X)` cannot be mistaken for an implication.
+pub fn reduce_ag_implies_next(formula: &Formula) -> Option<(NodeId, NodeId)> {
+    let Node::Nu { var, body } = formula.node(formula.root()) else {
+        return None;
+    };
+    let Node::And(l, r) = formula.node(*body) else {
+        return None;
+    };
+    let (implication_id, modal_id) = classify_and(formula, *l, *r, *var)?;
+    // The outer recursion box must be unconstrained, as in reduce_ag_boolean_body.
+    let Node::Modal {
+        kind: ModalKind::Box,
+        guard,
+        target,
+    } = formula.node(modal_id)
+    else {
+        return None;
+    };
+    if *guard != Guard::default() {
+        return None;
+    }
+    match formula.node(*target) {
+        Node::Variable(v) if *v == *var => {}
+        _ => return None,
+    }
+
+    // `¬A ∨ [] C` — exactly one disjunct is a box (the consequent).
+    let Node::Or(a, b) = formula.node(implication_id) else {
+        return None;
+    };
+    let (neg_ante, cons_modal) = match (is_plain_box(formula, *a), is_plain_box(formula, *b)) {
+        (true, false) => (*b, *a),
+        (false, true) => (*a, *b),
+        _ => return None,
+    };
+    let Node::Modal {
+        kind: ModalKind::Box,
+        guard,
+        target: cons,
+        ..
+    } = formula.node(cons_modal)
+    else {
+        return None;
+    };
+    if *guard != Guard::default() {
+        return None;
+    }
+    // Both sides must compile to pure boolean expressions — a modal or fixpoint inside either is
+    // out of the fragment.
+    if !is_compilable_boolean_body(formula, neg_ante) || !is_compilable_boolean_body(formula, *cons)
+    {
+        return None;
+    }
+    Some((neg_ante, *cons))
+}
+
+/// A `[…]` box node, whatever its target — as opposed to [`is_box_to_var`], which additionally
+/// requires the target to be the recursion variable.
+fn is_plain_box(formula: &Formula, id: NodeId) -> bool {
+    matches!(
+        formula.node(id),
+        Node::Modal {
+            kind: ModalKind::Box,
+            ..
+        }
+    )
+}
+
 /// Walk the subtree; verify it is only And/Or/Not/True/False/Predicate and every
 /// Predicate leaf parses as `PredicateExpr::Cmp`. A single modal / fixpoint /
 /// variable / CmpReg / CmpRegAddend / Select rejects the whole tree.
@@ -298,6 +385,33 @@ impl std::fmt::Display for RescueDecline {
     }
 }
 
+/// The compound-shape emission chain: `AG(boolean)` first, then `AG(A → AX C)`.
+///
+/// Ordered so the shipped `|->` / plain-invariant path emits byte-for-byte as before; the `|=>`
+/// reducer is reached only when the body is not a pure boolean invariant. A property matching
+/// NEITHER declines as [`RescueDecline::ShapeNotReducible`], which is what the `bottom-reason`
+/// note reports.
+fn emit_boolean_or_implies_next(
+    design_btor2: &str,
+    formula: &Formula,
+    reset_pinned: bool,
+) -> Result<String, RescueDecline> {
+    if let Some(root) = reduce_ag_boolean_body(formula) {
+        return emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned)
+            .map_err(|e| RescueDecline::MonitorEmissionFailed(e.message));
+    }
+    let (neg_ante, cons) =
+        reduce_ag_implies_next(formula).ok_or(RescueDecline::ShapeNotReducible)?;
+    crate::adapter::btor2::bad_monitor::emit_ag_implies_next_compound_monitor(
+        design_btor2,
+        formula,
+        neg_ante,
+        cons,
+        reset_pinned,
+    )
+    .map_err(|e| RescueDecline::MonitorEmissionFailed(e.message))
+}
+
 /// Thin wrapper preserving the original signature for existing callers.
 pub fn reach_portfolio_rescue(
     design_btor2: &str,
@@ -328,17 +442,12 @@ pub fn reach_portfolio_rescue_diagnosed(
                 // The single-atom emitter refused the signal (zero-state atom
                 // on a primary input, say). Try the compound path — its leaf
                 // resolution includes primary inputs.
-                let root =
-                    reduce_ag_boolean_body(formula).ok_or(RescueDecline::ShapeNotReducible)?;
-                emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned)
-                    .map_err(|e| RescueDecline::MonitorEmissionFailed(e.message))?
+                emit_boolean_or_implies_next(design_btor2, formula, reset_pinned)?
             }
         }
     } else {
-        // Non-single-atom shape — try compound.
-        let root = reduce_ag_boolean_body(formula).ok_or(RescueDecline::ShapeNotReducible)?;
-        emit_ag_boolean_invariant_monitor(design_btor2, formula, root, reset_pinned)
-            .map_err(|e| RescueDecline::MonitorEmissionFailed(e.message))?
+        // Non-single-atom shape — try compound, then the `|=>` implication.
+        emit_boolean_or_implies_next(design_btor2, formula, reset_pinned)?
     };
     let file = parser::parse(&monitored)
         .map_err(|e| RescueDecline::MonitoredDesignUnparseable(e.message))?;
@@ -751,6 +860,148 @@ mod tests {
                 .iter()
                 .any(|e| *e == "btormc" || *e == "pono"),
             "a subprocess member must carry the beyond-cap verdict; got {outcome:?}"
+        );
+    }
+
+    // `q` toggles every cycle (q' = !q), so a high `q` is ALWAYS followed by a low one.
+    // `zero` precedes `state` because BTOR2 `init` needs the value NID below the state NID.
+    const TOGGLING_PULSE: &str = "\
+1 sort bitvec 1
+2 zero 1
+3 state 1 q
+4 init 1 3 2
+5 not 1 3
+6 next 1 3 5
+";
+
+    // Same shape, but `q` latches a FREE input, so it can stay high two cycles running.
+    const FREE_PULSE: &str = "\
+1 sort bitvec 1
+2 zero 1
+3 state 1 q
+4 init 1 3 2
+5 input 1 d
+6 next 1 3 5
+7 input 1 e
+";
+
+    #[test]
+    fn implies_next_matches_the_non_overlapped_shape() {
+        // `q |=> !q`  →  nu X. ((!(q==1) || [] (!(q==1))) && [] X)
+        let f = parse("nu X. (((!(q == 1)) || [] (!(q == 1))) && [] X)");
+        assert!(
+            reduce_ag_implies_next(&f).is_some(),
+            "the `|=>` shape must match the implies-next reducer"
+        );
+        assert!(
+            reduce_ag_boolean_body(&f).is_none(),
+            "and must NOT match the boolean-body reducer — the inner box is not a boolean, so a \
+             reducer that accepted it would be compiling a modality away"
+        );
+    }
+
+    #[test]
+    fn implies_next_declines_the_overlapped_shape() {
+        // `q |-> !q` has no inner box; that is reduce_ag_boolean_body's shape, not this one.
+        let f = parse("nu X. (((!(q == 1)) || (!(q == 1))) && [] X)");
+        assert!(reduce_ag_implies_next(&f).is_none(), "`|->` is not `|=>`");
+        assert!(
+            reduce_ag_boolean_body(&f).is_some(),
+            "the overlapped form still belongs to the boolean-body reducer"
+        );
+    }
+
+    #[test]
+    fn implies_next_declines_a_nested_box_consequent() {
+        // `q |=> ##1 r` ⇒ `[] [] r`. The inner box is not a compilable boolean body.
+        let f = parse("nu X. (((!(q == 1)) || [] [] (r == 1)) && [] X)");
+        assert!(
+            reduce_ag_implies_next(&f).is_none(),
+            "a nested box must decline rather than be mis-compiled into a boolean"
+        );
+    }
+
+    #[test]
+    fn implies_next_declines_when_both_disjuncts_are_boxes() {
+        let f = parse("nu X. ((([] (q == 1)) || [] (r == 1)) && [] X)");
+        assert!(
+            reduce_ag_implies_next(&f).is_none(),
+            "which disjunct is the consequent is ambiguous — the match must not guess"
+        );
+    }
+
+    #[test]
+    fn implies_next_declines_a_recursion_variable_consequent() {
+        // Degenerate `nu X. ((!A || [] X) && [] X)` must not read as an implication.
+        let f = parse("nu X. (((!(q == 1)) || [] X) && [] X)");
+        assert!(
+            reduce_ag_implies_next(&f).is_none(),
+            "the recursion variable is not a boolean consequent"
+        );
+    }
+
+    #[test]
+    /// NEGATIVE CONTROL — the test that actually proves the monitor fires.
+    ///
+    /// `q` latches a free input, so `q` high twice running is reachable and `q |=> !q` is
+    /// genuinely VIOLATED. A latch wired wrong (init 1, or `next` reading the consequent) would
+    /// report Holds here, and a monitor that never fires would pass every positive test.
+    fn implies_next_catches_a_pulse_that_can_stay_high() {
+        let f = parse("nu X. (((!(q == 1)) || [] (!(q == 1))) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(FREE_PULSE, &f, false)
+            .expect("the `|=>` shape must now reach the rescue lane");
+        assert_eq!(
+            verdict,
+            RescueVerdict::Violated,
+            "`q` can stay high for two cycles, so the property is violated"
+        );
+    }
+
+    #[test]
+    /// The positive twin: over a design where the pulse genuinely cannot repeat, the same property
+    /// must HOLD — so the monitor is not simply reporting everything violated.
+    fn implies_next_holds_on_a_toggling_pulse() {
+        let f = parse("nu X. (((!(q == 1)) || [] (!(q == 1))) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(TOGGLING_PULSE, &f, false)
+            .expect("the `|=>` shape must reach the rescue lane");
+        assert_eq!(
+            verdict,
+            RescueVerdict::Holds,
+            "`q` toggles, so a high `q` is always followed by a low one"
+        );
+    }
+
+    #[test]
+    /// `init 0` must fabricate no obligation at reset. Over the toggling design the antecedent is
+    /// false at cycle 0 (q inits low); a latch initialised to 1 would report a violation at the
+    /// very first step on a design that never asserted the antecedent.
+    fn implies_next_makes_no_obligation_at_reset() {
+        // `!q |=> q` — holds on the toggler (low is always followed by high), and would be
+        // violated at cycle 0 by a latch that came up asserted.
+        let f = parse("nu X. (((!(q == 0)) || [] (q == 1)) && [] X)");
+        let (verdict, _) = reach_portfolio_rescue(TOGGLING_PULSE, &f, false).expect("reducible");
+        assert_eq!(
+            verdict,
+            RescueVerdict::Holds,
+            "an `init 1` latch would manufacture a cycle-0 violation here"
+        );
+    }
+
+    #[test]
+    /// The compound-antecedent axis — `emit_ag_implies_next_monitor` took a single atom, which is
+    /// half of why it never reached a real property.
+    fn implies_next_accepts_a_compound_antecedent() {
+        let f = parse("nu X. ((!((q == 1) && (e == 1)) || [] (q == 0)) && [] X)");
+        assert!(
+            reduce_ag_implies_next(&f).is_some(),
+            "a compound antecedent must match"
+        );
+        let (verdict, _) = reach_portfolio_rescue(FREE_PULSE, &f, false)
+            .expect("a compound antecedent must reach the rescue lane");
+        assert_eq!(
+            verdict,
+            RescueVerdict::Violated,
+            "`e` is free, so `q && e` then `q` again is reachable"
         );
     }
 }

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -7122,21 +7122,29 @@ endmodule
             );
         }
         assert_eq!(
-            holds, 12,
-            "config concretization lifts sysrst 9 → 12 HOLDS (sva_5/7/10/11); got {holds}"
+            holds, 14,
+            "config concretization lifts sysrst 9 → 12 HOLDS (sva_5/7/10/11), and the mununu#503 \
+             `|=>` rescue reducer adds sva_12 (pulse) + sva_14 (counter reset) for 14; got {holds}"
         );
-        // The residual ⊥ are the non-timer cases: sva_12 (pulse), sva_13/14
-        // (counter monotonicity/reset), sva_15 (arithmetic). H.H NOTE: the
-        // counter-bound `cnt_q <= 7` is auto-seeded here (the counter-bound note
-        // fires, asserted below), but it does NOT flip sva_13/14/15 — their ⊥ is
-        // co-dominated by the `cnt_clr` combinational-input ANTECEDENT (a separate
-        // cone-unwrap lever), not the counter bound. The bound is necessary infra
-        // (it excludes the abstract wraparound) but not sufficient for THIS fixture.
-        // The demonstrator `e2e_counter_bound_flips_saturating_monotonicity` below
-        // isolates a property where the bound alone flips ⊥ → HOLDS.
+        // The residual ⊥ are now just sva_13 (counter monotonicity) and sva_15 (arithmetic).
+        //
+        // mununu#503 — sva_12 and sva_14 USED to be residual ⊥ here and are not any more: their
+        // `A |=> C` shape now reduces to a `bad` monitor and the reachability portfolio decides
+        // both HOLDS (`portfolio-rescue` notes name engines `exact, native` and
+        // `exact, native, spacer`). What still declines is a REGISTER-VS-REGISTER consequent —
+        // sva_13's `cnt_q >= cnt_q__past` and sva_15's `cnt_q == cnt_q__past + 1` are `CmpReg` /
+        // `CmpRegAddend` leaves, which the boolean compiler does not accept. That is a leaf-shape
+        // gap, NOT the `cnt_clr` antecedent: the antecedent was never the blocker for sva_14,
+        // whose consequent (`cnt_q == 0`) is a plain comparison and now decides.
+        //
+        // H.H NOTE: the counter-bound `cnt_q <= 7` is auto-seeded here (the counter-bound note
+        // fires, asserted below), but it does NOT flip sva_13/15 — the bound is necessary infra
+        // (it excludes the abstract wraparound) but not sufficient for THIS fixture. The
+        // demonstrator `e2e_counter_bound_flips_saturating_monotonicity` below isolates a property
+        // where the bound alone flips ⊥ → HOLDS.
         assert_eq!(
-            unknown, 4,
-            "the non-timer residual ⊥ remain (bound is inert here — cnt_clr antecedent co-blocks); got UNKNOWN={unknown}"
+            unknown, 2,
+            "only the register-vs-register consequents (sva_13/15) stay ⊥; got UNKNOWN={unknown}"
         );
         // H.H — the counter-bound note fires (auto-inferred `cnt_q <= 7` from the
         // sibling `cnt_q >= cfg_detect_timer_i` comparison), even though it does not
@@ -7655,14 +7663,25 @@ endmodule
             "sva_2 (`trigger_i != !trigger_i` tautology) reaches a sound HOLDS; got {:?}",
             sva2.outcome
         );
-        // H.U.2 — a combinational output that is a function of STATE
-        // (`event_detected_o` / `event_detected_pulse_o` = f(state_q)) binds as a
-        // CUBE DIMENSION and reaches a DEFINITE verdict: sva_1
-        // (`cfg_enable_i → ¬event_detected_o ∧ ¬event_detected_pulse_o`) and
-        // sva_12 (`event_pulse → AX ¬event_pulse`) both HOLD. The still-⊥ props
-        // (sva_4..11) are ⊥ from their combinational-of-*input* antecedents
-        // (`trigger_active`/`cnt_q >= cfg_*`), NOT from any combinational binding
-        // gap — every combinational atom binds (SKIPPED is 0, asserted above).
+        // H.U.2 — the combinational `event_detected_*` outputs SEED as predicates, and both
+        // sva_1 (`cfg_enable_i → ¬event_detected_o ∧ ¬event_detected_pulse_o`) and sva_12
+        // (`event_pulse |=> ¬event_pulse`) reach a DEFINITE HOLDS. The still-⊥ props are ⊥ from
+        // their combinational-of-*input* antecedents (`trigger_active` / `cnt_q >= cfg_*`), NOT
+        // from any combinational binding gap — every combinational atom binds (SKIPPED is 0,
+        // asserted above).
+        //
+        // mununu#503 — the two properties hold by DIFFERENT mechanisms, and this comment used to
+        // assert the wrong one for sva_12:
+        //
+        // - **sva_1 decides in the cube.** Its atoms are pinned as cube dimensions.
+        // - **sva_12 does NOT.** It carries a `portfolio-rescue` note, i.e. the cube left it ⊥ and
+        //   the `|=>` reducer + reachability portfolio decided it. The old comment claimed
+        //   `event_detected_pulse_o = f(state_q)` and so "binds as a CUBE DIMENSION" — but the RTL
+        //   (sysrst_ctrl_detect.sv:122-215) makes that output a function of `cfg_enable_i`,
+        //   `trigger_i` and the timers as well, so `cone_reaches_input` correctly classifies it
+        //   `InputDependent` and it becomes a per-cube derived LABEL, which the cube cannot pin.
+        //   The assertion below is therefore on the VERDICT only; it deliberately does not claim a
+        //   binding mechanism, because for sva_12 that claim was false.
         for name in ["sysrst_ctrl_detect_sva_1", "sysrst_ctrl_detect_sva_12"] {
             let p = report
                 .properties
@@ -7678,8 +7697,8 @@ endmodule
             );
             assert!(
                 matches!(p.outcome, VerifyOutcome::Holds),
-                "{name} reaches a DEFINITE HOLDS (event_detected_* binds as a \
-                 function-of-state cube dimension); got {:?}",
+                "{name} reaches a DEFINITE HOLDS — sva_1 from the cube, sva_12 via the \
+                 mununu#503 `|=>` rescue lane; got {:?}",
                 p.outcome
             );
         }
@@ -7776,8 +7795,11 @@ endmodule
         }
         // The remaining ⊥ are the RELATIONAL-with-input compounds (`cnt_q >=
         // cfg_*_timer_i`, sva_5/7/10/11) — the input operand is inside a
-        // relational, which the cone-input seeder does not unwrap — plus the
-        // cnt_clr cases (sva_13/14). Honest ⊥, never a spurious verdict.
+        // relational, which the cone-input seeder does not unwrap — plus sva_13/15, whose
+        // consequents are register-vs-register (`cnt_q >= cnt_q__past`,
+        // `cnt_q == cnt_q__past + 1`). mununu#503: sva_14 is NO LONGER among them — its
+        // `cnt_clr |=> cnt_q == 0` reduces and the portfolio decides it. Honest ⊥, never a
+        // spurious verdict.
         for name in ["sysrst_ctrl_detect_sva_5", "sysrst_ctrl_detect_sva_7"] {
             let p = report
                 .properties

--- a/docs/consumer-briefings/2026-09-implies-next-rescue.md
+++ b/docs/consumer-briefings/2026-09-implies-next-rescue.md
@@ -1,0 +1,141 @@
+# Consumer briefing — `A |=> C` properties now decide via the safety-rescue lane
+
+> **Audience:** consumers of `mununu sv verify-auto` (CLI, `POST /api/sv/verify-auto`, mununu-ui)
+> and anything that parses a `PropertyVerdict`. **ROSF, monono, mununu-ui.**
+
+## TL;DR
+
+SVA's non-overlapped implication `A |=> C` — "if `A` holds this cycle, `C` holds the next" — used
+to come back `Unknown` whenever the predicate cube could not pin it. It now reduces to a `bad`
+monitor and is decided by the reachability portfolio.
+
+Measured on OpenTitan's `sysrst_ctrl_detect` (16 assertions, `mununu-sva` image): **HOLDS 12 → 14,
+UNKNOWN 4 → 2** under config concretization. Two properties moved, both `⊥ → Holds`. No verdict
+that was already definite changed, and nothing became `Violated`.
+
+## What actually changed
+
+`A |=> C` lifts to `nu X. ((¬A ∨ [] C) ∧ [] X)`, i.e. `AG (A → AX C)`. The safety-rescue lane had
+no reducer for that shape, so it declined with `bottom-reason: safety-shape-not-reducible`.
+
+An emitter for the shape did exist but could not reach a real property: it took a **single atom**
+as the antecedent and required the consequent to be a **state cell**. Real assertions are not
+shaped that way — OpenTitan writes
+
+```systemverilog
+`ASSERT(DetectStDropOut_A,
+    state_q == DetectSt && !trigger_active && cfg_enable_i
+    |=>
+    state_q == IdleSt)
+```
+
+a three-term antecedent, and `sysrst_ctrl_detect_sva_12`'s consequent
+(`!event_detected_pulse_o`) is combinational, not a state cell. Both limits are lifted: the
+antecedent may be any boolean tree, and the consequent may be combinational.
+
+The monitor synthesises a 1-bit latch (`mununu_ante_prev`, `init 0`, `next = A`) and asserts
+`bad = mununu_ante_prev ∧ ¬C`.
+
+### Soundness
+
+`bad` is reachable ⟺ ∃ a trace and a cycle `t` with `A` true at `t` and `C` false at `t+1` —
+exactly a violation of `AG (A → AX C)`, and exactly SVA's own reading of `A |=> C`. Three things
+carry that equivalence:
+
+- **`init 0` fabricates no obligation at reset.** Nothing precedes cycle 0. An `init 1` latch would
+  report a violation on a design that never asserted `A`; a regression test pins this.
+- **The latch is a pure monitor.** It adds no input and never feeds back into the transition
+  relation, so the reachable-state set is unchanged and a counterexample projects back onto the
+  original registers.
+- **A free next-cycle input is the correct reading of `[] C`.** A combinational `C` depends on the
+  inputs at `t+1`; `bad` reachability quantifies existentially over those, which is precisely
+  `¬(∀ successors. C)`.
+
+## Scope — how to tell if you are affected
+
+A property is affected **iff** it is an `A |=> C` (non-overlapped implication) that was previously
+returning `Unknown`. Overlapped `A |-> C`, plain invariants, and anything already definite are
+untouched.
+
+**What still declines**, and will keep reporting `safety-shape-not-reducible`:
+
+- **Register-vs-register consequents.** `sva_13`'s `cnt_q >= cnt_q__past` and `sva_15`'s
+  `cnt_q == cnt_q__past + 1` are `CmpReg` / `CmpRegAddend` leaves, which the boolean leaf compiler
+  does not accept. These are the 2 residual ⊥ above.
+- **Nested-box consequents.** `a |=> ##1 b`, and the nested form the translator emits for
+  multi-element antecedents (`a ##1 b |=> c`).
+
+Both decline rather than being mis-compiled. A modality silently flattened into a boolean would be
+a soundness bug, not a wider reach.
+
+## Per-consumer
+
+### ROSF / monono
+
+- **What to update:** nothing required.
+- **What to expect:** `|=>` properties that abstained now return a definite verdict. `ci_exit_code`
+  fails on `unknown` but never on `skipped`, so a suite that was passing *because* a `|=>` property
+  abstained will now see it decide. On this corpus every newly-decided property was `Holds`; a
+  `Violated` is possible in general, and would mean the gate is catching something it previously
+  could not check.
+- **Report parsing:** no shape change. Newly-decided properties carry a `portfolio-rescue`
+  verification note naming the deciding engines.
+
+### mununu-ui
+
+- **What to update:** nothing. No wire-format change.
+- **What to expect:** fewer ⊥ badges on `|=>` assertions; a `portfolio-rescue` note where one
+  appears.
+
+## Docker rebuild disposition
+
+| Image | Impact | Rebuild required? |
+|---|---|---|
+| `mununu-dev` | Rust only; no tool pins touched | No |
+| `mununu-sva` | Inherits `mununu-dev`; slang/sv2v/yosys pins unchanged | No |
+| `mununu-sva-pono` | Inherits `mununu-sva`; MathSAT/pono pins unchanged | No |
+| `hw-verif` | Not involved | No |
+
+## Test the transition
+
+Measured in the `mununu-sva` image (a bare-host green on an SVA path is presumed vacuous per
+CLAUDE.md):
+
+```
+note [portfolio-rescue] `sysrst_ctrl_detect_sva_12`: the cube abstraction left ⊥;
+     the reachability portfolio decided it HOLDS (engine(s): exact, native)
+note [portfolio-rescue] `sysrst_ctrl_detect_sva_14`: the cube abstraction left ⊥;
+     the reachability portfolio decided it HOLDS (engine(s): exact, native, spacer)
+note [coverage-summary] 16 assertion(s): 14 definite (HOLDS), 0 violated, 2 unknown (⊥)
+```
+
+- `sva_12` = `event_detected_pulse_o |=> !event_detected_pulse_o` — combinational consequent.
+- `sva_14` = `cnt_clr |=> cnt_q == 0` — plain comparison consequent.
+
+**On cross-checking these.** `concrete_oracle::ag_implies_next` cannot serve as the differential
+here: it evaluates the consequent as a function of the next *state* and refuses an input-dependent
+one. The exact-symbolic μ-calculus engine also abstained on this design (BDD arena exhausted / the
+derived-predicate limitation). What the verdicts do carry is **multi-engine agreement inside the
+reachability portfolio** — `exact` (BDD reachability, a proof of unreachability) alongside `native`
+BMC, and `spacer` additionally on `sva_14`. That is the honest strength of the evidence: a
+BDD-reachability proof plus concurring engines, not an independent μ-calculus cross-check.
+
+Unit-level, the monitor's two load-bearing properties are mutation-tested: an `init 1` latch fails
+`implies_next_makes_no_obligation_at_reset`, and a latch that never asserts fails
+`implies_next_catches_a_pulse_that_can_stay_high` and
+`implies_next_accepts_a_compound_antecedent`. Both mutants were run and confirmed to fail.
+
+## Provenance
+
+- Issue: mununu#503 (e2e non-regression gate), surfaced by the #504 C5 gate.
+- Fix: `reach_rescue::reduce_ag_implies_next` +
+  `btor2::bad_monitor::emit_ag_implies_next_compound_monitor`.
+- Diagnosis: `.claude/plans/agile-munching-bear.md` § "Cause 3".
+- Policy: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here
+
+- The register-vs-register leaf gap (`CmpReg` / `CmpRegAddend`) — the 2 residual ⊥ on this corpus.
+  Widening the leaf compiler to relational leaves is a separate change.
+- The four e2e failures this closes out had **four different causes**; the other three are covered
+  by `2026-09-internal-net-monitor-resolution.md` and `2026-09-infeasible-initial-cubes.md`.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -210,9 +210,23 @@ trial-and-error.
 
 **Compound-safety rescue.** A residual ⊥ on a safety property of the shape `AG(compound)` — where `compound` is a boolean tree over `And`/`Or`/`Not`/`True`/`False`/`Predicate` nodes and each `Predicate` leaf is a single `REG op VALUE` comparison — is now decided by the reachability portfolio. Widens the existing single-atom escalation to accept exclusion (`!a || !b`), implication (`!a || b`), and conjunctive (`a && b`) shapes, and — critically — resolves each leaf via state cell → output net → **primary input**, so a zero-state model (a purely combinational block like `mem_router`) can have its properties decided at k=0 without a state cone to walk. Preserves byte-for-byte behavior on the shipped single-atom path (single-atom shapes route through the original emitter; the compound emitter is a fallback).
 
+
+**Non-overlapped implication (`|=>`) rescue (mununu#503).**
+
+> Source of truth: [`reach_rescue::reduce_ag_implies_next`](../crates/mununu-core/src/adapter/reach_rescue.rs) — surface: (CLI+API+UI, via `sv verify-auto`'s escalation pass)
+
+A residual ⊥ on `A |=> C` — which lifts to `nu X. ((¬A ∨ [] C) ∧ [] X)`, i.e. `AG (A → AX C)` — is now reduced to a `bad` monitor and decided by the reachability portfolio, alongside the `AG(compound)` shape above. The monitor synthesises a 1-bit latch (`mununu_ante_prev`, `init 0`, `next = A`) and asserts `bad = mununu_ante_prev ∧ ¬C`.
+
+Two properties of this path are worth knowing:
+
+- **The antecedent may be compound and the consequent may be combinational.** Both were hard limits of the earlier single-atom emitter, and both are what real assertions need — OpenTitan's `sysrst_ctrl_detect` states its FSM transitions as `state_q == DetectSt && !trigger_active && cfg_enable_i |=> state_q == IdleSt`.
+- **It decides properties the concrete oracle cannot cross-check.** `concrete_oracle::ag_implies_next` refuses an input-dependent consequent because it evaluates the consequent as a function of the next *state* and has no next-cycle input to evaluate against. A `bad` monitor has no such gap — the next cycle's inputs are part of the trace. Where a differential is wanted for these, the exact-symbolic engine is the cross-check, not the oracle.
+
+**What still declines.** A register-vs-register leaf (`cnt_q >= cfg_debounce_timer_i`) is a `CmpReg`, which the leaf compiler does not accept; a nested-box consequent (`a |=> ##1 b`, and the nested form the translator emits for multi-element antecedents) is not a boolean body. Both decline as `safety-shape-not-reducible` rather than being mis-compiled — a modality silently flattened into a boolean would be a soundness bug, not a wider reach.
+
 **`bottom-reason` note.** For any property that stays ⊥ after the escalation pass, a new `bottom-reason` verification note classifies WHY the ⊥ stands:
 
-- **`safety-shape-not-reducible`** — the property is Safety-class but neither reducer accepts its shape (a compound with a register-vs-register `CmpReg` leaf, a non-standard AG outer shape, etc.). NOT the same as a resource abstain — this needs a property reshape or a new rescue reducer, not a bigger budget.
+- **`safety-shape-not-reducible`** — the property is Safety-class but **no** reducer accepts its shape (a compound with a register-vs-register `CmpReg` leaf, a nested-box consequent from `##k` / a multi-element antecedent, a non-standard AG outer shape, etc.). NOT the same as a resource abstain — this needs a property reshape or a new rescue reducer, not a bigger budget.
 - **`no-state-model-non-safety`** — the design has zero state registers AND this property is non-Safety (liveness / recoverability). On a stateless model, `AG EF good` is vacuously true and `AG(a → AF b)`'s l2s reduction has no lasso to close. The ⊥ is a modelling issue (compose with a stateful context or restrict to tier-1 safety), not an engine cap.
 - **`unclassified`** — the classifier did not narrow further; most commonly a resource abstain the engine already flagged with a `bit-cap` / `abstained on the …` sibling note.
 


### PR DESCRIPTION
Closes out the **fourth and last** e2e failure from the #504 C5 gate. All four had **different** causes.

## What

SVA's non-overlapped implication lifts to `nu X. ((¬A ∨ [] C) ∧ [] X)` = `AG (A → AX C)`. The safety-rescue lane had no reducer for that shape, so every `|=>` property the predicate cube could not pin declined as `safety-shape-not-reducible`.

An emitter existed but could not reach a real property: it took a **single atom** antecedent and required a **state-cell** consequent. Real assertions aren't shaped that way — OpenTitan writes

```systemverilog
`ASSERT(DetectStDropOut_A,
    state_q == DetectSt && !trigger_active && cfg_enable_i
    |=> state_q == IdleSt)
```

a three-term antecedent; and `sva_12`'s consequent (`!event_detected_pulse_o`) is combinational, not a state cell. Both limits are lifted.

Antecedent and consequent compile through `compile_boolean_subtree`, extracted verbatim from the `AG(compound)` emitter — **one compiler, not two**, because a gate and a compiler disagreeing about what a leaf means is exactly the bug #527 fixed once already.

## Soundness

`bad` reachable ⟺ ∃ a trace and cycle `t` with `A`@`t` and `¬C`@`t+1` — exactly a violation of `AG (A → AX C)`, and exactly SVA's reading of `A |=> C`.

- `init 0` fabricates no obligation at reset.
- The latch is a **pure monitor** — no new input, no feedback into the transition relation, so the reachable-state set is unchanged.
- A free next-cycle input is the correct reading of `[] C`: `bad` reachability quantifies existentially over precisely the inputs `¬(∀ successors. C)` does.

## Measurement (`mununu-sva` image)

```
note [portfolio-rescue] sysrst_ctrl_detect_sva_12: ... HOLDS (engine(s): exact, native)
note [portfolio-rescue] sysrst_ctrl_detect_sva_14: ... HOLDS (engine(s): exact, native, spacer)
note [coverage-summary] 16 assertion(s): 14 definite (HOLDS), 0 violated, 2 unknown (⊥)

e2e_sysrst_config_concretization_flips_timer_relationals ... ok
e2e_sysrst_detect_real_sva_verdict_breakdown ... ok   <- was FAILING
e2e_sysrst_symbolic_engine_runs_on_real_rtl ... ok
```

HOLDS 12 → 14, UNKNOWN 4 → 2. **The arithmetic is conservative**: 12+4 = 14+2 = 16, so exactly two properties moved ⊥→Holds and none moved back.

## The tests are mutation-tested, not just green

A monitor that never fires would pass every positive test. Both mutants were run and confirmed to fail:

| mutant | test that catches it |
|---|---|
| latch `init 1` | `implies_next_makes_no_obligation_at_reset` |
| latch never asserts (`next = 0`) | `implies_next_catches_a_pulse_that_can_stay_high`, `implies_next_accepts_a_compound_antecedent` |

## Corrects two false test comments

`sva_12` was documented as holding because `event_detected_pulse_o = f(state_q)` "binds as a CUBE DIMENSION". The RTL makes that output depend on `cfg_enable_i`/`trigger_i`/the timers too, so it is correctly classified `InputDependent` and the cube **cannot** pin it — it holds via the rescue lane and carries a `portfolio-rescue` note saying so. The two tests also **contradicted each other** about `sva_12`; both now agree with the measurement.

## What still declines, honestly

Register-vs-register consequents (`sva_13`'s `cnt_q >= cnt_q__past`, `sva_15`'s `cnt_q == cnt_q__past + 1` — `CmpReg`/`CmpRegAddend` leaves) and nested-box consequents (`a |=> ##1 b`). Declining beats mis-compiling: a modality silently flattened into a boolean would be a soundness bug, not wider reach.

## Cross-check caveat

`concrete_oracle::ag_implies_next` **cannot** serve as the differential — it evaluates the consequent as a next-*state* function and refuses an input-dependent one. The exact-symbolic μ-calculus engine also abstained on this design. What the verdicts carry is multi-engine agreement inside the reachability portfolio (`exact` BDD reachability — a proof of unreachability — plus `native` BMC, and `spacer` on `sva_14`). Stated plainly rather than dressed up as an independent μ-calculus cross-check.

Briefing: `docs/consumer-briefings/2026-09-implies-next-rescue.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)