### PR TITLE
feat(verify-auto): verdict expectations as a first-class surface (closes mununu#537)

### DIFF
--- a/.claude/skills/parity-check/SKILL.md
+++ b/.claude/skills/parity-check/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: parity-check
 description: >
-  Verifies a feature is wired consistently across mununu's three user-facing
-  surfaces — CLI, HTTP API, and UI. Reports drift (a flag with no API peer,
-  an API field absent from the UI client, a route with no UI consumer) and
-  the inverse case (code added to one surface but not exercised by another).
+  Verifies a feature is wired consistently across mununu's user-facing
+  surfaces — CLI and HTTP API always, plus the UI for CTXDSL-related
+  capabilities. Reports drift (a flag with no API peer, a CTXDSL feature
+  absent from the UI client) and the inverse case (code added to one surface
+  but not exercised by another).
   Use when reviewing changes to user-exposed features, or as a sub-step of
   domain-adequacy and review-orchestrator.
 ---
 
-Run a CLI ↔ API ↔ UI parity check on $ARGUMENTS (a feature name, file list, or "changed files" if no args).
+Run a CLI ↔ API (↔ UI, for CTXDSL-related capabilities) parity check on $ARGUMENTS (a feature name, file list, or "changed files" if no args).
 
 ## Scope determination
 
@@ -17,13 +18,24 @@ If $ARGUMENTS is empty, derive scope from `git diff --name-only HEAD~1 HEAD`. Ot
 - A feature/flag name (e.g., `--extract-strategy`, `synthesize`, `eval`) — search all three surfaces for it.
 - A file path or list — check whether any of the three surfaces touched by those files have peer changes on the other two.
 
-## The three surfaces
+## The surfaces
+
+> **Revised 2026-09-10 (mununu#537).** CLI and API parity is required for **every** capability. UI
+> parity is required **only for CTXDSL-related** capabilities — those whose *subject* is a CTXDSL
+> model (authoring, evaluating, composing, visualizing, synthesizing from, or importing into one).
+> The UI is a CTXDSL workbench.
+>
+> For anything else — RTL / SVA verification verbs (`sv verify-auto`, `sv lint`, `sv mutate`, the
+> `btor2` verbs), contract / black-box tooling, CI-gate ergonomics (exit codes, report formats,
+> verdict expectations) — **a missing UI affordance is NOT drift and must not be reported as one.**
+> Mark the UI column `n/a`. These features are consumed by CI lanes and orchestrators, not by
+> someone at a canvas.
 
 | Surface | Files |
 |---|---|
 | **CLI** | `crates/mununu-cli/src/main.rs` and `src/main.rs` (clap `Args` structs and command handlers — note that mununu ships *two* binaries named `mununu`; a feature that exists on one but not the other is itself a parity drift) |
 | **HTTP API** | `crates/mununu-core/src/api/handlers.rs` (request/response signatures), `crates/mununu-core/src/api/models.rs` (types), `crates/mununu-core/src/api/server.rs` (routes) |
-| **UI** | `mununu-ui/src/api/endpoints.ts` (typed clients), `mununu-ui/src/hooks/useCtxdslEditor.ts`, `mununu-ui/src/hooks/useSummary.ts`, and any other hook/component that consumes the endpoint |
+| **UI** *(CTXDSL-related only)* | `mununu-ui/src/api/endpoints.ts` (typed clients), `mununu-ui/src/hooks/useCtxdslEditor.ts`, `mununu-ui/src/hooks/useSummary.ts`, and any other hook/component that consumes the endpoint |
 
 ## Known feature groups and where they live
 
@@ -38,7 +50,11 @@ When scope determination identifies a change in one of these groups, search ever
 | **SV / RTL** | `mununu sv init\|discover` | `/api/v1/context/import` (with `format=sv-yosys`/`systemverilog`) | Import workflows in `UnifiedEditor` |
 | **Templates** | `mununu templates` | `/api/v1/templates` | `TemplatePicker` |
 
-A new feature added to any of these groups must wire all three columns in the same PR. A feature added *outside* these groups (a new top-level subcommand or skill) must either land in all three surfaces or carry an explicit "CLI-only / API-only" justification under Procedure step 3.
+**UI-required groups** (CTXDSL-related): Context core, Extraction, Templates. A new feature in one of these wires all three columns in the same PR.
+
+**CLI + API groups** (not CTXDSL-related): Contracts, Codesign, SV / RTL. A new feature in one of these wires CLI + API; the UI column is `n/a` and its absence is not a finding. Existing UI panels for these groups stay — the obligation to *grow* them is what was removed, not the panels themselves.
+
+A feature added *outside* these groups must land on CLI **and** API, or carry an explicit "CLI-only / API-only" justification under Procedure step 3.
 
 ## Procedure
 
@@ -51,7 +67,7 @@ A new feature added to any of these groups must wire all three columns in the sa
    - **CLI-only**: legitimate if the flag is a developer convenience (e.g., one-shot `--adapter` that the API decomposes into `/import` + `/eval`). Justify in writing.
    - **API-only**: legitimate if the surface is intentionally programmatic (e.g., raw graph dumps consumed only by tooling).
    - **UI-only**: almost always a bug — UI affordances should map to a documented API + CLI verb.
-   - **CLI + API but no UI**: acceptable for power-user features; flag for follow-up.
+   - **CLI + API but no UI**: **for a CTXDSL-related capability**, drift — report it. For anything else (RTL/SVA, contracts, CI-gate ergonomics) this is the EXPECTED shape: mark the UI column `n/a` and do not report it.
    - **Inverse drift**: code added to one surface but not exercised by either of the others — call out.
 
 ## Report format
@@ -63,7 +79,8 @@ Emit a Markdown table. The caller (an agent or a review report) can quote it ver
 
 | Change / feature | CLI | API | UI | Drift? | Notes |
 |---|---|---|---|---|---|
-| `--extract-strategy` | ✓ main.rs:L | ✓ handlers.rs:L | ✗ | YES | API exposes `extract_strategy` field; UI client missing |
+| `--extract-strategy` | ✓ main.rs:L | ✓ handlers.rs:L | ✗ | YES | CTXDSL-related: API exposes `extract_strategy`; UI client missing |
+| `--expect-all-hold` | ✓ main.rs:L | ✓ models.rs:L | n/a | none | CI-gate ergonomics — not CTXDSL-related, so no UI is expected |
 | `/context/synthesize` returns `counterstrategy` | ✓ | ✓ models.rs:L | ✓ endpoints.ts:L | none | aligned |
 ```
 
@@ -78,5 +95,5 @@ When invoked standalone, prepend a one-paragraph executive summary: number of ch
 ## Important
 
 - A pre-existing parity gap discovered during the audit is itself a finding. Report it under the same table even if it predates the current change.
-- New examples or workflows added under `examples/` should be reachable from all three surfaces (loadable from the UI editor, summarizable via CLI, verifiable via API). If only one surface works, treat it as an incomplete deliverable.
+- New examples or workflows added under `examples/` should be reachable from CLI and API (summarizable via CLI, verifiable via API), and from the UI editor as well when the example is a CTXDSL model. If only one surface works, treat it as an incomplete deliverable.
 - Do not modify any source file. This skill is read-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,13 +171,19 @@ Pass `--author="Mariano Cerrutti <vscorza@gmail.com>"` when committing, or set i
 
 ## Surface Parity
 
-Every user-visible capability ships on **CLI**, **HTTP API**, and **UI** in the same PR. The three surfaces are:
+**Every user-visible capability ships on CLI *and* HTTP API in the same PR. UI parity is required only for CTXDSL-related capabilities.** (Revised 2026-09-10; previously UI was mandatory for everything.)
 
 - **CLI**: a clap subcommand or flag in `crates/mununu-cli/src/main.rs`.
 - **API**: a handler in `crates/mununu-core/src/api/handlers.rs` (route in `server.rs`, types in `models.rs`).
-- **UI**: a typed client in `mununu-ui/src/api/endpoints.ts` or a hook/component that exercises the behavior.
+- **UI** *(CTXDSL-related capabilities only)*: a typed client in `mununu-ui/src/api/endpoints.ts` or a hook/component that exercises the behavior.
 
-The `/parity-check` skill verifies this automatically. PRs that drift the three surfaces are rejected. Single-surface exceptions (e.g., a developer-only CLI convenience) must declare themselves inline using the Documentation Traceability surface tag format: `surface: CLI-only — <one-line justification>`.
+**What counts as CTXDSL-related.** A capability whose *subject* is a CTXDSL model — authoring, evaluating, composing, visualizing, synthesizing from, or importing into one. The UI is a CTXDSL workbench, and that is the work it exists to support.
+
+Everything else is **CLI + API**, and the absence of a UI affordance for it is **not drift**: RTL / SVA verification verbs (`sv verify-auto`, `sv lint`, `sv mutate`, the `btor2` verbs), contract / black-box tooling, and CI-gate ergonomics (exit codes, report formats, verdict expectations). These are consumed by CI lanes and orchestrators, not by someone at a canvas — a UI control for "assert this run produced exactly these verdicts" would be an affordance with no user.
+
+This does **not** ask anyone to remove existing UI. It removes the obligation to grow it for work that is not about CTXDSL, so that a CI-facing feature is not blocked on, or padded with, a panel nobody opens.
+
+The `/parity-check` skill verifies this automatically. PRs that drift **CLI ↔ API** are rejected. A capability that lands on only one of those two must declare itself inline using the Documentation Traceability surface tag format: `surface: CLI-only — <one-line justification>`. A non-CTXDSL capability with no UI needs no such tag — that is now the expected shape.
 
 ## Soundness Guarantees
 

--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -64,6 +64,96 @@ struct CiArgs {
     fail_on: FailOn,
 }
 
+/// mununu#537 — verdict EXPECTATION flags, flattened into `sv verify-auto` beside [`CiArgs`].
+///
+/// A verification gate never wants "did it pass"; it wants **"did exactly this happen"**. These
+/// are the three assertions every consumer driving mununu rebuilds in shell, moved to where the
+/// verdict vocabulary is defined. See [`mununu_core::adapter::slang::expectations`] for the
+/// semantics and for why there is deliberately no fourth "tolerate undecided" verb.
+#[derive(Args, Debug, Default)]
+struct ExpectArgs {
+    /// Require EVERY property to hold, with nothing unsupported, unknown or skipped.
+    ///
+    /// Stricter than `--fail-on unknown`: it also rejects `skipped` (which the CI gate treats as
+    /// a pass) and an assertion that did not translate — both are properties that are not being
+    /// checked, which is the failure this verb exists to catch.
+    #[arg(long, conflicts_with_all = ["expect_violated", "expect"])]
+    expect_all_hold: bool,
+
+    /// Require EXACTLY this many properties. Usable on its own.
+    ///
+    /// A binding that stopped binding produces FEWER properties, and a smaller all-green set
+    /// reads as a clean pass. This is the only check that catches it, because a property that
+    /// stopped being produced is invisible to every per-property check.
+    #[arg(long, value_name = "N")]
+    expect_count: Option<usize>,
+
+    /// Comma-separated property names that must be VIOLATED — and every OTHER property must
+    /// hold.
+    ///
+    /// For a contrast twin: a twin that breaks every property teaches nothing about which
+    /// property covers which fault, so the "everything else still holds" half is not optional.
+    #[arg(long, value_name = "NAMES", value_delimiter = ',')]
+    expect_violated: Vec<String>,
+
+    /// `NAME=VERDICT` pairs (`holds` | `violated` | `unknown` | `skipped`, case-insensitive),
+    /// comma-separated or repeated.
+    ///
+    /// Each named property must return exactly that verdict. Unnamed properties are ignored,
+    /// EXCEPT that an unnamed VIOLATED is still a failure — surprises are never silent.
+    ///
+    /// `NAME=unknown` is the sound way to record a ⊥: it pins the abstention as a CLAIM that
+    /// fails when the property becomes decidable, rather than excusing it. That is the point —
+    /// an upstream improvement should break the pin loudly, not pass in silence.
+    #[arg(long = "expect", value_name = "NAME=VERDICT", value_delimiter = ',')]
+    expect: Vec<String>,
+}
+
+impl ExpectArgs {
+    /// Parse into the core type. `Err` on a malformed `NAME=VERDICT`, which is a usage error
+    /// (exit 1) — never a silently dropped claim, which would gate on nothing.
+    fn to_expectations(
+        &self,
+    ) -> Result<mununu_core::adapter::slang::expectations::Expectations, String> {
+        use mununu_core::adapter::slang::expectations::{Expectations, ExpectedVerdict};
+        let mut named = Vec::new();
+        for pair in &self.expect {
+            let (name, verdict) = pair.split_once('=').ok_or_else(|| {
+                format!("--expect `{pair}`: expected NAME=VERDICT (e.g. `sva_1=unknown`)")
+            })?;
+            let v = ExpectedVerdict::parse(verdict).ok_or_else(|| {
+                format!(
+                    "--expect `{pair}`: `{verdict}` is not a verdict — use holds | violated |                      unknown | skipped"
+                )
+            })?;
+            if name.trim().is_empty() {
+                return Err(format!("--expect `{pair}`: the property name is empty"));
+            }
+            named.push((name.trim().to_string(), v));
+        }
+        Ok(Expectations {
+            all_hold: self.expect_all_hold,
+            count: self.expect_count,
+            violated: self
+                .expect_violated
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
+            named,
+        })
+    }
+}
+
+/// mununu#537 — exit code for "a verdict was not what you claimed".
+///
+/// Distinct from every existing code on purpose: `1` is a tool/usage error (the run FAILED), `2`
+/// is a violated verdict and `3` an undecided one under the ordinary gate. A caller that declared
+/// expectations needs to tell "the run broke" apart from "the run worked and disagreed with me",
+/// and under `--expect-violated` the ordinary gate would exit 2 on the very violation that was
+/// asked for. So when expectations are declared they SUPERSEDE `--fail-on`.
+const EXPECTATIONS_UNMET_EXIT: i32 = 4;
+
 /// Map a single property verdict + the `--fail-on` policy to a process exit code.
 /// `0` = pass, `2` = violated, `3` = unknown. (`1` is reserved for tool/usage errors
 /// via `main`.) `holds` / `skipped` / any definite-good verdict is always `0`.
@@ -102,6 +192,89 @@ fn ci_gate_exit(verdict: &str, fail_on: FailOn) {
 #[cfg(test)]
 mod ci_gate_tests {
     use super::*;
+
+    // ---- mununu#537: expectation flag parsing --------------------------------------
+
+    fn expect_args(
+        all_hold: bool,
+        count: Option<usize>,
+        violated: &[&str],
+        expect: &[&str],
+    ) -> ExpectArgs {
+        ExpectArgs {
+            expect_all_hold: all_hold,
+            expect_count: count,
+            expect_violated: violated.iter().map(|s| s.to_string()).collect(),
+            expect: expect.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn no_expect_flags_is_an_empty_claim() {
+        // Which leaves the ordinary `--fail-on` gate in charge — the flags must not change
+        // behaviour for anyone who does not use them.
+        let exp = expect_args(false, None, &[], &[])
+            .to_expectations()
+            .expect("parses");
+        assert!(exp.is_empty());
+    }
+
+    #[test]
+    fn named_pairs_parse_case_insensitively() {
+        use mununu_core::adapter::slang::expectations::ExpectedVerdict;
+        let exp = expect_args(
+            false,
+            None,
+            &[],
+            &["a=HOLDS", "b=unknown", " c = Violated "],
+        )
+        .to_expectations()
+        .expect("parses");
+        assert_eq!(
+            exp.named,
+            vec![
+                ("a".to_string(), ExpectedVerdict::Holds),
+                ("b".to_string(), ExpectedVerdict::Unknown),
+                ("c".to_string(), ExpectedVerdict::Violated),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_malformed_pair_is_a_usage_error_not_a_dropped_claim() {
+        // A claim that silently does not run gates on NOTHING, which is worse than no claim at
+        // all: the caller believes they are covered.
+        let err = expect_args(false, None, &[], &["no_equals_sign"])
+            .to_expectations()
+            .expect_err("must reject");
+        assert!(err.contains("NAME=VERDICT"), "got: {err}");
+
+        let err = expect_args(false, None, &[], &["a=probably"])
+            .to_expectations()
+            .expect_err("must reject an unknown verdict");
+        assert!(err.contains("not a verdict"), "got: {err}");
+
+        let err = expect_args(false, None, &[], &["=holds"])
+            .to_expectations()
+            .expect_err("must reject an empty name");
+        assert!(err.contains("name is empty"), "got: {err}");
+    }
+
+    #[test]
+    fn the_expectation_exit_code_is_distinct_from_every_other() {
+        // The whole point of #537's exit contract: "a verdict was not what you claimed" must be
+        // tellable apart from "the run failed" (1) and from the ordinary gate (2 / 3).
+        assert_eq!(EXPECTATIONS_UNMET_EXIT, 4);
+        for verdict in ["holds", "violated", "unknown", "skipped"] {
+            for fail_on in [FailOn::Violated, FailOn::Unknown, FailOn::None] {
+                assert_ne!(
+                    ci_exit_code(verdict, fail_on),
+                    EXPECTATIONS_UNMET_EXIT,
+                    "the verdict gate must never produce the expectation code"
+                );
+            }
+        }
+    }
 
     #[test]
     fn default_fails_on_violated_only() {
@@ -1857,6 +2030,8 @@ struct SvVerifyAutoArgs {
     engine: EngineArg,
     #[command(flatten)]
     ci: CiArgs,
+    #[command(flatten)]
+    expect: ExpectArgs,
 }
 
 /// Shared SV → BTOR2 lift inputs for the SV-direct verbs (`sv verify` /
@@ -3802,10 +3977,34 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
     let report = verify_auto(&sources, &yopts, &opts)
         .map_err(|e| format!("sv verify-auto: {}", e.message))?;
 
+    // mununu#537 — evaluate the caller's claims against the report. `None` when nothing was
+    // claimed, which leaves the ordinary verdict gate in charge.
+    let expectations = args.expect.to_expectations()?;
+    let expectation_result = if expectations.is_empty() {
+        None
+    } else {
+        Some(mununu_core::adapter::slang::expectations::evaluate(
+            &report,
+            &expectations,
+        ))
+    };
     if args.json {
-        render_verify_auto_json(&report)?;
+        render_verify_auto_json(&report, &expectation_result)?;
     } else {
         render_verify_auto_text(&report);
+        render_expectations_text(&expectation_result);
+    }
+    // mununu#537 — when the caller DECLARED expectations, they supersede the verdict gate.
+    //
+    // This is required, not cosmetic: under `--expect-violated` the ordinary gate would exit 2 on
+    // the very violation that was asked for, so a satisfied contract could never exit 0. Exit 4
+    // says "a verdict was not what you claimed", distinct from 1 ("the run failed") and from the
+    // 2/3 the verdict gate uses when no claim was made.
+    if let Some(result) = &expectation_result {
+        if !result.satisfied {
+            std::process::exit(EXPECTATIONS_UNMET_EXIT);
+        }
+        return Ok(());
     }
     // CI gate: the most severe property verdict drives the exit code.
     let worst = worst_verdict(
@@ -3816,6 +4015,27 @@ fn sv_verify_auto(args: SvVerifyAutoArgs) -> Result<(), String> {
     );
     ci_gate_exit(worst, args.ci.fail_on);
     Ok(())
+}
+
+/// mununu#537 — the human-readable expectation verdict, printed after the report.
+fn render_expectations_text(
+    result: &Option<mununu_core::adapter::slang::expectations::ExpectationResult>,
+) {
+    let Some(result) = result else { return };
+    if result.satisfied {
+        println!("\nExpectations: MET");
+        return;
+    }
+    println!(
+        "\nExpectations: NOT MET ({} failure(s))",
+        result.failures.len()
+    );
+    for f in &result.failures {
+        match &f.property {
+            Some(name) => println!("  [expect] {name}: {}", f.reason),
+            None => println!("  [expect] {}", f.reason),
+        }
+    }
 }
 
 /// The canonical `PropertyVerdict` label for a `verify-auto` outcome.
@@ -3948,6 +4168,7 @@ fn note_level_glyph(level: mununu_core::adapter::slang::verify_auto::NoteLevel) 
 
 fn render_verify_auto_json(
     report: &mununu_core::adapter::slang::verify_auto::AutoVerifyReport,
+    expectations: &Option<mununu_core::adapter::slang::expectations::ExpectationResult>,
 ) -> Result<(), String> {
     // mununu#536 — serialize the SAME type the HTTP API returns, via the one shared conversion
     // (`impl From<&AutoVerifyReport> for SvVerifyAutoResponse`).
@@ -3959,7 +4180,10 @@ fn render_verify_auto_json(
     // `docs/api-schemas/sv-verify-auto-response.schema.json` and then running the CLI got a
     // different document. Going through the shared type means the schema drift test now covers
     // this output too, because it is literally the same type.
-    let view = mununu_core::api::models::SvVerifyAutoResponse::from(report);
+    let mut view = mununu_core::api::models::SvVerifyAutoResponse::from(report);
+    // mununu#537 — carry WHICH expectation failed in the machine-readable output, so a consumer
+    // never has to parse the human lines to find out. That is the point of doing #536 first.
+    view.expectations = expectations.as_ref().map(Into::into);
     println!(
         "{}",
         serde_json::to_string_pretty(&view).map_err(|e| format!("serialize report: {e}"))?

--- a/crates/mununu-core/src/adapter/slang/expectations.rs
+++ b/crates/mununu-core/src/adapter/slang/expectations.rs
@@ -1,0 +1,590 @@
+//! mununu#537 — verdict EXPECTATIONS: assert that a run produced the verdicts you claimed.
+//!
+//! # Why this is mununu's job and not each consumer's
+//!
+//! A verification gate never wants "did it pass". It wants **"did exactly this happen"**. Driving
+//! mununu across 22 RTL blocks, monono converged on three assertions and rebuilt them in shell —
+//! and every project driving mununu will want them, will write them in shell, and will
+//! independently rediscover the same traps. The vocabulary is about *verdicts*, which is mununu's
+//! domain: nothing in it mentions the consumer's problem space.
+//!
+//! # The three verbs
+//!
+//! | verb | meaning | the failure it was born from |
+//! |---|---|---|
+//! | all-hold (+ count) | every property HOLDS, nothing unsupported/unknown/skipped, and the COUNT is exactly N | a `bind` that stopped binding produces FEWER properties, and a smaller all-green set reads as a clean pass |
+//! | violated | the named are VIOLATED **and every other one still HOLDS** | a faulty twin that breaks *everything* teaches nothing about which property covers which fault |
+//! | named | each named returns exactly that verdict; an **unnamed** VIOLATED is still a failure | a recorded ⊥ is a claim about the ENGINE, and it must fail when it stops being true |
+//!
+//! # The fourth verb, which must NOT exist
+//!
+//! monono wrote `expect_all_hold_except` — name properties allowed to come back undecided, with a
+//! reason — and **deleted it**. It was written for `sdram_ctrl`'s three abstaining assertions;
+//! those turned out to be **FALSE rather than hard**. The engine had abstained, the excuse made
+//! the abstention comfortable, and three wrong assertions sat behind it until they were restated
+//! decidably and all nine held at real timings.
+//!
+//! So there is deliberately no "tolerate undecided" mode here. [`ExpectedVerdict::Unknown`] is the
+//! sound version of the same wish: it pins the ⊥ as a **claim** rather than excusing it, and it
+//! fails when the claim stops being true. That is not hypothetical — monono's `video_timing` twin
+//! pinned `sva_1=UNKNOWN`, mununu#503 made it decidable, and the gate failed on the next run,
+//! which is exactly the outcome you want. A verb that accepted "any verdict here is fine" cannot
+//! do that, and a tolerated ⊥ actively prevents it.
+//!
+//! If a genuinely-hard property ever needs an exemption, it should be added deliberately and with
+//! its own argument — not reintroduced here as a convenience, because the failure it enabled was
+//! not a tooling failure. It was that ⊥ stopped feeling like "not checked".
+
+use super::verify_auto::{AutoVerifyReport, VerifyOutcome};
+
+/// A verdict a caller can claim for a named property.
+///
+/// Mirrors [`VerifyOutcome`]'s four arms but carries no payload: a caller claims *that* a property
+/// is ⊥, never *how many cells* it left undecided — the cell count is an engine detail that moves
+/// with refinement, and pinning it would fail on improvements that are not regressions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpectedVerdict {
+    Holds,
+    Violated,
+    Unknown,
+    Skipped,
+}
+
+impl ExpectedVerdict {
+    /// Parse the CLI/API spelling. Case-insensitive, because the transcript prints `HOLDS` in caps
+    /// and `skipped` in lower case and a consumer should never have to care which.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "holds" => Some(Self::Holds),
+            "violated" => Some(Self::Violated),
+            "unknown" | "bottom" | "⊥" => Some(Self::Unknown),
+            "skipped" => Some(Self::Skipped),
+            _ => None,
+        }
+    }
+
+    /// The label this expectation matches, matching [`VerifyOutcome::label`].
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Holds => "holds",
+            Self::Violated => "violated",
+            Self::Unknown => "unknown",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+/// What a caller claims about a run. An empty `Expectations` asserts nothing and is satisfied by
+/// anything — the caller declared no claim, so there is none to break.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Expectations {
+    /// Every property must HOLD, and nothing may be unsupported, unknown or skipped.
+    pub all_hold: bool,
+    /// The property count must be exactly this. Usable on its own.
+    pub count: Option<usize>,
+    /// These must be VIOLATED, and **every other property must HOLD**.
+    pub violated: Vec<String>,
+    /// These must each return exactly the named verdict. Unnamed properties are ignored **except**
+    /// that an unnamed VIOLATED is still a failure.
+    pub named: Vec<(String, ExpectedVerdict)>,
+}
+
+impl Expectations {
+    /// True when the caller claimed nothing, so the verdict gate should stay in charge.
+    pub fn is_empty(&self) -> bool {
+        !self.all_hold && self.count.is_none() && self.violated.is_empty() && self.named.is_empty()
+    }
+}
+
+/// One unmet claim. `property` is `None` for a run-level claim (the count).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectationFailure {
+    pub property: Option<String>,
+    pub reason: String,
+}
+
+/// The outcome of checking a report against a caller's claims.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectationResult {
+    pub satisfied: bool,
+    pub failures: Vec<ExpectationFailure>,
+}
+
+/// Check a report against what the caller claimed.
+///
+/// Pure in `(report, expectations)` — no I/O, no toolchain — so the whole semantics is unit
+/// testable, which is where the test weight for this feature lives.
+///
+/// Every claim is evaluated; the result carries **all** failures rather than stopping at the
+/// first, because a gate's output is read by someone deciding what to fix.
+pub fn evaluate(report: &AutoVerifyReport, exp: &Expectations) -> ExpectationResult {
+    let mut failures = Vec::new();
+    let find = |name: &str| report.properties.iter().find(|p| p.name == name);
+
+    // --- the count ------------------------------------------------------------------
+    // Checked first and independently: a property that silently stopped being produced is
+    // invisible to every per-property check below, because there is nothing to check.
+    if let Some(want) = exp.count
+        && report.properties.len() != want
+    {
+        failures.push(ExpectationFailure {
+            property: None,
+            reason: format!(
+                "expected {want} propert{}, got {} — a binding that stopped binding produces \
+                 FEWER properties, and a smaller all-green set reads as a clean pass",
+                if want == 1 { "y" } else { "ies" },
+                report.properties.len()
+            ),
+        });
+    }
+
+    // --- all-hold -------------------------------------------------------------------
+    if exp.all_hold {
+        // An untranslatable assertion is a property that is NOT being checked, so it fails an
+        // all-hold claim even though it has no verdict to disagree with.
+        for (name, reason) in &report.unsupported {
+            failures.push(ExpectationFailure {
+                property: Some(name.clone()),
+                reason: format!("did not translate, so it is not being checked: {reason}"),
+            });
+        }
+        if report.properties.is_empty() && report.unsupported.is_empty() {
+            failures.push(ExpectationFailure {
+                property: None,
+                reason: "no properties were verified at all — an empty run is not an all-hold run"
+                    .to_string(),
+            });
+        }
+        for p in &report.properties {
+            if !matches!(p.outcome, VerifyOutcome::Holds) {
+                failures.push(ExpectationFailure {
+                    property: Some(p.name.clone()),
+                    reason: format!("expected holds, got {}", describe(&p.outcome)),
+                });
+            }
+        }
+    }
+
+    // --- violated (+ everything else holds) -----------------------------------------
+    for name in &exp.violated {
+        match find(name) {
+            None => failures.push(ExpectationFailure {
+                property: Some(name.clone()),
+                reason: absent_reason(report, name, "violated"),
+            }),
+            Some(p) if !matches!(p.outcome, VerifyOutcome::Violated { .. }) => {
+                failures.push(ExpectationFailure {
+                    property: Some(p.name.clone()),
+                    reason: format!("expected violated, got {}", describe(&p.outcome)),
+                })
+            }
+            Some(_) => {}
+        }
+    }
+    if !exp.violated.is_empty() {
+        // The other half of the contrast-twin claim: a twin that breaks EVERYTHING teaches
+        // nothing about which property covers which fault.
+        for p in &report.properties {
+            if exp.violated.iter().any(|n| n == &p.name) {
+                continue;
+            }
+            if !matches!(p.outcome, VerifyOutcome::Holds) {
+                failures.push(ExpectationFailure {
+                    property: Some(p.name.clone()),
+                    reason: format!(
+                        "not named as violated, so it must still hold, but got {} — a twin that \
+                         breaks every property does not show which property covers the fault",
+                        describe(&p.outcome)
+                    ),
+                });
+            }
+        }
+    }
+
+    // --- named --------------------------------------------------------------------
+    for (name, want) in &exp.named {
+        match find(name) {
+            None => failures.push(ExpectationFailure {
+                property: Some(name.clone()),
+                reason: absent_reason(report, name, want.label()),
+            }),
+            Some(p) if p.outcome.label() != want.label() => failures.push(ExpectationFailure {
+                property: Some(p.name.clone()),
+                reason: format!("expected {}, got {}", want.label(), describe(&p.outcome)),
+            }),
+            Some(_) => {}
+        }
+    }
+    if !exp.named.is_empty() {
+        // An UNNAMED violated is still a failure. Surprises are never silent: this is what keeps
+        // the named form from becoming a way to ignore whatever you did not mention.
+        for p in &report.properties {
+            if !matches!(p.outcome, VerifyOutcome::Violated { .. }) {
+                continue;
+            }
+            let claimed_violated = exp
+                .named
+                .iter()
+                .any(|(n, w)| n == &p.name && *w == ExpectedVerdict::Violated);
+            if !claimed_violated {
+                failures.push(ExpectationFailure {
+                    property: Some(p.name.clone()),
+                    reason: "VIOLATED but not named — an unnamed violation is still a failure"
+                        .to_string(),
+                });
+            }
+        }
+    }
+
+    ExpectationResult {
+        satisfied: failures.is_empty(),
+        failures,
+    }
+}
+
+/// Why a claimed property is not in the report — naming the untranslatable reason when there is
+/// one, because "absent" alone sends the reader hunting for something mununu already explained.
+fn absent_reason(report: &AutoVerifyReport, name: &str, want: &str) -> String {
+    if let Some((_, reason)) = report.unsupported.iter().find(|(n, _)| n == name) {
+        format!("expected {want}, but it did not translate: {reason}")
+    } else {
+        format!(
+            "expected {want}, but no property of that name is in the report — check the name, or \
+             whether the assertion still binds"
+        )
+    }
+}
+
+/// A verdict rendered for a failure message, carrying the figure that explains it.
+fn describe(outcome: &VerifyOutcome) -> String {
+    match outcome {
+        VerifyOutcome::Holds => "holds".to_string(),
+        VerifyOutcome::Violated { false_cells } => format!("violated ({false_cells} cell(s))"),
+        VerifyOutcome::Unknown { unknown_cells } => format!("unknown/⊥ ({unknown_cells} cell(s))"),
+        VerifyOutcome::Skipped { reason } => format!("skipped ({reason})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::slang::translate::SvaKind;
+    use crate::adapter::slang::verify_auto::PropertyVerdict;
+
+    fn report(props: &[(&str, VerifyOutcome)]) -> AutoVerifyReport {
+        AutoVerifyReport {
+            properties: props
+                .iter()
+                .map(|(name, outcome)| PropertyVerdict {
+                    name: (*name).to_string(),
+                    kind: SvaKind::Assert,
+                    formula: format!("formula::{name}"),
+                    outcome: outcome.clone(),
+                    seeded_predicates: Vec::new(),
+                    counterexample: None,
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn named(pairs: &[(&str, ExpectedVerdict)]) -> Expectations {
+        Expectations {
+            named: pairs.iter().map(|(n, v)| ((*n).to_string(), *v)).collect(),
+            ..Default::default()
+        }
+    }
+
+    fn violated(names: &[&str]) -> Expectations {
+        Expectations {
+            violated: names.iter().map(|n| (*n).to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    // ---- all-hold -----------------------------------------------------------------
+
+    #[test]
+    fn all_hold_is_satisfied_when_everything_holds() {
+        let r = report(&[("a", VerifyOutcome::Holds), ("b", VerifyOutcome::Holds)]);
+        let exp = Expectations {
+            all_hold: true,
+            ..Default::default()
+        };
+        assert!(evaluate(&r, &exp).satisfied);
+    }
+
+    #[test]
+    fn all_hold_fails_on_an_undecided_property() {
+        // NEGATIVE CONTROL for the verb. ⊥ is "not checked", never "near enough".
+        let r = report(&[
+            ("a", VerifyOutcome::Holds),
+            ("b", VerifyOutcome::Unknown { unknown_cells: 32 }),
+        ]);
+        let res = evaluate(
+            &r,
+            &Expectations {
+                all_hold: true,
+                ..Default::default()
+            },
+        );
+        assert!(!res.satisfied);
+        assert_eq!(res.failures.len(), 1);
+        assert_eq!(res.failures[0].property.as_deref(), Some("b"));
+        assert!(res.failures[0].reason.contains("unknown/⊥ (32 cell(s))"));
+    }
+
+    #[test]
+    fn all_hold_fails_on_a_skipped_property() {
+        // `skipped` never fails the ordinary CI gate (`ci_exit_code` maps it to 0), which is
+        // exactly why an all-hold CLAIM must reject it: otherwise a property the engine never
+        // evaluated passes the strictest verb the tool offers.
+        let r = report(&[(
+            "a",
+            VerifyOutcome::Skipped {
+                reason: "bit cap".into(),
+            },
+        )]);
+        assert!(
+            !evaluate(
+                &r,
+                &Expectations {
+                    all_hold: true,
+                    ..Default::default()
+                }
+            )
+            .satisfied
+        );
+    }
+
+    #[test]
+    fn all_hold_fails_when_an_assertion_did_not_translate() {
+        // An untranslatable assertion has no verdict to disagree with, and that is the point:
+        // it is not being checked, so it cannot ride along inside an all-green run.
+        let mut r = report(&[("a", VerifyOutcome::Holds)]);
+        r.unsupported
+            .push(("b".into(), "unsupported binary op: BinaryAnd".into()));
+        let res = evaluate(
+            &r,
+            &Expectations {
+                all_hold: true,
+                ..Default::default()
+            },
+        );
+        assert!(!res.satisfied);
+        assert!(
+            res.failures[0].reason.contains("BinaryAnd"),
+            "the refusal reason must be carried through — mununu says exactly why, and a harness \
+             that drops it reports only that something is 'absent'. Got: {}",
+            res.failures[0].reason
+        );
+    }
+
+    #[test]
+    fn all_hold_fails_on_an_empty_run() {
+        // Zero properties is vacuously "all hold" and must not be.
+        assert!(
+            !evaluate(
+                &report(&[]),
+                &Expectations {
+                    all_hold: true,
+                    ..Default::default()
+                }
+            )
+            .satisfied
+        );
+    }
+
+    // ---- count --------------------------------------------------------------------
+
+    #[test]
+    fn count_catches_a_binding_that_stopped_binding() {
+        // THE failure this verb exists for: fewer properties, all of them green.
+        let r = report(&[("a", VerifyOutcome::Holds)]);
+        let exp = Expectations {
+            all_hold: true,
+            count: Some(2),
+            ..Default::default()
+        };
+        let res = evaluate(&r, &exp);
+        assert!(
+            !res.satisfied,
+            "a smaller all-green set must NOT read as a pass"
+        );
+        assert!(
+            res.failures
+                .iter()
+                .any(|f| f.property.is_none() && f.reason.contains("expected 2 properties, got 1"))
+        );
+    }
+
+    #[test]
+    fn count_is_usable_on_its_own() {
+        let r = report(&[("a", VerifyOutcome::Holds), ("b", VerifyOutcome::Holds)]);
+        assert!(
+            evaluate(
+                &r,
+                &Expectations {
+                    count: Some(2),
+                    ..Default::default()
+                }
+            )
+            .satisfied
+        );
+    }
+
+    // ---- violated -----------------------------------------------------------------
+
+    #[test]
+    fn violated_requires_the_named_to_fail_and_the_rest_to_hold() {
+        let r = report(&[
+            ("twin", VerifyOutcome::Violated { false_cells: 1 }),
+            ("other", VerifyOutcome::Holds),
+        ]);
+        assert!(evaluate(&r, &violated(&["twin"])).satisfied);
+    }
+
+    #[test]
+    fn violated_fails_when_the_twin_breaks_everything() {
+        // A twin that breaks EVERY property teaches nothing about which property covers which
+        // fault — the contrast is the whole point of the verb.
+        let r = report(&[
+            ("twin", VerifyOutcome::Violated { false_cells: 1 }),
+            ("other", VerifyOutcome::Violated { false_cells: 4 }),
+        ]);
+        let res = evaluate(&r, &violated(&["twin"]));
+        assert!(!res.satisfied);
+        assert_eq!(res.failures[0].property.as_deref(), Some("other"));
+    }
+
+    #[test]
+    fn violated_fails_when_the_named_property_holds() {
+        // The vacuity catch: the twin was supposed to break this property and did not.
+        let r = report(&[("twin", VerifyOutcome::Holds)]);
+        assert!(!evaluate(&r, &violated(&["twin"])).satisfied);
+    }
+
+    // ---- named --------------------------------------------------------------------
+
+    #[test]
+    fn named_matches_each_claimed_verdict() {
+        let r = report(&[
+            ("a", VerifyOutcome::Holds),
+            ("b", VerifyOutcome::Unknown { unknown_cells: 4 }),
+            ("ignored", VerifyOutcome::Skipped { reason: "x".into() }),
+        ]);
+        let exp = named(&[
+            ("a", ExpectedVerdict::Holds),
+            ("b", ExpectedVerdict::Unknown),
+        ]);
+        assert!(
+            evaluate(&r, &exp).satisfied,
+            "an UNNAMED non-violated property is ignored by this verb"
+        );
+    }
+
+    #[test]
+    fn named_unknown_fails_once_the_property_becomes_decidable() {
+        // THE reason `=UNKNOWN` exists rather than a "tolerate undecided" verb. monono's
+        // video_timing twin pinned `sva_1=UNKNOWN`; mununu#503 made it decidable and the gate
+        // failed on the next run — the pin converted an upstream improvement into a signal
+        // instead of into silence. A verb that accepted any verdict could not do this.
+        let r = report(&[("sva_1", VerifyOutcome::Violated { false_cells: 1 })]);
+        let res = evaluate(&r, &named(&[("sva_1", ExpectedVerdict::Unknown)]));
+        assert!(
+            !res.satisfied,
+            "a ⊥ pinned by name is a CLAIM about the engine, and must fail when it stops holding"
+        );
+    }
+
+    #[test]
+    fn named_fails_on_an_unnamed_violation() {
+        // Surprises are never silent: this is what stops the named form becoming a way to
+        // ignore whatever you did not mention.
+        let r = report(&[
+            ("a", VerifyOutcome::Holds),
+            ("surprise", VerifyOutcome::Violated { false_cells: 2 }),
+        ]);
+        let res = evaluate(&r, &named(&[("a", ExpectedVerdict::Holds)]));
+        assert!(!res.satisfied);
+        assert_eq!(res.failures[0].property.as_deref(), Some("surprise"));
+        assert!(res.failures[0].reason.contains("not named"));
+    }
+
+    #[test]
+    fn named_reports_an_absent_property_with_its_refusal_reason() {
+        // "absent" alone sends the reader hunting for something mununu already explained.
+        let mut r = report(&[("a", VerifyOutcome::Holds)]);
+        r.unsupported
+            .push(("gone".into(), "dynamic bit-select `sig[idx]`".into()));
+        let res = evaluate(&r, &named(&[("gone", ExpectedVerdict::Holds)]));
+        assert!(!res.satisfied);
+        assert!(res.failures[0].reason.contains("dynamic bit-select"));
+    }
+
+    #[test]
+    fn named_reports_a_genuinely_missing_property_plainly() {
+        let r = report(&[("a", VerifyOutcome::Holds)]);
+        let res = evaluate(&r, &named(&[("typo", ExpectedVerdict::Holds)]));
+        assert!(!res.satisfied);
+        assert!(res.failures[0].reason.contains("no property of that name"));
+    }
+
+    // ---- the empty claim, and parsing ----------------------------------------------
+
+    #[test]
+    fn no_claim_is_satisfied_by_anything() {
+        // An empty `Expectations` must not turn every run into a failure — the caller declared
+        // no claim, so there is none to break, and the ordinary verdict gate stays in charge.
+        let r = report(&[("a", VerifyOutcome::Violated { false_cells: 1 })]);
+        let exp = Expectations::default();
+        assert!(exp.is_empty());
+        assert!(evaluate(&r, &exp).satisfied);
+    }
+
+    #[test]
+    fn verdict_spelling_is_case_insensitive() {
+        // mununu prints HOLDS in caps and `skipped` in lower case. A consumer got an EMPTY
+        // verdict out of a case-sensitive regex once, and its uncovered-counter then did not
+        // count the property at all — a guard that stops firing exactly when it is needed.
+        for s in ["HOLDS", "holds", "Holds", " holds "] {
+            assert_eq!(
+                ExpectedVerdict::parse(s),
+                Some(ExpectedVerdict::Holds),
+                "{s}"
+            );
+        }
+        assert_eq!(
+            ExpectedVerdict::parse("UNKNOWN"),
+            Some(ExpectedVerdict::Unknown)
+        );
+        assert_eq!(ExpectedVerdict::parse("⊥"), Some(ExpectedVerdict::Unknown));
+        assert_eq!(
+            ExpectedVerdict::parse("skipped"),
+            Some(ExpectedVerdict::Skipped)
+        );
+        assert_eq!(ExpectedVerdict::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn every_failure_is_reported_not_just_the_first() {
+        // A gate's output is read by someone deciding what to fix.
+        let r = report(&[
+            ("a", VerifyOutcome::Unknown { unknown_cells: 1 }),
+            ("b", VerifyOutcome::Violated { false_cells: 1 }),
+        ]);
+        let res = evaluate(
+            &r,
+            &Expectations {
+                all_hold: true,
+                count: Some(3),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            res.failures.len(),
+            3,
+            "one count failure + two property failures"
+        );
+    }
+}

--- a/crates/mununu-core/src/adapter/slang/mod.rs
+++ b/crates/mununu-core/src/adapter/slang/mod.rs
@@ -24,6 +24,7 @@ use std::process::Command;
 
 use crate::adapter::{AdapterError, AdapterErrorKind};
 
+pub mod expectations;
 pub mod extract;
 pub mod prim_stubs;
 pub mod translate;

--- a/crates/mununu-core/src/api/handlers.rs
+++ b/crates/mununu-core/src/api/handlers.rs
@@ -1878,7 +1878,22 @@ fn sv_verify_auto_handler_impl(
     // of hand-written field mapping that had already drifted from the CLI's independent
     // `serde_json::json!` literal; see the `From` impl's doc comment for why there is now
     // exactly one.
-    Ok(Json(SvVerifyAutoResponse::from(&report)))
+    let mut response = SvVerifyAutoResponse::from(&report);
+    // mununu#537 — check the caller's claims, if they made any. A malformed verdict spelling is
+    // a 400, never a silently dropped claim: a claim that does not run gates on nothing.
+    if let Some(req_exp) = &request.expectations {
+        let expectations = req_exp
+            .to_expectations()
+            .map_err(|message| ApiError::BadRequest {
+                message,
+                details: None,
+            })?;
+        if !expectations.is_empty() {
+            let result = crate::adapter::slang::expectations::evaluate(&report, &expectations);
+            response.expectations = Some((&result).into());
+        }
+    }
+    Ok(Json(response))
 }
 
 /// Shared parameters for the CEGAR run/report logic, sourced identically

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1716,6 +1716,63 @@ pub struct SvVerifyAutoRequest {
     /// thread-safe (unlike the env var, which is process-global).
     #[serde(default)]
     pub no_antecedent_shadow: Option<bool>,
+    /// mununu#537 — assert that this run produces the verdicts the caller claims. Omitted ⇒ no
+    /// claim, and the response carries no `expectations` block.
+    ///
+    /// The HTTP peer of the CLI's `--expect-all-hold` / `--expect-count` / `--expect-violated` /
+    /// `--expect`. A gate driving mununu over HTTP wants the same three assertions a gate driving
+    /// it on the command line does.
+    #[serde(default)]
+    pub expectations: Option<ExpectationsRequest>,
+}
+
+/// mununu#537 — the caller's claims about a run's verdicts.
+///
+/// There is deliberately **no** "tolerate undecided" field. Naming a property `unknown` in
+/// `named` is the sound version of that wish: it pins the abstention as a claim that fails when
+/// the property becomes decidable, instead of excusing it. See
+/// [`crate::adapter::slang::expectations`] for the incident that settled this.
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
+pub struct ExpectationsRequest {
+    /// Every property must hold, with nothing unsupported, unknown or skipped.
+    #[serde(default)]
+    pub all_hold: bool,
+    /// The property count must be exactly this — catches a binding that stopped binding, whose
+    /// smaller all-green set otherwise reads as a clean pass.
+    #[serde(default)]
+    pub count: Option<usize>,
+    /// These must be VIOLATED **and every other property must hold**.
+    #[serde(default)]
+    pub violated: Vec<String>,
+    /// `name -> verdict` (`"holds"` | `"violated"` | `"unknown"` | `"skipped"`). Unnamed
+    /// properties are ignored, except that an unnamed VIOLATED is still a failure.
+    #[serde(default)]
+    pub named: std::collections::BTreeMap<String, String>,
+}
+
+impl ExpectationsRequest {
+    /// Convert to the core type. `Err` names the bad verdict spelling rather than dropping the
+    /// claim, because a silently-dropped claim gates on nothing.
+    pub fn to_expectations(
+        &self,
+    ) -> Result<crate::adapter::slang::expectations::Expectations, String> {
+        use crate::adapter::slang::expectations::{Expectations, ExpectedVerdict};
+        let mut named = Vec::new();
+        for (name, verdict) in &self.named {
+            let v = ExpectedVerdict::parse(verdict).ok_or_else(|| {
+                format!(
+                    "expectations.named[{name}]: `{verdict}` is not a verdict — use holds |                      violated | unknown | skipped"
+                )
+            })?;
+            named.push((name.clone(), v));
+        }
+        Ok(Expectations {
+            all_hold: self.all_hold,
+            count: self.count,
+            violated: self.violated.clone(),
+            named,
+        })
+    }
 }
 
 /// Response for `/api/v1/sv/verify-auto`.
@@ -1734,6 +1791,47 @@ pub struct SvVerifyAutoResponse {
     /// scope and caveats are explicit in the payload.
     #[serde(default)]
     pub notes: Vec<VerificationNoteView>,
+    /// mununu#537 — the result of checking this run against the caller's declared expectations.
+    /// `None` (and omitted) when no expectations were declared, in which case the ordinary
+    /// verdict gate applies.
+    ///
+    /// Present so a consumer learns **which** claim failed without parsing prose.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expectations: Option<ExpectationResultView>,
+}
+
+/// mununu#537 — one unmet claim. `property` is absent for a run-level claim (the count).
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct ExpectationFailureView {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub property: Option<String>,
+    pub reason: String,
+}
+
+/// mununu#537 — the verdict on a caller's declared expectations.
+///
+/// `satisfied: false` corresponds to CLI exit code **4** — "a verdict was not what you claimed",
+/// deliberately distinct from a failed run (1) and from the ordinary verdict gate (2 / 3).
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct ExpectationResultView {
+    pub satisfied: bool,
+    pub failures: Vec<ExpectationFailureView>,
+}
+
+impl From<&crate::adapter::slang::expectations::ExpectationResult> for ExpectationResultView {
+    fn from(r: &crate::adapter::slang::expectations::ExpectationResult) -> Self {
+        Self {
+            satisfied: r.satisfied,
+            failures: r
+                .failures
+                .iter()
+                .map(|f| ExpectationFailureView {
+                    property: f.property.clone(),
+                    reason: f.reason.clone(),
+                })
+                .collect(),
+        }
+    }
 }
 
 /// mununu#536 — the ONE report→wire conversion, shared by the HTTP handler and the CLI's
@@ -1848,6 +1946,9 @@ impl From<&crate::adapter::slang::verify_auto::AutoVerifyReport> for SvVerifyAut
                 config_values: report.diagnostics.applied_config_values.clone(),
                 cutpoints: report.diagnostics.cutpoint_signals.clone(),
             },
+            // Expectations are not a property of the report — they are the caller's claim about
+            // it — so the conversion leaves this None and the caller fills it in.
+            expectations: None,
             notes: report
                 .notes
                 .iter()

--- a/docs/api-schemas/sv-verify-auto-request.schema.json
+++ b/docs/api-schemas/sv-verify-auto-request.schema.json
@@ -1,6 +1,43 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "ExpectationsRequest": {
+      "description": "mununu#537 — the caller's claims about a run's verdicts.\n\nThere is deliberately **no** \"tolerate undecided\" field. Naming a property `unknown` in `named` is the sound version of that wish: it pins the abstention as a claim that fails when the property becomes decidable, instead of excusing it. See [`crate::adapter::slang::expectations`] for the incident that settled this.",
+      "properties": {
+        "all_hold": {
+          "default": false,
+          "description": "Every property must hold, with nothing unsupported, unknown or skipped.",
+          "type": "boolean"
+        },
+        "count": {
+          "default": null,
+          "description": "The property count must be exactly this — catches a binding that stopped binding, whose smaller all-green set otherwise reads as a clean pass.",
+          "format": "uint",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "named": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "`name -> verdict` (`\"holds\"` | `\"violated\"` | `\"unknown\"` | `\"skipped\"`). Unnamed properties are ignored, except that an unnamed VIOLATED is still a failure.",
+          "type": "object"
+        },
+        "violated": {
+          "default": [],
+          "description": "These must be VIOLATED **and every other property must hold**.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "FileContent": {
       "description": "File content with optional name",
       "properties": {
@@ -67,6 +104,17 @@
         "string",
         "null"
       ]
+    },
+    "expectations": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ExpectationsRequest"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "mununu#537 — assert that this run produces the verdicts the caller claims. Omitted ⇒ no claim, and the response carries no `expectations` block.\n\nThe HTTP peer of the CLI's `--expect-all-hold` / `--expect-count` / `--expect-violated` / `--expect`. A gate driving mununu over HTTP wants the same three assertions a gate driving it on the command line does."
     },
     "gate_reset": {
       "default": null,

--- a/docs/api-schemas/sv-verify-auto-response.schema.json
+++ b/docs/api-schemas/sv-verify-auto-response.schema.json
@@ -66,6 +66,43 @@
       ],
       "type": "object"
     },
