### PR TITLE
feat(verify-auto): one typed report shape for CLI and API (mununu#536)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -3803,7 +3803,7 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
         .map_err(|e| format!("sv verify-auto: {}", e.message))?;
 
     if args.json {
-        render_verify_auto_json(&report);
+        render_verify_auto_json(&report)?;
     } else {
         render_verify_auto_text(&report);
     }
@@ -3946,96 +3946,25 @@ fn note_level_glyph(level: mununu_core::adapter::slang::verify_auto::NoteLevel) 
     }
 }
 
-/// Machine-stable kebab string for a note's severity (JSON + API parity).
-fn note_level_str(level: mununu_core::adapter::slang::verify_auto::NoteLevel) -> &'static str {
-    use mununu_core::adapter::slang::verify_auto::NoteLevel;
-    match level {
-        NoteLevel::Info => "info",
-        NoteLevel::ScopeCaveat => "scope-caveat",
-        NoteLevel::SoundnessCaveat => "soundness-caveat",
-    }
-}
-
-fn render_verify_auto_json(report: &mununu_core::adapter::slang::verify_auto::AutoVerifyReport) {
-    use mununu_core::adapter::slang::verify_auto::VerifyOutcome;
-    let props: Vec<serde_json::Value> = report
-        .properties
-        .iter()
-        .map(|p| {
-            let (status, detail) = match &p.outcome {
-                VerifyOutcome::Holds => ("holds", serde_json::Value::Null),
-                VerifyOutcome::Violated { false_cells } => (
-                    "violated",
-                    serde_json::json!({ "false_cells": false_cells }),
-                ),
-                VerifyOutcome::Unknown { unknown_cells } => (
-                    "unknown",
-                    serde_json::json!({ "unknown_cells": unknown_cells }),
-                ),
-                VerifyOutcome::Skipped { reason } => {
-                    ("skipped", serde_json::json!({ "reason": reason }))
-                }
-            };
-            // D1.8b — stall-lasso counterexample; each state is an ordered list of
-            // [register, value] pairs so the register order is preserved in JSON.
-            let counterexample = p.counterexample.as_ref().map(|c| {
-                let states = |v: &[Vec<(String, u64)>]| -> Vec<serde_json::Value> {
-                    v.iter()
-                        .map(|st| {
-                            serde_json::Value::Array(
-                                st.iter()
-                                    .map(|(k, val)| serde_json::json!([k, val]))
-                                    .collect(),
-                            )
-                        })
-                        .collect()
-                };
-                serde_json::json!({ "prefix": states(&c.prefix), "cycle": states(&c.cycle) })
-            });
-            serde_json::json!({
-                "name": p.name,
-                "kind": sva_kind_str(p.kind),
-                "formula": p.formula,
-                "outcome": status,
-                "detail": detail,
-                "seeded_predicates": p.seeded_predicates,
-                "counterexample": counterexample,
-            })
-        })
-        .collect();
-    let unsupported: Vec<serde_json::Value> = report
-        .unsupported
-        .iter()
-        .map(|(name, reason)| serde_json::json!({ "name": name, "reason": reason }))
-        .collect();
-    let notes: Vec<serde_json::Value> = report
-        .notes
-        .iter()
-        .map(|n| {
-            serde_json::json!({
-                "kind": n.kind,
-                "level": note_level_str(n.level),
-                "summary": n.summary,
-                "detail": n.detail,
-                "items": n.items,
-            })
-        })
-        .collect();
-    let out = serde_json::json!({
-        "properties": props,
-        "unsupported": unsupported,
-        "diagnostics": {
-            "state_register_count": report.diagnostics.state_register_count,
-            "blackboxed_modules": report.diagnostics.blackboxed_modules,
-            "gated_resets": report.diagnostics.gated_resets,
-            "auto_provided_stubs": report.diagnostics.auto_provided_stubs,
-        },
-        "notes": notes,
-    });
+fn render_verify_auto_json(
+    report: &mununu_core::adapter::slang::verify_auto::AutoVerifyReport,
+) -> Result<(), String> {
+    // mununu#536 — serialize the SAME type the HTTP API returns, via the one shared conversion
+    // (`impl From<&AutoVerifyReport> for SvVerifyAutoResponse`).
+    //
+    // This used to be an independent `serde_json::json!` literal, which meant two hand-written
+    // serializers for one documented shape. They had already drifted — `detail` was an object
+    // here and a string on the API, this one dropped `unreachable_target`, and neither carried
+    // the front end used — so a consumer reading
+    // `docs/api-schemas/sv-verify-auto-response.schema.json` and then running the CLI got a
+    // different document. Going through the shared type means the schema drift test now covers
+    // this output too, because it is literally the same type.
+    let view = mununu_core::api::models::SvVerifyAutoResponse::from(report);
     println!(
         "{}",
-        serde_json::to_string_pretty(&out).unwrap_or_else(|_| "{}".to_string())
+        serde_json::to_string_pretty(&view).map_err(|e| format!("serialize report: {e}"))?
     );
+    Ok(())
 }
 
 /// Shared CEGAR parameters for the CLI handlers. Both `btor2 cegar`

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -332,6 +332,20 @@ pub struct ModelDiagnostics {
     /// the one used succeeded), the prior attempt's error. `None` when there was no
     /// fallback (an explicit front end, or the first attempt succeeded).
     pub frontend_fallback_reason: Option<String>,
+    /// mununu#536 — config inputs pinned to constants for this run, each
+    /// `"<signal>=<value>"` (the `--config-value` / API `config_values` operands that were
+    /// actually APPLIED, not those merely requested).
+    ///
+    /// These already reach a human through the `config-concretization` note, but a note is
+    /// prose: a consumer asking "what was this verdict scoped to?" had to string-match a
+    /// summary line. A verdict pinned to `cfg_timer=7` is a claim about THAT configuration
+    /// and no other, so the scope belongs in the structured payload beside the verdicts.
+    pub applied_config_values: Vec<String>,
+    /// mununu#536 — signals cut to free inputs by `--cutpoint`, i.e. the control slice this
+    /// run verified under. Same reasoning as [`Self::applied_config_values`]: a cutpoint is
+    /// an over-approximation that shapes every verdict in the report, and it was reachable
+    /// only as `control-slice` note prose.
+    pub cutpoint_signals: Vec<String>,
 }
 
 /// Severity of a [`VerificationNote`] — how it bears on the verdict's trust.
@@ -516,6 +530,65 @@ fn partition_config_pins(
     (applied, unusable)
 }
 
+/// mununu#536 — the `coverage-summary` note, computed from a report's CURRENT verdicts.
+///
+/// Extracted so it can be recomputed AFTER the portfolio merge. It is the one note whose
+/// content is a function of the verdicts, which is exactly why it could go stale while every
+/// other note stayed true.
+fn coverage_summary_note(report: &AutoVerifyReport) -> VerificationNote {
+    let (mut holds, mut violated, mut unknown, mut skipped) = (0usize, 0usize, 0usize, 0usize);
+    for p in &report.properties {
+        match p.outcome {
+            VerifyOutcome::Holds => holds += 1,
+            VerifyOutcome::Violated { .. } => violated += 1,
+            VerifyOutcome::Unknown { .. } => unknown += 1,
+            VerifyOutcome::Skipped { .. } => skipped += 1,
+        }
+    }
+    VerificationNote {
+        kind: "coverage-summary".into(),
+        level: NoteLevel::Info,
+        summary: format!(
+            "{} assertion(s): {holds} definite (HOLDS), {violated} violated, {unknown} unknown (⊥), {skipped} skipped; {} untranslatable",
+            report.properties.len(),
+            report.unsupported.len(),
+        ),
+        detail: "A definite verdict transfers to the RTL (see abstraction-posture); ⊥ means the \
+                 abstraction is too coarse to decide — an honest 'don't know', not a violation."
+            .into(),
+        items: Vec::new(),
+    }
+}
+
+/// mununu#536 / mununu#498 — replace a report's `coverage-summary` note with one recomputed
+/// from its current verdicts.
+///
+/// # The bug this fixes
+///
+/// `merge_portfolio_reports` starts from `base.clone()`, where the base is the highest-precision
+/// engine, and that clone brings the base's NOTES with it. The merge then rewrites
+/// `properties[].outcome` with the first definite verdict across all engines — but nothing
+/// rewrote the notes, so the `coverage-summary` kept reporting the BASE ENGINE'S tally while
+/// `properties[]` reported the merged one. Since `portfolio-sequential` is the default engine,
+/// this was the common case, and it is exactly what mununu#498's minor and mununu#536 observed:
+/// a summary claiming `0 unknown` beside properties printing `UNKNOWN`.
+///
+/// A consumer that counted the summary line under-reported its own coverage. That was tolerable
+/// while the summary was prose a human skimmed; it is not tolerable inside a machine-readable
+/// report, which is why it is fixed in the same change that publishes one.
+fn refresh_coverage_summary(report: &mut AutoVerifyReport) {
+    let fresh = coverage_summary_note(report);
+    if let Some(slot) = report
+        .notes
+        .iter_mut()
+        .find(|n| n.kind == "coverage-summary")
+    {
+        *slot = fresh;
+    } else {
+        report.notes.push(fresh);
+    }
+}
+
 fn build_notes(
     report: &AutoVerifyReport,
     must_edge_inference: MustEdgeInference,
@@ -529,28 +602,7 @@ fn build_notes(
     let mut notes = Vec::new();
 
     // Coverage summary (Info) — the honest at-a-glance tally.
-    let (mut holds, mut violated, mut unknown, mut skipped) = (0usize, 0usize, 0usize, 0usize);
-    for p in &report.properties {
-        match p.outcome {
-            VerifyOutcome::Holds => holds += 1,
-            VerifyOutcome::Violated { .. } => violated += 1,
-            VerifyOutcome::Unknown { .. } => unknown += 1,
-            VerifyOutcome::Skipped { .. } => skipped += 1,
-        }
-    }
-    notes.push(VerificationNote {
-        kind: "coverage-summary".into(),
-        level: NoteLevel::Info,
-        summary: format!(
-            "{} assertion(s): {holds} definite (HOLDS), {violated} violated, {unknown} unknown (⊥), {skipped} skipped; {} untranslatable",
-            report.properties.len(),
-            report.unsupported.len(),
-        ),
-        detail: "A definite verdict transfers to the RTL (see abstraction-posture); ⊥ means the \
-                 abstraction is too coarse to decide — an honest 'don't know', not a violation."
-            .into(),
-        items: Vec::new(),
-    });
+    notes.push(coverage_summary_note(report));
 
     // #466 — which RTL front end produced the lift. `--frontend auto` picks one
     // silently, but read_verilog and yosys-slang differ in SOUNDNESS on partial
@@ -2105,6 +2157,10 @@ pub(crate) fn merge_portfolio_reports(
         ),
         items,
     });
+    // mununu#536 — every verdict is final now, so recompute the one note that counts them. The
+    // clone above carried the BASE engine's coverage summary, which the merge has just made
+    // wrong; see `refresh_coverage_summary`.
+    refresh_coverage_summary(&mut merged);
     if !contradictions.is_empty() {
         merged.notes.push(VerificationNote {
             kind: "portfolio-soundness-alarm".to_string(),
@@ -2219,7 +2275,7 @@ pub fn verify_auto(
     // former inline `verify_auto_portfolio`; the routing reasoning now lives in the planner.
     if opts.portfolio.is_some() {
         return match prepare_model(sources, yosys_opts, opts)? {
-            Prepared::Empty(report) => Ok(report),
+            Prepared::Empty(report) => Ok(*report),
             Prepared::Model(m) => {
                 let m = *m;
                 let task = crate::planner::VerificationTask {
@@ -2396,8 +2452,11 @@ impl PreparedModel {
 /// The result of `prepare_model`: either a design with NO translated properties (the empty report is
 /// final) or a fully-prepared [`PreparedModel`].
 pub(crate) enum Prepared {
-    /// No properties to verify — the report (posture + annotation note) is complete.
-    Empty(AutoVerifyReport),
+    /// No properties to verify — the report (posture + annotation note) is complete. Boxed for
+    /// the same reason `Model` is: `Prepared` is returned by value, and an `AutoVerifyReport`
+    /// carrying the full diagnostics + note set is not a cheap thing to move through the
+    /// enum's largest-variant footprint.
+    Empty(Box<AutoVerifyReport>),
     /// The prepared model, ready for `plan` + `verify_from_prepared`. Boxed — it is much larger
     /// than the `Empty` report, and `Prepared` is returned by value.
     Model(Box<PreparedModel>),
@@ -2477,7 +2536,7 @@ pub(crate) fn prepare_model(
         if let Some(n) = annotation_note(&ann_scan) {
             report.notes.push(n);
         }
-        return Ok(Prepared::Empty(report));
+        return Ok(Prepared::Empty(Box::new(report)));
     }
 
     // Reset inputs to pin inactive (reset-gating). Empty when gating is off or no `disable iff`
@@ -2722,7 +2781,7 @@ pub(crate) fn verify_auto_impl(
     } = match prepared {
         Some(m) => m,
         None => match prepare_model(sources, yosys_opts, opts)? {
-            Prepared::Empty(r) => return Ok(r),
+            Prepared::Empty(r) => return Ok(*r),
             Prepared::Model(m) => *m,
         },
     };
@@ -3498,6 +3557,14 @@ pub(crate) fn verify_auto_impl(
     } else {
         NotePosture::Cube
     };
+    // mununu#536 — record the run's SCOPE on the diagnostics, not only in note prose. Both
+    // operands are already in hand here (they are `build_notes` arguments); a consumer asking
+    // "what was this verdict scoped to?" should not have to parse a summary sentence.
+    report.diagnostics.applied_config_values = applied_config_values
+        .iter()
+        .map(|(sig, val)| format!("{sig}={val}"))
+        .collect();
+    report.diagnostics.cutpoint_signals = yosys_opts.cutpoint_signals.clone();
     report.notes = build_notes(
         &report,
         opts.must_edge_inference,
@@ -5176,6 +5243,87 @@ mod tests {
                 .any(|n| n.kind == "portfolio"
                     && n.items.iter().any(|i| i == "decided-by:symbolic=1")),
             "the note must attribute the verdict to the symbolic engine"
+        );
+    }
+
+    /// mununu#536 / mununu#498 — the merged report's `coverage-summary` must count the MERGED
+    /// verdicts, not the base engine's.
+    ///
+    /// The merge starts from `base.clone()`, which carries the base engine's notes; it then
+    /// rewrites `properties[].outcome` across engines. Nothing rewrote the summary, so it kept
+    /// reporting the base's tally. With `portfolio-sequential` as the DEFAULT engine this was
+    /// the common case, and it is what monono saw: a summary claiming `0 unknown` beside
+    /// properties printing `UNKNOWN`. A consumer counting the summary under-reported its own
+    /// coverage.
+    #[test]
+    fn portfolio_merge_recounts_the_coverage_summary() {
+        // The base (exact) leaves both ⊥; the explicit engine decides one. Merged: 1 holds, 1 ⊥.
+        let exact = (
+            "exact-symbolic",
+            Ok(mk_report(&[
+                (
+                    "p_decided_later",
+                    VerifyOutcome::Unknown { unknown_cells: 8 },
+                    None,
+                ),
+                (
+                    "p_stays_bottom",
+                    VerifyOutcome::Unknown { unknown_cells: 4 },
+                    None,
+                ),
+            ])),
+        );
+        let explicit = (
+            "explicit",
+            Ok(mk_report(&[
+                ("p_decided_later", VerifyOutcome::Holds, None),
+                (
+                    "p_stays_bottom",
+                    VerifyOutcome::Unknown { unknown_cells: 4 },
+                    None,
+                ),
+            ])),
+        );
+        let merged = merge_portfolio_reports(&[exact, explicit], PortfolioMode::Sequential)
+            .expect("merge ok");
+
+        // What the properties actually say, which is the record of truth.
+        let holds = merged
+            .properties
+            .iter()
+            .filter(|p| matches!(p.outcome, VerifyOutcome::Holds))
+            .count();
+        let unknown = merged
+            .properties
+            .iter()
+            .filter(|p| matches!(p.outcome, VerifyOutcome::Unknown { .. }))
+            .count();
+        assert_eq!(
+            (holds, unknown),
+            (1, 1),
+            "the merge decided exactly one property"
+        );
+
+        let cov = merged
+            .notes
+            .iter()
+            .find(|n| n.kind == "coverage-summary")
+            .expect("a coverage-summary note is present");
+        assert!(
+            cov.summary.contains("1 definite (HOLDS)") && cov.summary.contains("1 unknown"),
+            "the summary must count the MERGED verdicts (1 HOLDS, 1 ⊥). Before mununu#536 it \
+             reported the base engine's pre-merge tally (0 HOLDS, 2 ⊥) while the properties said \
+             otherwise — the disagreement a consumer parsed. Got: {}",
+            cov.summary
+        );
+        assert_eq!(
+            merged
+                .notes
+                .iter()
+                .filter(|n| n.kind == "coverage-summary")
+                .count(),
+            1,
+            "refreshing must REPLACE the stale note, not append a second contradicting one"
         );
     }
 

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1749,7 +1749,7 @@ fn sv_verify_auto_handler_impl(
     request: SvVerifyAutoRequest,
 ) -> ApiResult<Json<SvVerifyAutoResponse>> {
     use crate::adapter::btor2::kmts_lift::MustEdgeInference;
-    use crate::adapter::slang::verify_auto::{VerifyAutoOptions, VerifyOutcome, verify_auto};
+    use crate::adapter::slang::verify_auto::{VerifyAutoOptions, verify_auto};
     use crate::adapter::yosys::YosysOptions;
 
     let mut sources: Vec<(String, String)> = vec![("top.sv".to_string(), request.source.clone())];
@@ -1874,99 +1874,11 @@ fn sv_verify_auto_handler_impl(
         details: None,
     })?;
 
-    let kind_str = |k: crate::adapter::slang::translate::SvaKind| -> String {
-        use crate::adapter::slang::translate::SvaKind;
-        match k {
-            SvaKind::Assert => "assert".to_string(),
-            SvaKind::Assume => "assume".to_string(),
-            SvaKind::Cover => "cover".to_string(),
-        }
-    };
-    let properties = report
-        .properties
-        .iter()
-        .map(|p| {
-            let (outcome, detail) = match &p.outcome {
-                VerifyOutcome::Holds => ("holds".to_string(), None),
-                VerifyOutcome::Violated { false_cells } => (
-                    "violated".to_string(),
-                    Some(format!("{false_cells} cell(s)")),
-                ),
-                VerifyOutcome::Unknown { unknown_cells } => (
-                    "unknown".to_string(),
-                    Some(format!("{unknown_cells} cell(s)")),
-                ),
-                VerifyOutcome::Skipped { reason } => ("skipped".to_string(), Some(reason.clone())),
-            };
-            // D1.8b — carry the exact engine's stall-lasso counterexample.
-            let counterexample = p.counterexample.as_ref().map(|c| {
-                let states = |v: &[Vec<(String, u64)>]| -> Vec<Vec<CexCellView>> {
-                    v.iter()
-                        .map(|st| {
-                            st.iter()
-                                .map(|(register, value)| CexCellView {
-                                    register: register.clone(),
-                                    value: *value,
-                                })
-                                .collect()
-                        })
-                        .collect()
-                };
-                CounterexampleView {
-                    prefix: states(&c.prefix),
-                    cycle: states(&c.cycle),
-                    unreachable_target: c.unreachable_target.clone(),
-                }
-            });
-            PropertyVerdictView {
-                name: p.name.clone(),
-                kind: kind_str(p.kind),
-                formula: p.formula.clone(),
-                outcome,
-                detail,
-                seeded_predicates: p.seeded_predicates.clone(),
-                counterexample,
-            }
-        })
-        .collect();
-    let unsupported = report
-        .unsupported
-        .iter()
-        .map(|(name, reason)| UnsupportedAssertionView {
-            name: name.clone(),
-            kind: None,
-            reason: reason.clone(),
-        })
-        .collect();
-    let notes = report
-        .notes
-        .iter()
-        .map(|n| crate::api::models::VerificationNoteView {
-            kind: n.kind.clone(),
-            level: match n.level {
-                crate::adapter::slang::verify_auto::NoteLevel::Info => "info",
-                crate::adapter::slang::verify_auto::NoteLevel::ScopeCaveat => "scope-caveat",
-                crate::adapter::slang::verify_auto::NoteLevel::SoundnessCaveat => {
-                    "soundness-caveat"
-                }
-            }
-            .to_string(),
-            summary: n.summary.clone(),
-            detail: n.detail.clone(),
-            items: n.items.clone(),
-        })
-        .collect();
-    Ok(Json(SvVerifyAutoResponse {
-        properties,
-        unsupported,
-        diagnostics: ModelDiagnosticsView {
-            state_register_count: report.diagnostics.state_register_count,
-            blackboxed_modules: report.diagnostics.blackboxed_modules.clone(),
-            gated_resets: report.diagnostics.gated_resets.clone(),
-            auto_provided_stubs: report.diagnostics.auto_provided_stubs.clone(),
-        },
-        notes,
-    }))
+    // mununu#536 — ONE conversion, shared with the CLI's `--json`. This used to be ~90 lines
+    // of hand-written field mapping that had already drifted from the CLI's independent
+    // `serde_json::json!` literal; see the `From` impl's doc comment for why there is now
+    // exactly one.
+    Ok(Json(SvVerifyAutoResponse::from(&report)))
 }
 
 /// Shared parameters for the CEGAR run/report logic, sourced identically

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1736,6 +1736,138 @@ pub struct SvVerifyAutoResponse {
     pub notes: Vec<VerificationNoteView>,
 }
 
+/// mununu#536 — the ONE report→wire conversion, shared by the HTTP handler and the CLI's
+/// `--json`.
+///
+/// # Why this exists
+///
+/// There used to be two hand-written serializers for the same report: the API handler built
+/// [`SvVerifyAutoResponse`] field by field, and the CLI built a `serde_json::json!` literal.
+/// Only the API shape was described by `docs/api-schemas/sv-verify-auto-response.schema.json`
+/// and guarded by the drift test, so **a consumer reading the published schema and then
+/// running the CLI got a different document** — and the two had already drifted: `detail` was
+/// an object on one and a string on the other, the CLI dropped `unreachable_target`, and
+/// neither carried the front end used.
+///
+/// Two serializers for one documented shape cannot be kept in step by discipline; the fix is
+/// for there to be one. With both surfaces going through here, the schema drift test covers
+/// the CLI output too, because it is literally the same type.
+impl From<&crate::adapter::slang::verify_auto::AutoVerifyReport> for SvVerifyAutoResponse {
+    fn from(report: &crate::adapter::slang::verify_auto::AutoVerifyReport) -> Self {
+        use crate::adapter::slang::translate::SvaKind;
+        use crate::adapter::slang::verify_auto::{NoteLevel, VerifyOutcome};
+
+        let cells = |v: &[Vec<(String, u64)>]| -> Vec<Vec<CexCellView>> {
+            v.iter()
+                .map(|st| {
+                    st.iter()
+                        .map(|(register, value)| CexCellView {
+                            register: register.clone(),
+                            value: *value,
+                        })
+                        .collect()
+                })
+                .collect()
+        };
+
+        let properties = report
+            .properties
+            .iter()
+            .map(|p| {
+                // `detail` stays prose for existing consumers; the structured fields beside it
+                // are what a gate should read.
+                let (outcome, detail, false_cells, unknown_cells, skip_reason) = match &p.outcome {
+                    VerifyOutcome::Holds => ("holds", None, None, None, None),
+                    VerifyOutcome::Violated { false_cells } => (
+                        "violated",
+                        Some(format!("{false_cells} cell(s)")),
+                        Some(*false_cells),
+                        None,
+                        None,
+                    ),
+                    VerifyOutcome::Unknown { unknown_cells } => (
+                        "unknown",
+                        Some(format!("{unknown_cells} cell(s)")),
+                        None,
+                        Some(*unknown_cells),
+                        None,
+                    ),
+                    VerifyOutcome::Skipped { reason } => (
+                        "skipped",
+                        Some(reason.clone()),
+                        None,
+                        None,
+                        Some(reason.clone()),
+                    ),
+                };
+                PropertyVerdictView {
+                    name: p.name.clone(),
+                    kind: match p.kind {
+                        SvaKind::Assert => "assert",
+                        SvaKind::Assume => "assume",
+                        SvaKind::Cover => "cover",
+                    }
+                    .to_string(),
+                    formula: p.formula.clone(),
+                    outcome: outcome.to_string(),
+                    detail,
+                    false_cells,
+                    unknown_cells,
+                    skip_reason,
+                    seeded_predicates: p.seeded_predicates.clone(),
+                    counterexample: p.counterexample.as_ref().map(|c| CounterexampleView {
+                        prefix: cells(&c.prefix),
+                        cycle: cells(&c.cycle),
+                        unreachable_target: c.unreachable_target.clone(),
+                        inputs: cells(&c.inputs),
+                    }),
+                }
+            })
+            .collect();
+
+        SvVerifyAutoResponse {
+            properties,
+            unsupported: report
+                .unsupported
+                .iter()
+                .map(|(name, reason)| UnsupportedAssertionView {
+                    name: name.clone(),
+                    // The core report flattens to `(name, reason)`, so the SVA kind is already
+                    // gone by the time it reaches here — always `None`, not "unknown".
+                    kind: None,
+                    reason: reason.clone(),
+                })
+                .collect(),
+            diagnostics: ModelDiagnosticsView {
+                state_register_count: report.diagnostics.state_register_count,
+                blackboxed_modules: report.diagnostics.blackboxed_modules.clone(),
+                gated_resets: report.diagnostics.gated_resets.clone(),
+                auto_provided_stubs: report.diagnostics.auto_provided_stubs.clone(),
+                frontend: report.diagnostics.frontend.clone(),
+                frontend_fallback_reason: report.diagnostics.frontend_fallback_reason.clone(),
+                config_values: report.diagnostics.applied_config_values.clone(),
+                cutpoints: report.diagnostics.cutpoint_signals.clone(),
+            },
+            notes: report
+                .notes
+                .iter()
+                .map(|n| VerificationNoteView {
+                    kind: n.kind.clone(),
+                    level: match n.level {
+                        NoteLevel::Info => "info",
+                        NoteLevel::ScopeCaveat => "scope-caveat",
+                        NoteLevel::SoundnessCaveat => "soundness-caveat",
+                    }
+                    .to_string(),
+                    summary: n.summary.clone(),
+                    detail: n.detail.clone(),
+                    items: n.items.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
 /// One provenance note (mirrors
 /// [`crate::adapter::slang::verify_auto::VerificationNote`]).
 #[derive(Debug, Serialize, schemars::JsonSchema)]
@@ -1768,6 +1900,25 @@ pub struct ModelDiagnosticsView {
     /// Cut flop-primitive modules for which a behavioral stub was auto-injected
     /// so the register survives the lift (e.g. `prim_sparse_fsm_flop`).
     pub auto_provided_stubs: Vec<String>,
+    /// #466 / mununu#536 — the RTL front end that produced the lift (e.g.
+    /// `"read_verilog + sv2v"`, `"yosys-slang (read_slang)"`). `--frontend auto` picks one
+    /// silently and the two paths differ in SOUNDNESS on partial writes (#464/#465), so
+    /// "which lift produced this verdict?" is a question the payload must answer. It was
+    /// previously reachable only as `lift-frontend` note prose.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frontend: Option<String>,
+    /// #466 — when `--frontend auto` FELL BACK (an earlier front end errored), the prior
+    /// attempt's error. `None` when there was no fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frontend_fallback_reason: Option<String>,
+    /// mununu#536 — config inputs pinned for this run, each `"<signal>=<value>"`. A verdict
+    /// under a pin is a claim about THAT configuration only, so the scope ships with it.
+    #[serde(default)]
+    pub config_values: Vec<String>,
+    /// mununu#536 — signals cut to free inputs by `--cutpoint`: the control slice these
+    /// verdicts were reached under.
+    #[serde(default)]
+    pub cutpoints: Vec<String>,
 }
 
 /// One property's auto-verification verdict (mirrors `PropertyVerdict`).
@@ -1779,8 +1930,28 @@ pub struct PropertyVerdictView {
     pub formula: String,
     /// `"holds"` | `"violated"` | `"unknown"` | `"skipped"`.
     pub outcome: String,
-    /// `false_cells` (violated) / `unknown_cells` (unknown) / the skip reason.
+    /// Human-readable detail: `"N cell(s)"` (violated/unknown) or the skip reason.
+    ///
+    /// **Prefer the structured fields below.** This is prose and stays only so existing
+    /// consumers keep working; a gate that needs the figure should read `false_cells` /
+    /// `unknown_cells` / `skip_reason` rather than parsing this string.
     pub detail: Option<String>,
+    /// mununu#536 — the cell count behind a `violated` verdict, machine-readable.
+    /// `None` for every other outcome.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub false_cells: Option<usize>,
+    /// mununu#536 — the cell count behind an `unknown` (⊥) verdict, machine-readable.
+    /// `None` for every other outcome.
+    ///
+    /// This is the "cell/budget figure that accompanies a ⊥" the issue asks for: a ⊥ is a
+    /// statement about how much of the cube space stayed undecided, and a consumer tracking
+    /// whether refinement is helping needs the number, not a sentence containing it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unknown_cells: Option<usize>,
+    /// mununu#536 — why a `skipped` property was not evaluated. `None` for every other
+    /// outcome.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<String>,
     /// The cube predicates auto-seeded for this property (atom strings).
     pub seeded_predicates: Vec<String>,
     /// D1.8b — a concrete stall-lasso counterexample, present only for a Violated
@@ -1802,6 +1973,11 @@ pub struct CounterexampleView {
     /// stall-lasso / trap-path (liveness) counterexamples, which carry `prefix`/`cycle`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unreachable_target: Vec<String>,
+    /// P3 / mununu#536 — the per-cycle INPUT assignment that drives the trace, so the
+    /// counterexample can be replayed against the RTL. Present on the core report all along;
+    /// both wire shapes dropped it, which made a trace readable but not runnable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inputs: Vec<Vec<CexCellView>>,
 }
 
 /// One register's concrete value in a counterexample state.

--- a/crates/mununu-core/src/api/schema.rs
+++ b/crates/mununu-core/src/api/schema.rs
@@ -177,6 +177,189 @@ mod tests {
 
     /// The response schema must reference every wire type documented in
     /// `docs/api-schemas/verdict.md` — `PropertyVerdictView`, `CounterexampleView`,
+    /// mununu#536 — a REAL report, serialized through the one shared conversion, must conform
+    /// to the published response schema.
+    ///
+    /// The other drift tests compare the schema against the Rust types. This one compares an
+    /// actual serialized document against the schema, which is the thing a consumer holds. It
+    /// is the test that makes the CLI's `--json` and the HTTP response unable to diverge
+    /// again: both call `SvVerifyAutoResponse::from(&report)`, so conformance here is
+    /// conformance for both surfaces.
+    ///
+    /// Checks in both directions — every `required` key is present, and every emitted key is
+    /// declared. A one-directional check would miss the failure that actually happened: a
+    /// serializer emitting a field the schema never mentioned.
+    #[test]
+    fn a_serialized_report_conforms_to_the_published_response_schema() {
+        use crate::adapter::slang::translate::SvaKind;
+        use crate::adapter::slang::verify_auto::{
+            AutoVerifyReport, ExactCounterexample, ModelDiagnostics, NoteLevel, PropertyVerdict,
+            VerificationNote, VerifyOutcome,
+        };
+
+        // Exercise every outcome arm and every optional field, so the check is not vacuous on
+        // a report that happens to omit the interesting parts.
+        let report = AutoVerifyReport {
+            properties: vec![
+                PropertyVerdict {
+                    name: "p_holds".into(),
+                    kind: SvaKind::Assert,
+                    formula: "nu X. (a && [] X)".into(),
+                    outcome: VerifyOutcome::Holds,
+                    seeded_predicates: vec!["a == 1".into()],
+                    counterexample: None,
+                },
+                PropertyVerdict {
+                    name: "p_violated".into(),
+                    kind: SvaKind::Cover,
+                    formula: "mu X. (b || <> X)".into(),
+                    outcome: VerifyOutcome::Violated { false_cells: 3 },
+                    seeded_predicates: vec![],
+                    counterexample: Some(ExactCounterexample {
+                        prefix: vec![vec![("q".into(), 0)]],
+                        cycle: vec![vec![("q".into(), 1)]],
+                        inputs: vec![vec![("d".into(), 1)]],
+                        unreachable_target: vec!["b".into()],
+                    }),
+                },
+                PropertyVerdict {
+                    name: "p_unknown".into(),
+                    kind: SvaKind::Assume,
+                    formula: "nu X. (c && [] X)".into(),
+                    outcome: VerifyOutcome::Unknown { unknown_cells: 32 },
+                    seeded_predicates: vec![],
+                    counterexample: None,
+                },
+                PropertyVerdict {
+                    name: "p_skipped".into(),
+                    kind: SvaKind::Assert,
+                    formula: "nu X. (d && [] X)".into(),
+                    outcome: VerifyOutcome::Skipped {
+                        reason: "bit cap".into(),
+                    },
+                    seeded_predicates: vec![],
+                    counterexample: None,
+                },
+            ],
+            unsupported: vec![("u0".into(), "unsupported binary op: BinaryAnd".into())],
+            diagnostics: ModelDiagnostics {
+                state_register_count: 2,
+                blackboxed_modules: vec!["m".into()],
+                gated_resets: vec!["rst_n=1".into()],
+                auto_provided_stubs: vec![],
+                frontend: Some("read_verilog + sv2v".into()),
+                frontend_fallback_reason: Some("slang errored".into()),
+                applied_config_values: vec!["cfg=7".into()],
+                cutpoint_signals: vec!["fits".into()],
+            },
+            notes: vec![VerificationNote {
+                kind: "coverage-summary".into(),
+                level: NoteLevel::Info,
+                summary: "4 assertion(s)".into(),
+                detail: "d".into(),
+                items: vec!["i".into()],
+            }],
+        };
+
+        let doc = serde_json::to_value(SvVerifyAutoResponse::from(&report))
+            .expect("the response serialises");
+        let schema =
+            serde_json::to_value(sv_verify_auto_response_schema()).expect("schema serialises");
+
+        // Walk one object against one schema node: required present, emitted declared.
+        fn conforms(
+            doc: &serde_json::Value,
+            node: &serde_json::Value,
+            schema: &serde_json::Value,
+            path: &str,
+        ) {
+            // Follow a `$ref` / `allOf` indirection to the definition it names.
+            let node = resolve(node, schema);
+            let Some(props) = node.get("properties").and_then(|p| p.as_object()) else {
+                return;
+            };
+            let obj = doc
+                .as_object()
+                .unwrap_or_else(|| panic!("{path}: expected an object"));
+            if let Some(req) = node.get("required").and_then(|r| r.as_array()) {
+                for r in req {
+                    let k = r.as_str().unwrap_or_default();
+                    assert!(
+                        obj.contains_key(k),
+                        "{path}.{k} is `required` by the schema but absent from the serialized \
+                         document — a consumer following the schema would break"
+                    );
+                }
+            }
+            for (k, v) in obj {
+                let Some(child) = props.get(k) else {
+                    panic!(
+                        "{path}.{k} is emitted but NOT declared in the schema — this is exactly \
+                         the drift the shared conversion exists to prevent"
+                    );
+                };
+                match v {
+                    serde_json::Value::Object(_) => {
+                        conforms(v, child, schema, &format!("{path}.{k}"))
+                    }
+                    serde_json::Value::Array(items) => {
+                        let inner = resolve(child, schema);
+                        if let Some(item_schema) = inner.get("items") {
+                            for (i, it) in items.iter().enumerate() {
+                                if it.is_object() || it.is_array() {
+                                    conforms(it, item_schema, schema, &format!("{path}.{k}[{i}]"));
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // `$ref: "#/definitions/X"`, or an `allOf: [{ $ref }]` wrapper (how schemars emits a
+        // named type behind an optional field).
+        fn resolve<'a>(
+            node: &'a serde_json::Value,
+            schema: &'a serde_json::Value,
+        ) -> &'a serde_json::Value {
+            if let Some(r) = node.get("$ref").and_then(|r| r.as_str())
+                && let Some(name) = r.strip_prefix("#/definitions/")
+                && let Some(def) = schema.get("definitions").and_then(|d| d.get(name))
+            {
+                return resolve(def, schema);
+            }
+            if let Some(all) = node.get("allOf").and_then(|a| a.as_array())
+                && let Some(first) = all.first()
+            {
+                return resolve(first, schema);
+            }
+            node
+        }
+
+        conforms(&doc, &schema, &schema, "$");
+
+        // Non-vacuity: the walk must actually have reached the fields mununu#536 added, or a
+        // conformance pass proves nothing about them.
+        assert_eq!(
+            doc["properties"][2]["unknown_cells"], 32,
+            "the ⊥ figure is machine-readable"
+        );
+        assert_eq!(doc["properties"][1]["false_cells"], 3);
+        assert_eq!(doc["properties"][3]["skip_reason"], "bit cap");
+        assert_eq!(doc["diagnostics"]["frontend"], "read_verilog + sv2v");
+        assert_eq!(doc["diagnostics"]["config_values"][0], "cfg=7");
+        assert_eq!(doc["diagnostics"]["cutpoints"][0], "fits");
+        assert_eq!(
+            doc["properties"][1]["counterexample"]["inputs"][0][0]["register"],
+            "d"
+        );
+        // `holds` carries no cell count, and the optional fields are OMITTED rather than null —
+        // a consumer checking `"unknown_cells" in p` must not see a null.
+        assert!(doc["properties"][0].get("unknown_cells").is_none());
+        assert!(doc["properties"][0].get("false_cells").is_none());
+    }
+
     /// `CexCellView`, `VerificationNoteView`, `ModelDiagnosticsView`,
     /// `UnsupportedAssertionView`. Guards against silent removal of a
     /// documented type from the schema tree.

--- a/docs/api-schemas/README.md
+++ b/docs/api-schemas/README.md
@@ -1,5 +1,13 @@
 # mununu API — machine-readable JSON Schemas
 
+> **mununu#536 — one shape, two surfaces.** `sv-verify-auto-response.schema.json`
+> describes the HTTP response **and** the CLI's `mununu sv verify-auto --json`
+> output: both go through the single `impl From<&AutoVerifyReport> for
+> SvVerifyAutoResponse` in `crates/mununu-core/src/api/models.rs`, so the drift test
+> below covers both. There used to be two hand-written serializers for this shape and
+> they had diverged; a consumer reading this schema and then running the CLI got a
+> different document.
+
 This directory holds the **machine-readable** contract for mununu's HTTP API wire types, alongside the human-facing prose in [`verdict.md`](verdict.md).
 
 Each `*.schema.json` file is a JSON Schema (Draft-07) derived directly from the Rust source via `#[derive(schemars::JsonSchema)]` on the API types in [`crates/mununu-core/src/api/models.rs`](../../crates/mununu-core/src/api/models.rs). The generator lives at [`crates/mununu-core/src/api/schema.rs`](../../crates/mununu-core/src/api/schema.rs); the drift-detector at the bottom of that file's `#[cfg(test)]` block asserts every commit that the shipped file matches the current Rust types — a wire-format change without a schema update fails CI.

--- a/docs/api-schemas/sv-verify-auto-response.schema.json
+++ b/docs/api-schemas/sv-verify-auto-response.schema.json
@@ -32,6 +32,16 @@
           },
           "type": "array"
         },
+        "inputs": {
+          "description": "P3 / mununu#536 — the per-cycle INPUT assignment that drives the trace, so the counterexample can be replayed against the RTL. Present on the core report all along; both wire shapes dropped it, which made a trace readable but not runnable.",
+          "items": {
+            "items": {
+              "$ref": "#/definitions/CexCellView"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
         "prefix": {
           "description": "States from the reset state up to (excluding) the cycle entry.",
           "items": {
@@ -73,6 +83,38 @@
           },
           "type": "array"
         },
+        "config_values": {
+          "default": [],
+          "description": "mununu#536 — config inputs pinned for this run, each `\"<signal>=<value>\"`. A verdict under a pin is a claim about THAT configuration only, so the scope ships with it.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cutpoints": {
+          "default": [],
+          "description": "mununu#536 — signals cut to free inputs by `--cutpoint`: the control slice these verdicts were reached under.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "frontend": {
+          "description": "`\"read_verilog + sv2v\"`, `\"yosys-slang (read_slang)\"`). `--frontend auto` picks one silently and the two paths differ in SOUNDNESS on partial writes (#464/#465), so \"which lift produced this verdict?\" is a question the payload must answer. It was previously reachable only as `lift-frontend` note prose.",
+          "title": "466 / mununu#536 — the RTL front end that produced the lift (e.g.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "frontend_fallback_reason": {
+          "description": "attempt's error. `None` when there was no fallback.",
+          "title": "466 — when `--frontend auto` FELL BACK (an earlier front end errored), the prior",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "gated_resets": {
           "description": "Reset inputs pinned inactive at the model level (`\"<signal>=<value>\"`), with their `disable iff` guards dropped from the formulas. Empty when reset-gating is off or no `disable iff` reset was recognized.",
           "items": {
@@ -110,9 +152,18 @@
           "description": "D1.8b — a concrete stall-lasso counterexample, present only for a Violated bare `AF p` decided by the exact engine (`engine: \"exact-symbolic\"`)."
         },
         "detail": {
-          "description": "`false_cells` (violated) / `unknown_cells` (unknown) / the skip reason.",
+          "description": "Human-readable detail: `\"N cell(s)\"` (violated/unknown) or the skip reason.\n\n**Prefer the structured fields below.** This is prose and stays only so existing consumers keep working; a gate that needs the figure should read `false_cells` / `unknown_cells` / `skip_reason` rather than parsing this string.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "false_cells": {
+          "description": "mununu#536 — the cell count behind a `violated` verdict, machine-readable. `None` for every other outcome.",
+          "format": "uint",
+          "minimum": 0.0,
+          "type": [
+            "integer",
             "null"
           ]
         },
@@ -136,6 +187,22 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "skip_reason": {
+          "description": "mununu#536 — why a `skipped` property was not evaluated. `None` for every other outcome.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unknown_cells": {
+          "description": "mununu#536 — the cell count behind an `unknown` (⊥) verdict, machine-readable. `None` for every other outcome.\n\nThis is the \"cell/budget figure that accompanies a ⊥\" the issue asks for: a ⊥ is a statement about how much of the cube space stayed undecided, and a consumer tracking whether refinement is helping needs the number, not a sentence containing it.",
+          "format": "uint",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [

--- a/docs/api-schemas/verdict.md
+++ b/docs/api-schemas/verdict.md
@@ -16,6 +16,28 @@
 
 Mununu's verify surfaces (CLI, HTTP API, UI) all speak one verdict vocabulary. This document pins down the JSON wire format for the `sv verify-auto` response — the shape downstream tools should code against.
 
+> **mununu#536 — this shape is also the CLI's.** `mununu sv verify-auto --json` emits the *same document* as the HTTP response; both go through one conversion, so the schema and the drift test cover both surfaces. Do not parse the human transcript: its layout is not a contract and has already broken a consumer's gate.
+
+### Which field is authoritative
+
+**`properties[]` is the verdict record. `notes[]` is commentary and must never be counted.**
+
+This needs saying because it has bitten a consumer. A note is prose written for a human skimming a terminal — the `coverage-summary` note in particular is a convenience tally, and a harness that counted it under-reported its own coverage. `properties[]` is the answer: one entry per translated assertion, and an assertion **absent** from it is not being checked (look for it in `unsupported[]`, which carries mununu's own reason).
+
+Read the figures from the structured fields, not from prose:
+
+| you want | read | not |
+|---|---|---|
+| the verdict | `properties[].outcome` | the `[assert]` transcript line |
+| the ⊥ cell count | `properties[].unknown_cells` | `detail` (a sentence containing the number) |
+| the violated cell count | `properties[].false_cells` | `detail` |
+| why a property was skipped | `properties[].skip_reason` | `detail` |
+| why an assertion is missing | `unsupported[].reason` | the `[unsupported]` transcript line |
+| a scope caveat to act on | `notes[].level == "scope-caveat"` | string-matching `summary` |
+| what the run was scoped to | `diagnostics.config_values` / `.cutpoints` / `.frontend` | the `config-concretization` / `control-slice` / `lift-frontend` note prose |
+
+`detail` remains for existing consumers, but it is prose and should be treated as such.
+
 ## Contents
 
 1. [PropertyVerdict — the four canonical outcomes](#propertyverdict--the-four-canonical-outcomes)

--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -119,6 +119,32 @@ mununu --quiet sv lint rtl/mod.sv --frontend slang --fail-on none
 
 The JSON on stdout lists each flagged `signal` with a `kind` of `"register"` (the root — the register itself) or `"output"` (a downstream combinational output of one). See [`docs/verifying-rtl.md`](verifying-rtl.md) for the soundness background (the monono#partsel guard).
 
+## Gate CI on a SystemVerilog design's own assertions (machine-readable)
+
+> Source of truth: [`impl From<&AutoVerifyReport> for SvVerifyAutoResponse`](../crates/mununu-core/src/api/models.rs) — surface: (CLI+API)
+
+`mununu sv verify-auto --json` emits the **same document the HTTP API returns**, described by [`docs/api-schemas/sv-verify-auto-response.schema.json`](api-schemas/sv-verify-auto-response.schema.json) and pinned by a drift test. Parse that; do not parse the human transcript, whose layout is not a contract.
+
+```bash
+# every property and its verdict
+mununu --quiet sv verify-auto rtl/mod.sv --source rtl/mod_sva.sv --top mod --json \
+  | jq -r '.properties[] | "\(.name) \(.outcome)"'
+
+# anything that did NOT translate, with mununu's own reason
+mununu --quiet sv verify-auto rtl/mod.sv --json | jq -r '.unsupported[] | "\(.name): \(.reason)"'
+
+# the ⊥ figure, as a NUMBER (do not parse `detail`, which is prose)
+mununu --quiet sv verify-auto rtl/mod.sv --json \
+  | jq -r '.properties[] | select(.outcome=="unknown") | "\(.name) \(.unknown_cells)"'
+
+# what was this run scoped to?
+mununu --quiet sv verify-auto rtl/mod.sv --json | jq '.diagnostics | {frontend, config_values, cutpoints}'
+```
+
+**`properties[]` is the verdict record; the `notes` are commentary and must not be counted.** A property that is absent from `properties[]` is not being checked — look for it in `unsupported[]`, which says why.
+
+Exit codes are the usual gate (`0` pass, `2` violated, `3` unknown under `--fail-on unknown`, `1` tool error); `1` implies empty stdout, while `2`/`3` still emit the full document.
+
 ## Check that a design's properties are adequate (mutation testing)
 
 > Source of truth: [`mutate_and_compare`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L1824) — surface: (CLI+API+UI)

--- a/docs/consumer-briefings/2026-09-unified-verify-auto-report.md
+++ b/docs/consumer-briefings/2026-09-unified-verify-auto-report.md
@@ -1,0 +1,177 @@
+# Consumer briefing — `sv verify-auto --json` is now the same document as the API response
+
+> **Audience:** anyone parsing `mununu sv verify-auto` output. **monono, ROSF, mununu-ui.**
+>
+> **Read this if you parse the transcript.** You do not need to, and should not — see
+> *"If you are parsing the transcript"* below.
+
+## TL;DR
+
+`mununu sv verify-auto --json` and `POST /api/v1/sv/verify-auto` now emit the **same document**,
+described by [`sv-verify-auto-response.schema.json`](../api-schemas/sv-verify-auto-response.schema.json)
+and pinned by a drift test that now covers both surfaces.
+
+Three things changed for consumers:
+
+1. **New structured fields** — the ⊥/violated cell counts, the skip reason, the front end used, the
+   applied `--config-value`s, the cutpoints, and the counterexample's input trace.
+2. **One breaking change on the CLI** — `properties[].detail` is now a string, not an object. The
+   number it used to hold is a first-class field.
+3. **A wrong count is fixed** — the `coverage-summary` note could disagree with the verdicts on a
+   portfolio run, which is the default. If you counted that note, your numbers were wrong.
+
+## `--json` already existed
+
+Worth stating plainly, because [mununu#536](https://github.com/Mumunu-team/mununu/issues/536) was
+filed as *"offers no `--report json`"*: `sv verify-auto --json` has shipped since verify-auto
+itself (#169, 2026-06-27) and is advertised in `--help`. If you built transcript parsing, you can
+delete it today.
+
+## What was actually broken
+
+There were **two hand-written serializers for one documented shape** — the CLI built a
+`serde_json::json!` literal, the API built the response struct field by field — and only the API
+shape was described by the published schema. So a consumer reading the schema and then running the
+CLI got a different document. They had already drifted:
+
+| | CLI `--json` (before) | API (before) |
+|---|---|---|
+| `properties[].detail` | object: `{"unknown_cells": 32768}` | string: `"32768 cell(s)"` |
+| `counterexample.unreachable_target` | absent | present |
+| `counterexample.inputs` | absent | absent |
+| `diagnostics.frontend` | absent | absent |
+
+Two serializers for one shape cannot be kept in step by discipline. There is now exactly one
+(`impl From<&AutoVerifyReport> for SvVerifyAutoResponse`), so the schema drift test guards both.
+
+## The breaking change, stated plainly
+
+**`properties[].detail` on the CLI changes from an object to a string.**
+
+```jsonc
+// before (CLI only)
+{ "outcome": "unknown", "detail": { "unknown_cells": 32768 } }
+// after (CLI and API)
+{ "outcome": "unknown", "detail": "32768 cell(s)", "unknown_cells": 32768 }
+```
+
+Net strictly better — the number is now a first-class field on *both* surfaces instead of an object
+on one and a sentence on the other — but it is a shape change, not an addition. It is justified
+because the alternative was keeping two shapes forever, and because the known consumer of this
+output parses the transcript rather than the JSON. If you did parse CLI `--json`, read
+`unknown_cells` / `false_cells` / `skip_reason` instead of `detail`.
+
+Everything else is **additive**. The API response gains fields and loses none.
+
+## New fields
+
+| field | what it answers |
+|---|---|
+| `properties[].unknown_cells` | the ⊥ figure, as a number — track whether refinement is helping |
+| `properties[].false_cells` | the violated cell count, as a number |
+| `properties[].skip_reason` | why a `skipped` property was not evaluated |
+| `diagnostics.frontend` | **which lift produced this verdict** (#466). The two front ends differ in soundness on partial writes (#464/#465), so a silent choice mattered; it was previously only note prose |
+| `diagnostics.frontend_fallback_reason` | if `--frontend auto` fell back, the earlier attempt's error |
+| `diagnostics.config_values` | the `--config-value` pins actually applied — a verdict under a pin is a claim about **that** configuration only |
+| `diagnostics.cutpoints` | the control slice these verdicts were reached under |
+| `counterexample.inputs` | the per-cycle input assignment, so a trace can be **replayed** against the RTL rather than only read |
+
+## The count that was wrong
+
+`merge_portfolio_reports` starts from `base.clone()` — the highest-precision engine — and that
+clone brought the base's **notes** with it. The merge then rewrote `properties[].outcome` with the
+first definite verdict across all engines, but nothing rewrote the notes. So the `coverage-summary`
+reported the *base engine's* tally while `properties[]` reported the merged one.
+
+`portfolio-sequential` is the **default** engine, so this was the common case. It is exactly what
+mununu#498's minor and #536 observed: a summary claiming `0 unknown` beside properties printing
+`UNKNOWN`.
+
+**If your gate counted the `coverage-summary` note, it under-reported your coverage.** It now
+counts the merged verdicts. Expect the numbers in that note to change — to the correct ones.
+
+## The rule that prevents the next one
+
+**`properties[]` is the verdict record. `notes[]` is commentary and must never be counted.**
+
+A note is prose for a human skimming a terminal. An assertion absent from `properties[]` is not
+being checked — look for it in `unsupported[]`, which carries mununu's own reason
+(`"unsupported binary op: BinaryAnd"`). This is now stated in
+[`docs/api-schemas/verdict.md`](../api-schemas/verdict.md) with a field-by-field table of what to
+read instead of what to parse.
+
+## If you are parsing the transcript
+
+Stop. The transcript's layout is not a contract and has already broken a gate: an earlier regex
+captured `[A-Z]*` only, so a `skipped` property — which mununu prints in lower case — came back
+with an **empty** verdict, which the harness read as "absent" and its uncovered-counter did not
+count at all. A guard that stops firing exactly when it is needed.
+
+```bash
+# every property and its verdict
+mununu --quiet sv verify-auto design.sv --json | jq -r '.properties[] | "\(.name) \(.outcome)"'
+# what did NOT translate, and why
+mununu --quiet sv verify-auto design.sv --json | jq -r '.unsupported[] | "\(.name): \(.reason)"'
+```
+
+## Per-consumer
+
+### monono
+
+- **What to update:** replace `_verdicts()` / `_uncovered()` / `_unsupported_reasons()` in
+  `verify/lib.sh` with `jq` over `--json`. The lower-case-`skipped` bug cannot recur.
+- **What to expect:** no verdict changes. The `coverage-summary` note's numbers become correct on
+  portfolio runs.
+
+### ROSF
+
+- **What to update:** nothing required; the API response is additive. Adopt `unknown_cells` /
+  `frontend` when convenient.
+
+### mununu-ui
+
+- **What to update:** nothing required — additive. `PropertyVerdictView` and
+  `ModelDiagnosticsView` gained optional fields; `src/api/endpoints.ts` can adopt them when the UI
+  wants to show the front end used or the ⊥ figure.
+
+## Docker rebuild disposition
+
+| Image | Impact | Rebuild required? |
+|---|---|---|
+| `mununu-dev` | Rust only; no tool pins touched | No |
+| `mununu-sva` | Inherits `mununu-dev`; tool pins unchanged | No |
+| `mununu-sva-pono` | Inherits `mununu-sva`; tool pins unchanged | No |
+| `hw-verif` | Not involved | No |
+
+## Test the transition
+
+```bash
+mununu --quiet sv verify-auto design.sv --json | jq -e '.properties | length > 0'
+mununu --quiet sv verify-auto design.sv --json | jq '.diagnostics.frontend'
+```
+
+Covered by `a_serialized_report_conforms_to_the_published_response_schema`, which serializes a real
+report through the shared conversion and checks it against the published schema **in both
+directions** — every `required` key present, and every emitted key declared. A one-directional
+check would have missed the failure that actually happened: a serializer emitting a field the
+schema never mentioned. The count fix is pinned by
+`portfolio_merge_recounts_the_coverage_summary`, which fails without it.
+
+## Provenance
+
+- Issue: [mununu#536](https://github.com/Mumunu-team/mununu/issues/536); the count fix also closes
+  [mununu#498](https://github.com/Mumunu-team/mununu/issues/498)'s minor.
+- Implementation: `impl From<&AutoVerifyReport> for SvVerifyAutoResponse`
+  (`crates/mununu-core/src/api/models.rs`), `refresh_coverage_summary`
+  (`crates/mununu-core/src/adapter/slang/verify_auto.rs`).
+- Policy: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here
+
+- **`unsupported[].kind` is still always `null`.** The core report flattens to `(name, reason)`
+  before the wire layer, so the SVA kind is gone by then. Fixing it means widening the core type.
+- **`reason` has no machine-stable taxonomy.** It is human-authored prose, so classifying
+  "unsupported binary op" vs "unbounded repetition" still needs string matching. A reason *code*
+  would be a separate change.
+- **Verdict expectations** — asserting that a run produced the verdicts you claimed — are
+  [mununu#537](https://github.com/Mumunu-team/mununu/issues/537), landing next.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -162,6 +162,48 @@ The response reports a verdict per translated assertion, plus a list of assertio
 that did **not** translate (surfaced honestly, never silently dropped) and
 model-level diagnostics.
 
+### The machine-readable report: `--json` (mununu#536)
+
+> Source of truth: [`impl From<&AutoVerifyReport> for SvVerifyAutoResponse`](../crates/mununu-core/src/api/models.rs) — surface: (CLI+API)
+
+**Do not parse the transcript.** `sv verify-auto --json` emits the *same document* the HTTP API returns, described by [`docs/api-schemas/sv-verify-auto-response.schema.json`](api-schemas/sv-verify-auto-response.schema.json) and pinned by a drift test. One shape, both surfaces:
+
+```bash
+mununu --quiet sv verify-auto design.sv --source design_sva.sv --top design --json
+```
+
+```jsonc
+{
+  "properties": [
+    { "name": "dut_sva_0", "kind": "assert", "formula": "nu X. …", "outcome": "holds",
+      "detail": null, "seeded_predicates": ["st_q == 2"] },
+    { "name": "dut_sva_1", "kind": "assert", "formula": "nu X. …", "outcome": "unknown",
+      "detail": "32768 cell(s)", "unknown_cells": 32768, "seeded_predicates": [] }
+  ],
+  "unsupported": [ { "name": "dut_sva_2", "kind": null,
+                     "reason": "unsupported binary op: BinaryAnd" } ],
+  "diagnostics": { "state_register_count": 12, "blackboxed_modules": [], "gated_resets": ["rst_n=1"],
+                   "auto_provided_stubs": [], "frontend": "read_verilog + sv2v",
+                   "config_values": ["cfg_timer=7"], "cutpoints": [] },
+  "notes": [ { "kind": "coverage-summary", "level": "info", "summary": "…", "items": [] } ]
+}
+```
+
+**`properties[]` is the verdict record. Notes are commentary — never count them.** A note is prose written for a human reading a terminal; `properties[]` is the answer. Concretely: read `outcome` per property, and take the ⊥ figure from `unknown_cells` (or `false_cells` / `skip_reason`) rather than parsing the `detail` sentence that contains it.
+
+```bash
+# every property and its verdict
+mununu --quiet sv verify-auto design.sv --json | jq -r '.properties[] | "\(.name) \(.outcome)"'
+
+# did anything fail to translate, and why?
+mununu --quiet sv verify-auto design.sv --json | jq -r '.unsupported[] | "\(.name): \(.reason)"'
+
+# act on a scope caveat without string-matching prose
+mununu --quiet sv verify-auto design.sv --json | jq '[.notes[] | select(.level=="scope-caveat")]'
+```
+
+`unsupported[]` carries mununu's own **reason** for every assertion it could not translate (`"unsupported binary op: BinaryAnd"`, `"dynamic bit-select …"`). An assertion that does not appear in `properties[]` is not being checked, and this is where it says why.
+
 ### Shrinking a parameterised design: `--param`
 
 > Source of truth: [`build_chparam_passes`](../crates/mununu-core/src/adapter/yosys/mod.rs) — surface: (CLI+API+UI)


### PR DESCRIPTION
## The issue's premise was wrong, and the real defect is better worth fixing

#536 asks for `sv verify-auto --report json`. **That flag already exists** — `--json` shipped with verify-auto itself (`a3f1041`, #169, 2026-06-27) and is advertised in `--help`. monono even uses the convention elsewhere (`verify/models.sh` runs `mununu verify --json`); they built transcript parsing for this verb anyway. I've [commented on the issue](https://github.com/Mumunu-team/mununu/issues/536) with the real output so they can drop that parsing today.

The actual defect: **two hand-written serializers for one documented shape.** The CLI built a `serde_json::json!` literal; the API built the response struct field by field. Only the API shape was described by the published schema and guarded by the drift test — so a consumer reading `docs/api-schemas/` and then running the CLI got a *different document*. They had already drifted:

| field | CLI | API |
|---|---|---|
| `properties[].detail` | `{"unknown_cells": N}` | `"N cell(s)"` |
| `counterexample.unreachable_target` | absent | present |
| `counterexample.inputs` | absent | absent |
| `diagnostics.frontend` | absent | absent |

There is now exactly **one** conversion — `impl From<&AutoVerifyReport> for SvVerifyAutoResponse` — called by both surfaces, so the schema drift test covers the CLI output because it is literally the same type.

## Fields closed (additive on the API)

- `false_cells` / `unknown_cells` / `skip_reason` — the ⊥ figure **as a number**. `detail` stays for compatibility but is prose; a gate shouldn't parse a sentence to get an int.
- `diagnostics.frontend` + `frontend_fallback_reason` (#466) — which lift produced the verdict. The front ends differ in **soundness** on partial writes (#464/#465); this was note prose only.
- `diagnostics.config_values` + `cutpoints` — what the run was scoped to.
- `counterexample.inputs` — so a trace is replayable, not just readable.

## A count was wrong, not merely inconsistent

The three disagreeing notes #536 reproduces (and #498's minor) traced to `merge_portfolio_reports`: it starts from `base.clone()`, which carries the base engine's **notes**, then rewrites `properties[].outcome` across engines — but nothing rewrote the notes. So `coverage-summary` reported the *base engine's* tally while `properties[]` reported the merged one.

`portfolio-sequential` is the **default** engine, so this was the common case. **Anything counting that note under-reported its own coverage.** `refresh_coverage_summary` recomputes it once every verdict is final; `portfolio_merge_recounts_the_coverage_summary` is **mutation-tested** — removing the refresh makes it fail.

## One breaking change, called out rather than buried

CLI `--json`'s `detail` becomes a string (matching the API), with the number promoted to a first-class field. Net strictly better, but a shape change. Justified: the alternative is two shapes forever, and the consumer who filed this parses the transcript, not this JSON.

## Verification

`a_serialized_report_conforms_to_the_published_response_schema` serializes a real report through the shared conversion and checks it against the published schema **in both directions** — every `required` key present, every emitted key declared. One-directional would have missed the failure that actually happened: a serializer emitting a field the schema never mentioned.

End-to-end in `mununu-sva` (a bare-host green on an SVA path is presumed vacuous per CLAUDE.md):

```json
{ "outcome": "violated", "detail": "1 cell(s)", "false_cells": 1 }
"diagnostics": { "frontend": "read_verilog + sv2v", "config_values": [], "cutpoints": [] }
```

and the coverage-summary ("1 HOLDS, 1 violated") now agrees with the portfolio note ("2/2 decided").

## Docs say which field is authoritative

Because that has bitten a consumer: **`properties[]` is the verdict record; `notes[]` is commentary and must never be counted.** `verdict.md` gains a field-by-field table of what to read instead of what to parse, and `--json` is now in the cookbook — it appeared **zero** times there before, which is a fair part of why it wasn't found.

Briefing: `docs/consumer-briefings/2026-09-unified-verify-auto-report.md`

#537 (the expectation verbs) builds on this and is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)