### PR TITLE
feat: name a property by its SVA label, not only its index (closes mununu#544)

### DIFF
--- a/crates/mununu-cli/src/main.rs
+++ b/crates/mununu-cli/src/main.rs
@@ -105,6 +105,13 @@ struct ExpectArgs {
     /// `NAME=unknown` is the sound way to record a ⊥: it pins the abstention as a CLAIM that
     /// fails when the property becomes decidable, rather than excusing it. That is the point —
     /// an upstream improvement should break the pin loudly, not pass in silence.
+    ///
+    /// mununu#544 — NAME may be the assertion's **SV label** (`a_reseed_only_at_a_span_edge`) or
+    /// its positional `<module>_sva_<index>`. **Prefer the label:** it is what the author wrote,
+    /// so a reorder is a no-op and a rename is a hard error. An index re-points on any
+    /// insertion mid-file, which fails silently — the pin still resolves, to a different
+    /// property. The label is tried first. `@mununu_guarantee` properties have no label and
+    /// stay positional (`ann_guarantee_<index>`).
     #[arg(long = "expect", value_name = "NAME=VERDICT", value_delimiter = ',')]
     expect: Vec<String>,
 }

--- a/crates/mununu-core/src/adapter/slang/expectations.rs
+++ b/crates/mununu-core/src/adapter/slang/expectations.rs
@@ -119,7 +119,19 @@ pub struct ExpectationResult {
 /// first, because a gate's output is read by someone deciding what to fix.
 pub fn evaluate(report: &AutoVerifyReport, exp: &Expectations) -> ExpectationResult {
     let mut failures = Vec::new();
-    let find = |name: &str| report.properties.iter().find(|p| p.name == name);
+    // mununu#544 — a claim may name a property by its SV **label** or by its positional
+    // `<module>_sva_<index>` name. Matching either is deliberately migration-safe: a consumer
+    // holding index-based pins keeps working on upgrade and can move to labels one property at a
+    // time, instead of in one cut. The label is tried FIRST so that a design where a label
+    // happens to collide with another property's positional name resolves to what the author
+    // wrote.
+    let find = |name: &str| {
+        report
+            .properties
+            .iter()
+            .find(|p| p.label.as_deref() == Some(name))
+            .or_else(|| report.properties.iter().find(|p| p.name == name))
+    };
 
     // --- the count ------------------------------------------------------------------
     // Checked first and independently: a property that silently stopped being produced is
@@ -277,6 +289,26 @@ mod tests {
                 .iter()
                 .map(|(name, outcome)| PropertyVerdict {
                     name: (*name).to_string(),
+                    label: None,
+                    kind: SvaKind::Assert,
+                    formula: format!("formula::{name}"),
+                    outcome: outcome.clone(),
+                    seeded_predicates: Vec::new(),
+                    counterexample: None,
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// A report whose properties carry BOTH a positional name and an SV label.
+    fn labelled_report(props: &[(&str, &str, VerifyOutcome)]) -> AutoVerifyReport {
+        AutoVerifyReport {
+            properties: props
+                .iter()
+                .map(|(name, label, outcome)| PropertyVerdict {
+                    name: (*name).to_string(),
+                    label: Some((*label).to_string()),
                     kind: SvaKind::Assert,
                     formula: format!("formula::{name}"),
                     outcome: outcome.clone(),
@@ -585,6 +617,65 @@ mod tests {
             res.failures.len(),
             3,
             "one count failure + two property failures"
+        );
+    }
+    /// mununu#544 — a claim may name a property by its SV LABEL.
+    ///
+    /// monono measured `--expect "a_reseed_only_at_a_span_edge=holds"` exiting 4 while the
+    /// positional `affine_spr_sva_sva_0` exited 0 on the same run. The label is what the author
+    /// wrote, so it survives a reorder; the index re-points on any insertion.
+    #[test]
+    fn a_claim_can_name_a_property_by_its_sv_label() {
+        let r = labelled_report(&[
+            (
+                "m_sva_0",
+                "a_reseed_only_at_a_span_edge",
+                VerifyOutcome::Holds,
+            ),
+            ("m_sva_1", "a_other", VerifyOutcome::Holds),
+        ]);
+        let res = evaluate(
+            &r,
+            &named(&[("a_reseed_only_at_a_span_edge", ExpectedVerdict::Holds)]),
+        );
+        assert!(
+            res.failures.is_empty(),
+            "the label must resolve: {:?}",
+            res.failures
+        );
+    }
+
+    /// ...and the POSITIONAL name keeps working, which is what makes an upgrade safe for a
+    /// consumer holding index-based pins: they migrate property-by-property, not in one cut.
+    #[test]
+    fn a_claim_by_positional_name_still_resolves_after_labels_land() {
+        let r = labelled_report(&[(
+            "m_sva_0",
+            "a_reseed_only_at_a_span_edge",
+            VerifyOutcome::Holds,
+        )]);
+        let res = evaluate(&r, &named(&[("m_sva_0", ExpectedVerdict::Holds)]));
+        assert!(
+            res.failures.is_empty(),
+            "an existing index pin must not break on upgrade: {:?}",
+            res.failures
+        );
+    }
+
+    /// A RENAME is now a hard error rather than a silent re-point — the whole point of the ask.
+    /// Before labels, renaming an assertion left its index intact, so the pin kept passing while
+    /// naming a different property than the author intended.
+    #[test]
+    fn a_renamed_label_fails_the_claim_instead_of_silently_re_pointing() {
+        let r = labelled_report(&[("m_sva_0", "a_renamed_by_someone", VerifyOutcome::Holds)]);
+        let res = evaluate(
+            &r,
+            &named(&[("a_reseed_only_at_a_span_edge", ExpectedVerdict::Holds)]),
+        );
+        assert_eq!(
+            res.failures.len(),
+            1,
+            "a claim naming a label that no longer exists must FAIL"
         );
     }
 }

--- a/crates/mununu-core/src/adapter/slang/translate.rs
+++ b/crates/mununu-core/src/adapter/slang/translate.rs
@@ -75,10 +75,17 @@ pub enum SvaKind {
 /// A successfully-translated assertion.
 #[derive(Debug, Clone)]
 pub struct TranslatedAssertion {
-    /// Best-effort name: `<module>_sva_<index>` (slang's `--ast-json` does not
-    /// attach the SV label to the assertion node — the label lives on a separate
-    /// symbol-table entry; XL.1c can recover it).
+    /// Positional name: `<module>_sva_<index>`. Stable within one run, but an insertion
+    /// mid-file re-points every later name — see [`Self::label`], which does not move.
     pub name: String,
+    /// mununu#544 — the assertion's SV **label**, when it has one.
+    ///
+    /// The label is what a human wrote (`a_reseed_only_at_a_span_edge:`), so it survives a
+    /// reorder and a rename becomes a hard error instead of a silent re-point. Consumers should
+    /// prefer it over [`Self::name`] when pinning an expectation.
+    ///
+    /// `None` for a genuinely unlabelled assertion, which keeps only its positional name.
+    pub label: Option<String>,
     pub kind: SvaKind,
     /// mu-calculus formula; guaranteed to parse via
     /// [`crate::mu_calculus::parser::parse`].
@@ -202,8 +209,8 @@ pub fn translate_ast_json_with_options(
         })?
     };
 
-    let mut found: Vec<(String, &Value)> = Vec::new();
-    collect_assertions(&root, "design", &mut found);
+    let mut found: Vec<(String, Option<String>, &Value)> = Vec::new();
+    collect_assertions(&root, "design", None, &mut found);
 
     // XL.6b follow-up — enum-constant resolution. slang keeps an enum-member
     // reference (e.g. `MainSmError`) as a `NamedValue`, NOT folded to its value,
@@ -213,8 +220,9 @@ pub fn translate_ast_json_with_options(
     let enum_values = collect_enum_values(&root);
 
     let mut report = TranslationReport::default();
-    for (idx, (module, node)) in found.iter().enumerate() {
+    for (idx, (module, label, node)) in found.iter().enumerate() {
         let name = format!("{module}_sva_{idx}");
+        let label = label.clone();
         let kind = match node.get("assertionKind").and_then(Value::as_str) {
             Some("Assert") => SvaKind::Assert,
             Some("Assume") => SvaKind::Assume,
@@ -252,6 +260,7 @@ pub fn translate_ast_json_with_options(
                 collect_shadow_signals(spec, &mut report.required_shadows);
                 report.translated.push(TranslatedAssertion {
                     name,
+                    label,
                     kind,
                     formula,
                     recoverability_companion,
@@ -299,11 +308,45 @@ fn collect_parameter_names(node: &Value, out: &mut Vec<String>) {
 
 /// Recursively collect `ConcurrentAssertion` nodes, tracking the nearest
 /// enclosing `name` (the module) for a best-effort assertion name.
-fn collect_assertions<'a>(node: &'a Value, enclosing: &str, out: &mut Vec<(String, &'a Value)>) {
+/// mununu#544 — recover an assertion's SV label from slang's `--ast-json`.
+///
+/// The label is NOT a field on the `ConcurrentAssertion` node, which carries only
+/// `assertionKind` / `ifTrue` / `kind` / `propertySpec` — which is why it was once believed
+/// absent. slang emits a labelled statement as an enclosing `Block` whose `block` field is the
+/// symbol-table entry, rendered as `"<address> <label>"`:
+///
+/// ```text
+/// ProceduralBlock → body: Block { block: "6338700059712 ap_bool", body: ConcurrentAssertion }
+/// ```
+///
+/// So the nearest enclosing `Block` names the assertion. Returns `None` when the field carries
+/// no identifier tail — an UNLABELLED assertion, whose tail is the bare address. A leading digit
+/// is a reliable discriminator because an SV identifier cannot start with one.
+fn block_label(block: &str) -> Option<String> {
+    let tail = block.rsplit(' ').next()?;
+    let mut chars = tail.chars();
+    let first = chars.next()?;
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return None;
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$') {
+        return None;
+    }
+    Some(tail.to_string())
+}
+
+/// Collect every `ConcurrentAssertion`, with the module that encloses it and its SV label (see
+/// [`block_label`]) when it has one.
+fn collect_assertions<'a>(
+    node: &'a Value,
+    enclosing: &str,
+    label: Option<&str>,
+    out: &mut Vec<(String, Option<String>, &'a Value)>,
+) {
     match node {
         Value::Object(map) => {
             if map.get("kind").and_then(Value::as_str) == Some("ConcurrentAssertion") {
-                out.push((enclosing.to_string(), node));
+                out.push((enclosing.to_string(), label.map(str::to_string), node));
             }
             // Update the enclosing name for descendants when this node names one.
             let next = map
@@ -311,13 +354,23 @@ fn collect_assertions<'a>(node: &'a Value, enclosing: &str, out: &mut Vec<(Strin
                 .and_then(Value::as_str)
                 .filter(|s| !s.is_empty())
                 .unwrap_or(enclosing);
+            // A `Block` carrying a symbol-table entry re-labels its descendants; the NEAREST
+            // enclosing one wins, so a nested block shadows an outer label rather than leaking it.
+            let owned = (map.get("kind").and_then(Value::as_str) == Some("Block"))
+                .then(|| {
+                    map.get("block")
+                        .and_then(Value::as_str)
+                        .and_then(block_label)
+                })
+                .flatten();
+            let next_label = owned.as_deref().or(label);
             for v in map.values() {
-                collect_assertions(v, next, out);
+                collect_assertions(v, next, next_label, out);
             }
         }
         Value::Array(items) => {
             for v in items {
-                collect_assertions(v, enclosing, out);
+                collect_assertions(v, enclosing, label, out);
             }
         }
         _ => {}
@@ -2515,6 +2568,78 @@ mod tests {
             "== is an XNOR expansion: {xnor}"
         );
         assert_ne!(xor, xnor, "XOR and XNOR expansions differ");
+    }
+
+    /// mununu#544 — every labelled assertion recovers the label its author wrote.
+    ///
+    /// monono's measurement: `--expect "a_reseed_only_at_a_span_edge=holds"` exited 4 while
+    /// `--expect "affine_spr_sva_sva_0=holds"` exited 0 on the same run — the index was the only
+    /// name that worked, so inserting a property mid-file silently re-pointed every later pin.
+    ///
+    /// The label was believed unavailable: it is not a field on the `ConcurrentAssertion` node.
+    /// It is on the enclosing `Block`, as `"<address> <label>"`.
+    #[test]
+    fn an_assertions_sv_label_is_recovered_from_the_enclosing_block() {
+        for (json, want) in [
+            (
+                TIER1_JSON,
+                vec!["ap_bool", "ap_impl", "ap_nimpl", "ap_assume", "cp_cover"],
+            ),
+            (
+                TIER2_JSON,
+                vec!["ap_stable", "ap_changed", "ap_rose", "ap_fell", "ap_past"],
+            ),
+        ] {
+            let report = translate_ast_json(json).expect("valid ast-json");
+            let got: Vec<String> = report
+                .translated
+                .iter()
+                .map(|t| {
+                    t.label
+                        .clone()
+                        .unwrap_or_else(|| panic!("{} recovered no label", t.name))
+                })
+                .collect();
+            assert_eq!(got, want, "labels must come back in source order");
+
+            // The positional name still exists alongside it — that is what keeps an upgrade
+            // migration-safe for a consumer holding index-based pins.
+            for (idx, t) in report.translated.iter().enumerate() {
+                assert!(
+                    t.name.ends_with(&format!("_sva_{idx}")),
+                    "positional name must survive: {}",
+                    t.name
+                );
+            }
+        }
+    }
+
+    /// ...and the extractor does not invent one. An UNLABELLED assertion's `Block` carries the
+    /// bare address, whose tail is all digits — and an SV identifier cannot start with a digit,
+    /// so that is a sound discriminator. Fabricating a label here would be worse than having
+    /// none: a consumer would pin to an address that changes every elaboration.
+    #[test]
+    fn an_unlabelled_assertion_gets_no_label_rather_than_an_address() {
+        assert_eq!(
+            super::block_label("6338700059712 ap_bool").as_deref(),
+            Some("ap_bool")
+        );
+        assert_eq!(
+            super::block_label("6338700059712"),
+            None,
+            "bare address is not a label"
+        );
+        assert_eq!(super::block_label(""), None);
+        assert_eq!(
+            super::block_label("6338700059712 9bad"),
+            None,
+            "cannot start with a digit"
+        );
+        assert_eq!(
+            super::block_label("6338700059712 a_reseed_only_at_a_span_edge").as_deref(),
+            Some("a_reseed_only_at_a_span_edge"),
+            "monono's actual label shape"
+        );
     }
 
     #[test]

--- a/crates/mununu-core/src/adapter/slang/verify_auto.rs
+++ b/crates/mununu-core/src/adapter/slang/verify_auto.rs
@@ -190,7 +190,13 @@ impl VerifyOutcome {
 /// One assertion's auto-verification result.
 #[derive(Debug, Clone)]
 pub struct PropertyVerdict {
+    /// Positional name: `<module>_sva_<index>` (or `ann_guarantee_<index>`). An insertion
+    /// mid-file re-points every later one — prefer [`Self::label`] when pinning.
     pub name: String,
+    /// mununu#544 — the assertion's SV label, when it has one. Survives a reorder; a rename
+    /// becomes a hard error rather than a silent re-point. `None` for an unlabelled assertion
+    /// and for every `@mununu_guarantee` annotation (which carry no name today).
+    pub label: Option<String>,
     pub kind: SvaKind,
     pub formula: String,
     pub outcome: VerifyOutcome,
@@ -1518,7 +1524,15 @@ fn scan_annotation_properties(sources: &[(String, String)]) -> AnnotationScan {
                     match crate::mu_calculus::parser::parse(body) {
                         Ok(_) => {
                             scan.guarantees.push(TranslatedAssertion {
+                                // mununu#544 — RESIDUAL GAP, stated rather than papered over.
+                                // `@mununu_guarantee` properties are positional too
+                                // (`ann_guarantee_<idx>`), and carry no label because
+                                // `MununuAnnotation` has no name field — only `tag`, `value` and
+                                // `source_line`. So an insertion mid-file re-points these exactly
+                                // as it used to re-point SVA names. Giving the annotation an
+                                // optional name is a separate surface change.
                                 name: format!("ann_guarantee_{idx}"),
+                                label: None,
                                 kind: SvaKind::Assert,
                                 formula: body.to_string(),
                                 recoverability_companion: None,
@@ -1832,6 +1846,7 @@ fn synth_sidecar_json(
 fn abstained(t: &crate::adapter::slang::translate::TranslatedAssertion) -> PropertyVerdict {
     PropertyVerdict {
         name: t.name.clone(),
+        label: t.label.clone(),
         kind: t.kind,
         formula: t.formula.clone(),
         outcome: VerifyOutcome::Unknown { unknown_cells: 0 },
@@ -3020,6 +3035,7 @@ pub(crate) fn verify_auto_impl(
             Err(e) => {
                 report.properties.push(PropertyVerdict {
                     name: t.name.clone(),
+                    label: t.label.clone(),
                     kind: t.kind,
                     formula: formula_str.clone(),
                     outcome: VerifyOutcome::Skipped {
@@ -3103,6 +3119,7 @@ pub(crate) fn verify_auto_impl(
             };
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
+                label: t.label.clone(),
                 kind: t.kind,
                 formula: formula_str.clone(),
                 outcome: VerifyOutcome::Skipped {
@@ -3176,6 +3193,7 @@ pub(crate) fn verify_auto_impl(
             };
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
+                label: t.label.clone(),
                 kind: t.kind,
                 formula: formula_str.clone(),
                 outcome,
@@ -3238,6 +3256,7 @@ pub(crate) fn verify_auto_impl(
             let reason = unseedable_skip_reason(&seeded.unseedable, &report.diagnostics);
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
+                label: t.label.clone(),
                 kind: t.kind,
                 formula: formula_str.clone(),
                 outcome: VerifyOutcome::Skipped { reason },
@@ -3251,6 +3270,7 @@ pub(crate) fn verify_auto_impl(
         {
             report.properties.push(PropertyVerdict {
                 name: t.name.clone(),
+                label: t.label.clone(),
                 kind: t.kind,
                 formula: formula_str.clone(),
                 outcome: VerifyOutcome::Skipped {
@@ -3483,6 +3503,7 @@ pub(crate) fn verify_auto_impl(
         }
         report.properties.push(PropertyVerdict {
             name: t.name.clone(),
+            label: t.label.clone(),
             kind: t.kind,
             formula: formula_str.clone(),
             outcome,
@@ -4402,6 +4423,7 @@ mod tests {
                 .iter()
                 .map(|(name, outcome, cx)| PropertyVerdict {
                     name: name.to_string(),
+                    label: None,
                     kind: crate::adapter::slang::translate::SvaKind::Assert,
                     formula: format!("formula::{name}"),
                     outcome: outcome.clone(),
@@ -4432,6 +4454,7 @@ mod tests {
         use crate::adapter::slang::translate::SvaKind;
         let prop = |name: &str, formula: &str| PropertyVerdict {
             name: name.into(),
+            label: None,
             kind: SvaKind::Assert,
             formula: formula.into(),
             outcome: VerifyOutcome::Holds,
@@ -4495,6 +4518,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "big_zero".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu X. ((big == 0) && [] X)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -4534,6 +4558,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "cnt_ne_3".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu X. ((cnt != 3) && [] X)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -4646,6 +4671,7 @@ mod tests {
     fn abstained_marks_an_unreached_property_as_unknown_not_skipped() {
         let t = crate::adapter::slang::translate::TranslatedAssertion {
             name: "p1".into(),
+            label: None,
             kind: SvaKind::Assert,
             formula: "nu X. ([] X)".into(),
             recoverability_companion: None,
@@ -4668,6 +4694,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "no_deadlock".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu X.(<> true && [] X)".to_string(),
                 outcome: VerifyOutcome::Skipped {
@@ -4706,6 +4733,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "no_deadlock".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu X.(<> true && [] X)".to_string(),
                 outcome: VerifyOutcome::Skipped {
@@ -4744,6 +4772,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "recover".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 // AG EF (recoverability) — diamond inner, not an AG-invariant.
                 formula: "nu Y. ((mu X. ((big == 0) || <> X)) && [] Y)".to_string(),
@@ -4807,6 +4836,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "req_grant".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu Z. ((!(st == 1) || mu Y. ((st == 2) || [] Y)) && [] Z)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -4860,6 +4890,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "req_ack".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu Z. ((!(req == 1) || mu Y. ((ack == 1) || [] Y)) && [] Z)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -4896,6 +4927,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "req_ack".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu Z. ((!(req == 1) || mu Y. ((ack == 1) || [] Y)) && [] Z)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -4944,6 +4976,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "recover".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 // A νμ recoverability (`AG(a → EF b)`), NOT the box-AF shape the primitive expects.
                 formula: "nu Z. ((!(req == 1) || mu Y. ((ack == 1) || <> Y)) && [] Z)".to_string(),
@@ -4980,6 +5013,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "recover".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu Z. ((!(st == 1) || mu Y. ((st == 2) || <> Y)) && [] Z)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -5021,6 +5055,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "recover_idle".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu Y. ((mu X. ((st == 0) || <> X)) && [] Y)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -5064,6 +5099,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "recover_to_zero".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu Y.((mu X.(cnt == 0 || <> X)) && [] Y)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -5109,6 +5145,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "mem_router_exclusion".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu X. (((!(a == 1)) || (!(b == 1))) && [] X)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 2 },
@@ -5153,6 +5190,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "compound_with_relational_leaf".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 formula: "nu X. (((a == 1) && (b == c)) && [] X)".to_string(),
                 outcome: VerifyOutcome::Unknown { unknown_cells: 1 },
@@ -5190,6 +5228,7 @@ mod tests {
         let mut report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "vacuous_recoverability".to_string(),
+                label: None,
                 kind: crate::adapter::slang::translate::SvaKind::Assert,
                 // AG EF (a == 1) — recoverability on a stateless model.
                 formula: "nu Y. ((mu X. ((a == 1) || <> X)) && [] Y)".to_string(),
@@ -5908,6 +5947,7 @@ module uart_tx(); endmodule"#;
         let translated = vec![
             crate::adapter::slang::translate::TranslatedAssertion {
                 name: "m_sva_5".into(),
+                label: None,
                 kind: SvaKind::Assert,
                 // `cnt_q >= cfg_detect_timer_i` — the comparison that reveals the bound.
                 formula: "nu X. ((cnt_q >= cfg_detect_timer_i) && [] X)".into(),
@@ -5915,6 +5955,7 @@ module uart_tx(); endmodule"#;
             },
             crate::adapter::slang::translate::TranslatedAssertion {
                 name: "m_sva_13".into(),
+                label: None,
                 kind: SvaKind::Assert,
                 // The monotonicity property — needs the bound but never names cfg.
                 formula: "nu X. ((cnt_q >= cnt_q__past) && [] X)".into(),
@@ -5937,6 +5978,7 @@ module uart_tx(); endmodule"#;
             properties: vec![
                 PropertyVerdict {
                     name: "p_holds".into(),
+                    label: None,
                     kind: SvaKind::Assert,
                     formula: "nu X. (a && [] X)".into(),
                     outcome: VerifyOutcome::Holds,
@@ -5945,6 +5987,7 @@ module uart_tx(); endmodule"#;
                 },
                 PropertyVerdict {
                     name: "p_unknown".into(),
+                    label: None,
                     kind: SvaKind::Assert,
                     formula: "nu X. (b && [] X)".into(),
                     outcome: VerifyOutcome::Unknown { unknown_cells: 2 },
@@ -6166,6 +6209,7 @@ module uart_tx(); endmodule"#;
         let report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "p".into(),
+                label: None,
                 kind: SvaKind::Assert,
                 formula: "nu X. (a && [] X)".into(),
                 outcome: VerifyOutcome::Holds,
@@ -6218,6 +6262,7 @@ module uart_tx(); endmodule"#;
         let report = AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: "recover".into(),
+                label: None,
                 kind: SvaKind::Assert,
                 formula: "nu Y. ((mu X. (idle || <> X)) && [] Y)".into(),
                 outcome: VerifyOutcome::Holds,

--- a/crates/mununu-core/src/api/models.rs
+++ b/crates/mununu-core/src/api/models.rs
@@ -1900,6 +1900,7 @@ impl From<&crate::adapter::slang::verify_auto::AutoVerifyReport> for SvVerifyAut
                 };
                 PropertyVerdictView {
                     name: p.name.clone(),
+                    label: p.label.clone(),
                     kind: match p.kind {
                         SvaKind::Assert => "assert",
                         SvaKind::Assume => "assume",
@@ -2025,7 +2026,16 @@ pub struct ModelDiagnosticsView {
 /// One property's auto-verification verdict (mirrors `PropertyVerdict`).
 #[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct PropertyVerdictView {
+    /// Positional name: `<module>_sva_<index>` (or `ann_guarantee_<index>`). An insertion
+    /// mid-file re-points every later one — prefer `label` when pinning an expectation.
     pub name: String,
+    /// mununu#544 — the assertion's SV label, when it has one.
+    ///
+    /// This is what the author wrote (`a_reseed_only_at_a_span_edge:`), so it survives a reorder
+    /// and a rename becomes a hard error instead of a silent re-point. Absent for an unlabelled
+    /// assertion and for every `@mununu_guarantee` annotation (which carry no name today).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
     /// `"assert"` | `"assume"` | `"cover"`.
     pub kind: String,
     pub formula: String,

--- a/crates/mununu-core/src/api/schema.rs
+++ b/crates/mununu-core/src/api/schema.rs
@@ -203,6 +203,7 @@ mod tests {
             properties: vec![
                 PropertyVerdict {
                     name: "p_holds".into(),
+                    label: Some("a_holds_forever".into()),
                     kind: SvaKind::Assert,
                     formula: "nu X. (a && [] X)".into(),
                     outcome: VerifyOutcome::Holds,
@@ -211,6 +212,7 @@ mod tests {
                 },
                 PropertyVerdict {
                     name: "p_violated".into(),
+                    label: Some("c_cover_b".into()),
                     kind: SvaKind::Cover,
                     formula: "mu X. (b || <> X)".into(),
                     outcome: VerifyOutcome::Violated { false_cells: 3 },
@@ -224,6 +226,7 @@ mod tests {
                 },
                 PropertyVerdict {
                     name: "p_unknown".into(),
+                    label: None,
                     kind: SvaKind::Assume,
                     formula: "nu X. (c && [] X)".into(),
                     outcome: VerifyOutcome::Unknown { unknown_cells: 32 },
@@ -232,6 +235,7 @@ mod tests {
                 },
                 PropertyVerdict {
                     name: "p_skipped".into(),
+                    label: Some("a_wide_cone".into()),
                     kind: SvaKind::Assert,
                     formula: "nu X. (d && [] X)".into(),
                     outcome: VerifyOutcome::Skipped {

--- a/crates/mununu-core/src/planner/mod.rs
+++ b/crates/mununu-core/src/planner/mod.rs
@@ -796,6 +796,7 @@ mod tests {
         AutoVerifyReport {
             properties: vec![PropertyVerdict {
                 name: name.into(),
+                label: None,
                 kind: SvaKind::Assert,
                 formula: formula.into(),
                 outcome: VerifyOutcome::Skipped {
@@ -899,6 +900,7 @@ mod tests {
             properties: vec![
                 PropertyVerdict {
                     name: "p_wide".into(),
+                    label: None,
                     kind: SvaKind::Assert,
                     formula: "mu X.(big == 0 || <> X)".into(),
                     outcome: VerifyOutcome::Skipped {
@@ -912,6 +914,7 @@ mod tests {
                 },
                 PropertyVerdict {
                     name: "p_ok".into(),
+                    label: None,
                     kind: SvaKind::Assert,
                     formula: "big == 0".into(),
                     outcome: VerifyOutcome::Holds,

--- a/docs/api-schemas/sv-verify-auto-response.schema.json
+++ b/docs/api-schemas/sv-verify-auto-response.schema.json
@@ -211,7 +211,15 @@
           "description": "`\"assert\"` | `\"assume\"` | `\"cover\"`.",
           "type": "string"
         },
+        "label": {
+          "description": "mununu#544 — the assertion's SV label, when it has one.\n\nThis is what the author wrote (`a_reseed_only_at_a_span_edge:`), so it survives a reorder and a rename becomes a hard error instead of a silent re-point. Absent for an unlabelled assertion and for every `@mununu_guarantee` annotation (which carry no name today).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "name": {
+          "description": "Positional name: `<module>_sva_<index>` (or `ann_guarantee_<index>`). An insertion mid-file re-points every later one — prefer `label` when pinning an expectation.",
           "type": "string"
         },
         "outcome": {

--- a/docs/api-schemas/verdict.md
+++ b/docs/api-schemas/verdict.md
@@ -28,6 +28,7 @@ Read the figures from the structured fields, not from prose:
 
 | you want | read | not |
 |---|---|---|
+| which property this is | `properties[].label` (falls back to `.name`) | `properties[].name` alone — it is positional |
 | the verdict | `properties[].outcome` | the `[assert]` transcript line |
 | the ⊥ cell count | `properties[].unknown_cells` | `detail` (a sentence containing the number) |
 | the violated cell count | `properties[].false_cells` | `detail` |
@@ -89,7 +90,8 @@ Rust source: [`PropertyVerdictView`](../../crates/mununu-core/src/api/models.rs#
 
 ```jsonc
 {
-  "name":               "my_assertion",
+  "name":               "my_module_sva_0",    // POSITIONAL; re-points on an insertion
+  "label":              "my_assertion",        // the SV label; absent when unlabelled
   "kind":               "assert",              // "assert" | "assume" | "cover"
   "formula":            "nu X. ((!req || [] grant) && [] X)",  // mu-calc lift of the SVA
   "outcome":            "holds",               // canonical PropertyVerdict as-string
@@ -101,7 +103,15 @@ Rust source: [`PropertyVerdictView`](../../crates/mununu-core/src/api/models.rs#
 
 **Field-by-field:**
 
-- `name` — SVA label from the source (`assert property (foo) …` → `"foo"` when labelled).
+- `name` — **positional**: `<module>_sva_<index>`, or `ann_guarantee_<index>` for a
+  `@mununu_guarantee` annotation. *(Corrected in mununu#544: this field was previously documented
+  here as "SVA label from the source", which it never was. A consumer reasonably read that and
+  pinned an expectation to the label, which did not resolve.)* An insertion mid-file re-points
+  every later name, and the pin still resolves — to a different property. Prefer `label`.
+- `label` — mununu#544 — the assertion's **SV label**, when it has one (`a_reseed_only_at_a_span_edge:
+  assert property …` → `"a_reseed_only_at_a_span_edge"`). This is what the author wrote, so a
+  reorder is a no-op and a rename is a hard error. Absent for an unlabelled assertion and for
+  every `@mununu_guarantee` annotation. **`--expect NAME=VERDICT` accepts either**, label first.
 - `kind` — `"assert"` / `"assume"` / `"cover"`.
 - `formula` — the mu-calc string the engine actually evaluated. Round-trip-parseable via `mu_calculus::parser::parse`.
 - `outcome` — one of the four canonical `PropertyVerdict` values. This is the field to gate on.

--- a/docs/consumer-briefings/2026-09-sva-label-names.md
+++ b/docs/consumer-briefings/2026-09-sva-label-names.md
@@ -1,0 +1,93 @@
+# Consumer briefing — 2026-09 a property can be named by its SVA **label**, not just its index
+
+> **Audience:** monono (reported it — ask 22), ROSF, and any consumer that pins `--expect` or reads `properties[].name`.
+>
+> **Provenance:** [mununu#544](https://github.com/Mumunu-team/mununu/issues/544). Builds on [#537](https://github.com/Mumunu-team/mununu/issues/537) (`--expect*`) and [#536](https://github.com/Mumunu-team/mununu/issues/536) (the typed report). Policy: [`docs/policies/cross-repo-impact.md`](../policies/cross-repo-impact.md).
+
+## TL;DR
+
+`properties[]` now carries **`label`** — the assertion's SV label — alongside the positional `name`. `--expect NAME=VERDICT` accepts **either**, label first.
+
+**Nothing breaks.** Existing index-based pins keep resolving, deliberately, so you can migrate property-by-property instead of in one cut. The only additive change to the wire format is one optional field.
+
+## What was wrong
+
+`--expect` took the **positional** name. monono measured, on one run:
+
+| invocation | exit |
+|---|---|
+| `--expect "a_reseed_only_at_a_span_edge=holds"` | **4** |
+| `--expect "affine_spr_sva_sva_0=holds"` | **0** |
+
+So the index was load-bearing in a CI surface. Inserting a property mid-file silently re-points every later name — and the pin still *resolves*, to a different property. It happened to monono, and their gate caught it **by luck**: the newly-named property happened to hold in the twin.
+
+`--expect-count` (which they now pin for all 23 arities) catches the insertion case, because an insertion changes the count. It does not catch a property **replaced in place**: same count, different meaning.
+
+### Two of our own records were wrong, and one of them caused this
+
+1. **`docs/api-schemas/verdict.md` documented `name` as "SVA label from the source".** It never was. A consumer reading that would reasonably pin to the label and expect it to resolve — which is exactly what happened. **Corrected in this change.**
+2. **`translate.rs` said the label was unavailable** — *"slang's `--ast-json` does not attach the SV label to the assertion node — the label lives on a separate symbol-table entry."* The second half is wrong, and it made this ask look expensive. The label needs no symbol table: it is inline on the **enclosing `Block`** node, as `"<address> <label>"`. Verified against our own checked-in fixtures:
+
+```text
+ProceduralBlock → body: Block { block: "6338700059712 ap_bool", body: ConcurrentAssertion }
+```
+
+The `ConcurrentAssertion` node carries only `assertionKind` / `ifTrue` / `kind` / `propertySpec` — which is why it was believed absent. It is one level up.
+
+## What changed
+
+- `properties[].label` — the SV label, when the assertion has one. `null`/absent otherwise.
+- `properties[].name` — unchanged, still `<module>_sva_<index>`.
+- `--expect NAME=VERDICT` resolves `NAME` against the **label first**, then the positional name.
+- A **rename** is now a hard error instead of a silent re-point; a **reorder** is a no-op.
+
+## What to update, per consumer
+
+### monono
+
+- **Migrate your 23 pins to labels, at whatever pace suits.** Both spellings resolve, so a half-migrated set is fine. Once a property is pinned by label, an insertion or reorder cannot re-point it.
+- **Keep `--expect-count`.** It still catches a property that stopped being produced entirely, which no per-property pin can see.
+- **Residual gap, stated rather than papered over:** `@mununu_guarantee` properties have **no label** and stay positional (`ann_guarantee_<index>`), because `MununuAnnotation` carries only `tag`, `value` and `source_line` — no name field. If you pin annotation-derived properties, they remain index-fragile. Giving the annotation an optional name is a separate surface change; say the word and it gets an issue.
+
+### ROSF
+
+- The lane reads `properties[]` from the schema-pinned document, so **no code change is required** — the new field is optional and additive.
+- Worth adopting anyway: rosf's `[[queries]]` name properties, and binding those to labels rather than indices makes a corpus manifest robust against an upstream RTL edit.
+
+### Report-parsing impact
+
+**Additive only.** One new optional field (`label`), `skip_serializing_if = "Option::is_none"`, so a report with no labelled assertions is byte-identical to before. No field renamed, removed, or retyped. No verdict value changes. The JSON schema is regenerated in this change (`docs/api-schemas/sv-verify-auto-response.schema.json`) and the drift detector passes.
+
+## Docker rebuild disposition
+
+| Image | Impact | Rebuild required? |
+|---|---|---|
+| `mununu` (prod) | new `label` field + `--expect` accepts labels | **Yes** |
+| `mununu-dev` | test/lint image; carries the new tests | **Yes** |
+| `mununu-sva` | extends `mununu-dev`; this is the SVA path | **Yes** |
+| `mununu-sva-pono` | extends the above | **Yes** |
+| `rosf` (runtime) | bundles its own mununu; rebuild only when adopting labels | Optional |
+| `rosf-dev` | no mununu inside | No |
+| `hw-verif` | Verilator only | No |
+
+## Test the transition
+
+```bash
+# 1. The label is recovered, and the positional name still works.
+cargo test -p mununu-core --lib -- adapter::slang::translate::tests::an_assertions_sv_label \
+  adapter::slang::translate::tests::an_unlabelled \
+  adapter::slang::expectations::tests::a_claim_can_name \
+  adapter::slang::expectations::tests::a_claim_by_positional \
+  adapter::slang::expectations::tests::a_renamed_label
+
+# 2. On your own corpus: the label now appears, and BOTH spellings resolve.
+mununu sv verify-auto <design> --frontend slang --json | jq '.properties[] | {name, label}'
+mununu sv verify-auto <design> --frontend slang --expect "<your_label>=holds"   # exit 0
+```
+
+## Not covered here
+
+- **`@mununu_guarantee` labels** — the residual gap above. No issue yet; ask if you want one.
+- **[#543](https://github.com/Mumunu-team/mununu/issues/543)** — the exit-134 triage. Open.
+- **[#545](https://github.com/Mumunu-team/mununu/issues/545)** — a cutpoint that frees an array read's value but keeps its timing. Open; design work.
+- **[#541](https://github.com/Mumunu-team/mununu/issues/541)** — extending the typed report to `verify-recoverability` / `verify-liveness` / `context synth`. The `label` field lives in the shared shape, so those three inherit it when they land.


### PR DESCRIPTION
Closes #544.

**Filed from monono (their ask 22).** `--expect NAME=VERDICT` took the **positional** name, so the index was load-bearing in a CI surface.

Their measurement, one run:

| invocation | exit |
|---|---|
| `--expect "a_reseed_only_at_a_span_edge=holds"` | **4** |
| `--expect "affine_spr_sva_sva_0=holds"` | **0** |

Inserting a property mid-file re-points every later name — and the pin still **resolves**, to a different property. It happened to them, and the gate caught it **by luck**: the newly-named property happened to hold in the twin.

## What this does

`properties[]` carries **`label`** alongside `name`, and `--expect` resolves against the **label first**, then the positional name. A rename becomes a hard error; a reorder becomes a no-op.

Matching **both** is deliberate: existing index pins keep working on upgrade, so a consumer migrates property-by-property instead of in one cut.

## Two of our own records were wrong, and one caused the report

**`docs/api-schemas/verdict.md` documented `name` as "SVA label from the source".** It never was. A consumer reading that would reasonably pin to the label and expect it to resolve — which is exactly what monono did. Corrected here.

**`translate.rs` said the label "lives on a separate symbol-table entry"**, which is what made this ask look expensive. It needs no symbol table. slang emits a labelled statement as an enclosing `Block` whose `block` field is the symbol-table entry rendered as `"<address> <label>"`:

```text
ProceduralBlock → body: Block { block: "6338700059712 ap_bool", body: ConcurrentAssertion }
```

The `ConcurrentAssertion` node carries only `assertionKind` / `ifTrue` / `kind` / `propertySpec` — which is why the label was believed absent. It is one level up. Verified against both checked-in `ast-json` fixtures.

An **unlabelled** assertion gets no label rather than an address: that field's tail is then all digits, and an SV identifier cannot start with one. Fabricating a label would be worse than having none — a consumer would pin to an address that changes every elaboration.

## Residual gap, recorded rather than papered over

`@mununu_guarantee` properties have **no label** and stay positional (`ann_guarantee_<index>`), because `MununuAnnotation` carries only `tag` / `value` / `source_line` — no name field. Annotation-derived pins remain index-fragile. Noted in the code, the briefing, and here; giving the annotation an optional name is a separate surface change.

## Compatibility

**Additive.** One optional field with `skip_serializing_if`, so a report with no labelled assertions is byte-identical to before. Nothing renamed, removed or retyped; **no verdict values move.** Schema regenerated, drift detector passes.

The field lives in the **shared** report shape, so #541's three verbs inherit it rather than needing a retrofit.

## Surface parity

- **CLI** — `--expect` help updated to say labels are preferred and why.
- **API** — `PropertyVerdictView.label` + regenerated `sv-verify-auto-response.schema.json`.
- **UI** — no obligation; not a CTXDSL capability.
- **Consumer briefing** — `docs/consumer-briefings/2026-09-sva-label-names.md`.

## Tests

Five new: label recovery across both fixtures (in source order, positional name preserved); `block_label` rejecting a bare address and a digit-leading tail, accepting monono's actual label shape; `--expect` resolving by label; resolving by positional name after labels land; and a renamed label **failing** the claim instead of silently re-pointing.

`make ci`: **3137 tests, green.** Workspace check + doctests + `clippy --all-targets` green — `PropertyVerdict` is a load-bearing struct and 28 construction sites were updated, so the full pre-push check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