+    "ExpectationFailureView": {
+      "description": "mununu#537 — one unmet claim. `property` is absent for a run-level claim (the count).",
+      "properties": {
+        "property": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason"
+      ],
+      "type": "object"
+    },
+    "ExpectationResultView": {
+      "description": "mununu#537 — the verdict on a caller's declared expectations.\n\n`satisfied: false` corresponds to CLI exit code **4** — \"a verdict was not what you claimed\", deliberately distinct from a failed run (1) and from the ordinary verdict gate (2 / 3).",
+      "properties": {
+        "failures": {
+          "items": {
+            "$ref": "#/definitions/ExpectationFailureView"
+          },
+          "type": "array"
+        },
+        "satisfied": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "failures",
+        "satisfied"
+      ],
+      "type": "object"
+    },
     "ModelDiagnosticsView": {
       "description": "Model-level lift diagnostics (mirrors [`crate::adapter::slang::verify_auto::ModelDiagnostics`]).",
       "properties": {
@@ -282,6 +319,17 @@
         }
       ],
       "description": "Model-level diagnostics: state-register count + black-boxed (cut) modules. Lets a SKIPPED outcome point at its root cause."
+    },
+    "expectations": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ExpectationResultView"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "mununu#537 — the result of checking this run against the caller's declared expectations. `None` (and omitted) when no expectations were declared, in which case the ordinary verdict gate applies.\n\nPresent so a consumer learns **which** claim failed without parsing prose."
     },
     "notes": {
       "default": [],

--- a/docs/cli-cookbook.md
+++ b/docs/cli-cookbook.md
@@ -145,6 +145,25 @@ mununu --quiet sv verify-auto rtl/mod.sv --json | jq '.diagnostics | {frontend, 
 
 Exit codes are the usual gate (`0` pass, `2` violated, `3` unknown under `--fail-on unknown`, `1` tool error); `1` implies empty stdout, while `2`/`3` still emit the full document.
 
+### Assert the verdicts you claim (mununu#537)
+
+A gate rarely wants "did it pass" — it wants "did exactly this happen":
+
+```bash
+# every property holds, nothing unsupported/unknown/skipped, and EXACTLY 8 of them
+mununu sv verify-auto rtl/mod.sv --source rtl/mod_sva.sv --top mod --expect-all-hold --expect-count 8
+
+# a contrast twin: these must be VIOLATED, every other property must still HOLD
+mununu sv verify-auto rtl/faulty.sv --source rtl/mod_sva.sv --top mod --expect-violated mod_sva_sva_1
+
+# exact per-property claims; an UNNAMED violated is still a failure
+mununu sv verify-auto rtl/mod.sv --top mod --expect 'mod_sva_sva_0=holds,mod_sva_sva_1=unknown'
+```
+
+Declaring an expectation **supersedes** `--fail-on` (it must — `--expect-violated` would otherwise exit 2 on the violation you asked for). Exit `4` means "a verdict was not what you claimed"; `1` still means the run itself failed, including a malformed `NAME=VERDICT`.
+
+`--expect-count` is the one that catches a binding that stopped binding: fewer properties, all of them green, which otherwise reads as a clean pass.
+
 ## Check that a design's properties are adequate (mutation testing)
 
 > Source of truth: [`mutate_and_compare`](../crates/mununu-core/src/adapter/slang/verify_auto.rs#L1824) — surface: (CLI+API+UI)

--- a/docs/consumer-briefings/2026-09-verdict-expectations.md
+++ b/docs/consumer-briefings/2026-09-verdict-expectations.md
@@ -1,0 +1,191 @@
+# Consumer briefing — assert the verdicts you claim (`--expect-*`), and a new exit code
+
+> **Audience:** anyone gating CI on `mununu sv verify-auto`. **monono, ROSF.**
+> Also: a **binding-rule change** to Surface Parity that affects every contributor — see the last
+> section.
+
+## TL;DR
+
+Three assertions, on CLI and HTTP API:
+
+```bash
+# every property holds, nothing unsupported/unknown/skipped, and EXACTLY 8 of them
+mununu sv verify-auto dut.sv --source dut_sva.sv --top dut --expect-all-hold --expect-count 8
+
+# a contrast twin: these must be VIOLATED, every other property must still HOLD
+mununu sv verify-auto faulty.sv --source dut_sva.sv --top dut --expect-violated dut_sva_sva_1
+
+# exact per-property claims; an UNNAMED violated is still a failure
+mununu sv verify-auto dut.sv --source dut_sva.sv --top dut --expect 'sva_0=holds,sva_1=unknown'
+```
+
+**New exit code `4` = "a verdict was not what you claimed."** Declaring an expectation supersedes
+`--fail-on`.
+
+Nothing changes for anyone who does not pass an `--expect-*` flag.
+
+## Why upstream
+
+Three consumers already exist and would each write these in shell — and would each independently
+rediscover the same traps, including the lower-case-`skipped` regex bug that made a guard stop
+firing exactly when it was needed. The vocabulary is about **verdicts**, which is mununu's domain;
+nothing in it mentions any consumer's problem space.
+
+## The verbs, and the failure each exists to catch
+
+| flag | catches |
+|---|---|
+| `--expect-all-hold` | Stricter than `--fail-on unknown`: also rejects `skipped` — which the CI gate treats as a **pass** — and an assertion that did not translate. Both are properties that are **not being checked**. |
+| `--expect-count N` | A binding that stopped binding produces **fewer** properties, and a smaller all-green set reads as a clean pass. Nothing else catches this, because a property that stopped being produced is invisible to every per-property check. |
+| `--expect-violated a,b` | The named must be VIOLATED **and every other property must still HOLD**. A twin that breaks *everything* teaches nothing about which property covers which fault, so the second half is not optional. |
+| `--expect 'a=VERDICT,…'` | Each named property returns exactly that verdict. Unnamed are ignored — **except** that an unnamed VIOLATED is still a failure, so the verb cannot become a way to ignore what you did not mention. |
+
+Verdict spellings are **case-insensitive** (`holds` / `HOLDS` / `Holds`), and `⊥` is accepted for
+`unknown`. A malformed `NAME=VERDICT` is a **usage error (exit 1)**, never a silently dropped
+claim — a claim that does not run gates on nothing, which is worse than no claim at all.
+
+## Exit codes
+
+| exit | meaning |
+|---|---|
+| `0` | expectations met |
+| `1` | the run failed (tool/usage error, including a malformed `--expect` pair) — still implies empty stdout |
+| `4` | **an expectation was not met** |
+
+`2` (violated) and `3` (unknown under `--fail-on unknown`) remain the ordinary gate for runs that
+declare no expectations.
+
+**Expectations supersede `--fail-on`, and they have to.** Under `--expect-violated` the ordinary
+gate would exit `2` on the very violation you asked for, so a satisfied claim could never exit 0.
+Note also a pre-existing collision worth knowing: clap's own argument-parse failures exit `2`.
+
+## Pinning a ⊥ is the sound way to record one
+
+`--expect 'sva_1=unknown'` records an abstention as a **claim**, and the claim fails when the
+property becomes decidable. **That is the point**, not an annoyance: monono's `video_timing` twin
+pinned `sva_1=UNKNOWN`, mununu#503 made it decidable, and the gate failed on the next run — an
+upstream improvement surfaced as a signal instead of vanishing into silence.
+
+### There is deliberately no "tolerate undecided" flag
+
+One was written downstream (`expect_all_hold_except`) and **deleted**. It was introduced for
+`sdram_ctrl`'s three abstaining assertions; those turned out to be **false rather than hard**. The
+engine had abstained, the excuse made the abstention comfortable, and three wrong assertions sat
+behind it until they were restated decidably and all nine held at real timings.
+
+If a genuinely-hard property ever needs an exemption, it should be argued for on its own terms —
+not reintroduced as a convenience. A ⊥ should keep feeling like "not checked".
+
+## Per-consumer
+
+### monono
+
+- **What to update:** `verify/lib.sh`'s three helpers become flags. `expect_all_hold` →
+  `--expect-all-hold [--expect-count N]`; `expect_violated` → `--expect-violated`; `expect_named`
+  → `--expect`. Treat exit `4` as the assertion failure and exit `1` as the run failure — a
+  distinction the shell version could not make, since it could only see "non-zero".
+- **What to expect:** identical verdicts. The `--json` output gains
+  `expectations: { satisfied, failures[] }`, so a failing check reports *which* claim broke
+  without any transcript parsing.
+
+**The mapping, against a real block** (`rtl/vpu/tmds_serialiser/verify.sh`, which uses two of the
+three verbs):
+
+```bash
+# before
+expect_all_hold "tiers 1+2+3 all hold" \
+    "$HERE/tmds_serialiser.sv" --source "$HERE/tmds_serialiser_sva.sv" --source "$STUBS" \
+    --top tmds_serialiser --config-value rst_n=1
+
+# after — the invocation is unchanged; only the assertion moves
+mununu sv verify-auto "$HERE/tmds_serialiser.sv" \
+    --source "$HERE/tmds_serialiser_sva.sv" --source "$STUBS" \
+    --top tmds_serialiser --config-value rst_n=1 \
+    --expect-all-hold
+```
+
+```bash
+# before
+expect_violated "faulty twin: four shift cycles instead of five" \
+    "tmds_serialiser_sva_sva_1" -- "$HERE/faulty/tmds_serialiser_short_phase.sv" ...
+
+# after
+mununu sv verify-auto "$HERE/faulty/tmds_serialiser_short_phase.sv" ... \
+    --expect-violated tmds_serialiser_sva_sva_1
+```
+
+Note what does **not** move: sources, stubs, `--top`, `--config-value`, the label, and the
+PASS/FAIL formatting. Your runner already expresses the invocation well — only the assertion
+belonged upstream, which is why this shipped as flags rather than as a contract file that would
+have had to duplicate the rest.
+
+Two behaviours you can now delete rather than reimplement: the `--config-value` transcript grep
+(unusable pins are a hard error upstream), and the case-insensitivity workaround for
+lower-case `skipped` (verdict spellings are matched case-insensitively here).
+
+### ROSF
+
+- **What to update:** nothing required. To use it over HTTP, add an `expectations` object to the
+  request (`all_hold`, `count`, `violated`, `named`); the response carries
+  `expectations: { satisfied, failures[] }`. A bad verdict spelling is a `400`.
+
+### mununu-ui
+
+- **What to update:** nothing. No UI is expected for this — see below.
+
+## Binding-rule change: Surface Parity
+
+**Surface Parity now requires CLI + HTTP API for every capability, and UI parity only for
+CTXDSL-related capabilities** (those whose *subject* is a CTXDSL model — authoring, evaluating,
+composing, visualizing, synthesizing from, or importing into one).
+
+For everything else — RTL / SVA verification verbs, contract / black-box tooling, and CI-gate
+ergonomics like this feature — **a missing UI affordance is no longer drift**. A UI control for
+"assert this run produced exactly these verdicts" would be an affordance with no user: CI lanes
+and orchestrators consume it, not someone at a canvas.
+
+This does **not** remove existing UI. It removes the obligation to *grow* it for work that is not
+about CTXDSL. `CLAUDE.md` §Surface Parity and `.claude/skills/parity-check/SKILL.md` are updated
+together, so the tooling and the rule agree; `/parity-check` now marks such rows `n/a` instead of
+reporting them as gaps.
+
+## Docker rebuild disposition
+
+| Image | Impact | Rebuild required? |
+|---|---|---|
+| `mununu-dev` | Rust only; no tool pins touched | No |
+| `mununu-sva` | Inherits `mununu-dev`; tool pins unchanged | No |
+| `mununu-sva-pono` | Inherits `mununu-sva`; tool pins unchanged | No |
+| `hw-verif` | Not involved | No |
+
+## Test the transition
+
+```bash
+# should exit 0
+mununu sv verify-auto dut.sv --source dut_sva.sv --top dut --expect-all-hold; echo $?
+# should exit 4 and name the property
+mununu sv verify-auto dut.sv --source dut_sva.sv --top dut --expect 'sva_0=violated'; echo $?
+```
+
+The semantics is covered by 18 unit tests over hand-built reports — no toolchain needed — each
+verb with a **negative control**, because an evaluator that always returned "satisfied" would pass
+every positive test. Both were mutation-tested: disabling the unnamed-VIOLATED rule fails exactly
+one test, and an always-satisfied evaluator fails 11 of 18.
+
+## Provenance
+
+- Issue: [mununu#537](https://github.com/Mumunu-team/mununu/issues/537). Depends on
+  [#536](https://github.com/Mumunu-team/mununu/issues/536), which made the report machine-readable.
+- Implementation: `crates/mununu-core/src/adapter/slang/expectations.rs` (the pure evaluator),
+  `ExpectArgs` in `crates/mununu-cli/src/main.rs`, `ExpectationsRequest` /
+  `ExpectationResultView` in `crates/mununu-core/src/api/models.rs`.
+- Policy: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## Not covered here
+
+- **No contract file.** The assertions are flags. A file beside the sources would either duplicate
+  the invocation a consumer's runner already expresses, or become a new format to version and
+  drift-check. If per-design storage turns out to be wanted, it can desugar to the same evaluator.
+- **No resume / no partial expectations.** The claims are evaluated against a completed report.
+- **`--expect-count` counts translated properties**, not assertions in the source; an assertion
+  that did not translate appears in `unsupported[]` and fails `--expect-all-hold` separately.

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -887,6 +887,7 @@ JSON.
 | `0` | property holds (or all properties hold) — the step passes |
 | `2` | a property is **violated** — the step fails |
 | `3` | a property is **unknown** *and* `--fail-on unknown` was set |
+| `4` | **an expectation was not met** (mununu#537) — the run worked and disagreed with a `--expect-*` claim. Distinct from `1` (the run failed) on purpose, and it SUPERSEDES `--fail-on`: under `--expect-violated`, `2` would fire on the very violation you asked for. |
 | `1` | tool / usage error (bad file, unparseable atom, missing toolchain) |
 
 - `--fail-on <violated\|unknown\|none>` picks the gate policy. Default `violated`:

--- a/docs/verifying-rtl.md
+++ b/docs/verifying-rtl.md
@@ -204,6 +204,49 @@ mununu --quiet sv verify-auto design.sv --json | jq '[.notes[] | select(.level==
 
 `unsupported[]` carries mununu's own **reason** for every assertion it could not translate (`"unsupported binary op: BinaryAnd"`, `"dynamic bit-select …"`). An assertion that does not appear in `properties[]` is not being checked, and this is where it says why.
 
+### Asserting the verdicts you claim: `--expect-*` (mununu#537)
+
+> Source of truth: [`adapter::slang::expectations::evaluate`](../crates/mununu-core/src/adapter/slang/expectations.rs) — surface: (CLI+API)
+
+A verification gate never wants "did it pass". It wants **"did exactly this happen"**. Three verbs, on both surfaces:
+
+```bash
+# every property holds, nothing unsupported/unknown/skipped, and there are EXACTLY 8 of them
+mununu sv verify-auto dut.sv --source dut_sva.sv --top dut --expect-all-hold --expect-count 8
+
+# a contrast twin: these must be VIOLATED, and every other property must still HOLD
+mununu sv verify-auto faulty.sv --source dut_sva.sv --top dut --expect-violated dut_sva_sva_1
+
+# exact per-property claims; unnamed properties are ignored, but an unnamed VIOLATED still fails
+mununu sv verify-auto dut.sv --source dut_sva.sv --top dut \
+    --expect 'dut_sva_sva_0=holds,dut_sva_sva_1=unknown'
+```
+
+| flag | the failure it exists to catch |
+|---|---|
+| `--expect-all-hold` | stricter than `--fail-on unknown`: also rejects `skipped` (which the gate treats as a pass) and an assertion that did not translate — both are properties not being checked |
+| `--expect-count N` | a binding that stopped binding produces **fewer** properties, and a smaller all-green set reads as a clean pass. Nothing else catches it, because a property that stopped being produced is invisible to every per-property check |
+| `--expect-violated a,b` | a twin that breaks *every* property teaches nothing about which property covers which fault, so "everything else still holds" is not optional |
+| `--expect 'a=VERDICT,…'` | pins exact verdicts; an **unnamed** VIOLATED is still a failure, so the verb cannot become a way to ignore what you did not mention |
+
+**Exit codes.** Declaring an expectation **supersedes** `--fail-on` — it has to, or `--expect-violated` would exit 2 on the very violation you asked for.
+
+| exit | meaning |
+|---|---|
+| `0` | expectations met |
+| `4` | **a verdict was not what you claimed** |
+| `1` | the run failed (tool/usage error) — including a malformed `NAME=VERDICT` |
+
+`2` / `3` remain the ordinary verdict gate for runs that declare no expectations.
+
+#### Pinning a ⊥ is the sound way to record one
+
+`--expect 'sva_1=unknown'` records an abstention as a **claim**, and the claim fails when the property becomes decidable. That is the desired behaviour, not an annoyance: monono's `video_timing` twin pinned `sva_1=UNKNOWN`, mununu#503 made it decidable, and the gate failed on the next run — an upstream improvement surfaced as a signal instead of vanishing into silence.
+
+There is deliberately **no** "tolerate undecided" flag. One was written downstream and deleted: it was introduced for three abstaining assertions that turned out to be **false rather than hard**, and the excuse made the abstention comfortable until they were restated decidably and all nine held. A ⊥ should keep feeling like "not checked".
+
+The API peer is an `expectations` object on the request (`all_hold`, `count`, `violated`, `named`), with the result returned as `expectations: { satisfied, failures[] }` — so an HTTP consumer learns *which* claim failed without parsing prose.
+
 ### Shrinking a parameterised design: `--param`
 
 > Source of truth: [`build_chparam_passes`](../crates/mununu-core/src/adapter/yosys/mod.rs) — surface: (CLI+API+UI)

--- a/wiki/CI-and-Agent-Integration.md
+++ b/wiki/CI-and-Agent-Integration.md
@@ -19,6 +19,7 @@ Every verify verb — `btor2 verify` / `verify-liveness` / `verify-recoverabilit
 | `0` | property holds (or all properties hold) — the step passes |
 | `2` | a property is **violated** — the step fails |
 | `3` | a property is **unknown** *and* `--fail-on unknown` was passed |
+| `4` | **an expectation was not met** (mununu#537) — the run worked and disagreed with a `--expect-*` claim. Distinct from `1` (the run failed) on purpose, and it SUPERSEDES `--fail-on`: under `--expect-violated`, `2` would fire on the very violation you asked for. |
 | `1` | tool / usage error (missing file, unparseable atom, missing toolchain) |
 
 - **`--fail-on <violated \| unknown \| none>`** picks the gate policy (default `violated`). An undecided `unknown` does **not** fail the build by default — it is "not decided," not "broken." Use `--fail-on unknown` for a strict gate that also fails on `⊥`, or `--fail-on none` for report-only (always exit `0`).


### PR DESCRIPTION
Depends on #539 (merged), which made the report machine-readable.

## What

A verification gate never wants "did it pass". It wants **"did exactly this happen"**. Three assertions, on CLI and HTTP API — taken from the shell verbs a consumer had already converged on across 22 RTL blocks, read directly rather than from the issue's summary of them.

```
--expect-all-hold        every property HOLDS, nothing unsupported/unknown/skipped
--expect-count N         EXACTLY N properties
--expect-violated a,b    the named are VIOLATED and every OTHER one still HOLDS
--expect 'a=VERDICT,..'  exact per-property claims; an UNNAMED violated still fails
```

Each exists for a failure a plain "did it pass" cannot see:

- **all-hold** is *stricter* than `--fail-on unknown` — it also rejects `skipped`, which `ci_exit_code` maps to **0** (a pass), and an assertion that did not translate. Both are properties not being checked.
- **count** catches a binding that stopped binding. Fewer properties, all green, reads as a clean pass — and nothing else catches it, because a property that stopped being produced is invisible to every per-property check.
- **violated** requires everything else to still hold: a twin that breaks *every* property teaches nothing about which property covers which fault.
- **named** ignores what you didn't mention **except** an unnamed VIOLATED, so it can't become a way to hide surprises.

## There is deliberately no fourth "tolerate undecided" verb

`expect_all_hold_except` was written downstream and **deleted**: introduced for three abstaining assertions that turned out to be **false rather than hard**, and the excuse made the abstention comfortable until they were restated decidably and all nine held.

`--expect name=unknown` is the sound version of the same wish — it pins the ⊥ as a **claim** that fails when the property becomes decidable. Not hypothetical: a downstream twin pinned `sva_1=UNKNOWN`, #503 made it decidable, and the gate failed on the next run. That's the outcome you want. The module comment records this so it isn't re-added as a convenience.

## Naming: not "contract"

`mununu contract` already exists — assume-guarantee tooling for black-box module interfaces, six subcommands. Reusing the word would collide with a shipped, unrelated concept. The surface is `--expect-*` / `Expectations` throughout.

## Exit codes

New **`4` = "a verdict was not what you claimed"**, and declaring an expectation **supersedes** `--fail-on`. That's required, not cosmetic: under `--expect-violated` the ordinary gate would exit 2 on the very violation the caller asked for, so a satisfied claim could never exit 0.

Validated end-to-end in `mununu-sva`, all eight cases as designed:

```
1. --expect-all-hold, design HAS a violated property     exit=4
2. --expect-violated names it correctly                  exit=0   <- would be 2 unsuperseded
3. --expect-violated names the WRONG one                 exit=4
4. --expect-count 5 but there are 2                      exit=4
5. --expect-count 2, correct                             exit=0
6. malformed NAME=VERDICT (usage error)                  exit=1
7. no expect flags: ordinary verdict gate applies        exit=2
8. exact named claims that match                         exit=0
```

Cases **2 and 7 together** are the point: the supersede works, and nothing changes for anyone not using the flags.

The JSON names *which* claim failed, so no consumer parses prose:

```json
{ "satisfied": false, "failures": [
    { "property": "e537_sva_1", "reason": "expected holds, got violated (1 cell(s))" } ] }
```

## Tests

`evaluate()` is **pure** in `(report, expectations)`, so the whole semantics is unit-tested with no toolchain: **18 tests**, each verb with a **negative control** — an evaluator that always returned "satisfied" would pass every positive test. **Mutation-tested twice**: disabling the unnamed-VIOLATED rule fails exactly one test; an always-satisfied evaluator fails **11 of 18**.

Plus 4 CLI arg-parsing tests, including that a malformed pair is a usage error rather than a silently dropped claim — a claim that doesn't run gates on nothing.

## ⚠️ Binding-rule change: Surface Parity

User-directed, shipped here because this is the first feature it governs.

**CLI + HTTP API for every capability; UI parity only for CTXDSL-related ones** — those whose *subject* is a CTXDSL model. RTL/SVA verbs, contract tooling and CI-gate ergonomics are CLI+API, and a missing UI affordance for them is **no longer drift**. A UI control for "assert this run produced exactly these verdicts" would be an affordance with no user.

This removes the obligation to **grow** UI for non-CTXDSL work; it removes no existing UI. `CLAUDE.md` and `.claude/skills/parity-check/SKILL.md` are updated **together** so the rule and its enforcement can't drift apart — `/parity-check` now marks such rows `n/a`. Run against this change: **0 drift**.

Briefing: `docs/consumer-briefings/2026-09-verdict-expectations.md` — with the concrete before/after for a real consumer block and the two workarounds they can now delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)