### PR TITLE
fix: an engine budget abstention is a verdict, not a panic or a skip (closes mununu#542)

### DIFF
--- a/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs
@@ -973,6 +973,13 @@ impl BddBitBlaster {
         let k = pred_bdds.len();
 
         // Allocate 2k fresh predicate vars at the bottom of the order: p_i then p'_i.
+        //
+        // mununu#542 — the two `BDDFunction::var(..).unwrap()` below are the only `unwrap`s left
+        // in this function. Each allocates ONE node for a fresh variable: O(1), independent of the
+        // cone, and done at entry before any wide operation has grown the arena. They also sit
+        // inside `with_manager_exclusive`, whose closure returns a tuple rather than a `Result`, so
+        // propagating would mean restructuring the allocation for a case that cannot realistically
+        // arise. Every cone-sized operation below propagates via `oom`.
         let (present, next, present_varnos) = self._manager.with_manager_exclusive(|m| {
             let range = m.add_vars(2 * k as VarNo);
             let present: Vec<BDDFunction> = (0..k)
@@ -987,7 +994,7 @@ impl BddBitBlaster {
         // The cube of next predicate vars (to quantify out in a preimage).
         let mut next_cube = self.tt.clone();
         for v in &next {
-            next_cube = next_cube.and(v).unwrap();
+            next_cube = oom(next_cube.and(v))?;
         }
 
         // The present→next substitution: each register bit var ↦ its
@@ -1018,18 +1025,18 @@ impl BddBitBlaster {
             let is_ctrl = !cell.is_state && controllable.is_some_and(|c| c.contains(&cell.symbol));
             for v in &cell.vars {
                 if cell.is_state {
-                    reg_cube = reg_cube.and(v).unwrap();
+                    reg_cube = oom(reg_cube.and(v))?;
                 } else {
-                    input_cube = input_cube.and(v).unwrap();
+                    input_cube = oom(input_cube.and(v))?;
                     if is_ctrl {
-                        ctrl_cube = ctrl_cube.and(v).unwrap();
+                        ctrl_cube = oom(ctrl_cube.and(v))?;
                     } else {
-                        env_cube = env_cube.and(v).unwrap();
+                        env_cube = oom(env_cube.and(v))?;
                     }
                 }
             }
         }
-        let xi_cube = reg_cube.and(&input_cube).unwrap();
+        let xi_cube = oom(reg_cube.and(&input_cube))?;
 
         // A(x, p) and A'(x, i, p').
         let mut a = self.tt.clone();
@@ -1039,8 +1046,7 @@ impl BddBitBlaster {
             let pred_next = if sub_vars.is_empty() {
                 pred.clone()
             } else {
-                pred.substitute(&Subst::new(sub_vars.clone(), sub_repl.clone()))
-                    .unwrap()
+                oom(pred.substitute(&Subst::new(sub_vars.clone(), sub_repl.clone())))?
             };
             // p_i ⟺ pred  and  p'_i ⟺ pred_next  (via XNOR).
             let iff_present = oom(self.xor(&present[i], &pred)?.not())?;
@@ -1050,9 +1056,9 @@ impl BddBitBlaster {
         }
 
         // R_may = ∃(x ∪ i). A ∧ A'   (fused relational product).
-        let r_may = a
-            .apply_exists(BooleanOperator::And, &a_prime, &xi_cube)
-            .unwrap();
+        // The widest operation in this function — the fused relational product over the whole
+        // (register ∪ input) cube. mununu#542: exhausting the arena here must ABSTAIN, not panic.
+        let r_may = oom(a.apply_exists(BooleanOperator::And, &a_prime, &xi_cube))?;
 
         // The FEASIBLE present cubes `∃x. A(x,p)` — the cubes some concrete
         // register state inhabits. Used to restrict `R_must` (below) and to scope
@@ -1060,7 +1066,7 @@ impl BddBitBlaster {
         // `reg_cube` (unchanged) — the two-player GAME relation depends on this
         // exact value; the input-predicate hazard is handled by disabling `R_must`
         // on the standard path (below), not by re-scoping `feasible_present`.
-        let feasible_present = a.exists(&reg_cube).unwrap();
+        let feasible_present = oom(a.exists(&reg_cube))?;
 
         // SOUNDNESS (must ⊆ may fix, symbolic engine) — must-edges are DISABLED
         // (may-only, `r_must = None`) when a predicate is over an INPUT.
@@ -1083,30 +1089,29 @@ impl BddBitBlaster {
         // inputs explicitly as env/ctrl moves and *requires* `r_must` for the
         // controllable predecessor (`AbstractRelation::evaluate`); it does not go
         // through the box_pre panic, so it keeps its must-relation unchanged.
-        let inputs_in_predicates = feasible_present != a.exists(&xi_cube).unwrap();
+        let inputs_in_predicates = feasible_present != oom(a.exists(&xi_cube))?;
         let r_must = if inputs_in_predicates && controllable.is_none() {
             None
         } else {
-            must.map(|sem| {
+            must.map(|sem| -> Result<BDDFunction, String> {
                 let raw = match sem {
                     MustSemantics::ForallExists => {
                         // ∀x. ( A(x,p) → ∃i. A'(x,i,p') )
-                        let exists_i = a_prime.exists(&input_cube).unwrap();
-                        a.not()
-                            .unwrap()
-                            .or(&exists_i)
-                            .unwrap()
-                            .forall(&reg_cube)
-                            .unwrap()
+                        //
+                        // mununu#542 was reported here: the `∃i` exhausted the arena and
+                        // `.unwrap()` panicked, which aborts on the unwind of the exhausted
+                        // manager (see `oom`) — exit 101/134 and NO report, where the engine
+                        // owes an abstention.
+                        let exists_i = oom(a_prime.exists(&input_cube))?;
+                        let not_a = oom(a.not())?;
+                        let implies = oom(not_a.or(&exists_i))?;
+                        oom(implies.forall(&reg_cube))?
                     }
                     MustSemantics::ForallForall => {
                         // ∀(x ∪ i). ( A(x,p) → A'(x,i,p') )
-                        a.not()
-                            .unwrap()
-                            .or(&a_prime)
-                            .unwrap()
-                            .forall(&xi_cube)
-                            .unwrap()
+                        let not_a = oom(a.not())?;
+                        let implies = oom(not_a.or(&a_prime))?;
+                        oom(implies.forall(&xi_cube))?
                     }
                 };
                 // A vacuously-empty (unsatisfiable) source cube yields `¬A ≡ ⊤`
@@ -1115,8 +1120,9 @@ impl BddBitBlaster {
                 // Intersecting with `feasible_present` keeps must-edges leaving
                 // only inhabited cubes, so `R_must ⊆ R_may` holds globally over
                 // the `2^k` cube space (the R-F5.4.1 evaluator relies on it).
-                raw.and(&feasible_present).unwrap()
+                oom(raw.and(&feasible_present))
             })
+            .transpose()?
         };
 
         // P2.5-F — retain the concrete game pieces when a controllable partition was requested.

--- a/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
+++ b/crates/mununu-core/src/adapter/btor2/symbolic_engine.rs
@@ -50,7 +50,10 @@ pub struct SymbolicCubeVerdicts {
 
 fn ir_err(message: String) -> AdapterError {
     AdapterError {
-        kind: AdapterErrorKind::IrConsistencyError,
+        // mununu#542 — a budget abstention (NODE / ITERATION / WALL-CLOCK / OxiDD OutOfMemory)
+        // must NOT arrive as an IR defect: `verify_auto`'s generic error arm maps that to
+        // `Skipped`, which no CI gate fails on. Classify it so it lands as `Unknown`.
+        kind: crate::adapter::classify_engine_error(&message, AdapterErrorKind::IrConsistencyError),
         message: format!("adapter/btor2/symbolic_engine: {message}"),
         location: None,
     }
@@ -318,6 +321,34 @@ pub fn symbolic_cegar_refine(
 
 #[cfg(test)]
 mod tests {
+    /// mununu#542 — the WIRING: this module converts every engine `String` error, so a budget
+    /// abstention must leave here already classified. `verify_auto`'s generic arm maps anything
+    /// else to `Skipped`, and no CI gate fails on `skipped`.
+    ///
+    /// This is the half that was missing. `verify_auto` already mapped
+    /// `ResourceBudgetExceeded → Unknown` (mununu#504), but nothing on the symbolic path ever
+    /// produced that kind — `ir_err` stamped `IrConsistencyError` on everything.
+    #[test]
+    fn ir_err_classifies_a_budget_abstention_as_a_budget_error() {
+        use crate::adapter::AdapterErrorKind;
+
+        let e = super::ir_err(
+            "symbolic bit-blaster: BDD arena exhausted (OxiDD OutOfMemory) — abstained on the \
+             NODE budget; the cone does not compress to a tractable BDD"
+                .to_string(),
+        );
+        assert_eq!(
+            e.kind,
+            AdapterErrorKind::ResourceBudgetExceeded,
+            "an arena exhaustion is an abstention, not an IR defect — it must reach verify_auto \
+             as `unknown`, never `skipped`"
+        );
+
+        // A genuine IR defect keeps its kind and so still maps to `Skipped` with its message.
+        let d = super::ir_err("predicate register not found in the cone".to_string());
+        assert_eq!(d.kind, AdapterErrorKind::IrConsistencyError);
+    }
+
     use super::*;
     use crate::adapter::btor2::predicate_expr::CmpOp;
     use crate::clts::{Clts, DefaultLabelIdx, DefaultStateIdx, TransitionModality, Tristate};

--- a/crates/mununu-core/src/adapter/mod.rs
+++ b/crates/mununu-core/src/adapter/mod.rs
@@ -443,6 +443,31 @@ pub enum AdapterErrorKind {
     ResourceBudgetExceeded,
 }
 
+/// mununu#542 — classify an ENGINE error message as a budget abstention or a real defect.
+///
+/// The BDD / predicate-cube engines signal failure with a `String`, and every *abstention*
+/// message carries an `abstained on the <NODE|ITERATION|WALL-CLOCK|BIT CAP> budget` marker (see
+/// [`crate::adapter::btor2::symbolic_bitblast`]'s `oom` helper and the budget checks) or names
+/// OxiDD's `OutOfMemory` directly.
+///
+/// Such a message is NOT a defect in the input — the design is fine, we stopped — so it must
+/// reach `verify_auto` as [`AdapterErrorKind::ResourceBudgetExceeded`], which maps to `Unknown`.
+/// Any other kind falls into `verify_auto`'s generic arm and becomes `Skipped`, and
+/// `ci_exit_code` does not fail on `skipped` — so a strict `--fail-on unknown` gate would go
+/// GREEN on a property the engine never decided. That is the same silent pass mununu#504
+/// removed for the wall-clock budget; this extends it to the engine's other budgets, which were
+/// still arriving as `IrConsistencyError`.
+pub fn classify_engine_error(message: &str, default: AdapterErrorKind) -> AdapterErrorKind {
+    /// Markers that identify an abstention rather than a defect. Kept as substrings because the
+    /// engine layer's error channel is `String`; a marker change must update this list.
+    const BUDGET_MARKERS: [&str; 2] = ["abstained on the", "OutOfMemory"];
+    if BUDGET_MARKERS.iter().any(|m| message.contains(m)) {
+        AdapterErrorKind::ResourceBudgetExceeded
+    } else {
+        default
+    }
+}
+
 impl fmt::Display for AdapterError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(loc) = &self.location {
@@ -690,6 +715,57 @@ pub fn auto_translate(
 
 #[cfg(test)]
 mod tests {
+    /// mununu#542 — an engine BUDGET abstention must be classified `ResourceBudgetExceeded`, so
+    /// `verify_auto` maps it to `Unknown`.
+    ///
+    /// Before this, every engine error — including the NODE / ITERATION / WALL-CLOCK budget
+    /// abstentions and OxiDD's `OutOfMemory` — arrived as `IrConsistencyError` and fell into
+    /// `verify_auto`'s generic arm, which yields `Skipped`. `ci_exit_code` never fails on
+    /// `skipped`, so a strict `--fail-on unknown` gate went GREEN on a property the engine had
+    /// explicitly abstained on. mununu#504 removed that silent pass for the wall-clock budget at
+    /// the `verify_auto` seam; the engine's own budgets were still arriving misclassified.
+    #[test]
+    fn an_engine_budget_abstention_is_a_budget_error_not_an_ir_defect() {
+        use super::{AdapterErrorKind, classify_engine_error};
+
+        // Every abstention the engine can emit (cf. `symbolic_bitblast`'s `oom` helper and the
+        // NODE / ITERATION / WALL-CLOCK guards).
+        for msg in [
+            "symbolic bit-blaster: BDD arena exhausted (OxiDD OutOfMemory) — abstained on the \
+             NODE budget; the cone does not compress to a tractable BDD",
+            "abstained on the ITERATION budget",
+            "abstained on the WALL-CLOCK budget",
+            "abstained on the BIT CAP",
+            "called `Result::unwrap()` on an `Err` value: OutOfMemory",
+        ] {
+            assert_eq!(
+                classify_engine_error(msg, AdapterErrorKind::IrConsistencyError),
+                AdapterErrorKind::ResourceBudgetExceeded,
+                "abstention must reach verify_auto as a budget error, else it becomes \
+                 `Skipped` and no CI gate fails on it: {msg}"
+            );
+        }
+    }
+
+    /// ...and the special case stays NARROW: a real defect keeps its kind, so it still maps to
+    /// `Skipped` with its message. Widening this would hide genuine input defects as `unknown`.
+    #[test]
+    fn a_real_engine_defect_keeps_its_kind() {
+        use super::{AdapterErrorKind, classify_engine_error};
+
+        for msg in [
+            "adapter/btor2: operator Read unsupported in Phase 1 bit-blaster",
+            "label intern failed",
+            "builder.build failed",
+        ] {
+            assert_eq!(
+                classify_engine_error(msg, AdapterErrorKind::IrConsistencyError),
+                AdapterErrorKind::IrConsistencyError,
+                "a defect must NOT be laundered into a budget abstention: {msg}"
+            );
+        }
+    }
+
     use super::detect_format_by_extension;
     use std::path::Path;
 

--- a/docs/consumer-briefings/2026-09-engine-budget-abstention-is-unknown.md
+++ b/docs/consumer-briefings/2026-09-engine-budget-abstention-is-unknown.md
@@ -1,0 +1,93 @@
+# Consumer briefing — 2026-09 an engine budget abstention is `unknown`, not `skipped` (and an OOM no longer panics)
+
+> **Audience:** monono (reported it — ask 25), ROSF, and any consumer that reads `sv verify-auto` outcomes or gates on its exit code.
+>
+> **Provenance:** [mununu#542](https://github.com/Mumunu-team/mununu/issues/542). Extends [mununu#504](https://github.com/Mumunu-team/mununu/issues/504)'s wall-clock rule to the engine's other budgets. Policy: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## ⚠ TL;DR — this can turn a GREEN gate RED, and that is the fix
+
+Two changes, one root:
+
+1. **A bit-blaster OOM used to PANIC** — exit 101, no report at all. It now abstains.
+2. **Every engine budget abstention used to arrive as `skipped`.** It is now `unknown`.
+
+`ci_exit_code` fails on `unknown` and never on `skipped`. So a strict `--fail-on unknown` gate that was **passing** on a property the engine had explicitly abstained on will now **fail**. That is correct: the property was never decided. If a gate goes red on this upgrade, the property was not being verified before either — you are seeing it for the first time, not breaking it.
+
+## What changed
+
+### 1. The OOM panic
+
+```
+thread 'main' panicked at crates/mununu-core/src/adapter/btor2/symbolic_bitblast.rs:1094:68:
+called `Result::unwrap()` on an `Err` value: OutOfMemory
+```
+
+Exit 101, **no report**. monono's report: the design verifies under the same pins; a twin adds one register and the cone stops fitting.
+
+The site was the `MustSemantics::ForallExists` must-edge `∃i` existential in `abstract_relation_impl`. Every cone-sized BDD operation in that function now propagates through the existing `oom` helper instead of `unwrap`-ing. The only `unwrap`s left there allocate a single fresh variable each — O(1), at function entry — and carry a comment saying so.
+
+**Why it panicked there specifically, and not elsewhere:** the engine's node-budget guard is a *start-of-op* check inside `eval_op`, and the arena is deliberately sized **above** the budget so the guard fires first and returns cleanly. The must-relation construction calls OxiDD directly (`exists` / `not` / `or` / `forall`) and never passes through `eval_op`, so it had no guard and no propagation.
+
+**Why a panic here was so damaging:** a panic while an OxiDD manager is exhausted aborts on the unwind — `catch_unwind` cannot save it. So this could surface as exit 101 *or* exit 134.
+
+### 2. The misclassification (the wider half)
+
+`symbolic_engine::ir_err` stamped `IrConsistencyError` on **every** engine error, including the deliberate abstentions:
+
+- `abstained on the NODE budget`
+- `abstained on the ITERATION budget`
+- `abstained on the WALL-CLOCK budget`
+- `abstained on the BIT CAP`
+
+`verify_auto`'s generic error arm maps any non-budget error to `Skipped`. So the engine said "I abstained" and the report said "not attempted" — and no CI gate fails on `skipped`.
+
+`AdapterErrorKind::ResourceBudgetExceeded` and its `→ Unknown` mapping already existed (#504) — **nothing on the symbolic path ever produced that kind.** A new `classify_engine_error` closes it. The special case stays narrow: a genuine defect (an unsupported operator, a failed intern) keeps its kind and still maps to `skipped` with its message.
+
+## What to update, per consumer
+
+### monono
+
+- **Expect new `unknown`s.** Any property whose engine abstained on a budget was reported `skipped` and is now `unknown`. Re-run and re-pin: `--expect NAME=unknown` is the sound way to record one.
+- **The six dead twins.** Your `expect_violated` reported `"1 violated as required"` on a run that produced no verdict lines. After this change that run yields a parseable report with `unknown`, so the comparison has something to iterate over. **The harness lesson stands independently:** a run producing zero verdict lines should fail your gate regardless of exit code — belt and braces.
+- **`MUNUNU_VERIFY_AUTO_PARTIAL_JSON` already does what you need — verified, no change required.** It flushes at the **top** of each property iteration, before that property's (possibly fatal) work. A death during property *N* leaves records for `0..N-1` on disk. Read the **last** record per property name.
+- **Your exit-134s are tracked separately** at [mununu#543](https://github.com/Mumunu-team/mununu/issues/543) and are **not** closed by this change. Your hypothesis that they share a root is plausible and now cheaper to test: if raising `MUNUNU_BDD_ARENA_NODES` removes them, they were this bug; if raising `RUST_MIN_STACK` removes them, they are genuine recursion. One knob at a time, ≥3 runs each given the reported flakiness.
+
+### ROSF
+
+- The `mununu` lane maps `holds | violated | unknown | skipped` 1:1, so **no code change** — but the *distribution* shifts: fewer `skipped`, more `unknown`. Any dashboard or threshold keyed on `skipped` counts will move.
+- rosf already treats a timeout as `unknown` rather than `skipped` for exactly this reason, so the semantics now agree end to end.
+
+### Report-parsing impact
+
+No shape change. `PropertyVerdict` fields, the JSON schema, and the outcome vocabulary are all unchanged — only which of the four a budget abstention lands on. No schema regeneration was needed and the drift detector is untouched.
+
+## Docker rebuild disposition
+
+| Image | Impact | Rebuild required? |
+|---|---|---|
+| `mununu` (prod) | verdict values: budget abstention `skipped` → `unknown`; OOM no longer exits 101 | **Yes** |
+| `mununu-dev` | test/lint image; carries the new unit tests | **Yes** |
+| `mununu-sva` | extends `mununu-dev`; same verdict change on the SVA path | **Yes** |
+| `mununu-sva-pono` | extends the above | **Yes** |
+| `rosf` (runtime) | bundles its own mununu; rebuild to pick up the verdict change | **Yes** |
+| `rosf-dev` | no mununu inside | No |
+| `hw-verif` | Verilator only, no mununu | No |
+
+## Test the transition
+
+```bash
+# 1. A budget abstention is now `unknown`, and the classification is locked in both directions.
+cargo test -p mununu-core --lib -- adapter::tests::an_engine_budget \
+  adapter::tests::a_real_engine adapter::btor2::symbolic_engine::tests::ir_err
+
+# 2. Re-run any corpus that previously reported `skipped`, and diff the outcome column.
+#    A property moving skipped -> unknown is this change. A property moving either of those to
+#    holds/violated is NOT, and is worth reporting.
+```
+
+## Not covered here
+
+- **[#543](https://github.com/Mumunu-team/mununu/issues/543)** — the exit-134 triage. Open.
+- **[#544](https://github.com/Mumunu-team/mununu/issues/544)** — naming a property by its SVA label instead of its index. Open; ships separately and *will* change the report shape.
+- **[#545](https://github.com/Mumunu-team/mununu/issues/545)** — a cutpoint that frees an array read's value but keeps its timing. Open; design work.
+- **Forcing a real arena exhaustion from a unit test.** The arena is deliberately sized above the node budget so the guard fires first, which makes a genuine OxiDD `OutOfMemory` unreachable from a unit test. The propagation is therefore verified by inspection — no cone-sized `unwrap` remains in the function, and the two O(1) exceptions are annotated — plus the two classification tests above. **Stated because it matters: the no-panic property itself is not covered by an automated test.** The end-to-end evidence is monono's original report and the absence of the `unwrap`.


### PR DESCRIPTION
Closes #542.

**Filed from monono (their ask 25), and their ordering was right: this is close to a one-line change and it prevents the worst failure mode they hit this week.**

## Two fixes, one root

### 1. The panic

An OOM in the predicate-cube bit-blaster panicked — exit **101, no report at all** — where the engine owes an abstention. monono gated on that path: their comparison loop had no verdict lines to iterate over, reported `"1 violated as required"`, and **six twins were green while never running**.

The site was the `MustSemantics::ForallExists` must-edge `∃i` in `abstract_relation_impl`. The `oom` helper was already in that file, and its own comment already said why an `unwrap` there is unsafe — a panic while the OxiDD manager is exhausted aborts on the unwind, and `catch_unwind` cannot save it. **This was missing coverage, not a missing idea:** #462 swept `bit_blast.rs` for this class and never reached `symbolic_bitblast.rs`.

**Why that function and not elsewhere:** the node-budget guard is a start-of-op check inside `eval_op`, and the arena is deliberately sized *above* the budget so the guard fires first and returns cleanly. The must-relation construction calls OxiDD directly (`exists` / `not` / `or` / `forall`) and never passes through `eval_op` — so it had neither guard nor propagation. Every cone-sized op there now propagates. The two `unwrap`s left allocate one fresh variable each (O(1), at entry) and say so.

### 2. The misclassification — wider than the report

`symbolic_engine::ir_err` stamped `IrConsistencyError` on **every** engine error, including the deliberate abstentions: NODE, ITERATION, WALL-CLOCK, BIT CAP. `verify_auto`'s generic arm maps those to `Skipped`, and `ci_exit_code` never fails on `skipped`.

So the engine said *"I abstained"* and the report said *"not attempted"*, and a strict `--fail-on unknown` gate went **green on a property nobody had decided**.

`ResourceBudgetExceeded` and its `→ Unknown` mapping already existed from #504 — **nothing on the symbolic path ever produced that kind.** `classify_engine_error` closes it, narrowly: a genuine defect keeps its kind and still maps to `skipped` with its message.

## ⚠ This changes verdict values

A budget abstention that read `skipped` now reads `unknown`, which a strict gate fails on. **That is the point** — if a consumer's gate goes red on this, the property was not being verified before either. Consumer briefing ships in this PR: `docs/consumer-briefings/2026-09-engine-budget-abstention-is-unknown.md`, with the Docker-rebuild table.

## Verification boundary, stated because it matters more than the count

**The no-panic property itself is NOT covered by an automated test.** The arena is sized above the node budget precisely so the guard fires first, which makes a genuine OxiDD `OutOfMemory` unreachable from a unit test. Propagation is verified by inspection — no cone-sized `unwrap` remains in the function, and the two O(1) exceptions are annotated.

The **classification** — the half that silently passed gates — is covered in both directions by three new tests: the classifier on all five abstention markers, a real defect keeping its kind, and `ir_err`'s wiring.

## Also verified, no change needed

`MUNUNU_VERIFY_AUTO_PARTIAL_JSON` (#504 C7) already flushes at the **top** of each property iteration, before that property's work — so the breadcrumb survives a death mid-property. Item 4 of the issue was already satisfied. That is the mitigation to hand consumers until this is deployed.

## Not in scope

- **#543** — monono's exit-134 aborts on three blocks. Their shared-root hypothesis is plausible and now cheaper to test (arena knob vs `RUST_MIN_STACK`, one at a time), but unproven, so it stays open.
- **#544**, **#545** — their asks 22 and 24.

`make ci`: **3135 tests, green.** Pre-commit hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
